### PR TITLE
BZ_1266561 - Handle duplicate hostnames

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -139,7 +139,7 @@ module EmsRefresh::SaveInventoryInfra
           elsif ["localhost", "localhost.localdomain", "127.0.0.1"].include_none?(h[:hostname], h[:ipaddress])
             # host = Host.find_by_hostname(hostname) has a risk of creating duplicate hosts
             _log.debug "#{log_header} Host database lookup - hostname: [#{h[:hostname]}] IP: [#{h[:ipaddress]}]"
-            found = Host.lookUpHost(h[:hostname], h[:ipaddress])
+            found = Host.lookUpHost(h[:hostname], h[:ipaddress], :ems_ref => h[:ems_ref], :ems_id => ems.id)
           end
         end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -661,11 +661,20 @@ class Host < ActiveRecord::Base
     self.power_state = new_state
   end
 
-  def self.lookUpHost(hostname, ipaddr)
+  def self.lookUpHost(hostname, ipaddr, opts = {})
     h   = Host.where("lower(hostname) = ?", hostname.downcase).find_by(:ipaddress => ipaddr) if hostname && ipaddr
     h ||= Host.find_by("lower(hostname) = ?", hostname.downcase)                             if hostname
     h ||= Host.find_by(:ipaddress => ipaddr)                                                 if ipaddr
     h ||= Host.find_by("lower(hostname) LIKE ?", "#{hostname.downcase}.%")                   if hostname
+
+    # If we're given an ems_ref or ems_id then ensure that the host
+    # we looked-up does not have a different ems_ref and is not
+    # owned by another provider, this would cause us to overwrite
+    # a different host record
+    if (opts[:ems_ref] && h.ems_ref != opts[:ems_ref]) || (opts[:ems_id] && h.ems_id != opts[:ems_id])
+      h = nil
+    end unless h.nil?
+
     h
   end
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -362,6 +362,34 @@ describe Host do
         Host.lookUpHost(@bad_partial_hostname_multi, nil).should be_nil
       end
     end
+    context "when hosts have duplicate hostnames" do
+      before do
+        @fqdn_hostname            = "test1.fake.com"
+        @ipaddress_1              = "1.1.1.1"
+        @ipaddress_2              = "2.2.2.2"
+        @ems_id_1                 = 1
+        @ems_id_2                 = 2
+        @ems_ref_1                = "host-1"
+        @ems_ref_2                = "host-2"
+        @host = FactoryGirl.create(:host_vmware, :hostname => @fqdn_hostname, :ipaddress => @ipaddress_1,
+                                   :ems_ref => @ems_ref_1, :ems_id => @ems_id_1)
+      end
+      it "with only fqdn and ipaddress" do
+        Host.lookUpHost(@fqdn_hostname, @ipaddress_1).should == @host
+      end
+      it "with fqdn, ipaddress, and ems_ref finds right host" do
+        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1).should == @host
+      end
+      it "with fqdn, ipaddress, and different ems_ref returns nil" do
+        Host.lookUpHost(@fqdn_hostname, @ipaddress_2, :ems_ref => @ems_ref_2).should be_nil
+      end
+      it "with ems_ref and ems_id" do
+        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_1).should == @host
+      end
+      it "with ems_ref and other ems_id" do
+        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_2).should be_nil
+      end
+    end
   end
 
   it ".host_discovery_types" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1266561

If two or more hosts have the same hostname then save_inventory_infra finds the first host record correctly, then each subsequent host with a duplicate hostname overwrites the previous record instead of updating its own record.  To fix this add in a check of a unique value (ems_id+ems_ref) to make sure Host.lookUpHost() doesn't return a different host record.