### PR TITLE
Lookup for FloatingIp model in the top level

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota < ::Cloud
 
   # neutron
   def floatingip_quota_used
-    FloatingIp.where(:cloud_tenant_id => cloud_tenant_id).count
+    ::FloatingIp.where(:cloud_tenant_id => cloud_tenant_id).count
   end
 
   # nova


### PR DESCRIPTION
This is to fix a model lookup problem, which only shows
in production mode, when accessing tenant details page:

```
FATAL -- : Error caught: [NameError] uninitialized constant
ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota::FloatingIp
app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb:38:in
`floatingip_quota_used'
app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb:33:in
`floating_ips_quota_used'
app/models/cloud_resource_quota.rb:11:in `used'
app/helpers/cloud_tenant_helper/textual_summary.rb:54:in
`textual_quotas'
app/helpers/cloud_tenant_helper/textual_summary.rb:15:in `block in
textual_group_quotas'
activerecord-4.2.4/lib/active_record/relation/delegation.rb:46:in
`collect'
activerecord-4.2.4/lib/active_record/relation/delegation.rb:46:in
`collect'
app/helpers/cloud_tenant_helper/textual_summary.rb:15:in
`textual_group_quotas'
app/views/cloud_tenant/_main.html.haml:5
```

https://bugzilla.redhat.com/show_bug.cgi?id=1275380