### PR TITLE
fix for the MiqRequestWorkflow.descendants issue

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -4,6 +4,9 @@ require 'miq-hash_struct'
 class MiqRequestWorkflow
   include Vmdb::Logging
 
+  # We rely on MiqRequestWorkflow's descendants to be comprehensive
+  singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
+
   attr_accessor :dialogs, :requester, :values, :last_vm_id
 
   def self.automate_dialog_request


### PR DESCRIPTION
Fix for the MiqRequestWorkflow.descendants issue
    
We rely on MiqRequestWorkflow descendants to be comprehensive as methods like all_encrypted_options_fields rely on that information.