### PR TITLE
containers: add support for hawkular metrics

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -60,6 +60,12 @@ module ContainersCommonMixin
       drop_breadcrumb(:name => "Timelines",
                       :url  => "/#{controller_name}/show/#{record.id}" \
                                "?refresh=n&display=timeline")
+    elsif @display == "performance"
+      @showtype = "performance"
+      drop_breadcrumb(:name => "#{record.name} Capacity & Utilization",
+                      :url  => "/#{controller_name}/show/#{record.id}" \
+                               "?display=#{@display}&refresh=n")
+      perf_gen_init_options # Intialize options, charts are generated async
     elsif @display == "container_groups" || session[:display] == "container_groups" && params[:display].nil?
       show_container_display(record, "container_groups", ContainerGroup)
     elsif @display == "containers"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1126,7 +1126,7 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Vm"
       case id
-      when "instance_perf", "vm_perf"
+      when "instance_perf", "vm_perf", "container_perf"
         return "No Capacity & Utilization data has been collected for this VM" unless @record.has_perf_data?
       when "instance_check_compliance", "vm_check_compliance"
         model = model_for_vm(@record).to_s

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -18,6 +18,7 @@ class Container < ActiveRecord::Base
   has_many   :vim_performance_states, :as => :resource
 
   # Needed for metrics
+  delegate   :ems_id, :to => :container_group
   delegate   :my_zone, :to => :ext_management_system
 
   include EventMixin

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -1,10 +1,53 @@
 module ManageIQ::Providers
   class Kubernetes::ContainerManager::MetricsCapture < BaseManager::MetricsCapture
+    class CollectionFailure < RuntimeError; end
+    class TargetValidationError < RuntimeError; end
+
+    require_nested :CaptureContext
+
+    INTERVAL = 20.seconds
+
+    VIM_STYLE_COUNTERS = {
+      "cpu_usage_rate_average"     => {
+        :counter_key           => "cpu_usage_rate_average",
+        :instance              => "",
+        :capture_interval      => "#{INTERVAL}",
+        :precision             => 1,
+        :rollup                => "average",
+        :unit_key              => "percent",
+        :capture_interval_name => "realtime"
+      },
+      "mem_usage_absolute_average" => {
+        :counter_key           => "mem_usage_absolute_average",
+        :instance              => "",
+        :capture_interval      => "#{INTERVAL}",
+        :precision             => 1,
+        :rollup                => "average",
+        :unit_key              => "percent",
+        :capture_interval_name => "realtime"
+      }
+    }
+
     def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
+      start_time ||= 15.minutes.ago.beginning_of_minute.utc
+
       target_name = "#{target.class.name.demodulize}(#{target.id})"
       _log.info("Collecting metrics for #{target_name} [#{interval_name}] " \
                 "[#{start_time}] [#{end_time}]")
