### PR TITLE
Optimize MiqServer::LogManagement#base_zip_log_name

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -253,7 +253,7 @@ module MiqServer::LogManagement
   end
 
   def base_zip_log_name
-    t = Time.now.utc.iso8601.gsub!(/:|\./, "_")
+    t = Time.now.utc.strftime('%FT%H_%M_%SZ'.freeze)
     # Name the file based on GUID and time.  GUID and Date/time of the request are as close to unique filename as we're going to get
     "App-#{guid}-#{t}"
   end

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -253,8 +253,8 @@ module MiqServer::LogManagement
   end
 
   def base_zip_log_name
-    t = Time.now.utc.iso8601
+    t = Time.now.utc.iso8601.gsub!(/:|\./, "_")
     # Name the file based on GUID and time.  GUID and Date/time of the request are as close to unique filename as we're going to get
-    "App-#{guid}-#{t}".gsub!(/:|\./, "_")
+    "App-#{guid}-#{t}"
   end
 end

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -255,6 +255,6 @@ module MiqServer::LogManagement
   def base_zip_log_name
     t = Time.now.utc.iso8601
     # Name the file based on GUID and time.  GUID and Date/time of the request are as close to unique filename as we're going to get
-    %(App-#{guid}-#{t}).gsub!(/:|\./, "_")
+    "App-#{guid}-#{t}".gsub!(/:|\./, "_")
   end
 end


### PR DESCRIPTION
There are 2 things:

1. Guids are in format like this `"e13a0faa-7bea-11e5-84a5-0023dfa65e00"` and they can't possibly contain dots or colons. So, we don't need to `gsub` on the whole string, `gsub`bing only the time part is enough.
2. Converting time to a string and then modifying the string in order to get rid of unwanted characters is overkill. We can generate the string we want without intermediate steps using `strftime`.

Benchmarks:

```ruby
  def guid
    "e13a0faa-7bea-11e5-84a5-0023dfa65e00".freeze
  end

  def base_zip_log_name_old
    t = Time.now.utc.iso8601
    # Name the file based on GUID and time.  GUID and Date/time of the request are as close to unique filename as we're going to get
    %(App-#{guid}-#{t}).gsub!(/:|\./, "_")
  end

  def base_zip_log_name_new
    t = Time.now.utc.strftime('%FT%H_%M_%SZ'.freeze)
    # Name the file based on GUID and time.  GUID and Date/time of the request are as close to unique filename as we're going to get
    "App-#{guid}-#{t}"
  end

  Benchmark.ips do |x|
    x.report('old') { base_zip_log_name_old }
    x.report('new') { base_zip_log_name_new }
    x.compare!
  end
__END__
Comparison:
                 new:    86341.3 i/s
                 old:    39912.3 i/s - 2.16x slower
```

And a little kinda proof that it works as intended:
```
>  puts [base_zip_log_name_old, base_zip_log_name_new]
App-e13a0faa-7bea-11e5-84a5-0023dfa65e00-2015-10-26T14_34_08Z
App-e13a0faa-7bea-11e5-84a5-0023dfa65e00-2015-10-26T14_34_08Z
```
