### PR TITLE
Account for restful routes when accessing a page via dashboard maintab

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1229,6 +1229,7 @@ class ApplicationController < ActionController::Base
     else
       @breadcrumbs.push(new_bc)
     end
+    @breadcrumbs.push(new_bc) if onlyreplace && @breadcrumbs.empty?
     if (@lastaction == "registry_items" || @lastaction == "filesystems" || @lastaction == "files") && new_bc[:name].length > 50
       @title = new_bc [:name].slice(0..50) + "..."  # Set the title to be the new breadcrumb
     else

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -982,6 +982,7 @@ module ApplicationController::CiProcessing
       bc_name += " - " + session["#{self.class.session_key_prefix}_type".to_sym].titleize if session["#{self.class.session_key_prefix}_type".to_sym]
       bc_name += " (filtered)" if @filters && (!@filters[:tags].blank? || !@filters[:cats].blank?)
       action = %w(container service vm_cloud vm_infra vm_or_template).include?(self.class.table_name) ? "explorer" : "show_list"
+      @breadcrumbs.clear
       drop_breadcrumb(:name => bc_name, :url => "/#{self.class.table_name}/#{action}")
     end
     @layout = session["#{self.class.session_key_prefix}_type".to_sym] if session["#{self.class.session_key_prefix}_type".to_sym]

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -71,6 +71,7 @@ class DashboardController < ApplicationController
 
   # A main tab was pressed
   def maintab
+    @breadcrumbs.clear
     tab = VALID_TABS[params[:tab]]
 
     unless tab # no tab name or invalid tab name was passed in

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -83,7 +83,13 @@ class DashboardController < ApplicationController
     when :vi, :svc, :clo, :inf, :cnt, :con, :aut, :opt, :set
 
       if session[:tab_url].key?(tab) # we remember url for this tab
-        redirect_to(session[:tab_url][tab].merge(:only_path => true))
+        if restful_routed_action?(session[:tab_url][tab][:controller], session[:tab_url][tab][:action])
+          session[:tab_url][tab].delete(:action)
+          redirect_to(polymorphic_path(session[:tab_url][tab][:controller],
+                                       session[:tab_url][tab]))
+        else
+          redirect_to(session[:tab_url][tab].merge(:only_path => true))
+        end
         return
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,6 +91,12 @@ module ApplicationHelper
     respond_to?("#{model.model_name.route_key}_path")
   end
 
+  def restful_routed_action?(controller = controller_name, action = action_name)
+    restful_routed?(("#{controller.camelize}Controller").constantize.model) && !%w(explorer show_list).include?(action)
+  rescue
+    false
+  end
+
   def url_for_record(record, action = "show") # Default action is show
     @id = to_cid(record.id)
     db =

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -22,8 +22,10 @@ describe ContainerGroupController do
     get :show, :id => container_group.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Group (Summary)",