-      [{target.ems_ref => {}}, {target.ems_ref => {}}]
+
+      context = CaptureContext.new(target, start_time, end_time, INTERVAL)
+
+      Benchmark.realtime_block(:collect_data) do
+        begin
+          context.collect_metrics
+        rescue CollectionFailure => e
+          _log.error("Hawkular metrics service unavailable: #{e.message}")
+          return [{}, {}]
+        end
+      end
+
+      [{target.ems_ref => VIM_STYLE_COUNTERS},
+       {target.ems_ref => context.ts_values}]
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -1,0 +1,189 @@
+class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
+  class CaptureContext
+    def initialize(target, start_time, end_time, interval)
+      @target = target
+      @start_time = start_time || 15.minutes.ago.beginning_of_minute.utc
+      @end_time = end_time
+      @interval = interval
+      @tenant = target.try(:container_project).try(:name) || '_system'
+      @ext_management_system = @target.ext_management_system
+      @ts_values = Hash.new { |h, k| h[k] = {} }
+      @metrics = []
+
+      if @target.respond_to?(:hardware)
+        hardware = @target.hardware
+      else
+        hardware = @target.container_node.hardware
+      end
+
+      @node_cores = hardware.try(:cpu_total_cores)
+      @node_memory = hardware.try(:memory_mb)
+
+      validate_target
+    end
+
+    def collect_metrics
+      case @target
+      when ContainerNode  then collect_node_metrics
+      when Container      then collect_container_metrics
+      when ContainerGroup then collect_group_metrics
+      else raise TargetValidationError, "Validation error: unknown target"
+      end
+    end
+
+    def ts_values
+      # Filtering out entries that are not containing all the metrics.
+      # This generally happens because metrics are collected at slightly
+      # different times and could produce entries that are incomplete.
+      @ts_values.select { |_, v| @metrics.all? { |k| v.key?(k) } }
+    end
+
+    private
+
+    CPU_NANOSECONDS = 1e09
+
+    def target_name
+      "#{@target.class.name.demodulize}(#{@target.id})"
+    end
+
+    def validate_target
+      raise TargetValidationError, "Validation error: ems not defined"    unless @ext_management_system
+      raise TargetValidationError, "Validation error: cores not defined"  unless @node_cores.to_i > 0
+      raise TargetValidationError, "Validation error: memory not defined" unless @node_memory.to_i > 0
+    end
+
+    def collect_node_metrics
+      cpu_resid = "machine/#{@target.name}/cpu/usage"
+      process_cpu_counters_rate(fetch_counters_rate(cpu_resid))
+
+      mem_resid = "machine/#{@target.name}/memory/usage"
+      process_mem_gauges_data(fetch_gauges_data(mem_resid))
+    end
+
+    def collect_container_metrics
+      group_id = @target.container_group.ems_ref
+
+      cpu_resid = "#{@target.name}/#{group_id}/cpu/usage"
+      process_cpu_counters_rate(fetch_counters_rate(cpu_resid))
+
+      mem_resid = "#{@target.name}/#{group_id}/memory/usage"
+      process_mem_gauges_data(fetch_gauges_data(mem_resid))
+    end
+
+    def collect_group_metrics
+      group_id = @target.ems_ref
+
+      cpu_counters = @target.containers.collect do |c|
+        fetch_counters_rate("#{c.name}/#{group_id}/cpu/usage")
+      end
+      process_cpu_counters_rate(compute_summation(cpu_counters))
+
+      mem_gauges = @target.containers.collect do |c|
+        fetch_gauges_data("#{c.name}/#{group_id}/memory/usage")
+      end
+      process_mem_gauges_data(compute_summation(mem_gauges))
+    end
+
+    def hawkular_client
+      require 'hawkularclient'
+      @client ||= Hawkular::Metrics::Client.new(
+        hawkular_entrypoint, hawkular_credentials, hawkular_options)
+    end
+
+    def hawkular_entrypoint
+      worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
+      URI::HTTPS.build(
+        :host => @ext_management_system.hostname,
+        :port => worker_class.worker_settings[:metrics_port],
+        :path => worker_class.worker_settings[:metrics_path])
+    end
+
+    def hawkular_credentials
+      {:token => @ext_management_system.try(:authentication_token)}
+    end
+
+    def hawkular_options
+      {:tenant     => @tenant,
+       :verify_ssl => @ext_management_system.verify_ssl_mode}
+    end
+
+    def fetch_counters_rate(resource)
+      compute_derivative(fetch_counters_data(resource))
+    end
+
+    def fetch_counters_data(resource)
+      sort_and_normalize(
+        hawkular_client.counters.get_data(
+          resource,
+          :starts         => (@start_time - @interval).to_i.in_milliseconds,
+          :bucketDuration => "#{@interval}s"))
+    rescue SystemCallError => e
+      raise CollectionFailure, e.message
+    end
+
+    def fetch_gauges_data(resource)
+      sort_and_normalize(
+        hawkular_client.gauges.get_data(
+          resource,
+          :starts         => @start_time.to_i.in_milliseconds,
+          :bucketDuration => "#{@interval}s"))
+    rescue SystemCallError => e
+      raise CollectionFailure, e.message
+    end
+
+    def process_cpu_counters_rate(counters_rate)
+      @metrics |= ['cpu_usage_rate_average'] if counters_rate.length > 0
+      total_cpu_time = @node_cores * CPU_NANOSECONDS * @interval
+      counters_rate.each do |x|
+        timestamp = Time.at(x['start'] / 1.in_milliseconds).utc
+        avg_usage = (x['avg'] * 100.0) / total_cpu_time
+        @ts_values[timestamp]['cpu_usage_rate_average'] = avg_usage
+      end
+    end
+
+    def process_mem_gauges_data(gauges_data)
+      @metrics |= ['mem_usage_absolute_average'] if gauges_data.length > 0
+      gauges_data.each do |x|
+        timestamp = Time.at(x['start'] / 1.in_milliseconds).utc
+        avg_usage = (x['avg'] / 1.megabytes) * 100.0 / @node_memory
+        @ts_values[timestamp]['mem_usage_absolute_average'] = avg_usage
+      end
+    end
+
+    def compute_summation(data)
+      ts_data = Hash.new { |h, k| h[k] = [] }
+
+      data.flatten.each { |x| ts_data[x['start']] << x }
+      ts_data.delete_if { |_k, v| v.length != data.length }
+
+      ts_data.keys.sort.map do |k|
+        ts_data[k].inject do |sum, n|
+          # Add min, median, max, percentile95th, etc. if needed
+          {
+            'start' => k,
+            'end'   => [sum['end'], n['end']].max,
+            'avg'   => sum['avg'] + n['avg']
+          }
+        end
+      end
+    end
+
+    def sort_and_normalize(data)
+      # Sorting and removing last entry because always incomplete
+      # as it's still in progress.
+      norm_data = (data.sort_by { |x| x['start'] }).slice(0..-2)
+      norm_data.reject { |x| x.values.include?('NaN') }
+    end
+
+    def compute_derivative(counters)
+      counters.each_cons(2).map do |prv, n|
+        # Add min, median, max, percentile95th, etc. if needed
+        {
+          'start' => n['start'],
+          'end'   => n['end'],
+          'avg'   => n['avg'] - prv['avg']
+        }
+      end
+    end
+  end
+end

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -90,7 +90,7 @@ module Metric::Processing
       when "numvcpus" # This is actually logical cpus.  See note above.
         # Do not derive "available" values if there haven't been any usage
         # values collected
