### PR TITLE
Simple corrections of numvcpus => cpu_total_cores

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_resource_quota.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota < ::Cloud
     Hardware.joins(:vm)
       .where(:vms => {:cloud_tenant_id => cloud_tenant_id})
       .where("vms.#{VMS_POWER_FILTER}")
-      .sum(:numvcpus)
+      .sum(:cpu_total_cores)
   end
 
   def instances_quota_used

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -412,7 +412,7 @@ class MiqAlert < ActiveRecord::Base
         ]},
       {:name => "reconfigured_hardware_value", :description => "Hardware Reconfigured", :db => ["Vm"], :responds_to_events => "vm_reconfigure",
         :options => [
-          {:name => :hdw_attr, :description => "Hardware Attribute", :values => {:memory_mb => Dictionary.gettext("memory_mb", :type => "column"), :numvcpus => Dictionary.gettext("numvcpus", :type => "column")}},
+          {:name => :hdw_attr, :description => "Hardware Attribute", :values => {:memory_mb => Dictionary.gettext("memory_mb", :type => "column"), :cpu_total_cores => Dictionary.gettext("cpu_total_cores", :type => "column")}},
           {:name => :operator, :description => "Operator", :values => ["Increased", "Decreased"]}
         ]},
       {:name => "changed_vm_value", :description => "VM Value changed", :db => ["Vm"], :responds_to_events => "vm_reconfigure",

--- a/db/fixtures/miq_alerts.yml
+++ b/db/fixtures/miq_alerts.yml
@@ -77,7 +77,7 @@
     :mode: internal
     :options: 
       :operator: Decreased
-      :hdw_attr: :numvcpus
+      :hdw_attr: :cpu_total_cores
     :eval_method: reconfigured_hardware_value
   description: VM CPU count was decreased
   db: Vm
@@ -125,7 +125,7 @@
     :mode: internal
     :options: 
       :operator: Increased
-      :hdw_attr: :numvcpus
+      :hdw_attr: :cpu_total_cores
     :eval_method: reconfigured_hardware_value
   description: VM CPU count was increased
   db: Vm
@@ -202,8 +202,8 @@
       - CONTAINS: 
           tag: Vm.managed-service_level
           value: silver
-      - ">": 
-          field: Vm.hardware-numvcpus
+      - ">":
+          field: Vm.hardware-cpu_total_cores
           value: 1
   :db: Vm
   :guid: fdee2784-bf2c-11de-b3b4-000c290de4f9

--- a/product/compare/hosts.yaml
+++ b/product/compare/hosts.yaml
@@ -27,7 +27,7 @@ include:
   hardware:
     group: Properties
     columns:
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
     - memory_console
     - bios
@@ -164,7 +164,7 @@ col_order:
 - ssh_permit_root_login
 - last_compliance_status
 - last_compliance_timestamp
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 - hardware.memory_console
 - hardware.bios

--- a/product/compare/vms.yaml
+++ b/product/compare/vms.yaml
@@ -43,7 +43,7 @@ include:
     columns:
     - guest_os_full_name
     - guest_os
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
     - bios
     - config_version
@@ -224,7 +224,7 @@ col_order:
 - last_compliance_timestamp
 - hardware.guest_os_full_name
 - hardware.guest_os
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 - hardware.bios
 - hardware.config_version

--- a/product/reports/110_Configuration Management - Hosts/011_Host Summary with VM info.yaml
+++ b/product/reports/110_Configuration Management - Hosts/011_Host Summary with VM info.yaml
@@ -15,7 +15,7 @@ col_order:
 - host.name
 - name
 - power_state
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 timeline:
 id: 110
@@ -28,7 +28,7 @@ db_options: {}
 include: 
   hardware: 
     columns: 
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
   host:
     columns:

--- a/product/reports/425_VM Sprawl - Candidates/055_VMs Powered Off registered to a Host.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/055_VMs Powered Off registered to a Host.yaml
@@ -34,7 +34,7 @@ col_order:
 - vendor
 - platform
 - operating_system.product_name
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 - power_state
 timeline: 
@@ -50,7 +50,7 @@ include:
   hardware: 
     columns: 
     - annotation
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
   operating_system:
     columns:

--- a/product/reports/425_VM Sprawl - Candidates/056_VMs pending Retirement.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/056_VMs pending Retirement.yaml
@@ -27,7 +27,7 @@ col_order:
 - storage.name
 - retired
 - retires_on
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 - hardware.size_on_disk
 - managed.department
@@ -48,7 +48,7 @@ include:
   hardware: 
     columns: 
     - annotation
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
     - size_on_disk
   managed: 

--- a/product/reports/425_VM Sprawl - Candidates/057_VMs that are Retired.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/057_VMs that are Retired.yaml
@@ -24,7 +24,7 @@ col_order:
 - storage.name
 - retired
 - retires_on
-- hardware.numvcpus
+- hardware.cpu_total_cores
 - hardware.memory_mb
 - hardware.size_on_disk
 - managed.department
@@ -45,7 +45,7 @@ include:
   hardware: 
     columns: 
     - annotation
-    - numvcpus
+    - cpu_total_cores
     - memory_mb
     - size_on_disk
   managed: 

--- a/product/reports/425_VM Sprawl - Candidates/058_VMs with invalid allocation of RAM.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/058_VMs with invalid allocation of RAM.yaml
@@ -32,7 +32,7 @@ col_order:
 - operating_system.product_name
 - operating_system.bitness
 - hardware.annotation
-- hardware.numvcpus
+- hardware.cpu_total_cores
 timeline: 
 id: 187
 file_mtime: 
@@ -48,7 +48,7 @@ include:
     - memory_mb
     - guest_os_full_name
     - annotation
-    - numvcpus
+    - cpu_total_cores
   operating_system: 
     columns: 
     - product_name


### PR DESCRIPTION
Renaming the cpu columns exposes many places that the incorrect column was used.  This corrects simple cases, I will create a follow-up PR correcting the more complicated uses.