### PR TITLE
[api] Incorrect entitlement role for rates create action.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -482,7 +482,11 @@
     :collection_actions:
       :post:
       - :name: create
-        :identifier: chargeback_rates_create
+        :identifier: chargeback_rates_new
+      - :name: edit
+        :identifier: chargeback_rates_edit
+      - :name: delete
+        :identifier: chargeback_rates_delete
     :resource_actions:
       :post:
       - :name: edit


### PR DESCRIPTION
- Updated entitlement role to chargeback_rates_new
- Allows updates and delete of rates at the collection level
