### PR TITLE
Introduce miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_tenant

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_tenant.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Openstack_CloudManager_CloudTenant < MiqAeServiceCloudTenant
+  end
+end


### PR DESCRIPTION
This is required to show all cloud tenants available for provisioning

https://bugzilla.redhat.com/show_bug.cgi?id=1275405