### PR TITLE
Reinstate ruby expression support

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -196,6 +196,8 @@ class Condition < ActiveRecord::Base
     if checkmode == "count"
       e = check.gsub(/<count>/i, list.length.to_s)
       left, operator, right = e.split
+      raise "Illegal operator, '#{operator}'" unless %w(== != < > <= >=).include?(operator)
+
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression after substitution: [#{e}]")
       _ = inputs # used by eval (presumably?)
       result = !!left.to_f.send(operator, right.to_f)

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -90,7 +90,10 @@ class Condition < ActiveRecord::Base
   def self.do_eval(expr)
     # Remove this [DEPRECATION] in the next version
     if expr =~ /^__start_ruby__\s?__start_context__\s?(.*)\s?__type__\s?(.*)\s?__end_context__\s?__start_script__\s?(.*)\s?__end_script__\s?__end_ruby__$/im
-      raise "Ruby scripts in expressions are no longer supported. Please use the regular expression feature of conditions instead."
+      context, col_type, script = [$1, $2, $3]
+      context = MiqExpression.quote(context, col_type)
+      result = SafeNamespace.eval_script(script, context)
+      raise "Expected return value of true or false from ruby script but instead got result: [#{result.inspect}]" unless result.kind_of?(TrueClass) || result.kind_of?(FalseClass)
     else
       result = eval(expr) ? true : false
     end
@@ -298,4 +301,42 @@ class Condition < ActiveRecord::Base
 
     return c, status
   end
+
+  protected
+
+  module SafeNamespace
+    def self.eval_script(script, context)
+      _log.debug("Context: [#{context}], Class: [#{context.class.name}]")
+      _log.debug("Script:\n#{script}")
+      begin
+        t = Thread.new do
+          Thread.current["result"] = _eval(context, script)
+        end
+        to = 20 # allow 20 seconds for script to complete
+        Timeout::timeout(to) { t.join }
+      rescue TimeoutError => err
+        t.exit
+        _log.error  "The following error occurred during ruby evaluation"
+        _log.error  "  #{err.class}: #{err.message}"
+        raise "Ruby script timed out after #{to} seconds"
+      rescue Exception => err
+        _log.error  "The following error occurred during ruby evaluation"
+        _log.error  "  #{err.class}: #{err.message}"
+        raise "Ruby script raised error [#{err.message}]"
+      ensure
+        (t["log"] || []).each {|m| _log.info("#{m}")} unless t.nil?
+      end
+      return t["result"]
+    end
+
+    def self._eval(context, script)
+      proc { $SAFE = 3; eval(script) }.call
+    end
+
+    def self.log(msg)
+      Thread.current["log"] ||= []
+      Thread.current["log"] << "[#{Time.now.utc.iso8601(6).chop}] #{msg}"
+    end
+  end
+
 end # class Condition

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -35,6 +35,26 @@ describe Condition do
         expr.taint
         -> { Condition.subst(expr, @cluster, nil) }.should_not raise_error(SecurityError)
       end
+
+      it "tests all allowed operators in find/check expression clause" do
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> == 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'false'
+
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> > 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'true'
+
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> >= 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'true'
+
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> < 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'false'
+
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> <= 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'false'
+
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> != 0</check></find>"
+        Condition.subst(expr, @cluster, nil).should == 'true'
+      end
     end
 
     context "expression with <registry>" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -55,6 +55,11 @@ describe Condition do
         expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> != 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'true'
       end
+
+      it "rejects and expression with an illegal operator" do
+        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> !! 0</check></find>"
+        expect { Condition.subst(expr, @cluster, nil).should == 'false' }.to raise_error(RuntimeError, "Illegal operator, '!!'")
+      end
     end
 
     context "expression with <registry>" do


### PR DESCRIPTION
This PR replaces https://github.com/ManageIQ/manageiq/pull/3806

It reinstates the code that supports the evaluation of limited ruby code in an expression. The code was originally removed in #3708 because it was thought to be obsolete. However, it is still necessary for evaluating "find / check" expressions and therefore needed to be put back.