-        result[col] = state.numvcpus if obj.kind_of?(VmOrTemplate) && have_cpu_metrics && state.numvcpus.to_i > 0
+        result[col] = state.numvcpus if have_cpu_metrics && state.try(:numvcpus).to_i > 0
       when "sockets"
         result[col] = state.host_sockets
       end

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -8,5 +8,9 @@
         = render(:partial => "layouts/tl_show")
         :javascript
             var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    - when "performance"
+        = render(:partial => "layouts/performance")
+        :javascript
+            var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - else
         = render :partial => @showtype

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -10,5 +10,9 @@
   = render(:partial => "layouts/tl_show")
   :javascript
     var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+- elsif @showtype == "performance"
+  = render(:partial => "layouts/performance")
+  :javascript
+    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -13,7 +13,7 @@
         - if request.parameters["controller"] == "storage" && @perf_options[:cat]
           = select("perf", "typ", %w(Hourly Daily), {:selected => @perf_options[:typ]},
                                                       :disabled => "")
-        - elsif %(Host VmOrTemplate).include?(@perf_options[:model]) && !@rt_hide
+        - elsif %(Host VmOrTemplate ContainerNode Container ContainerGroup).include?(@perf_options[:model]) && !@rt_hide
           = select_tag("perf_typ",
                         options_for_select(["Hourly", "Daily", ["Most Recent Hour", "realtime"]], @perf_options[:typ]),
                         "data-miq_sparkle_on" => true,

--- a/app/views/layouts/listnav/_container_group.html.haml
+++ b/app/views/layouts/listnav/_container_group.html.haml
@@ -12,6 +12,15 @@
         %li
           = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, :title => _("Show Summary"))
 
