### PR TITLE
Google Cloud Provider can be authenticated using service accounts.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem "aws-sdk",                        "~>1.56.0",  :require => false
 gem "dalli",                          "~>2.7.4",   :require => false
 gem "elif",                           "=0.1.0",    :require => false
 gem "google-api-client",              ">=0.8.0",   :require => false
+gem "fog-google",                     ">=0.1.1",   :require => false
 gem "hamlit",                         "~>1.7.2",   :require => false
 gem "inifile",                        "~>3.0",     :require => false
 gem "logging",                        "~>1.6.1",   :require => false  # Ziya depends on this

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -7,6 +7,7 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
       provider_id: '',
       zone: '',
       hostname: '',
+      project: '',
       api_port: '',
       api_version: '',
       provider_region: '',
@@ -22,6 +23,7 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
       ssh_keypair_userid: '',
       ssh_keypair_password: '',
       ssh_keypair_verify: '',
+      service_account: '',
       emstype_vm: false,
       ems_common: true,
       azure_tenant_id: ''
@@ -61,6 +63,7 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
         $scope.emsCommonModel.emstype                         = data.emstype;
         $scope.emsCommonModel.zone                            = data.zone;
         $scope.emsCommonModel.hostname                        = data.hostname;
+        $scope.emsCommonModel.project                         = data.project;
 
         $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
         $scope.emsCommonModel.provider_id                     = data.provider_id.toString();
@@ -71,6 +74,8 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
 
         $scope.emsCommonModel.default_userid                  = data.default_userid;
         $scope.emsCommonModel.amqp_userid                     = data.amqp_userid;
+
+        $scope.emsCommonModel.service_account                 = data.service_account;
 
         $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
 
@@ -106,10 +111,7 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
   }
 
   $scope.canValidateBasicInfo = function () {
-    if ($scope.isBasicInfoValid())
-      return true;
-    else
-      return false;
+    return $scope.isBasicInfoValid()
   }
 
   $scope.isBasicInfoValid = function() {
@@ -131,7 +133,9 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
        $scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid &&
        $scope.emsCommonModel.default_verify != '' && $scope.angularForm.default_verify.$valid)) {
       return true;
-    } else if($scope.emsCommonModel.emstype == "gce") {
+    } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
+      ($scope.currentTab == "default" || 
+      ($scope.currentTab == "service_account" && $scope.emsCommonModel.service_account != ''))) {
       return true;
     }
     else

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -214,6 +214,10 @@ class EmsCloudController < ApplicationController
     ems.provider_id     = params[:provider_id]
     ems.zone            = Zone.find_by_name(params[:zone])
 
+    if ems.kind_of?(ManageIQ::Providers::Google::CloudManager)
+      ems.project = params[:project]
+    end
+
     if ems.kind_of?(ManageIQ::Providers::Microsoft::InfraManager)
       ems.security_protocol = params[:security_protocol]
       ems.realm = params[:realm]
@@ -238,6 +242,9 @@ class EmsCloudController < ApplicationController
     if ems.supports_authentication?(:amqp) && params[:amqp_userid]
       amqp_password = params[:amqp_password] ? params[:amqp_password] : ems.authentication_password(:amqp)
       creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password}
+    end
+    if ems.supports_authentication?(:service_account) && params[:service_account]
+      creds[:service_account] = {:service_account => params[:service_account], :userid => "_"}
     end
     if ems.supports_authentication?(:oauth) && !session[:oauth_response].blank?
       auth = session[:oauth_response]

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -895,6 +895,9 @@ module EmsCommon
     if ems.supports_authentication?(:bearer) && !@edit[:new][:bearer_token].blank?
       creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => "_"} # Must have userid
     end
+    if ems.supports_authentication?(:service_account) && !@edit[:new][:service_account].blank?
+      creds[:service_account] = {:service_account => @edit[:new][:service_account], :userid => "_"}
+    end
     ems.update_authentication(creds, :save => (mode != :validate))
   end
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -11,6 +11,7 @@ class Authentication < ActiveRecord::Base
   include PasswordMixin
   encrypt_column :auth_key
   encrypt_column :password
+  encrypt_column :service_account
 
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -58,6 +58,10 @@ module AuthenticationMixin
     authentication_component(type, :password_encrypted)
   end
 
+  def authentication_service_account(type = nil)
+    authentication_component(type, :service_account)
+  end
+
   def required_credential_fields(_type)
     [:userid]
   end
@@ -158,6 +162,8 @@ module AuthenticationMixin
       cred.userid = value[:userid]
       cred.password = value[:password]
       cred.auth_key = value[:auth_key]
+      # TODO(lwander) this should have its own cred attribute
+      cred.service_account = value[:service_account]
 
       cred.save if options[:save] && id
     end

