### PR TITLE
Change the criteria when an event is not being raised to automate

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -29,8 +29,10 @@ class MiqEvent < EventStream
     raise "Unable to find object for target: [#{target}]" unless target
 
     event = normalize_event(raw_event.to_s)
-    # TODO: how to handle unknow MiqEvent - event not defined in MiqEventDefinition?
-    return if event == 'unknown'
+    if event == 'unknown' && target.class.base_class.in?(SUPPORTED_POLICY_AND_ALERT_CLASSES)
+      _log.warn("Event #{raw_event} for class [#{target.class.name}] id [#{target.id}] was not raised: #{raw_event} is not defined in MiqEventDefinition")
+      return
+    end
 
     event_obj = build_evm_event(event, target)
     inputs.merge!('MiqEvent::miq_event' => event_obj.id, :miq_event_id => event_obj.id)

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -67,6 +67,17 @@ describe MiqEvent do
         MiqAeEvent.should_receive(:raise_evm_event)
         MiqEvent.raise_evm_event([:MiqServer, @miq_server.id], event)
       end
+
+      it "will raise undefined event for classes that do not support policy" do
+        service = FactoryGirl.create(:service)
+        expect(MiqAeEvent).to receive(:raise_evm_event)
+        MiqEvent.raise_evm_event(service, "request_service_retire")
+      end
+
+      it "will not raise undefined event for classes that support policy" do
+        expect(MiqAeEvent).not_to receive(:raise_evm_event)
+        MiqEvent.raise_evm_event(@miq_server, "evm_server_start")
+      end
     end
 
     context "#process_evm_event" do


### PR DESCRIPTION
Don't raise the event that is not defined in MiqEventDefinition and the event target is of one of the classes that support policy and alert.
So all events for classes that don't support policy and alert can be raised up to automate without an entry in MiqEventDefinition.
This is the behavior before event switchboard.

Follow-up on #4328