### PR TITLE
Tenant create request with requester

### DIFF
--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -19,12 +19,12 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     false
   end
 
-  def create_request(values, requester_id, auto_approve = false)
-    super(values, requester_id, auto_approve) { update_selected_storage_names(values) }
+  def create_request(values, requester, auto_approve = false)
+    super(values, requester, auto_approve) { update_selected_storage_names(values) }
   end
 
-  def update_request(request, values, requester_id)
-    super(request, values, requester_id) { update_selected_storage_names(values) }
+  def update_request(request, values, requester)
+    super(request, values, requester) { update_selected_storage_names(values) }
   end
 
   def get_source_and_targets(_refresh = false)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -47,7 +47,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     super(message, [:request_type, :source_type, :target_type], extra_attrs)
   end
 
-  def create_request(values, _requester_id = nil, auto_approve = false)
+  def create_request(values, _requester = nil, auto_approve = false)
     if @running_pre_dialog == true
       continue_request(values)
       password_helper(values, true)
@@ -57,7 +57,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 
-  def update_request(request, values, _requester_id = nil)
+  def update_request(request, values, _requester = nil)
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
     request.src_vm_id = request.get_option(:src_vm_id)
     super

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -441,7 +441,6 @@ class MiqRequest < ActiveRecord::Base
     request.save!
 
     request.set_description
-    request.create_request
 
     request.log_request_success(requester, :created)
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -94,13 +94,13 @@ class MiqRequest < ActiveRecord::Base
   end
 
   def initialize_attributes
-    self.requester ||= User.find_by_userid(userid) if userid
-    self.requester ||= User.find_by_name(requester_name) if requester_name
-    self.requester_name ||= requester.try(:name)
-    self.userid ||= requester.try(:userid)
-    self.tenant ||= requester.try(:current_tenant)
     self.approval_state ||= "pending_approval"
-    miq_approvals << build_default_approval
+    miq_approvals << build_default_approval if miq_approvals.empty?
+
+    return unless requester
+    self.requester_name ||= requester.name
+    self.userid         ||= requester.userid
+    self.tenant         ||= requester.current_tenant
   end
 
   # TODO: Move call_automate_event_queue from MiqProvisionWorkflow to be done here automagically

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -88,7 +88,6 @@ class MiqRequestWorkflow
     end
 
     request.set_description
-    request.create_request
 
     request.log_request_success(@requester, :created)
 

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -62,15 +62,15 @@ class MiqRequestWorkflow
   end
 
   # Helper method when not using workflow
-  def make_request(request, values, requester_id = nil, auto_approve = false)
+  def make_request(request, values, requester = nil, auto_approve = false)
     if request
-      update_request(request, values, requester_id)
+      update_request(request, values, requester)
     else
-      create_request(values, requester_id, auto_approve)
+      create_request(values, requester, auto_approve)
     end
   end
 
-  def create_request(values, _requester_id = nil, auto_approve = false)
+  def create_request(values, _requester = nil, auto_approve = false)
     return false unless validate(values)
 
     set_request_values(values)
@@ -78,7 +78,7 @@ class MiqRequestWorkflow
 
     yield if block_given?
 
-    request = request_class.create(:options => values, :userid => @requester.userid, :request_type => request_type.to_s)
+    request = request_class.create(:options => values, :requester => @requester, :request_type => request_type.to_s)
     begin
       request.save!  # Force validation errors to raise now
     rescue => err
@@ -98,7 +98,7 @@ class MiqRequestWorkflow
     request
   end
 
-  def update_request(request, values, _requester_id = nil)
+  def update_request(request, values, _requester = nil)
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
 
     return false unless validate(values)
@@ -113,7 +113,7 @@ class MiqRequestWorkflow
     request.update_attribute(:options, request.options.merge(values))
     request.set_description(true)
 
-    request.log_request_success(@requester.userid, :updated)
+    request.log_request_success(@requester, :updated)
 
     request.call_automate_event_queue("request_updated")
     request

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -145,8 +145,7 @@ class ServiceTemplate < ActiveRecord::Base
                                                           parent_svc) unless parent_svc
     svc = create_service(service_task, parent_svc)
 
-    user = User.find_by_userid(service_task.userid)
-    set_ownership(svc, user) unless user.nil?
+    set_ownership(svc, service_task.get_user)
 
     service_task.destination = svc
 

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -10,7 +10,7 @@ describe "CatalogBundleInitialization Automate Method" do
   end
 
   def create_request_and_tasks(dialog_options = {})
-    @request = build_service_template_request("top", @user.userid, dialog_options)
+    @request = build_service_template_request("top", @user, dialog_options)
     service_template_stubs
     request_stubs
     @request.create_request_tasks
@@ -23,11 +23,11 @@ describe "CatalogBundleInitialization Automate Method" do
                                                   'vm_service2' => {:provision_index => 1}}},
              "vm_service1" => {:type    => 'atomic',
                                :request => {:src_vm_id => @src_vm.id,
-                                            :number_of_vms => 1, :userid => @user.userid}
+                                            :number_of_vms => 1, :requester => @user}
                               },
              "vm_service2" => {:type    => 'atomic',
                                :request => {:src_vm_id => @src_vm.id,
-                                            :number_of_vms => 1, :userid => @user.userid}
+                                            :number_of_vms => 1, :requester => @user}
                               }
             }
     build_service_template_tree(model)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -10,7 +10,7 @@ describe "CatalogItemInitialization Automate Method" do
   end
 
   def create_request_and_tasks(dialog_options = {})
