### PR TITLE
Fix Deprecation warning "expect not_to raise_error(SpecificError)"

### DIFF
--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -33,7 +33,7 @@ describe Condition do
       it "valid expression as a tainted object should not raise security error" do
         expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> >= 0</check></find>"
         expr.taint
-        -> { Condition.subst(expr, @cluster, nil) }.should_not raise_error(SecurityError)
+        expect { Condition.subst(expr, @cluster, nil) }.to raise_error(RuntimeError, "Ruby script raised error [Insecure operation - eval]")
       end
 
       it "tests all allowed operators in find/check expression clause" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -27,7 +27,7 @@ describe Condition do
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2; system('ls /etc')</check></find>"
-        -> { Condition.subst(expr, @cluster, nil) }.should_not raise_error(SecurityError)
+        expect { Condition.subst(expr, @cluster, nil) }.not_to raise_error
       end
 
       it "valid expression as a tainted object should not raise security error" do


### PR DESCRIPTION
Update tests to not expect any error and expect a specific error