### PR TITLE
Stop using adminURL OSP service endpoints

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -51,10 +51,11 @@ module OpenstackHandle
 
     def self.raw_connect(username, password, auth_url, service = "Compute", extra_opts = nil)
       opts = {
-        :provider           => 'OpenStack',
-        :openstack_auth_url => auth_url,
-        :openstack_username => username,
-        :openstack_api_key  => password,
+        :provider                => 'OpenStack',
+        :openstack_auth_url      => auth_url,
+        :openstack_username      => username,
+        :openstack_api_key       => password,
+        :openstack_endpoint_type => 'publicURL',
       }
       opts.merge!(extra_opts) if extra_opts
 


### PR DESCRIPTION
Fog defaults to using adminURL OSP service endpoints for some services.  A blind
grep of Fog code shows the following:

> identity_v2.rb: @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> identity_v3.rb: @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> image_v1.rb:    @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> image_v2.rb:    @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> metering.rb:    @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> planning.rb:    @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
> volume.rb:      @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'

By explicitly setting the openstack_endpoint_type to 'publicURL', manageIQ will
always use the publicURL for all connections to any OpenStack Service Endpoint.

https://bugzilla.redhat.com/show_bug.cgi?id=1276118