### PR TITLE
Adding logic so that custom buttons collapse based on space

### DIFF
--- a/spa_ui/self_service/client/app/components/custom-button/_custom-button.sass
+++ b/spa_ui/self_service/client/app/components/custom-button/_custom-button.sass
@@ -1,0 +1,18 @@
+.custom_actions_menu
+  li
+    a
+      display: block
+      padding: 3px 20px
+      clear: both
+      color: $app-color-dark-gray-2
+      line-height: 1.66666667
+      white-space: nowrap
+      border-color: transparent
+      border-style: solid
+      border-width: 1px 0
+
+      &:hover
+        text-decoration: none
+        background-color: $app-color-light-blue-5
+        border-color: $app-color-light-blue-4
+        color: $app-color-medium-gray-2 !important

--- a/spa_ui/self_service/client/app/components/custom-button/custom-button.directive.js
+++ b/spa_ui/self_service/client/app/components/custom-button/custom-button.directive.js
@@ -5,7 +5,7 @@
     .directive('customButton', CustomButtonDirective);
 
   /** @ngInject */
-  function CustomButtonDirective() {
+  function CustomButtonDirective($window, $timeout) {
     var directive = {
       restrict: 'AE',
       replace: true,
@@ -24,6 +24,38 @@
 
     function link(scope, element, attrs, vm, transclude) {
       vm.activate();
+      
+      var win = angular.element($window);
+      win.bind('resize', function() { 
+        scope.$apply();
+      });
+
+      scope.$watch(getWindowWidth, function(newWidth, oldWidth) {
+        if (newWidth !== oldWidth) {
+          checkRoomForButtons();
+        }
+      });
+
+      // Set inital button state
+      checkRoomForButtons();
+
+      function checkRoomForButtons() {
+        // Allow the buttons to render to calculate width
+        vm.collapseCustomButtons = false;
+
+        $timeout(function() {
+          var outerWidth = document.querySelectorAll('.ss-details-header__actions')[0].offsetWidth;
+          var innerWidth = document.querySelectorAll('.ss-details-header__actions__inner')[0].offsetWidth;
+          if (innerWidth >= outerWidth) {
+            // Not enough room - collapse them down
+            vm.collapseCustomButtons = true;
+          }
+        }, 0);
+      }
+
+      function getWindowWidth() {
+        return win.width();
+      }
     }
 
     /** @ngInject */
@@ -32,6 +64,7 @@
 
       vm.activate = activate;
       vm.customButtonAction = customButtonAction;
+      vm.collapseCustomButtons = false;
 
       function activate() {
         angular.forEach(vm.actions, processActionButtons);

--- a/spa_ui/self_service/client/app/components/custom-button/custom-button.html
+++ b/spa_ui/self_service/client/app/components/custom-button/custom-button.html
@@ -1,24 +1,49 @@
 <span>
-  <span ng-repeat="button in vm.customActions.buttons">
-     <button class="btn btn-default custom-button"
+  <span ng-if="!vm.collapseCustomButtons">
+    <span ng-repeat="button in vm.customActions.buttons">
+       <button class="btn btn-default custom-button"
              title="{{button.description}}"
              type="button"
              ng-click="vm.customButtonAction(button)">
-       {{button.name }}
-     </button>
-  </span>
-  <span class="dropdown" ng-repeat="buttonGroup in vm.customActions.button_groups">
-    <button class="btn btn-default dropdown-toggle custom-button" title="{{buttonGroup.description}}"
+         {{button.name }}
+       </button>
+    </span>
+    <div class="btn-group dropdown" ng-repeat="buttonGroup in vm.customActions.button_groups">
+      <button class="btn btn-default dropdown-toggle custom-button" title="{{buttonGroup.description}}"
             type="button" id="{{buttonGroup.id}}" data-toggle="dropdown">
-      {{ buttonGroup.name}}
-      <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu" aria-labelledby="{{buttonGroup.id}}">
-      <li ng-repeat="button in buttonGroup.buttons" role="presentation">
-        <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
-          {{ button.name }}
-        </a>
-      </li>
-    </ul>
+        {{ buttonGroup.name}}
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" aria-labelledby="{{buttonGroup.id}}">
+        <li ng-repeat="button in buttonGroup.buttons" role="presentation">
+          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
+            {{ button.name }}
+          </a>
+        </li>
+      </ul>
+    </div>
+  </span>
+  <span ng-if="vm.collapseCustomButtons">
+    <div class="btn-group dropdown custom_actions_menu" ng-if="vm.customActions.buttons.length >=1 || vm.customActions.button_groups >=1">
+      <button class="btn btn-default dropdown-toggle custom-button" title="Actions"
+            type="button" id="button_custom_actions" data-toggle="dropdown">
+        Actions
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" aria-labelledby="button_custom_actions">
+        <li ng-repeat="button in vm.customActions.buttons" role="presentation">
+          <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
+            {{ button.name }}
+          </a>
+        </li>
+        <div ng-repeat="buttonGroup in vm.customActions.button_groups">
+          <li ng-repeat="button in buttonGroup.buttons" role="presentation">
+            <a role="menuitem" tabindex="-1" ng-click="vm.customButtonAction(button)">
+              {{ buttonGroup.name}} - {{ button.name }}
+            </a>
+          </li>
+        </div>
+      </ul>
+    </div>
   </span>
 </span>

--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.directive.js
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.directive.js
@@ -44,8 +44,9 @@
         if (vm.options) {
           angular.forEach(vm.options, parseOptions);
         }
-
-        vm.dialog.dialog_tabs.forEach(iterateBGroups);
+        if (angular.isDefined(vm.dialog)) {
+          vm.dialog.dialog_tabs.forEach(iterateBGroups);
+        }
       }
 
       // Private functions

--- a/spa_ui/self_service/client/app/states/services/details/details.html
+++ b/spa_ui/self_service/client/app/states/services/details/details.html
@@ -13,7 +13,7 @@
       <section>
         <div class="col-md-12 ss-details-header">
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-lg-5 col-md-6 col-sm-6 col-xs-6">
               <div class="ss-details-header__title-img">
                 <span class="ss-details-header__title-img__center"></span>
                 <img class="ss-details-header__title-img__logo" ng-src="{{ ::vm.service.picture.image_href }}"
@@ -26,7 +26,8 @@
                 <h4>{{ ::vm.service.long_description || vm.service.description }}</h4>
               </div>
             </div>
-            <div class="col-md-6 ss-details-header__actions">
+            <div class="col-lg-7 col-md-6 col-sm-6 col-xs-6 ss-details-header__actions">
+              <div class="ss-details-header__actions__inner">
               <custom-button custom-actions="vm.service.custom_actions" actions="vm.service.actions"></custom-button>
               <button class="btn btn-default" type="button"
                     confirmation
@@ -56,6 +57,7 @@
                 </ul>
               </div>
               <button class="btn btn-primary" type="button" ng-click="vm.editServiceModal()">Edit Service</button>
+            </div>
             </div>
           </div>
         </div>

--- a/spa_ui/self_service/client/assets/sass/_app_colors.sass
+++ b/spa_ui/self_service/client/assets/sass/_app_colors.sass
@@ -7,9 +7,11 @@ $app-color-light-gray-2: $color-cararra-approx
 $app-color-light-gray-5: $color-light-gray-approx
 $app-color-light-gray-6: $color-gray-nurse-approx
 $app-color-medium-gray: $color-mountain-mist-approx
+$app-color-medium-gray-2: $color-abbey-approx
 $app-color-gray: $color-bombay-approx
 $app-color-gray-2: $color-concrete-solid
 $app-color-dark-gray: $color-cape-cod-approx
+$app-color-dark-gray-2: $color-mine-shaft-approx
 $app-color-black: $color-black
 
 // Reds
@@ -42,6 +44,7 @@ $app-color-light-blue: $color-polar-approx
 $app-color-light-blue-2: $color-pale-cerulean-approx
 $app-color-light-blue-3: $color-pattens-blue-approx
 $app-color-light-blue-4: $color-spindle-approx
+$app-color-light-blue-5: $color-onahau-approx
 
 $app-color-deep-blue: $color-deep-ocean-approx
 $app-color-dark-blue-gray: $color-tarawera-approx

--- a/spa_ui/self_service/client/assets/sass/_colors.sass
+++ b/spa_ui/self_service/client/assets/sass/_colors.sass
@@ -28,7 +28,9 @@ $color-gray-nurse-approx: #E9E8E8     // Light Gray 6
 $color-bombay-approx: #B1B3B6         // Gray
 $color-concrete-solid: #F2F2F2        // Gray 2
 $color-mountain-mist-approx: #939598  // Medium Gray
+$color-abbey-approx: #4C4F56          // Medium Gray 2
 $color-cape-cod-approx: #414042       // Dark Gray
+$color-mine-shaft-approx #333333      // Dark Gray 2
 $color-black: #000000                 // Black
 
 // Reds
@@ -65,6 +67,7 @@ $color-deep-ocean-approx: #1C3753     // Dark Ocean Blue
 $color-tarawera-approx: #063451       // Dark Blue Gray
 $color-pattens-blue-approx: #E3F4FD   // Light Blue 3
 $color-spindle-approx: #b3d3e7        // Light Blue 4
+$color-onahau-approx: #D4EDFA         // Light Blue 5
 
 // Purples
 $color-prelude-approx: #cebee1

--- a/spa_ui/self_service/client/assets/sass/_details-view.sass
+++ b/spa_ui/self_service/client/assets/sass/_details-view.sass
@@ -42,6 +42,8 @@
 
     h2
       margin-top: 10px
+      text-overflow: ellipsis
+      overflow: hidden
 
     h4
       color: #666
@@ -55,6 +57,10 @@
 
     .btn
       margin-right: 2px
+
+  +element(actions__inner)
+    white-space: nowrap
+    display: inline
 
 .ss-form-readonly
   .form-control


### PR DESCRIPTION
If there is not enough room to render the custom buttons they collapse into an actions menu.

If a custom button was a dropdown with sub menu items they are listed flat in the actions menu with the button group name as a prefix. This needed to be done since bootstrap does not support cascading menus since they don't work well on touch devices.