### PR TITLE
Toolbar fixes

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -28,8 +28,6 @@ class ApplicationHelper::ToolbarBuilder
   ###
 
   def build_toolbar(tb_name)
-    text = nil                                                      # Local vars for text and title
-    title = nil
     tb_hash = tb_name == "custom_buttons_tb" ? build_custom_buttons_toolbar(@record) : YAML.load(File.open("#{TOOLBARS_FOLDER}/#{tb_name}.yaml"))
 
     toolbar = []

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -47,6 +47,7 @@ class ApplicationHelper::ToolbarBuilder
         # keeping track of groups that were not skipped to add separator, else it adds a separator before a button even tho no other groups were shown, i.e. vm sub screens, drift_history
         groups_added.push(bg_idx)
       end
+
       bg[:items].each do |bgi|                                      # Go thru all of the button group items
         if bgi.key?(:buttonSelect)                              # buttonSelect node found
           bs_children = false
@@ -93,6 +94,7 @@ class ApplicationHelper::ToolbarBuilder
 
           toolbar << props
           current_item = props
+          any_visible = false
           bgi[:items].each_with_index do |bsi, bsi_idx|             # Go thru all of the buttonSelect items
             if bsi.key?(:separator)                             # If separator found, add it
               props = {"id" => "sep_#{bg_idx}_#{bsi_idx}", "type" => "separator"}
@@ -122,7 +124,11 @@ class ApplicationHelper::ToolbarBuilder
             current_item[:items] ||= []
             current_item[:items] << props
             build_toolbar_save_button(bsi, props, bgi[:buttonSelect]) if bsi[:button] # Save if a button (not sep)
+
+            any_visible ||= !props[:hidden]
           end
+          current_item[:hidden] = !any_visible
+
           build_toolbar_save_button(bgi, current_item) if bs_children || bgi[:buttonSelect] == "history_choice"
           if bs_children
             sep_added = true                                        # Separator has officially been added

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -50,7 +50,6 @@ module ToolbarHelper
     when 'buttonTwoState'
       toolbar_top_button_normal(props)
     when 'separator'
-      toolbar_button_separator(props)
     else
       raise 'Invalid top button type.'
     end


### PR DESCRIPTION
  * Top button with no chindren now hidden.
  * Removed the temporary separator between top toolbar buttons as the proper markup was not yet implemented (as discussed in https://github.com/ManageIQ/manageiq/pull/4853)

Before:
![auto-d-before](https://cloud.githubusercontent.com/assets/51095/10825193/2daf627e-7e64-11e5-9bef-50fbb562491c.png)

After:
![auto-d-after](https://cloud.githubusercontent.com/assets/51095/10825359/fc125a04-7e64-11e5-9fdc-7c44fa2c8c15.png)

@epwinchell : please, check.

I will now work on splitting the toolbars where the separators should be and when that is done make the view button toolbar changes on top of that.