-    @request = build_service_template_request("top", @user.userid, dialog_options)
+    @request = build_service_template_request("top", @user, dialog_options)
     service_template_stubs
     request_stubs
     @request.create_request_tasks
@@ -23,11 +23,11 @@ describe "CatalogItemInitialization Automate Method" do
                                                   'vm_service2' => {:provision_index => 1}}},
              "vm_service1" => {:type    => 'atomic',
                                :request => {:src_vm_id => @src_vm.id,
-                                           :number_of_vms => 1, :userid => @user.userid}
+                                           :number_of_vms => 1, :requester => @user}
                              },
              "vm_service2" => {:type    => 'atomic',
                                :request => {:src_vm_id => @src_vm.id,
-                                           :number_of_vms => 1, :userid => @user.userid}
+                                           :number_of_vms => 1, :requester => @user}
                              }
             }
     build_service_template_tree(model)

--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -10,7 +10,7 @@ describe "FilterByDialogParameters Automate Method" do
   end
 
   def post_create(dialog_options = {})
-    @request = build_service_template_request("top", @user.userid, dialog_options)
+    @request = build_service_template_request("top", @user, dialog_options)
     service_template_stubs
     request_stubs
     @request.create_request_tasks
@@ -21,7 +21,7 @@ describe "FilterByDialogParameters Automate Method" do
              "middle"     => {:type    => 'composite', :children => ['vm_service']},
              "vm_service" => {:type    => 'atomic',
                               :request => {:target_name => "fred", :src_vm_id => @src_vm.id,
-                                           :number_of_vms => 1, :userid => @user.userid}
+                                           :number_of_vms => 1, :requester => @user}
                              }
             }
     build_service_template_tree(model)

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -5,7 +5,7 @@ describe "Orchestration check_provisioned Method Validation" do
   let(:ems_amazon)              { FactoryGirl.create(:ems_amazon, :last_refresh_date => Time.now - 100) }
   let(:failure_msg)             { "failure message" }
   let(:miq_request_task)        { FactoryGirl.create(:miq_request_task, :destination => service_orchestration, :miq_request => request) }
-  let(:request)                 { FactoryGirl.create(:service_template_provision_request, :userid => user.userid) }
+  let(:request)                 { FactoryGirl.create(:service_template_provision_request, :requester => user) }
   let(:service_orchestration)   { FactoryGirl.create(:service_orchestration, :orchestration_manager => ems_amazon) }
   let(:stack_ems_ref)           { "12345" }
   let(:user)                    { FactoryGirl.create(:user_with_group) }

--- a/spec/automation/unit/method_validation/orchestration_provision_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_provision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Orchestration provision Method Validation" do
   let(:miq_request_task)      { FactoryGirl.create(:miq_request_task, :destination => service_orchestration, :miq_request => request) }
-  let(:request)               { FactoryGirl.create(:service_template_provision_request, :userid => user.userid) }
+  let(:request)               { FactoryGirl.create(:service_template_provision_request, :requester => user) }
   let(:service_orchestration) { FactoryGirl.create(:service_orchestration) }
   let(:user)                  { FactoryGirl.create(:user_with_group) }
   let(:ws)                    { MiqAeEngine.instantiate("/Cloud/Orchestration/Provisioning/StateMachines/Methods/Provision?MiqRequestTask::service_template_provision_task=#{miq_request_task.id}", user) }

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -110,7 +110,7 @@ describe MiqRequestController do
       EvmSpecHelper.create_guid_miq_server_zone
       @miq_request = MiqProvisionConfiguredSystemRequest.create(:description    => "Foreman provision",
                                                                 :approval_state => "pending_approval",
-                                                                :userid         => User.current_user.userid)
+                                                                :requester      => User.current_user)
     end
     it "when edit request button is pressed" do
       post :button, :pressed => "miq_request_edit", :id => @miq_request.id, :format => :js
@@ -133,7 +133,7 @@ describe MiqRequestController do
       EvmSpecHelper.create_guid_miq_server_zone
       @miq_request = MiqProvisionConfiguredSystemRequest.create(:description    => "Foreman provision",
                                                                 :approval_state => "pending_approval",
-                                                                :userid         => User.current_user.userid)
+                                                                :requester      => User.current_user)
     end
     it "when the edit button is pressed the request is displayed" do
       session[:settings] = {:display   => {:quad_truncate => 'f'},

--- a/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
@@ -119,7 +119,7 @@ module MiqAeEventSpec
 
       context "with MiqRequest event" do
         it "has tenant" do
-          request = FactoryGirl.create(:vm_reconfigure_request, :userid => user.userid)
+          request = FactoryGirl.create(:vm_reconfigure_request, :requester => user)
           args    = {:user_id      => user.id,
                      :miq_group_id => user.current_group.id,
                      :tenant_id    => user.current_tenant.id

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
@@ -35,19 +35,18 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
                                                     :provision_type => 'template',
                                                     :state => 'pending', :status => 'Ok',
                                                     :src_vm_id => @vm_template.id,
-                                                    :userid => @user.userid)
+                                                    :requester => @user)
         @miq_provision.miq_provision_request = @miq_provision_request
         @miq_provision.save!
         @miq_provision_request.save!
       end
 
       it "#miq_request" do
