### PR TITLE
More toolbar fixes and todos

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1216,8 +1216,8 @@ function miqAccordSelect(e) {
 
 // This function is called in miqOnLoad
 function miqInitToolbars() {
-  $("#toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").off('click');
-  $("#toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").click(miqToolbarOnClick);
+  $("#toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a, #toolbar .toolbar-pf-view-selector > ul.list-inline > li > a").off('click');
+  $("#toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a, #toolbar .toolbar-pf-view-selector > ul.list-inline > li > a").click(miqToolbarOnClick);
 }
 
 // Function to run transactions when toolbar button is clicked

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -39,6 +39,12 @@
     height: 100%;
     overflow: auto;
   }
+
+  /* compensates for left-padding of first rendered form-group */
+  .toolbar-pf > .col-md-12 {
+    padding-left: 0 !important;
+  }
+
   #paging_div {
     position: absolute;
     bottom: 0;
@@ -292,15 +298,13 @@ iframe, .iframe {
 }
 
 /* toolbar styling */
-div#view_tb {
-  float: right;
-}
 
 .toolbar-pf-actions .btn-group.dropdown > button > img {
   padding-right: 3px;
 }
 
 /* Adds padding between buttons when they wrap */
+
 .toolbar-pf#toolbar .toolbar-pf-actions .form-group {
   margin-bottom: 10px !important
 }

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -48,13 +48,16 @@ class ApplicationHelper::ToolbarBuilder
         groups_added.push(bg_idx)
       end
 
-      bg[:items].each do |bgi|                                      # Go thru all of the button group items
-        if bgi.key?(:buttonSelect)                              # buttonSelect node found
+      bg[:items].each do |bgi|
+        if bgi.key?(:buttonSelect)
           bs_children = false
-          props = {"id"     => bgi[:buttonSelect],
-                   "type"   => "buttonSelect",
-                   "img"    => "#{bgi[:image] ? bgi[:image] : bgi[:buttonSelect]}.png",
-                   "imgdis" => "#{bgi[:image] ? bgi[:image] : bgi[:buttonSelect]}.png"}
+          props = {
+            "id"     => bgi[:buttonSelect],
+            "type"   => "buttonSelect",
+            "img"    => img = "#{bgi[:image] ? bgi[:image] : bgi[:buttonSelect]}.png",
+            "imgdis" => img,
+            :icon    => bgi[:icon]
+          }
           props["title"] = bgi[:title] unless bgi[:title].blank?
           props["text"] = CGI.escapeHTML("#{bgi[:text]}") unless bgi[:text].blank?
           if bgi[:buttonSelect] == "history_choice" && x_tree_history.length < 2
@@ -102,10 +105,13 @@ class ApplicationHelper::ToolbarBuilder
               next if bsi[:image] == 'pdf' && !PdfGenerator.available?
               next if build_toolbar_hide_button(bsi[:pressed] || bsi[:button])  # Use pressed, else button name
               bs_children = true
-              props = {"id"     => bgi[:buttonSelect] + "__" + bsi[:button],
-                       "type"   => "button",
-                       "img"    => "#{bsi[:image] ? bsi[:image] : bsi[:button]}.png",
-                       "imgdis" => "#{bsi[:image] ? bsi[:image] : bsi[:button]}.png"}
+              props = {
+                "id"     => bgi[:buttonSelect] + "__" + bsi[:button],
+                "type"   => "button",
+                "img"    => img = "#{bsi[:image] ? bsi[:image] : bsi[:button]}.png",
+                "imgdis" => img,
+                :icon    => bsi[:icon]
+              }
               if bsi[:button].starts_with?("history_")
                 if x_tree_history.length > 1
                   props["text"] = CGI.escapeHTML(x_tree_history[bsi[:button].split("_").last.to_i][:text])
@@ -144,10 +150,13 @@ class ApplicationHelper::ToolbarBuilder
                            timeline_txt timeline_csv timeline_pdf).include?(bgi[:button])
           end
           sep_needed = true unless button_hide
-          props = {"id"     => bgi[:button],
-                   "type"   => "button",
-                   "img"    => "#{get_image(bgi[:image], bgi[:button]) ? get_image(bgi[:image], bgi[:button]) : bgi[:button]}.png",
-                   "imgdis" => "#{bgi[:image] ? bgi[:image] : bgi[:button]}.png"}
+          props = {
+            "id"     => bgi[:button],
+            "type"   => "button",
+            "img"    => "#{get_image(bgi[:image], bgi[:button]) ? get_image(bgi[:image], bgi[:button]) : bgi[:button]}.png",
+            "imgdis" => "#{bgi[:image] ? bgi[:image] : bgi[:button]}.png",
+            :icon    => bgi[:icon]
+          }
           props["enabled"] = "#{bgi[:enabled]}" unless bgi[:enabled].blank?
           props["enabled"] = "false" if dis_title = build_toolbar_disable_button(bgi[:button]) || button_hide
           props["text"] = CGI.escapeHTML("#{bgi[:text]}") unless bgi[:text].blank?
@@ -178,8 +187,9 @@ class ApplicationHelper::ToolbarBuilder
           props = {
             "id"     => bgi[:buttonTwoState],
             "type"   => "buttonTwoState",
-            "img"    => "#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png",
-            "imgdis" => "#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png"
+            "img"    => img = "#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png",
+            "imgdis" => img,
+            :icon    => bgi[:icon]
           }
           props["title"]    = eval("\"#{bgi[:title]}\"") unless bgi[:title].blank?
           props["enabled"]  = "#{bgi[:enabled]}" unless bgi[:enabled].blank?

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -6,9 +6,11 @@ module ToolbarHelper
   # Called directly when updating toolbars in an existing page.
   #
   def buttons_to_html(buttons)
