### PR TITLE
Fix installed_rpms method

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -141,7 +141,7 @@ module Vmdb
     def self.installed_rpms
       File.open(log_dir.join("package_list_rpm.txt"), "a") do |file|
         file.puts "start: date time is: #{Time.now.utc}"
-        LinuxAdmin.Rpm.list_installed.sort.each do |name, version|
+        LinuxAdmin::Rpm.list_installed.sort.each do |name, version|
           file.puts "#{name} #{version}"
         end
       end

--- a/spec/lib/vmdb/appliance_spec.rb
+++ b/spec/lib/vmdb/appliance_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'stringio'
+
+describe Vmdb::Appliance do
+  describe ".installed_rpms (private)" do
+    it "writes the correct string" do
+      file = StringIO.new
+      rpms = {
+        "one"   => "v1",
+        "two"   => "v2",
+        "three" => "v3",
+        "aaaa"  => "va"
+      }
+      out = "aaaa va\none v1\nthree v3\ntwo v2"
+      path = Pathname.new("/var/www/miq/vmdb/log/package_list_rpm.txt")
+
+      expect(File).to receive(:open).with(path, "a").and_yield(file)
+      expect(LinuxAdmin::Rpm).to receive(:list_installed).and_return(rpms)
+      described_class.send(:installed_rpms)
+      file.rewind
+      expect(file.read).to include(out)
+    end
+  end
+end


### PR DESCRIPTION
LinuxAdmin::Rpm is a class, not a method.

https://bugzilla.redhat.com/show_bug.cgi?id=1275666