+        - if @record.has_perf_data?
+          %li
+            = link_to(_('Capacity & Utilization'),
+              {:action => 'show', :id => @record, :display => 'performance'},
+              :title => _("Show Capacity & Utilization"))
+        - else
+          %li.disabled
+            = link_to(_('Capacity & Utilization'), "#")
+
         - if @record.has_events? || @record.has_events?(:policy_events)
           %li
             = link_to('Timelines',

--- a/app/views/layouts/listnav/_container_node.html.haml
+++ b/app/views/layouts/listnav/_container_node.html.haml
@@ -12,6 +12,15 @@
         %li
           = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, :title => _("Show Summary"))
 
+        - if @record.has_perf_data?
+          %li
+            = link_to(_('Capacity & Utilization'),
+              {:action => 'show', :id => @record, :display => 'performance'},
+              :title => _("Show Capacity & Utilization"))
+        - else
+          %li.disabled
+            = link_to(_('Capacity & Utilization'), "#")
+
         - if @record.has_events? || @record.has_events?(:policy_events)
           %li
             = link_to('Timelines',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -534,6 +534,7 @@ en:
       v_derived_host_count: State - Number of Hosts  - Hourly Count / Daily Avg
       v_derived_memory_reserved_pct: Memory - Available (%)
       v_derived_vm_count: State - Peak Avg VMs - Hourly Count / Daily Avg
+      v_derived_cpu_total_cores_used: CPU - Usage Rate for Collected Intervals (Number of Cores)
 
       # Right-Sizing Recommendations
       aggressive_mem_recommended_change: Memory - Aggressive Recommendation Savings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,7 @@ Vmdb::Application.routes.draw do
       :get  => %w(
         download_data
         explorer
+        perf_top_chart
         show
         tagging_edit
         tag_edit_form_field_changed
@@ -318,6 +319,7 @@ Vmdb::Application.routes.draw do
       ) +
                adv_search_post +
                exp_post +
+               perf_post +
                save_post +
                x_post
     },
@@ -328,6 +330,7 @@ Vmdb::Application.routes.draw do
         edit
         index
         new
+        perf_top_chart
         show
         show_list
         tagging_edit
@@ -352,6 +355,7 @@ Vmdb::Application.routes.draw do
       ) +
                adv_search_post +
                exp_post +
+               perf_post +
                save_post
     },
 
@@ -361,6 +365,7 @@ Vmdb::Application.routes.draw do
         edit
         index
         new
+        perf_top_chart
         show
         show_list
         tagging_edit
@@ -385,6 +390,7 @@ Vmdb::Application.routes.draw do
       ) +
                adv_search_post +
                exp_post +
+               perf_post +
                save_post
     },
 

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -348,6 +348,8 @@ workers:
           :poll_method: :escalate
         :ems_metrics_collector_worker_kubernetes:
           :poll_method: :escalate
+          :metrics_port: 5000
+          :metrics_path: '/hawkular/metrics'
         :ems_metrics_collector_worker_openshift:
           :poll_method: :escalate
         :ems_metrics_collector_worker_atomic:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3115,6 +3115,10 @@
       :description: Display Timelines for Pods
       :feature_type: view
       :identifier: container_group_timeline
+    - :name: Utilization
+      :description: Show Capacity & Utilization data of Pods
+      :feature_type: view
+      :identifier: container_group_perf
   - :name: Modify
     :description: Modify Pods
     :feature_type: admin
@@ -3161,6 +3165,10 @@
       :description: Display Individual Container Nodes
       :feature_type: view
       :identifier: container_node_show
