### PR TITLE
Update simple callers of numvcpus to cpu_sockets

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1782,7 +1782,7 @@ class Host < ActiveRecord::Base
   end
 
   def num_cpu
-    hardware.nil? ? 0 : hardware.numvcpus
+    hardware.nil? ? 0 : hardware.cpu_sockets
   end
 
   def cpu_total_cores

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -360,7 +360,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
         :bitness              => ARCHITECTURE_TO_BITNESS[instance.architecture],
         :virtualization_type  => virtualization_type,
         :root_device_type     => root_device_type,
-        :numvcpus             => flavor[:cpus],
+        :cpu_sockets          => flavor[:cpus],
         :cpu_cores_per_socket => 1,
         :cpu_total_cores      => flavor[:cpus],
         :memory_mb            => flavor[:memory] / 1.megabyte,

--- a/app/models/manageiq/providers/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/infra_manager/provision_workflow.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::InfraManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def get_cpu_values_hash(vm)
     {
       :number_of_cpus    => vm.hardware.cpu_total_cores,
-      :number_of_sockets => vm.hardware.numvcpus,
+      :number_of_sockets => vm.hardware.cpu_sockets,
       :cores_per_socket  => vm.hardware.cpu_cores_per_socket
     }
   end

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -239,7 +239,7 @@ module ManageIQ::Providers::Microsoft
         :model                => cpu_model,
         :cpu_speed            => normalize_blank_property_num(p[:ProcessorSpeed]),
         :memory_mb            => normalize_blank_property(p[:TotalMemory]) / 1.megabyte,
