### PR TITLE
Speed up VMDB::Util.log_duration_gz

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -45,20 +45,10 @@ module VMDB
     end
 
     def self.log_duration(filename)
-      first, last = nil
+      require 'elif'
 
-      begin
-        start_of_file = File.open(filename, 'r')
-
-        require 'elif'
-        end_of_file = Elif.open(filename) # Use Elif to read a file backwards just as File.open does forwards
-
-        first = find_timestamp(start_of_file)
-        last  = find_timestamp(end_of_file)
-      ensure
-        start_of_file.close if start_of_file
-        end_of_file.close   if end_of_file
-      end
+      first = File.open(filename, 'r') { |f| find_timestamp(f) }
+      last  = Elif.open(filename, 'r') { |f| find_timestamp(f) }
 
       return first, last
     end

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -93,32 +93,21 @@ module VMDB
       begin
         _log.info "Opening filename: [#{filename}], size: [#{File.size(filename)}]"
         Zlib::GzipReader.open(filename) do |gz|
-          lcount = 0
-          gz.each_line { |_line| lcount += 1 }
-          _log.info "Lines in file: [#{lcount}]"
+          line_count = 0
+          start_line = nil
+          end_line   = nil
 
-          hlines = []
-          tlines = []
-
-          gz.rewind
-          # Collect 2 arrays of lines
           gz.each_line do |line|
-            hlines << line if gz.lineno <= 50
-            tlines << line if gz.lineno >= (lcount - 50)
+            line_count += 1
+            next unless line =~ LOG_TIMESTAMP_REGEX
+            start_line ||= line
+            end_line     = line
           end
 
-          start_time = nil
-          hlines.each do |l|
-            start_time = log_timestamp(l)
-            break unless start_time.nil?
-          end
+          start_time = log_timestamp(start_line)
+          end_time   = log_timestamp(end_line)
 
-          end_time = nil
-          tlines.reverse_each do |l|
-            end_time = log_timestamp(l)
-            break unless end_time.nil?
-          end
-
+          _log.info "Lines in file: [#{line_count}]"
           _log.info "Start Time: [#{start_time.inspect}]"
           _log.info "End   Time: [#{end_time.inspect}]"
 

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -166,18 +166,12 @@ module VMDB
     end
 
     def self.find_timestamp(handle)
-      lines     = 0
-      max_lines = 250
-      ts        = nil
-
-      handle.each_line do |l|
-        break if lines >= max_lines
-        ts = log_timestamp(l)
-        break if ts
-        lines += 1
-      end
-
-      ts
+      handle
+        .lazy
+        .take(250)
+        .map { |line| log_timestamp(line) if line =~ LOG_TIMESTAMP_REGEX }
+        .reject(&:nil?)
+        .first
     end
   end
 end

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -36,13 +36,15 @@ module VMDB
       files.find { |f| f.match(/\/evm\.log/) }
     end
 
+    LOG_TIMESTAMP_REGEX = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6})\s#/.freeze
+
     def self.log_timestamp(line)
       ts = nil
 
       # Look for 4 digit year, hyphen, 2 digit month, hyphen, 2 digit day, T, etc.
       # [2009-05-04T18:17:50.350850 #1335]
       # Parse only the time component
-      if line.match(/\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6})\s#/)
+      if line.match(LOG_TIMESTAMP_REGEX)
         t  = Time.parse($1)
         ts = Time.utc(t.year, t.month, t.day, t.hour, t.min, t.sec, 0)
       end

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -64,19 +64,13 @@ module VMDB
     end
 
     def self.get_log_start_end_times(filename)
-      start_time = nil
-      end_time   = nil
-
-      # Get the start and end time from the log
-      unless filename.nil? || !File.exist?(filename)
-        if filename.match(/\.gz$/)
-          start_time, end_time = log_duration_gz(filename)
-        else
-          start_time, end_time = log_duration(filename)
-        end
+      if filename.nil? || !File.exist?(filename)
+        return nil, nil
+      elsif filename.ends_with?('.gz')
+        log_duration_gz(filename)
+      else
+        log_duration(filename)
       end
-
-      return start_time, end_time
     end
 
     def self.log_duration_gz(filename)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -57,13 +57,11 @@ describe VMDB::Util do
       it "#{file_content.lines.count} lines, #{type == :normal_case ? 'normal case' : 'no leading timestamps'}" do
         filename = "abc.log"
         string1 = StringIO.new(file_content)
-        string1.should_receive(:close)
         string2 = StringIO.new(file_content)
-        string2.should_receive(:close)
 
-        File.stub(:open).with(filename, "r").and_return(string1)
+        File.stub(:open).with(filename, "r").and_yield(string1)
         require 'elif'
-        Elif.stub(:open).and_return(string2)
+        Elif.stub(:open).and_yield(string2)
 
         if type == :normal_case || file_content.lines.count <= 250
           start_time, end_time = described_class.log_duration(filename)


### PR DESCRIPTION
Basically the idea is to read the file once (previous version did it twice). It doesn't give much performance gain against small files, but with big files there is a noticeable win.

The behavior changed a bit: before this commit only first and last 50 lines were taken into account. Now the method greps through all the lines in the log. Even despite this fact, the performance is not worse than in the previous version. Benchmarks:

Big file (750MB+ unarchived, 38MB gzipped, 2.8M lines)

```
2.2.3 :037 > t = Time.now; VMDB::Util   .get_log_start_end_times('log/big.log.gz'); Time.now - t
 => 34.867957
2.2.3 :038 > t = Time.now; VMDB::UtilOld.get_log_start_end_times('log/big.log.gz'); Time.now - t
 => 41.215036
```

35s vs 41s - looks like a win. I ran it several times, every time the new version was under 35s and the old one was over 41s.

Medium-sized file (5.4MB, 426KB gzipped, 32434 lines)
```ruby
Benchmark.ips do |x|
  x.config(time: 50, warmup: 10)
  x.report('after')  { VMDB::Util   .get_log_start_end_times('log/medium.log.gz') }
  x.report('before') { VMDB::UtilOld.get_log_start_end_times('log/medium.log.gz') }
  x.compare!
end
__END__
Calculating -------------------------------------
               after     1.000  i/100ms
              before     1.000  i/100ms
-------------------------------------------------
               after      3.124  (± 0.0%) i/s -    157.000
              before      3.010  (± 0.0%) i/s -    151.000
Comparison:
               after:        3.1 i/s
              before:        3.0 i/s - 1.04x slower
```

Smallish file (28K, 4.2K gzipped, 100 lines)

```
Benchmark.ips do |x|
  x.report('after')  { VMDB::Util   .get_log_start_end_times('log/small.log.gz') }
  x.report('before') { VMDB::UtilOld.get_log_start_end_times('log/small.log.gz') }
  x.compare!
end
__END__
Calculating -------------------------------------
               after     9.000  i/100ms
              before     9.000  i/100ms
-------------------------------------------------
               after    103.052  (± 2.9%) i/s -    522.000
              before     99.273  (± 2.0%) i/s -    504.000

Comparison:
               after:      103.1 i/s
              before:       99.3 i/s - 1.04x slower
```

Stats related to medium- and small-sized jump around (sometimes the old version outperforms the new version by a percent or two), so the win only affects big log files. On my laptop, at least.

I also made several refactorings in order to be able to introduce this change.