### PR TITLE
MiqNfsSession should use mount point when provided.

### DIFF
--- a/gems/pending/MiqVm/MiqRhevmVm.rb
+++ b/gems/pending/MiqVm/MiqRhevmVm.rb
@@ -102,7 +102,7 @@ class MiqRhevmVm < MiqVm
     return if nfs_mounts[storage_id]
 
     mount_point = ::File.join(nfs_mount_root, nfs_mount_dir(storage_obj))
-    nfs_mounts[storage_id] = {:uri => "nfs://#{nfs_uri(storage_obj)}", :mount_point => mount_point}
+    nfs_mounts[storage_id] = {:uri => "nfs://#{nfs_uri(storage_obj)}", :mount_point => mount_point, :read_only => true}
   end
 
   def nfs_uri(storage_obj)

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -64,7 +64,7 @@ class MiqGenericMountSession
 
   def mount_share
     require 'tmpdir'
-    @mnt_point = Dir.mktmpdir("miq_", settings_mount_point)
+    @mnt_point = settings_mount_point || Dir.mktmpdir("miq_")
   end
 
   def get_ping_depot_options
@@ -455,8 +455,12 @@ class MiqGenericMountSession
 
   private
 
+  def settings_read_only?
+    @settings[:read_only] == true
+  end
+
   def settings_mount_point
-    return if @settings[:mount_point].blank? # Check if settings contains the mount_point to use
+    return nil if @settings[:mount_point].blank? # Check if settings contains the mount_point to use
     FileUtils.mkdir_p(@settings[:mount_point]).first
   end
 end

--- a/gems/pending/util/mount/miq_nfs_session.rb
+++ b/gems/pending/util/mount/miq_nfs_session.rb
@@ -20,12 +20,15 @@ class MiqNfsSession < MiqGenericMountSession
     # URI: nfs://192.168.252.139/exported/miq
     # mount 192.168.252.139:/exported/miq /mnt/miq
 
+    mount = "mount"
+    mount << " -r" if settings_read_only?
+
     # Quote the host:exported directory since the directory can have spaces in it
     case Sys::Platform::IMPL
     when :macosx
-      runcmd("sudo mount -t nfs -o resvport '#{@host}:#{@mount_path}' #{@mnt_point}")
+      runcmd("sudo #{mount} -t nfs -o resvport '#{@host}:#{@mount_path}' #{@mnt_point}")
     when :linux
-      runcmd("mount '#{@host}:#{@mount_path}' #{@mnt_point}")
+      runcmd("#{mount} '#{@host}:#{@mount_path}' #{@mnt_point}")
     else
       raise "platform not supported"
     end

--- a/gems/pending/util/mount/miq_smb_session.rb
+++ b/gems/pending/util/mount/miq_smb_session.rb
@@ -40,11 +40,14 @@ class MiqSmbSession < MiqGenericMountSession
       raise "Expected 'domain/username' or 'domain\\username' format, received: '#{@settings[:username]}'"
     end
 
+    mount = "mount"
+    mount << " -r" if settings_read_only?
+
     logger.info("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}], domain: [#{domain}], user: [#{user}], using mount point: [#{@mnt_point}]...")
     # mount -t cifs //192.168.252.140/temp /media/windows_share/ -o rw,username=jrafaniello,password=blah,domain=manageiq.com
 
     # Quote the hostname and share and username since they have spaces in it
-    runcmd("mount -t cifs '//#{File.join(@host, @mount_path)}' #{@mnt_point} -o rw,username='#{user}',password='#{@settings[:password]}',domain='#{domain}'")
+    runcmd("#{mount} -t cifs '//#{File.join(@host, @mount_path)}' #{@mnt_point} -o rw,username='#{user}',password='#{@settings[:password]}',domain='#{domain}'")
     logger.info("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}]...Complete")
   end
 end


### PR DESCRIPTION
When given a mount point, MiqNfsSession creates a temporary directory under it
and uses the temp dir as the mount point instead.
MiqNfsSession should only create a temporary directory when no explicit mount point is given.

https://bugzilla.redhat.com/show_bug.cgi?id=1276459