### PR TITLE
validate_supported_check return :available => false when SSA i…

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1931,7 +1931,7 @@ class VmOrTemplate < ActiveRecord::Base
               else
                 nil
               end
-    {:available => true,   :message => message}
+    {:available => message.nil?,   :message => message}
   end
 
   include DeprecatedCpuMethodsMixin

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1924,14 +1924,12 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def validate_supported_check(message_prefix)
-    message = if self.archived?
-                "#{message_prefix} cannot be performed on archived #{self.class.model_suffix} VM."
-              elsif self.orphaned?
-                "#{message_prefix} cannot be performed on orphaned #{self.class.model_suffix} VM."
-              else
-                nil
-              end
-    {:available => message.nil?,   :message => message}
+    return {:available => false, :message => nil} if self.archived?
+    if self.orphaned?
+      return {:available => false,
+              :message   => "#{message_prefix} cannot be performed on orphaned #{self.class.model_suffix} VM."}
+    end
+    {:available => true,   :message => nil}
   end
 
   include DeprecatedCpuMethodsMixin

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -53,6 +53,14 @@ module VmOrTemplate::Scanning
     end
   end
 
+  #
+  # Smartstate Analysis is unsupported by default.
+  # Subclasses need to override this method if they support SSA.
+  #
+  def validate_smartstate_analysis
+    validate_unsupported("Smartstate Analysis")
+  end
+
   # TODO: Vmware specfic
   def require_snapshot_for_scan?
     return false unless self.runnable?

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2377,6 +2377,8 @@ describe ApplicationHelper do
         before do
           @id = "vm_scan"
           @record = FactoryGirl.create(:vm_vmware, :vendor => "vmware")
+          @record.stub(:archived? => false)
+          @record.stub(:orphaned? => false)
           @record.stub(:has_active_proxy? => true)
         end
         it "when no active proxy" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -431,6 +431,8 @@ describe VmOrTemplate do
   context "#is_available? for Smartstate Analysis" do
     it "returns true for VMware VM" do
       vm =  FactoryGirl.create(:vm_vmware)
+      vm.stub(:archived? => false)
+      vm.stub(:orphaned? => false)
       expect(vm.is_available?(:smartstate_analysis)).to eq(true)
     end
 


### PR DESCRIPTION
…s not supported.

Also define a default superclass validate_smartstate_analysis that must be
overridden by subclasses that support SSA.

https://bugzilla.redhat.com/show_bug.cgi?id=1271359