### PR TITLE
Add :select to legacy finder options

### DIFF
--- a/lib/extensions/ar_merge_conditions.rb
+++ b/lib/extensions/ar_merge_conditions.rb
@@ -25,6 +25,7 @@ module ActiveRecord
       [:limit, :limit],
       [:order, :order],
       [:offset, :offset],
+      [:select, :select]
     ]
 
     def self.apply_legacy_finder_options(options)


### PR DESCRIPTION
This caused issues when find was called like is is here
https://github.com/ManageIQ/manageiq/blob/8007cc50bc45ffb509154957960600486477aee7/app/models/vim_performance_analysis.rb#L530

https://bugzilla.redhat.com/show_bug.cgi?id=1267749