### PR TITLE
move next sequence calculation into miq_group

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1130,8 +1130,6 @@ module OpsController::OpsRbac
   # Set group record variables to new values
   def rbac_group_set_record_vars(group)
     role = MiqUserRole.find_by_id(@edit[:new][:role])
-    groups = MiqGroup.all(:order => "sequence DESC")
-    group.sequence = groups.first.nil? ? 1 : groups.first.sequence + 1
     group.description = @edit[:new][:description]
     group.miq_user_role = role
     group.tenant = Tenant.find_by_id(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -30,6 +30,7 @@ class MiqGroup < ActiveRecord::Base
   serialize :settings
 
   default_value_for :group_type, USER_GROUP
+  default_value_for(:sequence) { next_sequence }
 
   acts_as_miq_taggable
   include ReportableMixin
@@ -67,17 +68,8 @@ class MiqGroup < ActiveRecord::Base
     true # Remove once this is implemented
   end
 
-  def self.add(attrs)
-    group = new(attrs)
-    if group.resource.nil?
-      groups = where(:resource_id => nil, :resource_type => nil).order("sequence DESC")
-    else
-      groups = group.resource.miq_groups.order("sequence DESC")
-    end
-    group.sequence = groups.first.nil? ? 1 : groups.first.sequence + 1
-    group.save!
-
-    group
+  def self.next_sequence
+    maximum(:sequence).to_i + 1
   end
 
   def self.seed

--- a/db/migrate/20151021174140_assign_tenant_default_group.rb
+++ b/db/migrate/20151021174140_assign_tenant_default_group.rb
@@ -33,6 +33,8 @@ class AssignTenantDefaultGroup < ActiveRecord::Migration
       create_with(
         :description      => "Tenant #{tenant.name} #{tenant.id} access",
         :group_type       => TENANT_GROUP,
+        :sequence         => 1,
+        :guid             => MiqUUID.new_guid,
         :miq_user_role_id => role.try(:id)
       ).find_or_create_by!(:tenant_id => tenant.id)
     end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     end
 
     guid { MiqUUID.new_guid }
-
+    sequence(:sequence)  # don't want to spend time looking these up
     description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
 
     after :build do |g, e|

--- a/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
+++ b/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
@@ -21,7 +21,9 @@ describe AssignTenantDefaultGroup do
 
         t.reload
         expect(t.default_miq_group_id).to be
-        expect(group_stub.find(t.default_miq_group_id).miq_user_role_id).to eq(tenant_role.id)
+        g = group_stub.find(t.default_miq_group_id)
+        expect(g.miq_user_role_id).to eq(tenant_role.id)
+        expect(g.sequence).to be
       end
 
       it "skips tenants that already have a group" do


### PR DESCRIPTION
This prevents groups from being sorted in all new databases and needs to be backported

- fix error around tenant groups with a nil sequence
- set sequence by default
- set sequence for tenant default_group

/cc @lgalis @abellotti this fixes bug in UI
/cc @gmcculloug fyi