-        :numvcpus             => normalize_blank_property_num(p[:PhysicalCPUCount]),
+        :cpu_sockets          => normalize_blank_property_num(p[:PhysicalCPUCount]),
         :cpu_total_cores      => normalize_blank_property_num(p[:LogicalProcessorCount]),
         :cpu_cores_per_socket => normalize_blank_property_num(p[:CoresPerCPU]),
         :guest_devices        => process_host_guest_devices(host),

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -371,7 +371,7 @@ module ManageIQ::Providers
         :connection_state    => "connected",
 
         :hardware            => {
-          :numvcpus             => flavor[:cpus],
+          :cpu_sockets          => flavor[:cpus],
           :cpu_cores_per_socket => 1,
           :cpu_total_cores      => flavor[:cpus],
           :memory_mb            => flavor[:memory] / 1.megabyte,

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -196,9 +196,9 @@ module ManageIQ
       end
 
       def process_host_hardware(host, extra_attributes)
-        numvcpus             = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
+        cpu_sockets          = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
         cpu_total_cores      = extra_attributes.fetch_path('cpu', 'logical', 'number').to_i
-        cpu_cores_per_socket = numvcpus > 0 ? cpu_total_cores / numvcpus : 0
+        cpu_cores_per_socket = cpu_sockets > 0 ? cpu_total_cores / cpu_sockets : 0
         # Get Cpu speed in Mhz
         cpu_speed        = extra_attributes.fetch_path('cpu', 'physical_0', 'frequency').to_i / 10**6
 
@@ -206,7 +206,7 @@ module ManageIQ
           :memory_mb            => host.properties['memory_mb'],
           :disk_capacity        => host.properties['local_gb'],
           :cpu_total_cores      => cpu_total_cores,
-          :numvcpus             => numvcpus,
+          :cpu_sockets          => cpu_sockets,
           :cpu_cores_per_socket => cpu_cores_per_socket,
           :cpu_speed            => cpu_speed,
           :cpu_type             => extra_attributes.fetch_path('cpu', 'physical_0', 'version'),

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -188,8 +188,8 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       result[:memory_mb] = memory_total.nil? ? 0 : memory_total[:values].first.to_i / 1.megabyte
 
       result[:cpu_cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1
-      result[:numvcpus]             = hdw.fetch_path(:topology, :sockets) || 1 # Number of physical sockets
-      result[:cpu_total_cores]      = result[:numvcpus] * result[:cpu_cores_per_socket]
+      result[:cpu_sockets]          = hdw.fetch_path(:topology, :sockets) || 1
+      result[:cpu_total_cores]      = result[:cpu_sockets] * result[:cpu_cores_per_socket]
     end
 
     result
@@ -408,8 +408,8 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
     hdw = inv[:cpu]
     result[:cpu_cores_per_socket] = hdw.fetch_path(:topology, :cores) || 1
-    result[:numvcpus]             = hdw.fetch_path(:topology, :sockets) || 1 # Number of sockets
-    result[:cpu_total_cores]      = result[:numvcpus] * result[:cpu_cores_per_socket]
+    result[:cpu_sockets]          = hdw.fetch_path(:topology, :sockets) || 1
+    result[:cpu_total_cores]      = result[:cpu_sockets] * result[:cpu_cores_per_socket]
 
     result[:memory_mb] = inv[:memory] / 1.megabyte
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -305,10 +305,10 @@ module ManageIQ::Providers
             result[:memory_console] = is_numeric?(console["serviceConsoleReserved"]) ? (console["serviceConsoleReserved"].to_f / 1048576).round : nil
           end
 
-          result[:numvcpus] = hdw["numCpuPkgs"] unless hdw["numCpuPkgs"].blank?
+          result[:cpu_sockets]     = hdw["numCpuPkgs"] unless hdw["numCpuPkgs"].blank?
           result[:cpu_total_cores] = hdw["numCpuCores"] unless hdw["numCpuCores"].blank?
           # Calculate the number of cores per socket by dividing total numCpuCores by numCpuPkgs
-          result[:cpu_cores_per_socket] = (result[:cpu_total_cores].to_f / result[:numvcpus].to_f).to_i unless hdw["numCpuCores"].blank? || hdw["numCpuPkgs"].blank?
+          result[:cpu_cores_per_socket] = (result[:cpu_total_cores].to_f / result[:cpu_sockets].to_f).to_i unless hdw["numCpuCores"].blank? || hdw["numCpuPkgs"].blank?
         end
 
         config = inv["config"]
@@ -812,7 +812,7 @@ module ManageIQ::Providers
         if inv["numCpu"].present?
           result[:cpu_total_cores]      = inv["numCpu"].to_i
           result[:cpu_cores_per_socket] = (config.try(:fetch_path, "hardware", "numCoresPerSocket") || 1).to_i
-          result[:numvcpus] = result[:cpu_total_cores] / result[:cpu_cores_per_socket]
+          result[:cpu_sockets]          = result[:cpu_total_cores] / result[:cpu_cores_per_socket]
         end
 
         result[:annotation] = inv["annotation"] unless inv["annotation"].blank?

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -42,7 +42,7 @@ module AggregationMixin
   Vmdb::Deprecation.deprecate_methods(self, :aggregate_logical_cpus => :aggregate_cpu_total_cores)
 
   def aggregate_physical_cpus(targets = nil)
-    aggregate_hardware(:hosts, :numvcpus, targets)
+    aggregate_hardware(:hosts, :cpu_sockets, targets)
   end
 
   def aggregate_memory(targets = nil)
@@ -50,7 +50,7 @@ module AggregationMixin
   end
 
   def aggregate_vm_cpus(targets = nil)
-    aggregate_hardware(:vms_and_templates, :numvcpus, targets)
+    aggregate_hardware(:vms_and_templates, :cpu_sockets, targets)
   end
 
   def aggregate_vm_memory(targets = nil)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1613,7 +1613,7 @@ class VmOrTemplate < ActiveRecord::Base
   alias_method :mem_cpu, :ram_size
 
   def num_cpu
-    hardware.nil? ? 0 : hardware.numvcpus
+    hardware.nil? ? 0 : hardware.cpu_sockets
   end
 
   def cpu_total_cores

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,7 +485,7 @@ en:
       num_cpu: Number of CPUs
       num_disks: Number of Disks
       num_hard_disks: Number of Hard Disks
-      numvcpus: Number of CPUs
+      cpu_sockets: Number of CPUs
       operational_status: Operational Status Code
       operational_status_str: Operational Status
       os_image_name: OS Name

--- a/gems/pending/Scvmm/MiqScvmmHost.rb
+++ b/gems/pending/Scvmm/MiqScvmmHost.rb
@@ -100,9 +100,9 @@ class MiqScvmmHost
     # hardware[:number_of_nics] = nil
     hardware[:memory_mb] = (props[:TotalMemory].to_f / 1.megabyte).round
 
-    hardware[:numvcpus]             = props[:PhysicalCPUCount]
+    hardware[:cpu_sockets]          = props[:PhysicalCPUCount]
     hardware[:cpu_cores_per_socket] = props[:CoresPerCPU]
-    hardware[:cpu_total_cores]      = hardware[:cpu_cores_per_socket].to_i * hardware[:numvcpus].to_i
+    hardware[:cpu_total_cores]      = hardware[:cpu_cores_per_socket].to_i * hardware[:cpu_sockets].to_i
 
     # Guest OS summary_config['product'] = {'name' => props[:VirtualizationPlatformString]}
 

--- a/gems/pending/Scvmm/MiqScvmmVm.rb
+++ b/gems/pending/Scvmm/MiqScvmmVm.rb
@@ -106,7 +106,7 @@ class MiqScvmmVm
     connection_state = false if power_state == "unknown"
 
     hardware = {}
-    hardware[:numvcpus] = props[:CPUCount]
+    hardware[:cpu_sockets] = props[:CPUCount]
     hardware[:annotation] = props[:Description]
     hardware[:memory_mb] = props[:Memory]
     hardware[:guest_os_full_name] = hardware[:guest_os] = "Other"

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -347,9 +347,9 @@ module ReportFormatter
     end
 
     def extract_column_names
-      # examples: 'Vm.hardware-numvcpus' gives 'hardware-numvcpus'
-      #           'Host-v_total_vms'     gives 'v_total_vms'
-      #           'Vm-num_cpu:total'     gives 'num_cpu' and 'num_cpu__total'
+      # examples: 'Vm.hardware-cpu_sockets' gives 'hardware-cpu_sockets'
+      #           'Host-v_total_vms'        gives 'v_total_vms'
+      #           'Vm-num_cpu:total'        gives 'num_cpu' and 'num_cpu__total'
 
       stage1, aggreg = mri.graph[:column].split(':', 2)
       model1, column = stage1.split('-', 2)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -141,7 +141,7 @@ describe ApplicationController do
       set_user_privileges
       @host = FactoryGirl.create(:host,
                                  :hardware => FactoryGirl.create(:hardware,
-                                                                 :numvcpus             => 2,
+                                                                 :cpu_sockets          => 2,
                                                                  :cpu_cores_per_socket => 4,
                                                                  :cpu_total_cores      => 8),
                                 )

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -162,7 +162,7 @@ describe HostController do
     set_user_privileges
     host = FactoryGirl.create(:host,
                               :hardware => FactoryGirl.create(:hardware,
-                                                              :numvcpus             => 2,
+                                                              :cpu_sockets          => 2,
                                                               :cpu_cores_per_socket => 4,
                                                               :cpu_total_cores      => 8
                                                              )

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -68,7 +68,7 @@ describe VmInfraController do
                                                                  :memory_mb            => 1024,
                                                                  :cpu_total_cores      => 1,
                                                                  :cpu_cores_per_socket => 1,
-                                                                 :numvcpus             => 1
+                                                                 :cpu_sockets          => 1
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
@@ -78,7 +78,7 @@ describe VmInfraController do
                                                             :memory_mb            => 1024,
                                                             :cpu_total_cores      => 1,
                                                             :cpu_cores_per_socket => 1,
-                                                            :numvcpus             => 1,
+                                                            :cpu_sockets          => 1,
                                                             :virtual_hw_version   => '04'
                                                            )
                            )
@@ -102,7 +102,7 @@ describe VmInfraController do
                                                                  :memory_mb            => 1024,
                                                                  :cpu_total_cores      => 1,
                                                                  :cpu_cores_per_socket => 1,
-                                                                 :numvcpus             => 1
+                                                                 :cpu_sockets          => 1
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
@@ -112,7 +112,7 @@ describe VmInfraController do
                                                             :memory_mb            => 1024,
                                                             :cpu_total_cores      => 1,
                                                             :cpu_cores_per_socket => 1,
-                                                            :numvcpus             => 1,
+                                                            :cpu_sockets          => 1,
                                                             :virtual_hw_version   => "04"
                                                            )
                            )