+    - :name: Utilization
+      :description: Show Capacity & Utilization data of Nodes
+      :feature_type: view
+      :identifier: container_node_perf
     - :name: Timeline
       :description: Display Timelines for Container Nodes
       :feature_type: view
@@ -3467,6 +3475,10 @@
         :description: Add a Container
         :feature_type: admin
         :identifier: container_new
+      - :name: Utilization
+        :description: Show Capacity & Utilization data of Containers
+        :feature_type: view
+        :identifier: container_perf
   - :name: Operate
     :description: Perform Operations on Containers
     :feature_type: control

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -273,6 +273,7 @@
     :v_pct_cpu_wait_delta_summation: :percent
     :v_provisioned_percent_of_total: :percent
     :v_vm_misc_percent_of_used: :percent
+    :v_derived_cpu_total_cores_used: :float
 
     # Right Sizing
     :recommended_mem: :megabytes

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -24,6 +24,7 @@ gem "fog",                     "~>2.0.0.pre.0",     :require => false
 gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.8.0",            :require => false
+gem "hawkular-client",         "~>0.1.2",           :require => false
 gem "linux_admin",             "~>0.12.1",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.11.0",          :require => false

--- a/product/charts/layouts/daily_perf_charts/Container.yaml
+++ b/product/charts/layouts/daily_perf_charts/Container.yaml
@@ -1,0 +1,12 @@
+# Container daily performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/daily_perf_charts/ContainerGroup.yaml
+++ b/product/charts/layouts/daily_perf_charts/ContainerGroup.yaml
@@ -1,0 +1,12 @@
+# Container group daily performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/daily_perf_charts/ContainerNode.yaml
+++ b/product/charts/layouts/daily_perf_charts/ContainerNode.yaml
@@ -1,0 +1,12 @@
+# Container node daily performance chart layouts
+---
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/hourly_perf_charts/Container.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Container.yaml
@@ -1,0 +1,12 @@
+# Container hourly performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/hourly_perf_charts/ContainerGroup.yaml
+++ b/product/charts/layouts/hourly_perf_charts/ContainerGroup.yaml
@@ -1,0 +1,12 @@
+# Container group hourly performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/hourly_perf_charts/ContainerNode.yaml
+++ b/product/charts/layouts/hourly_perf_charts/ContainerNode.yaml
@@ -1,0 +1,12 @@
+# Container node hourly performance chart layouts
+---
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/realtime_perf_charts/Container.yaml
+++ b/product/charts/layouts/realtime_perf_charts/Container.yaml
@@ -1,0 +1,12 @@
+# Container real time performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/realtime_perf_charts/ContainerGroup.yaml
+++ b/product/charts/layouts/realtime_perf_charts/ContainerGroup.yaml
@@ -1,0 +1,12 @@
+# Container group real time performance chart layouts
+---
+- :title: Cores Used
+  :type: Line
+  :columns:
+  - v_derived_cpu_total_cores_used
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/layouts/realtime_perf_charts/ContainerNode.yaml
+++ b/product/charts/layouts/realtime_perf_charts/ContainerNode.yaml
@@ -1,0 +1,12 @@
+# Container node real time performance chart layouts
+---
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - derived_memory_available

--- a/product/charts/miq_reports/vim_perf_daily.yaml
+++ b/product/charts/miq_reports/vim_perf_daily.yaml
@@ -33,6 +33,7 @@ cols:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - max_derived_memory_available
 - max_derived_memory_reserved
@@ -99,6 +100,7 @@ col_order:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - max_derived_memory_available
 - max_derived_memory_reserved

--- a/product/charts/miq_reports/vim_perf_hourly.yaml
+++ b/product/charts/miq_reports/vim_perf_hourly.yaml
@@ -27,6 +27,7 @@ cols:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - derived_memory_available
 - derived_memory_reserved
@@ -53,6 +54,7 @@ col_order:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - derived_memory_available
 - derived_memory_reserved

