### PR TITLE
Tenant assign groups

### DIFF
--- a/db/migrate/20151026220722_assign_vm_group.rb
+++ b/db/migrate/20151026220722_assign_vm_group.rb
@@ -1,0 +1,32 @@
+class AssignVmGroup < ActiveRecord::Migration
+  class Tenant < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+
+    def self.root_tenant
+      where(:ancestry => nil).first
+    end
+  end
+
+  class VmOrTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    self.table_name = 'vms'
+  end
+
+  class Service < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    group_id = Tenant.root_tenant.try(:default_miq_group_id)
+
+    return unless group_id
+
+    say_with_time "assign default vm groups" do
+      VmOrTemplate.where(:miq_group_id => nil).update_all(:miq_group_id => group_id)
+    end
+
+    say_with_time "assign default service miq_groups" do
+      Service.where(:miq_group_id => nil).update_all(:miq_group_id => group_id)
+    end
+  end
+end

--- a/spec/migrations/20151026220722_assign_vm_group_spec.rb
+++ b/spec/migrations/20151026220722_assign_vm_group_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require_migration
+
+describe AssignVmGroup do
+  let(:tenant_stub) { migration_stub(:Tenant) }
+  let(:vmt_stub) { migration_stub(:VmOrTemplate) }
+  let(:service_stub) { migration_stub(:Service) }
+
+  migration_context :up do
+    it "assigns vm groups" do
+      tenant_stub.create!(:default_miq_group_id => 1)
+
+      vm_without_group = vmt_stub.create!(:miq_group_id => nil)
+      vm_with_group = vmt_stub.create!(:miq_group_id => 2)
+      migrate
+
+      expect(vm_without_group.reload.miq_group_id).to eq(1)
+      expect(vm_with_group.reload.miq_group_id).to eq(2)
+    end
+
+    it "assigns service groups" do
+      tenant_stub.create!(:default_miq_group_id => 1)
+
+      service_without_group = service_stub.create!(:miq_group_id => nil)
+      service_with_group = service_stub.create!(:miq_group_id => 2)
+      migrate
+
+      expect(service_without_group.reload.miq_group_id).to eq(1)
+      expect(service_with_group.reload.miq_group_id).to eq(2)
+    end
+  end
+end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -238,21 +238,21 @@ describe MiqGroup do
     end
   end
 
-  describe "#destroy" "should not be deleted while a user is still assigned" do
+  describe "#destroy" do
     let(:group) { FactoryGirl.create(:miq_group) }
 
     it "can succeed" do
       expect { group.destroy }.not_to raise_error
     end
 
-    it "fails if referenced by current_group" do
+    it "fails if referenced by user#current_group" do
       FactoryGirl.create(:user, :miq_groups => [group])
 
       expect { group.destroy }.to raise_error
       MiqGroup.count.should eq 1
     end
 
-    it "fails if referenced by miq_groups" do
+    it "fails if referenced by user#miq_groups" do
       group2 = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
 
@@ -260,8 +260,8 @@ describe MiqGroup do
       MiqGroup.count.should eq 2
     end
 
-    it "fails if referenced by a default tenant" do
-      expect { FactoryGirl.create(:tenant).default_miq_group.destroy }.to raise_error
+    it "fails if referenced by a tenant#default_miq_group" do
+      expect { FactoryGirl.create(:tenant).default_miq_group.reload.destroy }.to raise_error
     end
   end
 

--- a/spec/models/mixins/tenancy_mixin_spec.rb
+++ b/spec/models/mixins/tenancy_mixin_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+describe TenancyMixin do
+  let(:root_tenant) do
+    Tenant.seed
+  end
+
+  let(:default_tenant) do
+    root_tenant
+    Tenant.default_tenant
+  end
+
+  describe "miq_group" do
+    let(:user)         { FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
+    let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
+    let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
+    let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
+
+    it "assigns owning group tenant" do
+      vm = FactoryGirl.create(:vm_vmware, :miq_group => tenant_group)
+
+      expect(vm.miq_group).to eql tenant_group
+      expect(vm.tenant).to eql tenant
+    end
+
+    it "assigns current user tenant" do
+      User.current_user = user
+      vm = FactoryGirl.create(:vm_vmware)
+
+      expect(vm.miq_group).to eql tenant_group
+      expect(vm.tenant).to eql tenant
+    end
+
+    it "assigns parent EMS tenant" do
+      tenant.save
+      ems = FactoryGirl.create(:ems_vmware, :name => 'ems', :tenant => tenant)
+      vm  = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+
+      expect(vm.miq_group).to eql tenant.default_miq_group
+      expect(vm.tenant).to eql tenant
+    end
+
+    it "assigns root tenant" do
+      root_tenant
+      vm = FactoryGirl.create(:vm_vmware)
+
+      expect(vm.miq_group).to eql root_tenant.default_miq_group
+      expect(vm.tenant).to eql root_tenant
+    end
+
+    it "assigns the tenant group" do
+      root_tenant
+      tenant.save
+
+      vm = FactoryGirl.create(:vm_vmware, :tenant => tenant)
+      expect(vm.tenant).to eq(tenant)
+      expect(vm.miq_group).to eq(tenant.default_miq_group)
+    end
+  end
+
+  describe "assigning tenants without a miq_group" do
+    let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
+    let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
+    let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
+
+    it "assigns current user tenant" do
+      User.current_user = FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group])
+      ems = FactoryGirl.create(:ext_management_system)
+
+      expect(ems.tenant).to eql tenant
+    end
+
+    it "assigns root tenant" do
+      root_tenant
+      ems = FactoryGirl.create(:ext_management_system)
+
+      expect(ems.tenant).to eql root_tenant
+    end
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -780,37 +780,4 @@ describe Tenant do
       expect(combined[:templates_allocated][:used]).to        eql 2
     end
   end
-
-  describe "assigning tenants" do
-    let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
-    let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
-    let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
-
-    it "assigns owning group tenant" do
-      vm = FactoryGirl.create(:vm_vmware, :miq_group => tenant_group)
-
-      expect(vm.tenant).to eql tenant
-    end
-
-    it "assigns current user tenant" do
-      User.current_user = FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group])
-      vm = FactoryGirl.create(:vm_vmware)
-
-      expect(vm.tenant).to eql tenant
-    end
-
-    it "assigns parent EMS tenant" do
-      ems = FactoryGirl.create(:ems_vmware, :name => 'ems', :tenant => tenant)
-      vm  = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
-
-      expect(vm.tenant).to eql tenant
-    end
-
-    it "assigns root tenant" do
-      root_tenant
-      vm = FactoryGirl.create(:vm_vmware)
-
-      expect(vm.tenant).to eql root_tenant
-    end
-  end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -410,7 +410,8 @@ describe VmOrTemplate do
   context "#tenant" do
     let(:tenant) { FactoryGirl.create(:tenant) }
     it "has a tenant" do
-      vm = FactoryGirl.create(:vm_vmware, :tenant => tenant)
+      vm = FactoryGirl.create(:vm_vmware, :tenant => tenant, :miq_group => nil)
+      expect(vm.reload.tenant).to eq(tenant)
       expect(tenant.vm_or_templates).to include(vm)
     end
   end


### PR DESCRIPTION
Assign a default `mig_group` to managed objects that use group to determine the tenant.

This ensures `Vm` and `Services` always have a `Group` relationship allowing the entitlement to be passed to automate.

Only the last 2 commits are in this PR.
~~The first 5 are in #5054.~~

/cc @chessbyte @gtanzillo 