@@ -130,8 +130,8 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4, :cpu_cores_per_socket => 4, :numvcpus => 1))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :numvcpus => 1))
+    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4, :cpu_cores_per_socket => 4, :cpu_sockets => 1))
+    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :cpu_sockets => 1))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id

--- a/spec/lib/report_formater/jqplot_formater_spec.rb
+++ b/spec/lib/report_formater/jqplot_formater_spec.rb
@@ -88,12 +88,12 @@ describe ReportFormatter::JqplotFormatter do
       report = MiqReport.new(
         :db          => "Vm",
         :cols        => %w(name),
-        :include     => {"hardware" => {"columns" => %w(cpu_speed numvcpus memory_mb)}},
-        :col_order   => %w(name hardware.cpu_speed hardware.numvcpus hardware.memory_mb),
+        :include     => {"hardware" => {"columns" => %w(cpu_speed cpu_sockets memory_mb)}},
+        :col_order   => %w(name hardware.cpu_speed hardware.cpu_sockets hardware.memory_mb),
         :headers     => ["Name", "Hardware CPU Speed", "Hardware Number of CPUs", "Hardware RAM"],
         :order       => "Ascending",
         :sortby      => %w(name),
-        :graph       => {:type => "Bar", :mode => "values", :column => "Vm.hardware-numvcpus", :count => 10, :other => true},
+        :graph       => {:type => "Bar", :mode => "values", :column => "Vm.hardware-cpu_sockets", :count => 10, :other => true},
         :dims        => 1,
         :col_options => {},
         :rpt_options => {},
@@ -101,7 +101,7 @@ describe ReportFormatter::JqplotFormatter do
       )
 
       report.table = Ruport::Data::Table.new(
-        :column_names => %w(name hardware.cpu_speed hardware.numvcpus hardware.memory_mb id),
+        :column_names => %w(name hardware.cpu_speed hardware.cpu_sockets hardware.memory_mb id),
         :data         => [
           ["Чук", nil, 4,   6_144, 42],
           ["Гек", nil, nil, 1_024, 49],

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -170,7 +170,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :guest_os_full_name => nil,
       :bios               => nil,
       :annotation         => nil,
-      :numvcpus           => 1, # wtf
+      :cpu_sockets        => 1, # wtf
       :memory_mb          => nil,
       :disk_capacity      => nil,
       :bitness            => 64
@@ -226,7 +226,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :guest_os_full_name => nil,
       :bios               => nil,
       :annotation         => nil,
-      :numvcpus           => 1,
+      :cpu_sockets        => 1,
       :memory_mb          => 613,
       :disk_capacity      => 0, # TODO: Change to a flavor that has disks
       :bitness            => 64

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -252,7 +252,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :guest_os_full_name  => nil,
       :bios                => nil,
       :annotation          => nil,
-      :numvcpus            => 1, # wtf
+      :cpu_sockets         => 1, # wtf
       :memory_mb           => nil,
       :disk_capacity       => nil,
       :bitness             => 64,
@@ -316,7 +316,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :guest_os_full_name  => nil,
       :bios                => nil,
       :annotation          => nil,
-      :numvcpus            => 1,
+      :cpu_sockets         => 1,
       :memory_mb           => 613,
       :disk_capacity       => 0, # TODO: Change to a flavor that has disks
       :bitness             => 64,
@@ -389,7 +389,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :guest_os_full_name => nil,
       :bios               => nil,
       :annotation         => nil,
-      :numvcpus           => 1,
+      :cpu_sockets        => 1,
       :memory_mb          => 613,
       :disk_capacity      => 0, # TODO: Change to a flavor that has disks
       :bitness            => 64

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -165,7 +165,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :guest_os_full_name  => nil,
       :bios                => nil,
       :annotation          => nil,
-      :numvcpus            => 1,
+      :cpu_sockets         => 1,
       :memory_mb           => 768,
       :disk_capacity       => 1043.megabyte,
       :bitness             => nil,
@@ -246,7 +246,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :guest_os_full_name => nil,
       :bios               => nil,
       :annotation         => nil,
-      :numvcpus           => 1,
+      :cpu_sockets        => 1,
       :memory_mb          => 768,
       :disk_capacity      => 1043.megabytes,
       :bitness            => nil

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -130,7 +130,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :model                => "Xeon",
       :memory_mb            => 131_059,
       :memory_console       => nil,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :cpu_total_cores      => 16,
       :cpu_cores_per_socket => 8,
       :guest_os             => nil,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -590,7 +590,7 @@ module Openstack
       end
 
       vm.hardware.should have_attributes(
-        :numvcpus      => vm.flavor.cpus,
+        :cpu_sockets   => vm.flavor.cpus,
         :memory_mb     => vm.flavor.memory / 1.megabyte,
         :disk_capacity => 2.5.gigabytes # TODO(lsmola) Where is this coming from?
       )

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -123,7 +123,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       :memory_mb            => 8192,
       :memory_console       => nil,
       :disk_capacity        => 40,
-      :numvcpus             => 4,
+      :cpu_sockets          => 4,
       :cpu_total_cores      => 4,
       :cpu_cores_per_socket => 1,
       :guest_os             => nil,

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -190,7 +190,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :number_of_nics       => nil,
       :memory_mb            => 7806,
       :memory_console       => nil,
-      :numvcpus             => 1,
+      :cpu_sockets          => 1,
       :cpu_total_cores      => 4,
       :cpu_cores_per_socket => 4,
       :guest_os             => nil,
@@ -295,7 +295,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
-      :numvcpus           => 2,
+      :cpu_sockets        => 2,
       :annotation         => "Powered On VM for EmsRefresh testing",
       :memory_mb          => 1024
     )
@@ -452,7 +452,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
-      :numvcpus           => 2,
+      :cpu_sockets        => 2,
       :annotation         => "Powered Off VM for EmsRefresh testing",
       :memory_mb          => 1024
     )