-        miq_request = @miq_provision_request.create_request
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
         @ae_method.update_attributes(:data => method)
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-        [:id].each { |meth| ae_object.send(meth).should == miq_request.send(meth) }
+        expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+        expect(ae_object.id).to eq(@miq_provision_request.id)
       end
 
       it "#miq_provision_request" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
@@ -15,7 +15,7 @@ module MiqAeServiceMiqHostProvisionRequestSpec
       @ae_result_key = 'foo'
 
       @user                       = FactoryGirl.create(:user_with_group)
-      @miq_host_provision_request = FactoryGirl.create(:miq_host_provision_request, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok', :userid => @user.userid)
+      @miq_host_provision_request = FactoryGirl.create(:miq_host_provision_request, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok', :requester => @user)
     end
 
     def invoke_ae
@@ -23,14 +23,13 @@ module MiqAeServiceMiqHostProvisionRequestSpec
     end
 
     it "#miq_request" do
-      miq_request = @miq_host_provision_request.create_request
       @miq_host_provision_request.save!
 
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_host_provision_request'].miq_request"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-      [:id].each { |method| ae_object.send(method).should == miq_request.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      expect(ae_object.id).to eq(@miq_host_provision_request.id)
     end
 
     it "#miq_host_provisions" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
@@ -17,7 +17,7 @@ module MiqAeServiceMiqHostProvisionSpec
     end
 
     it "#miq_host_provision_request" do
-      miq_host_provision_request = FactoryGirl.create(:miq_host_provision_request, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok', :userid => @user.userid)
+      miq_host_provision_request = FactoryGirl.create(:miq_host_provision_request, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok', :requester => @user)
       @miq_host_provision.miq_host_provision_request = miq_host_provision_request
       @miq_host_provision.save!
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
@@ -17,7 +17,7 @@ module MiqAeServiceMiqProvisionRequestSpec
       @ems                   = FactoryGirl.create(:ems_vmware_with_authentication)
       @vm_template           = FactoryGirl.create(:template_vmware, :ext_management_system => @ems)
       @user                  = FactoryGirl.create(:user_with_group)
-      @miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :userid => @user.userid)
+      @miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :requester => @user)
     end
 
     def invoke_ae
@@ -25,14 +25,13 @@ module MiqAeServiceMiqProvisionRequestSpec
     end
 
     it "#miq_request" do
-      miq_request = @miq_provision_request.create_request
       @miq_provision_request.save!
 
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_request"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-      [:id].each { |method| ae_object.send(method).should == miq_request.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      expect(ae_object.id).to eq(@miq_provision_request.id)
     end
 
     it "#miq_provisions" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
@@ -22,10 +22,7 @@ module MiqAeServiceMiqProvisionSpec
     end
 
     it "#miq_request" do
-      miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :userid => @user.userid)
-
-      miq_request = miq_provision_request.create_request
-      miq_provision_request.save!
+      miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :requester => @user)
 
       @miq_provision.miq_provision_request = miq_provision_request
       @miq_provision.save!
@@ -33,12 +30,12 @@ module MiqAeServiceMiqProvisionSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-      [:id].each { |method| ae_object.send(method).should == miq_request.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      expect(ae_object.id).to eq(miq_provision_request.id)
     end
 
     it "#miq_provision_request" do
-      miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :userid => @user.userid)
+      miq_provision_request = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => @vm_template.id, :requester => @user)
       @miq_provision.miq_provision_request = miq_provision_request
       @miq_provision.save!
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -13,7 +13,7 @@ module MiqAeServiceMiqRequestSpec
       @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
 
-      @fred          = FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone',  :userid => 'fred')
+      @fred          = FactoryGirl.create(:user_with_group)
       @miq_request   = FactoryGirl.create(:automation_request, :requester => @fred)
     end
 
@@ -51,8 +51,8 @@ module MiqAeServiceMiqRequestSpec
       @ae_method.update_attributes(:data => method)
       invoke_ae.root(@ae_result_key).should == []
 
-      wilma          = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'wilma',  :email => 'wilma@bedrock.gov')
-      betty          = FactoryGirl.create(:user, :name => 'Betty Rubble',     :userid => 'betty',  :email => 'betty@bedrock.gov')
+      wilma          = FactoryGirl.create(:user_with_email_and_group)
+      betty          = FactoryGirl.create(:user_with_email_and_group)
       wilma_approval = FactoryGirl.create(:miq_approval, :approver => wilma)
       betty_approval = FactoryGirl.create(:miq_approval, :approver => betty)
       @miq_request.miq_approvals = [wilma_approval, betty_approval]
@@ -96,10 +96,8 @@ module MiqAeServiceMiqRequestSpec
       @ae_method.update_attributes(:data => method)
 
       vm_template = FactoryGirl.create(:template_vmware, :name => "template1")
-      resource    = FactoryGirl.create(:miq_provision_request, :userid => @fred.userid, :src_vm_id => vm_template.id)
-      resource.create_request
+      resource    = FactoryGirl.create(:miq_provision_request, :requester => @fred, :src_vm_id => vm_template.id)
       @miq_request = resource
