### PR TITLE
Load template from VMDB if it cannot be retrieved from the provider

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -317,13 +317,18 @@ module ManageIQ::Providers
 
       def stack_template(deployment)
         uri = deployment.properties.try(:template_link).try(:uri)
-        return unless uri
 
-        content = download_template(uri)
+        content = uri.nil? ? template_from_vmdb(deployment) : download_template(uri)
         return unless content
 
         get_stack_template(deployment, content)
         @data_index.fetch_path(:orchestration_templates, deployment.id)
+      end
+
+      def template_from_vmdb(deployment)
+        find_by = {:name => deployment.name, :ems_ref => deployment.id, :ext_management_system => @ems}
+        stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.find_by(find_by)
+        stack.try(:orchestration_template).try(:content)
       end
 
       def download_template(uri)
@@ -379,7 +384,7 @@ module ManageIQ::Providers
       def parse_stack_template(deployment, content)
         # Only need a temporary unique identifier for the template. Using the stack id is the cheapest way.
         uid = deployment.id
-        ver = deployment.properties.template_link.content_version
+        ver = deployment.properties.try(:template_link).try(:content_version)
 
         new_result = {
           :type        => "OrchestrationTemplateAzure",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1276469

The Azure template of a stack cannot be retrieved if there is no URL for the stack. If the stack was created through manageiq orchestration service provisioning, the template is actually known. 

This work tries to load the template from VMDB if it can be found through the stack that already exists in our DB during the refresh. This sounds redundant because the stack and the template was already connected before the refresh. However the refresh process clears the association if no template can be retrieved from the provider prior to this fix.