### PR TITLE
Fix link to cloud provider in relationship accordion

### DIFF
--- a/app/views/layouts/listnav/_flavor.html.haml
+++ b/app/views/layouts/listnav/_flavor.html.haml
@@ -15,7 +15,7 @@
         - if role_allows(:feature => "ems_cloud_show") && @record.ext_management_system
           %li
             = link_to("#{ui_lookup(:table => "ext_management_systems")}: #{@record.ext_management_system.name}",
-              {:controller => "ems_cloud", :action => 'show', :id => @record.ext_management_system.id.to_s},
+              ems_cloud_path(@record.ext_management_system.id),
               :title => _("Show this Flavor's parent %s") % ui_lookup(:table => "ems_cloud"))
 
         - if role_allows(:feature => "vm_show_list")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1273436

before
![before](https://cloud.githubusercontent.com/assets/14937244/10736487/8efc113e-7c0d-11e5-900c-044c58a6fc94.png)

after - link change to the restful route
![after](https://cloud.githubusercontent.com/assets/14937244/10736488/9176367e-7c0d-11e5-939a-0d0f74fd420d.png)
