### PR TITLE
Add missing require_nested to openstack infra

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -1,16 +1,22 @@
 class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   require_nested :AuthKeyPair
+  require_nested :CloudNetwork
+  require_nested :CloudSubnet
   require_nested :EmsCluster
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :FloatingIp
   require_nested :Host
   require_nested :HostServiceGroup
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
+  require_nested :NetworkPort
+  require_nested :NetworkRouter
   require_nested :OrchestrationStack
   require_nested :Refresher
   require_nested :RefreshParser
   require_nested :RefreshWorker
+  require_nested :SecurityGroup
 
   include ManageIQ::Providers::Openstack::ManagerMixin
   include HasManyOrchestrationStackMixin


### PR DESCRIPTION
Some new and some old nested classes were missing from OpenstackInfra.

SecurityGroup was on causing particular problems.

/cc @matthewd 