-      @miq_request.save!
 
       ae_resource = invoke_ae.root(@ae_result_key)
       ae_class    = "MiqAeMethodService::MiqAeService#{resource.class.name.gsub(/::/, '_')}".constantize
@@ -113,7 +111,7 @@ module MiqAeServiceMiqRequestSpec
       reason = invoke_ae.root(@ae_result_key)
       reason.should be_nil
 
-      betty          = FactoryGirl.create(:user, :name => 'Betty Rubble',     :userid => 'betty',  :email => 'betty@bedrock.gov')
+      betty          = FactoryGirl.create(:user_with_email_and_group)
       betty_approval = FactoryGirl.create(:miq_approval, :approver => betty)
       @miq_request.miq_approvals = [betty_approval]
       @miq_request.save!
@@ -127,7 +125,7 @@ module MiqAeServiceMiqRequestSpec
       reason = invoke_ae.root(@ae_result_key)
       reason.should == betty_reason
 
-      wilma          = FactoryGirl.create(:user, :name => 'Wilma Flintstone', :userid => 'wilma',  :email => 'wilma@bedrock.gov')
+      wilma          = FactoryGirl.create(:user_with_email_and_group)
       wilma_approval = FactoryGirl.create(:miq_approval, :approver => wilma)
       @miq_request.miq_approvals << wilma_approval
       wilma_reason = "Where's Fred?"

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
@@ -28,7 +28,7 @@ module MiqAeServiceMiqRequestTaskSpec
       @ae_method.update_attributes(:data => method)
 
       user        = FactoryGirl.create(:user)
-      miq_request = FactoryGirl.create(:vm_migrate_request, :userid => user.userid)
+      miq_request = FactoryGirl.create(:vm_migrate_request, :requester => user)
       @miq_request_task.update_attributes(:miq_request => miq_request)
 
       result = invoke_ae.root(@ae_result_key)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
@@ -13,7 +13,7 @@ module MiqAeServiceServiceReconfigureRequestSpec
 
     let(:ae_method)     { ::MiqAeMethod.first }
     let(:user)          { FactoryGirl.create(:user_with_group) }
-    let(:request)       { FactoryGirl.create(:service_reconfigure_request, :requester => user, :userid => user.userid) }
+    let(:request)       { FactoryGirl.create(:service_reconfigure_request, :requester => user) }
 
     def invoke_ae
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceReconfigureRequest::request=#{request.id}", user)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -12,7 +12,7 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
       @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
       @user          = FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone',  :userid => 'fred')
-      @service_template_provision_request = FactoryGirl.create(:service_template_provision_request, :requester => @user, :userid => @user.userid)
+      @service_template_provision_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
     end
 
     def invoke_ae

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -28,7 +28,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
         :cpu_limit             => -1,
         :cpu_reserve           => 0)
       @vm          = FactoryGirl.create(:vm_microsoft, :name => "vm1",       :location => "abc/def.xml")