--- a/app/views/layouts/angular/_auth_service_account_angular.html.haml
+++ b/app/views/layouts/angular/_auth_service_account_angular.html.haml
@@ -1,0 +1,23 @@
+- ng_show ||= true
+- validate_url ||= 'log_depot_edit'
+- prefix ||= 'log'
+
+%div{"ng-controller" => "credentialsController"}
+  %div{"ng-show" => ng_show}
+    .form-group
+      %label.col-md-2.control-label{"for" => "textInput-markup"}
+        = _("Service Account JSON")
+      .col-md-4
+        %textarea.form-control{"id"       => "textInput-markup",
+                               "name"     => "service_account",
+                               "ng-model" => "#{ng_model}.service_account",
+                               "prefix"   => prefix}
+    .form-group
+      %label.col-md-2
+      .col-md-4
+        = render :partial => "layouts/angular/form_buttons_verify_angular",
+                                     :locals  => {:ng_show           => ng_show,
+                                                  :validate_url      => validate_url,
+                                                  :id                => id,
+                                                  :valtype           => prefix,
+                                                  :basic_info_needed => defined?(basic_info_needed) ? basic_info_needed : nil}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -14,6 +14,8 @@
         = _("AMQP")
       = miq_tab_header('ssh_keypair') do
         = _("RSA key pair")
+      = miq_tab_header('service_account') do
+        = _("Service Account")
     - else
       = miq_tab_header('remote') do
         = _("Remote Login")
@@ -42,12 +44,12 @@
                                               :prefix                 => "default",
                                               :verify_title_off       => _("Access Key ID and matching Secret Access Key fields are needed to perform verification of credentials"),
                                               :basic_info_needed      => true}
-        .col-md-12{"ng-if" => "#{ng_model}" != "emsCommonModel" || "#{ng_model}.emstype == 'gce'"}
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
           = render :partial => "layouts/angular/oauth_button_angular", 
                    :locals  => {:ng_show           => true,
                                 :title             => "Google OAuth 2.0",
                                 :auth_url          => "google_oauth2"}
-        .col-md-12{"ng-if" => "#{ng_model}" != "emsCommonModel" || "#{ng_model}.emstype != 'ec2'"}
+        .col-md-12{"ng-if" => "#{ng_model}.emstype != 'gce' && #{ng_model}.emstype != 'ec2'" || "#{ng_model}" != "emsCommonModel"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show           => true,
                                               :ng_model          => "#{ng_model}",
@@ -117,6 +119,20 @@
           .col-md-12
             %span{:style => "color:black"}
               = _("Used for SSH connection to all %s in this provider.") % title_for_hosts
+      = miq_tab_content('service_account', 'default') do
+        .form-group
+          .col-md-12
+            = render :partial => "layouts/angular/auth_service_account_angular",
+                                 :locals  => {:ng_show                => true,
+                                              :ng_model               => "#{ng_model}",
+                                              :validate_url           => validate_url,
+                                              :id                     => record.id,
+                                              :prefix                 => "service_account",
+                                              :basic_info_needed      => true}
+        .form-group
+          .col-md-12
+            %span{:style => "color:black"}
+              = _("Used to authenticate as a service account against your provider.")
     - else
       = miq_tab_content('remote', 'default') do
         .form-group
@@ -170,6 +186,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'gce'"}
@@ -177,6 +194,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#service_account_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'rhevm'"}
@@ -184,6 +202,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'openstack'"}
@@ -191,6 +210,7 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
+    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 %div{"ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
@@ -198,6 +218,7 @@
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", true);
+    miq_tabs_show_hide("#service_account_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -58,6 +58,35 @@
                      "required"                    => "",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
+      %label.col-md-2.control-label{"for" => "textInput-markup"}
+        = _('Region')
+      .col-md-8
+        = select_tag('provider_region',
+                     options_for_select([["<#{_('Choose')}>", nil]] + Array(@google_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
+                     "ng-model"                    => "emsCommonModel.provider_region",
+                     "required"                    => "",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.project.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
+      %label.col-md-2.control-label{"for" => "textInput-markup"}
+        = _('Project')
+      .col-md-8
+        %input.form-control{"type"        => "text",
+                            "id"          => "textInput-markup",
+                            "name"        => "project",
+                            "ng-model"    => "emsCommonModel.project",
+                            "maxlength"   => "#{MAX_NAME_LEN}",
+                            "required"    => "",
+                            "checkchange" => ""}
+        %span.help-block{"ng-show" => "angularForm.project.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}", 
+      "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'openstack'"}
+
     .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'openstack'"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _('Hostname (or IPv4 or IPv6 address)')

--- a/db/migrate/20151106164333_add_project_to_ext_management_system.rb
+++ b/db/migrate/20151106164333_add_project_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddProjectToExtManagementSystem < ActiveRecord::Migration
+  def change
+    add_column :ext_management_systems, :project, :string
+  end
+end

--- a/db/migrate/20151109203749_add_service_account_to_authentication.rb
+++ b/db/migrate/20151109203749_add_service_account_to_authentication.rb
@@ -1,0 +1,5 @@
+class AddServiceAccountToAuthentication < ActiveRecord::Migration
+  def change
+    add_column :authentications, :service_account, :string
+  end
+end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -229,6 +229,7 @@ describe EmsCloudController do
                                        :amqp_password    => amqp_creds[:password])
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
+      expect(mocked_ems).to receive(:supports_authentication?).with(:service_account)
       expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
     end
 
@@ -240,6 +241,7 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:authentication_password).with(:amqp).and_return(amqp_creds[:password])
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
+      expect(mocked_ems).to receive(:supports_authentication?).with(:service_account)
       expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
     end
   end


### PR DESCRIPTION
This is done using the fog-google gem. It introduces a new credentials
tab accepting a service account definition as JSON. The text entry is shown below:
![service-account](https://cloud.githubusercontent.com/assets/4874941/10855084/15a4709a-7f16-11e5-9772-ad2e339fc1f5.png)
