### PR TITLE
move next sequence calculation into miq_group

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1130,8 +1130,6 @@ module OpsController::OpsRbac
   # Set group record variables to new values
   def rbac_group_set_record_vars(group)
     role = MiqUserRole.find_by_id(@edit[:new][:role])
-    groups = MiqGroup.all(:order => "sequence DESC")
-    group.sequence = groups.first.nil? ? 1 : groups.first.sequence + 1
     group.description = @edit[:new][:description]
     group.miq_user_role = role
     group.tenant = Tenant.find_by_id(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -30,6 +30,7 @@ class MiqGroup < ActiveRecord::Base
   serialize :settings
 
   default_value_for :group_type, USER_GROUP
+  default_value_for(:sequence) { next_sequence }
 
   acts_as_miq_taggable
   include ReportableMixin
@@ -67,17 +68,8 @@ class MiqGroup < ActiveRecord::Base
     true # Remove once this is implemented
   end
 
-  def self.add(attrs)
-    group = new(attrs)
-    if group.resource.nil?
-      groups = where(:resource_id => nil, :resource_type => nil).order("sequence DESC")
-    else
-      groups = group.resource.miq_groups.order("sequence DESC")
-    end
-    group.sequence = groups.first.nil? ? 1 : groups.first.sequence + 1
-    group.save!
-
-    group
+  def self.next_sequence
+    maximum(:sequence).to_i + 1
   end
 
   def self.seed

--- a/db/migrate/20151021174140_assign_tenant_default_group.rb
+++ b/db/migrate/20151021174140_assign_tenant_default_group.rb
@@ -33,6 +33,8 @@ class AssignTenantDefaultGroup < ActiveRecord::Migration
       create_with(
         :description      => "Tenant #{tenant.name} #{tenant.id} access",
         :group_type       => TENANT_GROUP,
+        :sequence         => 1,
+        :guid             => MiqUUID.new_guid,
         :miq_user_role_id => role.try(:id)
       ).find_or_create_by!(:tenant_id => tenant.id)
     end

--- a/db/migrate/20151030201919_fix_miq_group_sequences.rb
+++ b/db/migrate/20151030201919_fix_miq_group_sequences.rb
@@ -1,0 +1,13 @@
+class FixMiqGroupSequences < ActiveRecord::Migration
+  class MiqGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    MiqGroup.where(:sequence => nil).update_all(:sequence => 1)
+
+    MiqGroup.where(:guid => nil).each do |g|
+      g.update_attributes(:guid => MiqUUID.new_guid)
+    end
+  end
+end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     end
 
     guid { MiqUUID.new_guid }
-
+    sequence(:sequence)  # don't want to spend time looking these up
     description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
 
     after :build do |g, e|

--- a/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
+++ b/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
@@ -21,7 +21,9 @@ describe AssignTenantDefaultGroup do
 
         t.reload
         expect(t.default_miq_group_id).to be
-        expect(group_stub.find(t.default_miq_group_id).miq_user_role_id).to eq(tenant_role.id)
+        g = group_stub.find(t.default_miq_group_id)
+        expect(g.miq_user_role_id).to eq(tenant_role.id)
+        expect(g.sequence).to be
       end
 
       it "skips tenants that already have a group" do

--- a/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
+++ b/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require_migration
+
+describe FixMiqGroupSequences do
+  let(:group_stub) { migration_stub(:MiqGroup) }
+
+  migration_context :up do
+    it "assigns sequence" do
+      g1 = group_stub.create
+      g2 = group_stub.create(:sequence => 3)
+
+      migrate
+
+      expect(g1.reload.sequence).to be
+      expect(g2.reload.sequence).to eq(3)
+    end
+
+    it "assigns guid" do
+      old_guid = MiqUUID.new_guid
+      g1 = group_stub.create
+      g2 = group_stub.create(:guid => old_guid)
+
+      migrate
+
+      expect(g1.reload.guid).to be
+      expect(g2.reload.guid).to eq(old_guid)
+    end
+  end
+end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -248,18 +248,18 @@ describe MiqGroup do
     it "fails if referenced by user#current_group" do
       FactoryGirl.create(:user, :miq_groups => [group])
 
-      current_count = MiqGroup.count
-      expect { group.destroy }.to raise_error
-      MiqGroup.count.should eq current_count
+      expect {
+        expect { group.destroy }.to raise_error
+      }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by user#miq_groups" do
       group2 = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
 
-      current_count = MiqGroup.count
-      expect { group.destroy }.to raise_error
-      MiqGroup.count.should eq current_count
+      expect {
+        expect { group.destroy }.to raise_error
+      }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by a tenant#default_miq_group" do
@@ -271,7 +271,6 @@ describe MiqGroup do
     it "adds new groups after initial seed" do
       [Tenant, MiqUserRole, MiqGroup].each(&:seed)
 
-      current_count = MiqGroup.count
       role_map_path = File.expand_path(File.join(Rails.root, "db/fixtures/role_map.yaml"))
       role_map = YAML.load_file(role_map_path)
       role_map.unshift('EvmRole-test_role' => 'tenant_quota_administrator')
@@ -281,9 +280,9 @@ describe MiqGroup do
       allow(YAML).to receive(:load_file).with(role_map_path).and_return(role_map)
       allow(YAML).to receive(:load_file).with(filter_map_path).and_return(filter_map)
 
-      MiqGroup.seed
-
-      expect(MiqGroup.count).to eql(current_count + 1)
+      expect {
+        MiqGroup.seed
+      }.to change { MiqGroup.count }
       expect(MiqGroup.last.name).to eql('EvmRole-test_role')
       expect(MiqGroup.last.sequence).to eql(1)
     end


### PR DESCRIPTION
clean cherry pick of https://github.com/ManageIQ/manageiq/pull/5164

- fix error around tenant groups with a nil sequence
- set sequence by default
- set sequence for tenant default_group