@@ -566,7 +566,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :guest_os             => "rhel_6x64",
       :guest_os_full_name   => nil,
       :bios                 => nil,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :cpu_cores_per_socket => 1,
       :cpu_total_cores      => 2,
       :annotation           => "Template for EmsRefresh testing",

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -206,7 +206,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :number_of_nics       => nil,
       :memory_mb            => 56333,
       :memory_console       => nil,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :cpu_total_cores      => 8,
       :cpu_cores_per_socket => 4,
       :guest_os             => nil,
@@ -304,7 +304,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :bios                 => nil,
       :cpu_cores_per_socket => 1,
       :cpu_total_cores      => 2,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :annotation           => "Powered On VM for EmsRefresh testing with DirectLUN Disk",
       :memory_mb            => 1024
     )
@@ -472,7 +472,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
-      :numvcpus           => 2,
+      :cpu_sockets        => 2,
       :annotation         => "Powered Off VM for EmsRefresh testing",
       :memory_mb          => 1024
     )
@@ -586,7 +586,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :guest_os             => "rhel_6x64",
       :guest_os_full_name   => nil,
       :bios                 => nil,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :cpu_cores_per_socket => 1,
       :cpu_total_cores      => 2,
       :annotation           => "Template for EmsRefresh testing",

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems  = FactoryGirl.create(:ems_redhat_with_authentication, :zone => zone)
-      @hw   = FactoryGirl.create(:hardware, :memory_mb => 1024, :numvcpus => 2, :cpu_cores_per_socket => 1)
+      @hw   = FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_sockets => 2, :cpu_cores_per_socket => 1)
       @vm   = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
 
       @cores_per_socket = 2

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser do
       def assert_cores_and_sockets_values(total, cores, sockets)
         result = described_class.vm_inv_to_hardware_hash(inv)
 