-    Array(buttons).collect do |button|
-      toolbar_top_button(button)
-    end.join('').html_safe
+    content_tag(:div, :class => 'form-group') do # form-group aroung each toolbar section
+      Array(buttons).collect do |button|
+        toolbar_top_button(button)
+      end.join('').html_safe
+    end
   end
 
   # Request that a toolbar is rendered.
@@ -30,7 +32,7 @@ module ToolbarHelper
   #
   def render_toolbars
     @toolbars.collect do |div_id, toolbar_name|
-      content_tag(:div, :id => div_id, :class => 'form-group') do # form-group aroung each toolbar
+      content_tag(:div, :id => div_id) do # div for each toolbar
         buttons = toolbar_name ? build_toolbar(toolbar_name) : nil
         buttons_to_html(buttons)
       end

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -5,12 +5,22 @@ module ToolbarHelper
   #
   # Called directly when updating toolbars in an existing page.
   #
-  def buttons_to_html(buttons)
-    content_tag(:div, :class => 'form-group') do # form-group aroung each toolbar section
-      Array(buttons).collect do |button|
-        toolbar_top_button(button)
-      end.join('').html_safe
-    end
+  def buttons_to_html(buttons_in)
+    groups = split_to_groups(Array(buttons_in))
+
+    groups.collect do |buttons|
+      content_tag(:div, :class => 'form-group') do # form-group aroung each toolbar section
+        Array(buttons).collect do |button|
+          toolbar_top_button(button)
+        end.join('').html_safe
+      end
+    end.join('').html_safe
+  end
+
+  # Split buttons to group at separators
+  #
+  def split_to_groups(buttons)
+    buttons.slice_before { |props| props['type'] == 'separator' }.to_a
   end
 
   # Request that a toolbar is rendered.

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -58,7 +58,7 @@ module ToolbarHelper
   def view_mode_buttons(buttons)
     content_tag(:ul, :class => 'list-inline') do
       buttons.collect do |button|
-        toolbar_button_normal(button)
+        toolbar_button_normal(button, true)
       end.join('').html_safe
     end
   end
@@ -165,9 +165,13 @@ module ToolbarHelper
 
   # Render normal push child button
   #
-  def toolbar_button_normal(props)
+  def toolbar_button_normal(props, view_button = false)
     hidden = props[:hidden]
-    cls = props['enabled'].to_s == 'false' ? 'disabled ' : ''
+    cls = if view_button
+            props['enabled'].to_s == 'false' ? 'active ' : ''
+          else
+            props['enabled'].to_s == 'false' ? 'disabled ' : ''
+          end
     content_tag(:li, :class => cls + (hidden ? 'hidden' : '')) do
       content_tag(:a, prepare_tag_keys(props).update(:href => '#')) do
         if props[:icon].present?

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -13,8 +13,9 @@
     .row#center_div{:style => "height: 100%"}
       #right_div.resizable{:style => "height: 100%", :class => "col-md-#{maindiv} col-md-push-#{sidewidth}"}
         .row.toolbar-pf#toolbar
-          .toolbar-pf-actions
-            = render :partial => "layouts/x_taskbar"
+          .col-md-12
+            .toolbar-pf-actions
+              = render :partial => "layouts/x_taskbar"
         .row{:style => "overflow: auto;height: calc(100% - 88px);"}
           .col-md-12
             .row
@@ -74,8 +75,9 @@
         .col-md-10.col-md-push-2.max-height
           - if taskbar_in_header?
             .row.toolbar-pf#toolbar
-              .toolbar-pf-actions
-                = render :partial => "layouts/taskbar"
+              .col-md-12
+                .toolbar-pf-actions
+                  = render :partial => "layouts/taskbar"
           .row{:style => "overflow: auto;height: calc(100% - 88px);"}
             .col-md-12
               .row

--- a/product/toolbars/gtl_view_tb.yaml
+++ b/product/toolbars/gtl_view_tb.yaml
@@ -9,14 +9,17 @@
     :title: "Grid View"
     :url: '#{@gtl_url}'
     :url_parms: '?type=grid'
+    :icon: 'fa fa-th'
   - :buttonTwoState: view_tile
     :title: "Tile View"
     :url: '#{@gtl_url}'
     :url_parms: '?type=tile'
+    :icon: 'fa fa-th-large'
   - :buttonTwoState: view_list
     :title: "List View"
     :url: '#{@gtl_url}'
     :url_parms: '?type=list'
+    :icon: 'fa fa-th-list'
 - :name: download_main
   :items:
   - :buttonSelect: download_choice

--- a/product/toolbars/x_gtl_view_tb.yaml
+++ b/product/toolbars/x_gtl_view_tb.yaml
@@ -9,14 +9,17 @@
     :title: "Grid View"
     :url: 'explorer'
     :url_parms: '?type=grid'
+    :icon: 'fa fa-th'
   - :buttonTwoState: view_tile
     :title: "Tile View"
     :url: 'explorer'
     :url_parms: '?type=tile'
+    :icon: 'fa fa-th-large'
   - :buttonTwoState: view_list
     :title: "List View"
     :url: 'explorer'
     :url_parms: '?type=list'
+    :icon: 'fa fa-th-list'
 - :name: download_main
   :items:
   - :buttonSelect: download_choice


### PR DESCRIPTION
  * toolbar separator view form-groups
  * special markup for view buttons
  * support icons instead of images

Missing tooltips: The tooltips are broken by bootstrap pop-over. @skateman is looking into it in a separate PR.

So please, review, merge. @h-kataria, please ;-)
