### PR TITLE
Removing ordering from Automate tree

### DIFF
--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -17,7 +17,7 @@ class TreeBuilderAeClass < TreeBuilder
               else
                 filter_ae_objects(User.current_tenant.visible_domains)
               end
-    count_only_or_objects(count_only, objects, [:priority])
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_class_kids(object, count_only, type)

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -42,4 +42,20 @@ describe TreeBuilderAeClass do
       domains.should_not include %w(test2)
     end
   end
+
+  context "#x_get_tree_roots" do
+    before do
+      user = FactoryGirl.create(:user_with_group)
+      login_as user
+      tenant1 = user.current_tenant
+      FactoryGirl.create(:miq_ae_domain, :name => "test1", :tenant => tenant1, :priority => 1)
+      FactoryGirl.create(:miq_ae_domain, :name => "test2", :tenant => tenant1, :priority => 2)
+    end
+
+    it "should return domains in correct order" do
+      tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
+      domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+      domains.should eq(%w(test2 test1))
+    end
+  end
 end


### PR DESCRIPTION
Removing ordering from Automate tree, visible_domains method return records in correct order. Previous changes were reverted in revision a39742cb301cfc8208e76907d72a5e45fc86b307

@mkanoor pls review

before:
![automate_tree_before](https://cloud.githubusercontent.com/assets/3450808/10798196/df737218-7d7c-11e5-9cbb-16ed9f841f9e.png)

after:
![automate_tree_after](https://cloud.githubusercontent.com/assets/3450808/10798199/e39f6608-7d7c-11e5-8d39-fcce658ef0f3.png)