-      @pr          = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+      @pr          = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
       @options = {
         :pass           => 1,
         :vm_name        => @target_vm_name,

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
         @ems         = FactoryGirl.create(:ems_redhat_with_authentication)
         @vm_template = FactoryGirl.create(:template_redhat, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
         @vm          = FactoryGirl.create(:vm_redhat, :name => "vm1",       :location => "abc/def.vmx")
-        @pr          = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+        @pr          = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
         @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
         @vm_prov = FactoryGirl.create(:miq_provision_redhat, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
         @ems         = FactoryGirl.create(:ems_redhat_with_authentication)
         @vm_template = FactoryGirl.create(:template_redhat, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
         @vm          = FactoryGirl.create(:vm_redhat, :name => "vm1",       :location => "abc/def.vmx")
-        @pr          = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+        @pr          = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
         @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
         @vm_prov = FactoryGirl.create(:miq_provision_redhat_via_iso, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe do
         @ems         = FactoryGirl.create(:ems_redhat_with_authentication)
         @vm_template = FactoryGirl.create(:template_redhat, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
         @vm          = FactoryGirl.create(:vm_redhat, :name => "vm1",       :location => "abc/def.vmx")
-        @pr          = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+        @pr          = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
         @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
         @vm_prov = FactoryGirl.create(:miq_provision_redhat_via_pxe, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         @ems         = FactoryGirl.create(:ems_vmware_with_authentication)
         @vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
         @vm          = FactoryGirl.create(:vm_vmware, :name => "vm1", :location => "abc/def.vmx")
-        @pr          = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+        @pr          = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
         @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
         @vm_prov = FactoryGirl.create(:miq_provision_vmware, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
       end

--- a/spec/models/miq_approval_spec.rb
+++ b/spec/models/miq_approval_spec.rb
@@ -25,7 +25,7 @@ describe MiqApproval do
       approval.stub(:authorized?).and_return(false)
       expect { approval.approve(approver, reason) }.to raise_error("not authorized")
 
-      miq_request = FactoryGirl.create(:vm_migrate_request, :userid => user.userid)
+      miq_request = FactoryGirl.create(:vm_migrate_request, :requester => user)
       approval.miq_request = miq_request
       approval.stub(:authorized?).and_return(true)
       Timecop.freeze do
@@ -42,7 +42,7 @@ describe MiqApproval do
     it "with an approver's own request" do
       vm_template = FactoryGirl.create(:template_vmware)
       user        = FactoryGirl.create(:user_miq_request_approver)
-      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :userid => user.userid)
+      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :requester => user)
       approval    = FactoryGirl.create(:miq_approval, :miq_request => request)
 
       expect { approval.approve(user, 'Why Not') }.to_not raise_error
@@ -51,7 +51,7 @@ describe MiqApproval do
     it "with an approver's object'" do
       vm_template = FactoryGirl.create(:template_vmware)
       user        = FactoryGirl.create(:user_miq_request_approver)
-      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :userid => user.userid)
+      request     = FactoryGirl.create(:miq_provision_request, :provision_type => 'template', :state => 'pending', :status => 'Ok', :src_vm_id => vm_template.id, :requester => user)
       approval    = FactoryGirl.create(:miq_approval, :miq_request => request)
 
       expect { approval.approve(user, 'Why Not') }.to_not raise_error
@@ -68,7 +68,7 @@ describe MiqApproval do
     approval.stub(:authorized?).and_return(false)
     expect { approval.deny(approver, reason) }.to raise_error("not authorized")
 
-    miq_request = FactoryGirl.create(:vm_migrate_request, :userid => user.userid)
+    miq_request = FactoryGirl.create(:vm_migrate_request, :requester => user)
     approval.miq_request = miq_request
     approval.stub(:authorized?).and_return(true)
     Timecop.freeze do

--- a/spec/models/miq_host_provision_request_spec.rb
+++ b/spec/models/miq_host_provision_request_spec.rb
@@ -5,14 +5,17 @@ describe MiqHostProvisionRequest do
     expect { FactoryGirl.create(:miq_host_provision_request, :userid => 'barney') }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
+  it "validates a requester is specified" do
+    expect { FactoryGirl.create(:miq_host_provision_request) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   context "with a valid userid and host," do
     before(:each) do
       @user = FactoryGirl.create(:user, :role => "admin")
       # approver is also an admin
       @approver = FactoryGirl.create(:user_miq_request_approver, :miq_groups => @user.miq_groups)
 
-      @pr = FactoryGirl.create(:miq_host_provision_request, :userid => @user.userid)
-      @pr.create_request
+      @pr = FactoryGirl.create(:miq_host_provision_request, :requester => @user)
     end
 
     it "should create an MiqHostProvisionRequest" do
@@ -206,6 +209,6 @@ describe MiqHostProvisionRequest do
   private
 
   def request(params = {})
-    FactoryGirl.create(:miq_host_provision_request, params.merge(:userid => FactoryGirl.create(:user).userid))
+    FactoryGirl.create(:miq_host_provision_request, params.merge(:requester => FactoryGirl.create(:user)))
   end
 end

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -28,8 +28,8 @@ describe MiqProvisionRequest do
     let(:vm)          { FactoryGirl.create(:vm_vmware, :name => "vm1", :location => "abc/def.vmx") }
     let(:vm_template) { FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems) }
 
-    it "should not be created without userid being specified" do
-      -> { FactoryGirl.create(:miq_provision_request) }.should raise_error(ActiveRecord::RecordInvalid)
+    it "should not be created without requester being specified" do
+      expect { FactoryGirl.create(:miq_provision_request) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should not be created with an invalid userid being specified" do
@@ -37,22 +37,21 @@ describe MiqProvisionRequest do
     end
 
     it "should not be created with a valid userid but no vm being specified" do
-      -> { FactoryGirl.create(:miq_provision_request, :userid => user.userid) }.should raise_error(ActiveRecord::RecordInvalid)
+      expect { FactoryGirl.create(:miq_provision_request, :requester => user) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should be created from either a VM or Template" do
-      -> { FactoryGirl.create(:miq_provision_request, :userid => user.userid, :src_vm_id => vm_template.id) }.should_not raise_error
-      -> { FactoryGirl.create(:miq_provision_request, :userid => user.userid, :src_vm_id => vm.id) }.should_not raise_error
+      expect { FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id) }.not_to raise_error
+      expect { FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm.id) }.not_to raise_error
     end
 
     it "should not be created with a valid userid but invalid vm being specified" do
-      -> { FactoryGirl.create(:miq_provision_request, :userid => user.userid, :src_vm_id => 42) }.should raise_error(ActiveRecord::RecordInvalid)
+      expect { FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => 42) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     context "with a valid userid and source vm," do
       before do
-        @pr = FactoryGirl.create(:miq_provision_request, :userid => user.userid, :src_vm_id => vm_template.id, :options => {:owner_email => 'tester@miq.com'})
-        @pr.create_request
+        @pr = FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id, :options => {:owner_email => 'tester@miq.com'})
         @request = @pr.miq_request
       end
 
@@ -125,8 +124,7 @@ describe MiqProvisionRequest do
 
         it "should return stats from quota methods" do
           prov_options = {:number_of_vms => [2, '2'], :owner_email => 'tester@miq.com', :vm_memory => ['1024', '1024'], :number_of_cpus => [2, '2']}
-          @pr2 = FactoryGirl.create(:miq_provision_request, :userid => user.userid, :src_vm_id => vm_template.id, :options => prov_options)
-          @pr2.create_request
+          @pr2 = FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id, :options => prov_options)
 
           #:requests_by_group
           stats = @pr.check_quota(:requests_by_owner)

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -19,9 +19,9 @@ describe MiqProvisionRequestTemplate do
   end
   let(:provision_request_template) do
     FactoryGirl.create(:miq_provision_request_template,
-                       :userid    => user.userid,
-                       :src_vm_id => template.id,
-                       :options   => {
+                       :requester    => user,
+                       :src_vm_id    => template.id,
+                       :options      => {
                          :src_vm_id           => template.id,
                          :service_resource_id => service_resource.id
                        })

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -8,7 +8,7 @@ describe MiqProvisionRequestTemplate do
   end
   let(:parent_svc)       { FactoryGirl.create(:service, :guid => MiqUUID.new_guid) }
   let(:service_resource) { FactoryGirl.create(:service_resource) }
-  let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :userid => user.userid) }
+  let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
   let(:service_task) do
     FactoryGirl.create(:service_template_provision_task,
                        :status       => 'Ok',

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -24,7 +24,7 @@ describe MiqProvision do
 
       context "with a valid userid and source vm," do
         before(:each) do
-          @pr = FactoryGirl.create(:miq_provision_request, :userid => @admin.userid, :src_vm_id => @vm_template.id)
+          @pr = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
           @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
           @vm_prov = FactoryGirl.create(:miq_provision, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
         end

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -273,7 +273,7 @@ describe MiqRequest do
     context 'VM provisioning' do
       let(:description) { 'my original information' }
       let(:template)    { FactoryGirl.create(:template_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication)) }
-      let(:request)     { FactoryGirl.build(:miq_provision_request, :userid => fred.userid, :description => description, :src_vm_id => template.id) }
+      let(:request)     { FactoryGirl.build(:miq_provision_request, :requester => fred, :description => description, :src_vm_id => template.id).tap(&:valid?) }
 
       it 'with 1 task' do
         request.options[:src_vm_id] = template.id

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -25,7 +25,7 @@ describe MiqRequest do
   context "A new request" do
     let(:event_name)   { "hello" }
     let(:host_request) { FactoryGirl.build(:miq_host_provision_request, :options => {:src_host_ids => [1]}) }
-    let(:request)      { FactoryGirl.create(:vm_migrate_request, :userid => fred.userid) }
+    let(:request)      { FactoryGirl.create(:vm_migrate_request, :requester => fred) }
     let(:ems)          { FactoryGirl.create(:ems_vmware) }
     let(:template)     { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
 
@@ -117,7 +117,7 @@ describe MiqRequest do
     end
 
     context "using Polymorphic Resource" do
-      let(:provision_request) { FactoryGirl.create(:miq_provision_request, :userid => fred.userid, :src_vm_id => template.id).create_request }
+      let(:provision_request) { FactoryGirl.create(:miq_provision_request, :requester => fred, :src_vm_id => template.id) }
 
       it { expect(provision_request.workflow_class).to eq(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow) }
       describe("#get_options")          { it { expect(provision_request.get_options).to eq(:number_of_vms => 1) } }
@@ -255,7 +255,7 @@ describe MiqRequest do
       MiqApproval.any_instance.stub(:authorized? => true)
       MiqServer.stub(:my_zone => "default")
 
-      provision_request = FactoryGirl.create(:miq_provision_request, :userid => fred.userid, :src_vm_id => template.id)
+      provision_request = FactoryGirl.create(:miq_provision_request, :requester => fred, :src_vm_id => template.id)
 
       provision_request.deny(fred, "Why Not?")
 
@@ -297,7 +297,7 @@ describe MiqRequest do
 
     it 'non VM provisioning' do
       description = 'Service Request'
-      request   = FactoryGirl.create(:service_template_provision_request, :description => description, :userid => fred.userid)
+      request = FactoryGirl.create(:service_template_provision_request, :description => description, :requester => fred)
       request.post_create_request_tasks
       expect(request.description).to eq(description)
     end

--- a/spec/models/miq_request_task/guest_installation_tools_spec.rb
+++ b/spec/models/miq_request_task/guest_installation_tools_spec.rb
@@ -5,7 +5,7 @@ describe MiqRequestTask do
     MiqRegion.seed
     EvmSpecHelper.create_guid_miq_server_zone
     user        = FactoryGirl.create(:user)
-    miq_request = FactoryGirl.create(:miq_host_provision_request, :userid => user.userid)
+    miq_request = FactoryGirl.create(:miq_host_provision_request, :requester => user)
     @task       = FactoryGirl.create(:miq_request_task, :miq_request => miq_request, :type => 'MiqRequestTask')
   end
 

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -6,7 +6,7 @@ describe ServiceReconfigureTask do
   let(:service)  { FactoryGirl.create(:service, :name => 'Test Service', :service_template => template) }
 
   let(:request) do
-    ServiceReconfigureRequest.create(:userid       => user.userid,
+    ServiceReconfigureRequest.create(:requester    => user,
                                      :options      => {:src_id => service.id},
                                      :request_type => 'service_reconfigure')
   end

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -7,7 +7,7 @@ describe "Service Filter" do
     user_helper
     build_small_environment
     build_model
-    @request = build_service_template_request("top", @user.userid)
+    @request = build_service_template_request("top", @user)
     service_template_stubs
     request_stubs
   end
@@ -17,7 +17,7 @@ describe "Service Filter" do
              "middle"     => {:type    => 'composite', :children => ['vm_service']},
              "vm_service" => {:type    => 'atomic',
                               :request => {:target_name => "fred", :src_vm_id => @src_vm.id,
-                                           :number_of_vms => 1, :userid => @user.userid}
+                                           :number_of_vms => 1, :requester => @user}
                              }
             }
     build_service_template_tree(model)

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -4,7 +4,7 @@ describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryGirl.create(:user_admin) }
   context "with multiple tasks" do
     before(:each) do
-      @request   = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :userid => admin.userid)
+      @request   = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :requester => admin)
 
       @task_1    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")
       @task_1_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 1', :userid => admin.userid, :status => "Ok", :state => "pending", :miq_request_id => @request.id, :request_type => "clone_to_service")

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -7,7 +7,7 @@ describe ServiceTemplateProvisionTask do
 
       @request = FactoryGirl.create(:service_template_provision_request,
                                     :description => 'Service Request',
-                                    :userid      => @admin.userid)
+                                    :requester   => @admin)
       @task_0 = create_stp('Task 0 (Top)')
       @task_1 = create_stp('Task 1', 'pending', 7, 1)
       @task_1_1 = create_stp('Task 1 - 1', 'pending', 1, 3)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -188,18 +188,14 @@ describe ServiceTemplate do
     end
 
     it "should set the owner and group for the service template" do
