### PR TITLE
Applied email address validation in Provision virtual machines form

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -490,6 +490,12 @@ class MiqRequestWorkflow
     return "#{required_description(dlg, fld)} must not be greater than #{fld[:max_length]} characters" if fld[:max_length] && value.to_s.length > fld[:max_length]
   end
 
+  def validate_regex(_field, _values, dlg, fld, value)
+    regex = fld[:required_regex]
+    return "#{required_description(dlg, fld)} is required" if value.blank?
+    return "#{required_description(dlg, fld)} must be correctly formatted" unless value.match(regex)
+  end
+
   def required_description(dlg, fld)
     "'#{dlg[:description]}/#{fld[:required_description] || fld[:description]}'"
   end

--- a/product/dialogs/miq_dialogs/miq_host_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_host_provision_dialogs.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email: 
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email: 
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs-user.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs_clone_to_vm.yaml
@@ -108,6 +108,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email:
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
@@ -99,6 +99,8 @@
           :data_type: :string
         :owner_email: 
           :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
           :required: true
           :display: :edit
           :data_type: :string

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -4,7 +4,7 @@ describe MiqRequestWorkflow do
   let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
 
   context "#validate" do
-    let(:dialog)   { workflow.instance_variable_get(:@dialogs) }
+    let(:dialog) { workflow.instance_variable_get(:@dialogs) }
 
     context "validation_method" do
       it "skips validation if no validation_method is defined" do
@@ -237,6 +237,27 @@ describe MiqRequestWorkflow do
       expect(hs.id).to               be_kind_of(Integer)
       expect(hs.evm_object_class).to eq(:ConfiguredSystem)
       expect(hs.name).to             be_kind_of(String)
+    end
+  end
+
+  context "#validate regex" do
+    let(:regex) { {:required_regex => "^n@test.com$"} }
+    let(:regex_two) { {:required_regex => "^n$"} }
+    let(:value_email) { 'n@test.com' }
+    let(:value_no_email) { 'n' }
+
+    it "returns nil when the value matches" do
+      expect(workflow.validate_regex(nil, {}, {}, regex, value_email)).to be_nil
+      expect(workflow.validate_regex(nil, {}, {}, regex_two, value_no_email)).to be_nil
+    end
+
+    it "returns a formatting message when value does not match regex" do
+      expect(workflow.validate_regex(nil, {}, {}, regex, value_no_email)).to eq "'/' must be correctly formatted"
+      expect(workflow.validate_regex(nil, {}, {}, regex_two, value_email)).to eq "'/' must be correctly formatted"
+    end
+
+    it "returns an error when no value exists" do
+      expect(workflow.validate_regex(nil, {}, {}, regex, '')).to eq "'/' is required"
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1110649

Added a required_method and required_regex key to the miq_provision_dialogs_template.yaml
both under the :owner_email dialog entry.

Included a default expression that can be modified by an end-user to suit their tastes.