### PR TITLE
Remove regex validator for timeout text field

### DIFF
--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -112,8 +112,6 @@ class OrchestrationTemplateDialogService
       :display        => "edit",
       :required       => false,
       :options        => {:protected => false},
-      :validator_type => 'regex',
-      :validator_rule => '^[1-9][0-9]*$',
       :label          => "Timeout(minutes, optional)",
       :position       => position,
       :dialog_group   => group

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -68,7 +68,7 @@ describe OrchestrationTemplateDialogService do
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
     assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
-    assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :validator_rule => '^[1-9][0-9]*$')
+    assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
   end
 
   def assert_azure_stack_group(group)


### PR DESCRIPTION
Timeout text field is integer type that does not need a regex validator
    
https://bugzilla.redhat.com/show_bug.cgi?id=1274673