### PR TITLE
Hide default tenant groups in UI

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -775,7 +775,7 @@ module OpsController::OpsRbac
                     when "user"
                       get_view(User, :named_scope => :in_my_region)
                     when "group"
-                      get_view(MiqGroup)
+                      get_view(MiqGroup, :named_scope => :non_tenant_groups)
                     when "role"
                       get_view(MiqUserRole)
                     when "tenant"
@@ -889,7 +889,7 @@ module OpsController::OpsRbac
     else  # Root node
       @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ => "Access Control", :name => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]", :model => ui_lookup(:model => "MiqRegion")}
       @users_count   = User.in_my_region.count
-      @groups_count  = MiqGroup.count
+      @groups_count  = MiqGroup.non_tenant_groups.count
       @roles_count   = MiqUserRole.count
       @tenants_count = Tenant.roots.count
     end
@@ -954,7 +954,7 @@ module OpsController::OpsRbac
     @edit[:new][:password] = @user.password
     @edit[:new][:password2] = @user.password
 
-    @edit[:groups] = MiqGroup.all.sort_by { |g| g.description.downcase }.collect { |g| [g.description, g.id] }
+    @edit[:groups] = MiqGroup.non_tenant_groups.sort_by { |g| g.description.downcase }.collect { |g| [g.description, g.id] }
     @edit[:new][:group] = @user.current_group ? @user.current_group.id : nil
 
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -31,7 +31,7 @@ class TreeBuilderOpsRbac < TreeBuilder
     objects =
       case object_hash[:id]
       when "u"  then User.in_my_region
-      when "g"  then MiqGroup.all
+      when "g"  then MiqGroup.non_tenant_groups
       when "ur" then MiqUserRole.all
       when "tn" then Tenant.roots
       end


### PR DESCRIPTION
Added changes to hide default tenant miq_groups from tree and user add/edit so those cannot be deleted or assigned to user.

@kbrock @gtanzillo @gmcculloug please review this should be merged after https://github.com/ManageIQ/manageiq/pull/5054

before:
![tenant_root_before](https://cloud.githubusercontent.com/assets/3450808/10739180/5b8d444c-7bf1-11e5-82ae-da06d7f374f8.png)
![group_list_before](https://cloud.githubusercontent.com/assets/3450808/10739182/5f62bb1a-7bf1-11e5-8085-cfcd528a1df1.png)

after:
![access_control_root_node](https://cloud.githubusercontent.com/assets/3450808/10738947/3879cd1e-7bf0-11e5-82bd-15e55639b982.png)

![miq_groups_after](https://cloud.githubusercontent.com/assets/3450808/10738939/32299016-7bf0-11e5-97a2-3d69fdf82b13.png)