--- a/product/charts/miq_reports/vim_perf_realtime.yaml
+++ b/product/charts/miq_reports/vim_perf_realtime.yaml
@@ -26,6 +26,7 @@ cols:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - derived_memory_available
 - disk_usage_rate_average
@@ -44,6 +45,7 @@ col_order:
 - v_pct_cpu_ready_delta_summation
 - v_pct_cpu_wait_delta_summation
 - v_pct_cpu_used_delta_summation
+- v_derived_cpu_total_cores_used
 - derived_memory_used
 - derived_memory_available
 - disk_usage_rate_average

--- a/product/toolbars/container_group_center_tb.yaml
+++ b/product/toolbars/container_group_center_tb.yaml
@@ -35,6 +35,12 @@
       :title: "Show Timelines for this Group"
       :url: '/show'
       :url_parms: '?display=timeline'
+    - :button: container_group_perf
+      :image: capacity
+      :text: "Utilization"
+      :title: "Show Capacity & Utilization data for this Group"
+      :url: '/show'
+      :url_parms: '?display=performance'
 - :name: container_group_policy
   :items:
   - :buttonSelect: container_group_policy_choice

--- a/product/toolbars/container_node_center_tb.yaml
+++ b/product/toolbars/container_node_center_tb.yaml
@@ -29,6 +29,12 @@
     :title: Monitoring
     :text: Monitoring
     :items:
+    - :button: container_node_perf
+      :image: capacity
+      :text: "Utilization"
+      :title: "Show Capacity & Utilization data for this Node"
+      :url: '/show'
+      :url_parms: '?display=performance'
     - :button: container_node_timeline
       :image: timeline
       :text: "Timelines"

--- a/product/toolbars/containers_center_tb.yaml
+++ b/product/toolbars/containers_center_tb.yaml
@@ -45,3 +45,15 @@
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
+- :name: container_monitoring
+  :items:
+  - :buttonSelect: container_monitoring_choice
+    :image: monitoring
+    :title: Monitoring
+    :text: Monitoring
+    :items:
+    - :button: container_perf
+      :image: capacity
+      :text: "Utilization"
+      :title: "Show Capacity & Utilization data for this Container"
+      :url_parms: '?display=performance'

--- a/spec/factories/container_nodes.rb
+++ b/spec/factories/container_nodes.rb
@@ -4,4 +4,9 @@ FactoryGirl.define do
       x.computer_system = FactoryGirl.create(:computer_system)
     end
   end
+
+  factory :kubernetes_node,
+          :aliases => ['app/models/manageiq/providers/kubernetes/container_manager/container_node'],
+          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode' do
+  end
 end

--- a/spec/factories/container_nodes.rb
+++ b/spec/factories/container_nodes.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
 
   factory :kubernetes_node,
           :aliases => ['app/models/manageiq/providers/kubernetes/container_manager/container_node'],
-          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode' do
+          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
+          :parent  => :container_node do
   end
 end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
 
   factory :kubernetes_container,
           :aliases => ['app/models/manageiq/providers/kubernetes/container_manager/container'],
-          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container' do
+          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container',
+          :parent  => :container do
   end
 end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -1,4 +1,9 @@
 FactoryGirl.define do
   factory :container do
   end
