### PR TITLE
Typo in code converts integer value to list

### DIFF
--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -138,7 +138,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
         args[:automate_message] = ra.ae_message   unless ra.ae_message.blank?
         args[:attrs].merge!(ra.ae_attributes)
       end
-      args[:user_id]      = get_user.id,
+      args[:user_id]      = get_user.id
       args[:miq_group_id] = get_user.current_group.id
       args[:tenant_id]    = get_user.current_tenant.id
 

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe ServiceTemplateProvisionTask do
   context "with multiple tasks" do
     before(:each) do
-      @admin      = FactoryGirl.create(:user_with_group)
+      @admin = FactoryGirl.create(:user_with_group)
 
-      @request   = FactoryGirl.create(:service_template_provision_request,
-                                      :description => 'Service Request',
-                                      :userid      => @admin.userid)
+      @request = FactoryGirl.create(:service_template_provision_request,
+                                    :description => 'Service Request',
+                                    :userid      => @admin.userid)
       @task_0 = create_stp('Task 0 (Top)')
       @task_1 = create_stp('Task 1', 'pending', 7, 1)
       @task_1_1 = create_stp('Task 1 - 1', 'pending', 1, 3)

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -3,16 +3,16 @@ require "spec_helper"
 describe ServiceTemplateProvisionTask do
   context "with multiple tasks" do
     before(:each) do
-      admin      = FactoryGirl.create(:user_admin)
+      @admin      = FactoryGirl.create(:user_with_group)
 
-      @request   = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :userid => admin.userid)
-      @task_0    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 0 (Top)', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service")
-      @task_1    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 7, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
-      @task_1_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 1', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 1, :scaling_min => 1, :scaling_max => 3, :resource_type => 'ServiceTemplate').id})
-      @task_1_2  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 2', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 5, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
-      @task_2    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 9, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
-      @task_2_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2 - 1', :userid => admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 2, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
-      @task_3    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 3', :userid => admin.userid, :status => "Ok", :state => "finished", :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 3, :scaling_min => 1, :scaling_max => 5, :resource_type => 'ServiceTemplate').id})
+      @request   = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :userid => @admin.userid)
+      @task_0    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 0 (Top)', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service")
+      @task_1    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 7, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
+      @task_1_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 1', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 1, :scaling_min => 1, :scaling_max => 3, :resource_type => 'ServiceTemplate').id})
+      @task_1_2  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 1 - 2', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 5, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
+      @task_2    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 9, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
+      @task_2_1  = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 2 - 1', :userid => @admin.userid, :status => "Ok", :state => "pending",  :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 2, :scaling_min => 1, :scaling_max => 1, :resource_type => 'ServiceTemplate').id})
+      @task_3    = FactoryGirl.create(:service_template_provision_task,    :description => 'Task 3', :userid => @admin.userid, :status => "Ok", :state => "finished", :miq_request_id => @request.id, :request_type => "clone_to_service", :options => {:service_resource_id => FactoryGirl.create(:service_resource, :provision_index => 3, :scaling_min => 1, :scaling_max => 5, :resource_type => 'ServiceTemplate').id})
 
       @request.miq_request_tasks = [@task_0, @task_1, @task_1_1, @task_1_2, @task_2, @task_2_1, @task_3]
       @task_0.miq_request_tasks  = [@task_1, @task_2, @task_3]
@@ -23,6 +23,30 @@ describe ServiceTemplateProvisionTask do
       @task_2.miq_request_task   =  @task_0
       @task_2.miq_request_tasks  = [@task_2_1]
       @task_3.miq_request_task   =  @task_0
+    end
+
+    it "deliver_to_automate" do
+      automate_args = {
+        :object_type      => 'ServiceTemplateProvisionTask',
+        :object_id        => @task_0.id,
+        :namespace        => 'Service/Provisioning/StateMachines',
+        :class_name       => 'ServiceProvision_Template',
+        :instance_name    => 'clone_to_service',
+        :automate_message => 'create',
+        :attrs            => {'request' => 'clone_to_service'},
+        :user_id          => @admin.id,
+        :miq_group_id     => @admin.current_group_id,
+        :tenant_id        => @admin.current_tenant.id,
+      }
+      @task_0.stub(:task_check_on_execute)
+      MiqQueue.should_receive(:put).with(
+        :class_name  => 'MiqAeEngine',
+        :method_name => 'deliver',
+        :args        => [automate_args],
+        :role        => 'automate',
+        :zone        => nil,
+        :task_id     => "service_template_provision_task_#{@task_0.id}")
+      @task_0.deliver_to_automate
     end
 
     it "service 1 child provision priority" do


### PR DESCRIPTION
Service Provision Fails because the userid is passed in as a list


x = 1,
y = 9
=> [1, 9]

Combines the 2 statements