-                                         :url  => "/container_group/show/#{container_group.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Pods",
+                                          :url  => "/container_group/show_list?page=&refresh=y"},
+                                         {:name => "Test Group (Summary)",
+                                          :url  => "/container_group/show/#{container_group.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -25,8 +25,10 @@ describe ContainerImageController do
     get :show, :id => container_image.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Image (Summary)",
-                                         :url  => "/container_image/show/#{container_image.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Images",
+                                          :url  => "/container_image/show_list?page=&refresh=y"},
+                                         {:name => "Test Image (Summary)",
+                                          :url  => "/container_image/show/#{container_image.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_image_registry_controller_spec.rb
+++ b/spec/controllers/container_image_registry_controller_spec.rb
@@ -20,8 +20,10 @@ describe ContainerImageRegistryController do
     get :show, :id => container_image_registry.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Image Registry (Summary)",
-                                         :url  => "/container_image_registry/show/#{container_image_registry.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Image Registry",
+                                          :url  => "/container_image_registry/show_list?page=&refresh=y"},
+                                         {:name => "Test Image Registry (Summary)",
+                                          :url  => "/container_image_registry/show/#{container_image_registry.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -19,8 +19,10 @@ describe ContainerNodeController do
     get :show, :id => container_node.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Node (Summary)",
-                                         :url  => "/container_node/show/#{container_node.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Nodes",
+                                          :url  => "/container_node/show_list?page=&refresh=y"},
+                                         {:name => "Test Node (Summary)",
+                                          :url  => "/container_node/show/#{container_node.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -19,8 +19,10 @@ describe ContainerProjectController do
     get :show, :id => container_project.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Project (Summary)",
-                                         :url  => "/container_project/show/#{container_project.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Projects",
+                                          :url  => "/container_project/show_list?page=&refresh=y"},
+                                         {:name => "Test Project (Summary)",
+                                          :url  => "/container_project/show/#{container_project.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_replicator_controller_spec.rb
+++ b/spec/controllers/container_replicator_controller_spec.rb
@@ -19,8 +19,10 @@ describe ContainerReplicatorController do
     get :show, :id => container_replicator.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Replicator (Summary)",
-                                         :url  => "/container_replicator/show/#{container_replicator.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Replicators",
+                                          :url  => "/container_replicator/show_list?page=&refresh=y"},
+                                         {:name => "Test Replicator (Summary)",
+                                          :url  => "/container_replicator/show/#{container_replicator.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_route_controller_spec.rb
+++ b/spec/controllers/container_route_controller_spec.rb
@@ -19,8 +19,10 @@ describe ContainerRouteController do
     get :show, :id => container_route.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Route (Summary)",
-                                         :url  => "/container_route/show/#{container_route.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Routes",
+                                          :url  => "/container_route/show_list?page=&refresh=y"},
+                                         {:name => "Test Route (Summary)",
+                                          :url  => "/container_route/show/#{container_route.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/container_service_controller_spec.rb
+++ b/spec/controllers/container_service_controller_spec.rb
@@ -19,8 +19,10 @@ describe ContainerServiceController do
     get :show, :id => container_service.id
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
-    expect(assigns(:breadcrumbs)).to eq([:name => "Test Service (Summary)",
-                                         :url  => "/container_service/show/#{container_service.id}"])
+    expect(assigns(:breadcrumbs)).to eq([{:name => "Container Services",
+                                          :url  => "/container_service/show_list?page=&refresh=y"},
+                                         {:name => "Test Service (Summary)",
+                                          :url  => "/container_service/show/#{container_service.id}"}])
   end
 
   it "renders show_list" do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -251,6 +251,19 @@ describe DashboardController do
     end
   end
 
+  context "#maintab" do
+    before do
+      described_class.any_instance.stub(:set_user_time_zone)
+      controller.stub(:check_privileges).and_return(true)
+    end
+    it "redirects a restful link correctly" do
+      ems_cloud_amz = FactoryGirl.create(:ems_amazon)
+      session[:tab_url] = {:clo => {:controller => "ems_cloud", :action => "show", :id => ems_cloud_amz.id}}
+      post :maintab, :tab => "clo"
+      expect(response.header['Location']).to include(ems_cloud_path(ems_cloud_amz))
+    end
+  end
+
   def skip_data_checks(url = '/')
     UserValidationService.any_instance.stub(:server_ready?).and_return(true)
     controller.stub(:start_url_for_user).and_return(url)

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -258,9 +258,12 @@ describe DashboardController do
     end
     it "redirects a restful link correctly" do
       ems_cloud_amz = FactoryGirl.create(:ems_amazon)
+      breadcrumbs = [{:name => "Name", :url => "/controller/action"}]
+      session[:breadcrumbs] = breadcrumbs
       session[:tab_url] = {:clo => {:controller => "ems_cloud", :action => "show", :id => ems_cloud_amz.id}}
       post :maintab, :tab => "clo"
       expect(response.header['Location']).to include(ems_cloud_path(ems_cloud_amz))
+      expect(controller.instance_variable_get(:@breadcrumbs)).to eq([])
     end
   end
 

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -202,4 +202,24 @@ describe EmsInfraController do
       end
     end
   end
+
+  describe "breadcrumbs path on a 'show' page of an Infrastructure Provider accessed from Dashboard maintab" do
+    before do
+      set_user_privileges
+      FactoryGirl.create(:vmdb_database)
+      EvmSpecHelper.create_guid_miq_server_zone
+      session[:settings] = {:views => {}}
+    end
+    context "when previous breadcrumbs path contained 'Cloud Providers'" do
+      it "shows 'Infrastructure Providers -> (Summary)' breadcrumb path" do
+        ems = FactoryGirl.create("ems_vmware")
+        get :show, :id => ems.id
+        breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
+        expect(breadcrumbs).to eq([{:name => "Infrastructure Providers",
+                                    :url  => "/ems_infra/show_list?page=&refresh=y"},
+                                   {:name => "#{ems.name} (Summary)",
+                                    :url  => "/ems_infra/show/#{ems.id}"}])
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1561,4 +1561,30 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#restful_routed_action?' do
+    context 'When controller is Dashboard and action is maintab' do
+      it 'returns false' do
+        expect(helper.restful_routed_action?('dashboard', 'maintab')).to eq(false)
+      end
+    end
+
+    context 'When controller is ems_infra and action is show' do
+      it 'returns false' do
+        expect(helper.restful_routed_action?('ems_infra', 'show')).to eq(false)
+      end
+    end
+
+    context 'When controller is ems_cloud and action is show_list' do
+      it 'returns false' do
+        expect(helper.restful_routed_action?('ems_cloud', 'show_list')).to eq(false)
+      end
+    end
+
+    context 'When controller is ems_cloud and action is show' do
+      it 'returns true' do
+        expect(helper.restful_routed_action?('ems_cloud', 'show')).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the routing issue seen when the dashboard ```maintab``` attempts to redirect to a restful route.

https://bugzilla.redhat.com/show_bug.cgi?id=1275589