-        expect(result[:numvcpus]).to             eq(sockets)
+        expect(result[:cpu_sockets]).to          eq(sockets)
         expect(result[:cpu_cores_per_socket]).to eq(cores)
         expect(result[:cpu_total_cores]).to      eq(total)
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -230,7 +230,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :number_of_nics       => 4,
       :memory_mb            => 57334,
       :memory_console       => nil,
-      :numvcpus             => 2,
+      :cpu_sockets          => 2,
       :cpu_total_cores      => 8,
       :cpu_cores_per_socket => 4,
       :guest_os             => "ESXi",
@@ -361,7 +361,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :guest_os           => "rhel5_64",
       :guest_os_full_name => "Red Hat Enterprise Linux 5 (64-bit)",
       :bios               => "422f5d16-c048-19e6-3212-e588fbebf7e0",
-      :numvcpus           => 2,
+      :cpu_sockets        => 2,
       :annotation         => nil,
       :memory_mb          => 4096
     )

--- a/spec/models/metric/processing_spec.rb
+++ b/spec/models/metric/processing_spec.rb
@@ -79,7 +79,7 @@ describe Metric::Processing do
         FactoryGirl.create(:vm_vmware, :hardware =>
           FactoryGirl.create(:hardware,
                              :cpu_total_cores      => 8,
-                             :numvcpus             => 4,
+                             :cpu_sockets          => 4,
                              :cpu_cores_per_socket => 2,
                              :cpu_speed            => 3_000,
                             )

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -429,7 +429,7 @@ describe Metric do
     context "with a small environment and time_profile" do
       before(:each) do
         @vm1 = FactoryGirl.create(:vm_vmware)
-        @vm2 = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :memory_mb => 4096, :numvcpus => 2))
+        @vm2 = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :memory_mb => 4096, :cpu_sockets => 2))
         @host1 = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
         @host2 = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576))
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -227,7 +227,7 @@ describe MiqGroup do
     end
 
     it "when the virtual column is nil" do