+
+  factory :kubernetes_container,
+          :aliases => ['app/models/manageiq/providers/kubernetes/container_manager/container'],
+          :class   => 'ManageIQ::Providers::Kubernetes::ContainerManager::Container' do
+  end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -1,0 +1,144 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
+  before do
+    @ems_kubernetes = FactoryGirl.create(:ems_kubernetes)
+
+    @node = FactoryGirl.create(:kubernetes_node,
+                               :name                  => 'node',
+                               :ext_management_system => @ems_kubernetes,
+                               :ems_ref               => 'target')
+
+    @node.computer_system.hardware = FactoryGirl.create(
+      :hardware,
+      :cpu_total_cores => 2,
+      :memory_mb       => 2048)
+
+    @group = FactoryGirl.create(:container_group,
+                                :ext_management_system => @ems_kubernetes,
+                                :container_node        => @node,
+                                :ems_ref               => 'group')
+
+    @container = FactoryGirl.create(:kubernetes_container,
+                                    :name            => 'container',
+                                    :container_group => @group,
+                                    :ems_ref         => 'target')
+  end
+
+  context "#perf_collect_metrics" do
+    it "raises an error when no ems is defined" do
+      @node.ext_management_system = nil
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
+        described_class::TargetValidationError)
+    end
+
+    it "raises an error when no cpu cores are defined" do
+      @node.hardware.cpu_total_cores = nil
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
+        described_class::TargetValidationError)
+    end
+
+    it "raises an error when memory is not defined" do
+      @node.hardware.memory_mb = nil
+      expect { @node.perf_collect_metrics('interval_name') }.to raise_error(
+        described_class::TargetValidationError)
+    end
+
+    # TODO: include also sort_and_normalize in the tests
+    METRICS_EXERCISES = [
+      {
+        :counters => [
+          {
+            :args => 'cpu/usage',
+            :data => [
+              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 0},
+              {'start' => 1446500020000, 'end' => 1446500040000, 'avg' => 4000000000}
+            ]
+          }
+        ],
+        :gauges => [
+          {
+            :args => 'memory/usage',
+            :data => [
+              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 1073741824}
+            ]
+          }
+        ],
+        :expected => {}
+      },
+      {
+        :counters => [
+          {
+            :args => 'cpu/usage',
+            :data => [
+              {'start' => 1446499980000, 'end' => 1446500000000, 'avg' => 0},
+              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 4000000000}
+            ]
+          }
+        ],
+        :gauges => [
+          {
+            :args => 'memory/usage',
+            :data => [
+              {'start' => 1446500000000, 'end' => 1446500020000, 'avg' => 1073741824}
+            ]
+          }
+        ],
+        :expected => {
+          Time.at(1446500000).utc => {
+            "cpu_usage_rate_average"     => 10.0,
+            "mem_usage_absolute_average" => 50.0
+          }
+        }
+      }
+    ]
+
+    it "node counters and gauges are correctly processed" do
+      METRICS_EXERCISES.each do |exercise|
+        exercise[:counters].each do |metrics|
+          described_class::CaptureContext
+            .any_instance
+            .stub(:fetch_counters_data)
+            .with("machine/node/#{metrics[:args]}")
+            .and_return(metrics[:data])
+        end
+
+        exercise[:gauges].each do |metrics|
+          described_class::CaptureContext
+            .any_instance
+            .stub(:fetch_gauges_data)
+            .with("machine/node/#{metrics[:args]}")
+            .and_return(metrics[:data])
+        end
+
+        _, values_by_ts = @node.perf_collect_metrics('realtime')
+
+        expect(values_by_ts['target']).to eq(exercise[:expected])
+      end
+    end
+
+    it "container counters and gauges are correctly processed" do
+      METRICS_EXERCISES.each do |exercise|
+        exercise[:counters].each do |metrics|
+          described_class::CaptureContext
+            .any_instance
+            .stub(:fetch_counters_data)
+            .with("container/group/#{metrics[:args]}")
+            .and_return(metrics[:data])
+        end
+
+        exercise[:gauges].each do |metrics|
+          described_class::CaptureContext
+            .any_instance
+            .stub(:fetch_gauges_data)
+            .with("container/group/#{metrics[:args]}")
+            .and_return(metrics[:data])
+        end
+
+        _, values_by_ts = @container.perf_collect_metrics('realtime')
+
+        expect(values_by_ts['target']).to eq(exercise[:expected])
+      end
+    end
+  end
+end

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe MiqProductFeature do
   before do
-    @expected_feature_count = 862
+    @expected_feature_count = 865
   end
 
   context ".seed" do


### PR DESCRIPTION
This pull requests add the support for collecting CPU and memory metrics from hawkular for the container providers (kubernetes, openshift and atomic).