-      @group        = FactoryGirl.create(:miq_group, :description => 'Test Group')
-      @user         = FactoryGirl.create(:user,
-                                         :name       => 'Test Service Owner',
-                                         :userid     => 'test_user',
-                                         :miq_groups => [@group])
+      @user         = FactoryGirl.create(:user_with_group)
       @test_service = FactoryGirl.create(:service, :name => 'test service')
       @test_service.evm_owner.should be_nil
       @st1.set_ownership(@test_service, @user)
       @test_service.reload
-      @test_service.evm_owner.name.should == 'Test Service Owner'
+      @test_service.evm_owner.name.should == @user.name
       @test_service.evm_owner.current_group.should_not be_nil
-      @test_service.evm_owner.current_group.description.should == 'Test Group'
+      @test_service.evm_owner.current_group.description.should == @user.current_group.description
     end
 
     it "should create an empty service template without a type" do
@@ -229,7 +225,7 @@ describe ServiceTemplate do
         admin = FactoryGirl.create(:user_admin)
 
         vm_template = Vm.first
-        ptr = FactoryGirl.create(:miq_provision_request_template, :userid => admin.userid, :src_vm_id => vm_template.id)
+        ptr = FactoryGirl.create(:miq_provision_request_template, :requester => admin, :src_vm_id => vm_template.id)
         @st1.add_resource(ptr)
       end
 