-      hw = FactoryGirl.create(:hardware, :numvcpus => @num_cpu, :memory_mb => @ram_size)
+      hw = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_mb => @ram_size)
       FactoryGirl.create(:vm_vmware,
                          :name         => "VM with no disk",
                          :miq_group_id => @miq_group.id,

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -26,7 +26,7 @@ describe MiqProvisionWorkflow do
           @ems         = FactoryGirl.create(:ems_vmware,  :name => "Test EMS",  :zone => server.zone)
           @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on', :ext_management_system => @ems)
           @vm_template = FactoryGirl.create(:template_vmware, :name => "template", :ext_management_system => @ems, :host => @host)
-          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro", :memory_mb => 512, :numvcpus => 2)
+          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro", :memory_mb => 512, :cpu_sockets => 2)
           @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
           @lan         = FactoryGirl.create(:lan, :name => "VM Network", :switch => @switch)
           @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan, :device_type => 'ethernet', :controller_type => 'ethernet', :address => '00:50:56:ba:10:6b', :present => false, :start_connected => true)

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -187,7 +187,7 @@ describe MiqReport do
           when 75..99 then group = 4
           end
           vm = FactoryGirl.build(:vm_vmware, :name => "Test Group #{group} VM #{i}")
-          vm.hardware = FactoryGirl.build(:hardware, :numvcpus => (group * 2), :memory_mb => (group * 1.megabytes), :guest_os => OS_LIST[group])
+          vm.hardware = FactoryGirl.build(:hardware, :cpu_sockets => (group * 2), :memory_mb => (group * 1.megabytes), :guest_os => OS_LIST[group])
           vm.host = @hosts[group - 1]
           vm.evm_owner_id = @user.id  if ((i % 5) == 0)
           vm.miq_group_id = @group.id if ((i % 7) == 0)

