### PR TITLE
Auto load container scan job

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :Scanning
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning
+  require_nested :Job
+end


### PR DESCRIPTION
Fixes #5161
Every nested constant should be autoloaded using 'require_nested',
otherwise in this case, ContainerImage scan doesn't work at all.