@@ -255,7 +251,7 @@ describe ServiceTemplate do
 
       user         = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
       @vm_template = FactoryGirl.create(:template_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication))
-      @ptr = FactoryGirl.create(:miq_provision_request_template, :userid => user.userid, :src_vm_id => @vm_template.id)
+      @ptr = FactoryGirl.create(:miq_provision_request_template, :requester => user, :src_vm_id => @vm_template.id)
     end
 
     it 'unknown' do

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -5,7 +5,7 @@ describe VmReconfigureRequest do
   let(:ems_vmware)    { FactoryGirl.create(:ems_vmware, :zone => zone2) }
   let(:host_hardware) { FactoryGirl.build(:hardware, :cpu_total_cores => 40, :cpu_sockets => 10, :cpu_cores_per_socket => 4) }
   let(:host)          { FactoryGirl.build(:host, :hardware => host_hardware) }
-  let(:request)       { FactoryGirl.create(:vm_reconfigure_request, :userid => admin.userid) }
+  let(:request)       { FactoryGirl.create(:vm_reconfigure_request, :requester => admin) }
   let(:vm_hardware)   { FactoryGirl.build(:hardware, :virtual_hw_version => "07") }
   let(:vm_redhat)     { FactoryGirl.create(:vm_redhat) }
   let(:vm_vmware)     { FactoryGirl.create(:vm_vmware, :hardware => vm_hardware, :host => host) }

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -121,7 +121,7 @@ describe ApiController do
     end
 
     it "query Provision Requests" do
-      FactoryGirl.create(:miq_provision_request, :source => template, :userid => api_config(:user))
+      FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
       test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
     end
 
@@ -146,7 +146,7 @@ describe ApiController do
     end
 
     it "query Requests" do
-      FactoryGirl.create(:vm_migrate_request, :userid => FactoryGirl.create(:user).userid)
+      FactoryGirl.create(:vm_migrate_request, :requester => @user)
       test_collection_query(:requests, requests_url, MiqRequest)
     end
 
@@ -181,7 +181,7 @@ describe ApiController do
     end
 
     it "query Service Requests" do