--- a/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/spec/models/mixins/aggregation_mixin_spec.rb
@@ -6,7 +6,7 @@ describe AggregationMixin do
       2.times.collect do
         FactoryGirl.create(:host,
                            :hardware => FactoryGirl.create(:hardware,
-                                                           :numvcpus             => 2,
+                                                           :cpu_sockets          => 2,
                                                            :cpu_cores_per_socket => 4,
                                                            :cpu_total_cores      => 8,
                                                            :cpu_speed            => 2_999,

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -612,7 +612,7 @@ describe Rbac do
           group = i + 1
           guest_os = %w(_none_ windows ubuntu windows ubuntu)[group]
           vm = FactoryGirl.build(:vm_vmware, :name => "Test Group #{group} VM #{i}")
-          vm.hardware = FactoryGirl.build(:hardware, :numvcpus => (group * 2), :memory_mb => (group * 1.megabytes), :guest_os => guest_os)
+          vm.hardware = FactoryGirl.build(:hardware, :cpu_sockets => (group * 2), :memory_mb => (group * 1.megabytes), :guest_os => guest_os)
           vm.host = @hosts[group - 1]
           vm.evm_owner_id = @user.id  if i.even?
           vm.miq_group_id = @group.id if i.odd?

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe VmReconfigureRequest do
   let(:admin)         { FactoryGirl.create(:user, :userid => "tester") }
   let(:ems_vmware)    { FactoryGirl.create(:ems_vmware, :zone => zone2) }
-  let(:host_hardware) { FactoryGirl.build(:hardware, :cpu_total_cores => 40, :numvcpus => 10, :cpu_cores_per_socket => 4) }
+  let(:host_hardware) { FactoryGirl.build(:hardware, :cpu_total_cores => 40, :cpu_sockets => 10, :cpu_cores_per_socket => 4) }
   let(:host)          { FactoryGirl.build(:host, :hardware => host_hardware) }
   let(:request)       { FactoryGirl.create(:vm_reconfigure_request, :userid => admin.userid) }
   let(:vm_hardware)   { FactoryGirl.build(:hardware, :virtual_hw_version => "07") }

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -52,7 +52,7 @@ describe ContainerTopologyService do
                                 :uid_ems => "abcd9a08-7b13-11e5-8546-129aa6621999",
                                 :ext_management_system => ems_rhev,
                                 :hardware => FactoryGirl.create(:hardware,
-                                                                :numvcpus         => 2,
+                                                                :cpu_sockets      => 2,
                                                                 :cores_per_socket => 4,
                                                                 :logical_cpus     => 8))
       vm_rhev.update_attribute(:host, host)

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -30,10 +30,10 @@ module QuotaHelper
     @ram_size = 1024
     @disk_size = 1_000_000
     @num_cpu = 0
-    @hw1 = FactoryGirl.create(:hardware, :numvcpus => @num_cpu, :memory_cpu => @ram_size)
-    @hw2 = FactoryGirl.create(:hardware, :numvcpus => @num_cpu, :memory_cpu => @ram_size)
-    @hw3 = FactoryGirl.create(:hardware, :numvcpus => @num_cpu, :memory_cpu => @ram_size)
-    @hw4 = FactoryGirl.create(:hardware, :numvcpus => @num_cpu, :memory_cpu => @ram_size)
+    @hw1 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_cpu => @ram_size)
+    @hw2 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_cpu => @ram_size)
+    @hw3 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_cpu => @ram_size)
+    @hw4 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_cpu => @ram_size)
     create_disks
   end
 
@@ -101,7 +101,7 @@ module QuotaHelper
 
     @vm_template = FactoryGirl.create(:template_vmware,
                                       :name     => "template1",
-                                      :hardware => FactoryGirl.create(:hardware, :numvcpus => 1, :memory_cpu => 512))
+                                      :hardware => FactoryGirl.create(:hardware, :cpu_sockets => 1, :memory_cpu => 512))
 
     create_tenant_quota
     create_request


### PR DESCRIPTION
Reduce deprecation warnings, saving the more complicated renamings (with corrections) for another PR since it will require a much closer review.