### PR TITLE
fully qualify SecurityGroup

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
 
                         return source.security_groups.non_cloud_network if source.tags.present?
 
-                        get_targets_for_ems(source, :cloud_filter, SecurityGroup, 'security_groups.non_cloud_network')
+                        get_targets_for_ems(source, :cloud_filter, ::SecurityGroup, 'security_groups.non_cloud_network')
                       end
 
     security_groups.each_with_object({}) { |sg, hash| hash[sg.id] = display_name_for_name_description(sg) }


### PR DESCRIPTION
Getting an running tests locally. I fully qualified SecurityGroup and it fixes it.

```
  1) ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow with empty relationships #allowed_security_groups
     Failure/Error: workflow.allowed_security_groups.should == {}
     NameError:
       uninitialized constant ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow::SecurityGroup
     # ./app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb:30:in `allowed_security_groups'
```

/cc @Fryguy @matthewd 