-      FactoryGirl.create(:service_template_provision_request, :userid => api_config(:user))
+      FactoryGirl.create(:service_template_provision_request, :requester => @user)
       test_collection_query(:service_requests, service_requests_url, ServiceTemplateProvisionRequest)
     end
 

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -23,7 +23,7 @@ describe ApiController do
   let(:service_request) do
     FactoryGirl.create(:service_template_provision_request,
                        :description => 'Service Request',
-                       :userid      => api_config(:user),
+                       :requester   => @user,
                        :source_id   => template.id)
   end
 

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -163,7 +163,7 @@ describe ApiController do
 
       template = FactoryGirl.create(:template_vmware, :name => "template1")
       request  = FactoryGirl.create(:miq_provision_request,
-                                    :userid      => api_config(:user),
+                                    :requester   => @user,
                                     :description => "sample provision",
                                     :src_vm_id   => template.id,
                                     :options     => options)

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -21,7 +21,7 @@ describe ApiController do
 
   let(:service_request) do
     FactoryGirl.create(:service_template_provision_request,
-                       :userid      => api_config(:user),
+                       :requester   => @user,
                        :source_id   => template.id,
                        :source_type => template.class.name)
   end

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -90,7 +90,6 @@ module QuotaHelper
                                                 :src_vm_id => @vm_template.id,
                                                 :options   => prov_options)
     @miq_request = @miq_provision_request.create_request
-    @miq_request.tenant = @tenant
     @miq_request.save!
   end
 

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -86,11 +86,10 @@ module QuotaHelper
                                          :number_of_sockets => [2, '2'],
                                          :cores_per_socket  => [2, '2']}
     @miq_provision_request = FactoryGirl.create(:miq_provision_request,
-                                                :userid    => @user.userid,
+                                                :requester => @user,
                                                 :src_vm_id => @vm_template.id,
                                                 :options   => prov_options)
-    @miq_request = @miq_provision_request.create_request
-    @miq_request.save!
+    @miq_request = @miq_provision_request
   end
 
   def setup_model

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -11,7 +11,7 @@ module ServiceTemplateHelper
                                                     :service_type => 'atomic')
       options = value[:request]
       mprt = FactoryGirl.create(:miq_provision_request_template,
-                                :userid    => options[:userid],
+                                :requester => options[:requester],
                                 :src_vm_id => options[:src_vm_id],
                                 :options   => options)
       add_st_resource(item, mprt)
@@ -48,7 +48,7 @@ module ServiceTemplateHelper
     svc.service_resources.each(&:save)
   end
 
-  def build_service_template_request(root_st_name, userid, dialog_options = {})
+  def build_service_template_request(root_st_name, user, dialog_options = {})
     root = ServiceTemplate.find_by_name(root_st_name)
     return nil unless root
     options = {:src_id => root.id, :target_name => "barney"}.merge(dialog_options)
@@ -59,7 +59,7 @@ module ServiceTemplateHelper
                        :request_type   => 'clone_to_service',
                        :approval_state => 'approved',
                        :source_id      => root.id,
-                       :userid         => userid,
+                       :requester      => user,
                        :options        => options)
   end
 

--- a/spec/views/miq_request/_prov_options.html.erb_spec.rb
+++ b/spec/views/miq_request/_prov_options.html.erb_spec.rb
@@ -15,10 +15,10 @@ describe 'miq_request/_prov_options.html.haml' do
       @users = [@admin, @vm_user, @desktop, @approver]
 
       # Create requests
-      FactoryGirl.create(:vm_migrate_request, :userid => @admin.userid)
-      FactoryGirl.create(:vm_migrate_request, :userid => @vm_user.userid)
-      FactoryGirl.create(:vm_migrate_request, :userid => @desktop.userid)
-      FactoryGirl.create(:vm_migrate_request, :userid => @approver.userid)
+      FactoryGirl.create(:vm_migrate_request, :requester => @admin)
+      FactoryGirl.create(:vm_migrate_request, :requester => @vm_user)
+      FactoryGirl.create(:vm_migrate_request, :requester => @desktop)
+      FactoryGirl.create(:vm_migrate_request, :requester => @approver)
 
       # Set instance variables
       sb = {:prov_options => {
@@ -64,7 +64,7 @@ describe 'miq_request/_prov_options.html.haml' do
 
     it 'for desktop' do
       desktop = FactoryGirl.create(:user, :role => "desktop")
-      FactoryGirl.create(:vm_migrate_request, :userid => desktop.userid)
+      FactoryGirl.create(:vm_migrate_request, :requester => desktop)
 
       sb = {:prov_options => {
         :resource_type       => :MiqProvisionRequest,
@@ -88,7 +88,7 @@ describe 'miq_request/_prov_options.html.haml' do
 
     it 'for vm_user' do
       vm_user = FactoryGirl.create(:user, :role => "vm_user")
-      FactoryGirl.create(:vm_migrate_request, :userid => vm_user.userid)
+      FactoryGirl.create(:vm_migrate_request, :requester => vm_user)
 
       # Set instance variables
       sb = {:prov_options => {


### PR DESCRIPTION
The goal is to pass a user objects when creating a `MiqRequest` so the proper `tenant` and `miq_group` can be assigned.

This shows up in 4 areas (10 lines?):

1. `miq_request#create_request` and `miq_request_workflow` now pass `:requester => user` into `miq_request.create`.
2. `miq_request#initialize_attributes` uses `:requester` to populate `:userid` and `tenant`.
3. `service_template` sets the vm owner with `service_task.get_user`. It was using `:userid`.
4. `miq_request#create_request` only accepts a `requester` object. It used to also accept a userid.

A majority of the changed files are spec changes to pass `:requester`. A few places have parameter changes to rename `requester_id` to `requester` to ensure people know a user object is required.

/cc @gmcculloug last of the tenancy enhancements.
/cc @chessbyte this needs to be a PR and our last tenancy PR