### PR TITLE
migrate miq_groups to assign sequence and guid

### DIFF
--- a/db/migrate/20151030201919_fix_miq_group_sequences.rb
+++ b/db/migrate/20151030201919_fix_miq_group_sequences.rb
@@ -1,0 +1,13 @@
+class FixMiqGroupSequences < ActiveRecord::Migration
+  class MiqGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    MiqGroup.where(:sequence => nil).update_all(:sequence => 1)
+
+    MiqGroup.where(:guid => nil).each do |g|
+      g.update_attributes(:guid => MiqUUID.new_guid)
+    end
+  end
+end

--- a/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
+++ b/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require_migration
+
+describe FixMiqGroupSequences do
+  let(:group_stub) { migration_stub(:MiqGroup) }
+
+  migration_context :up do
+    it "assigns sequence" do
+      g1 = group_stub.create
+      g2 = group_stub.create(:sequence => 3)
+
+      migrate
+
+      expect(g1.reload.sequence).to be
+      expect(g2.reload.sequence).to eq(3)
+    end
+
+    it "assigns guid" do
+      old_guid = MiqUUID.new_guid
+      g1 = group_stub.create
+      g2 = group_stub.create(:guid => old_guid)
+
+      migrate
+
+      expect(g1.reload.guid).to be
+      expect(g2.reload.guid).to eq(old_guid)
+    end
+  end
+end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -248,18 +248,18 @@ describe MiqGroup do
     it "fails if referenced by user#current_group" do
       FactoryGirl.create(:user, :miq_groups => [group])
 
-      current_count = MiqGroup.count
-      expect { group.destroy }.to raise_error
-      MiqGroup.count.should eq current_count
+      expect {
+        expect { group.destroy }.to raise_error
+      }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by user#miq_groups" do
       group2 = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
 
-      current_count = MiqGroup.count
-      expect { group.destroy }.to raise_error
-      MiqGroup.count.should eq current_count
+      expect {
+        expect { group.destroy }.to raise_error
+      }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by a tenant#default_miq_group" do
@@ -271,7 +271,6 @@ describe MiqGroup do
     it "adds new groups after initial seed" do
       [Tenant, MiqUserRole, MiqGroup].each(&:seed)
 
-      current_count = MiqGroup.count
       role_map_path = File.expand_path(File.join(Rails.root, "db/fixtures/role_map.yaml"))
       role_map = YAML.load_file(role_map_path)
       role_map.unshift('EvmRole-test_role' => 'tenant_quota_administrator')
@@ -281,9 +280,9 @@ describe MiqGroup do
       allow(YAML).to receive(:load_file).with(role_map_path).and_return(role_map)
       allow(YAML).to receive(:load_file).with(filter_map_path).and_return(filter_map)
 
-      MiqGroup.seed
-
-      expect(MiqGroup.count).to eql(current_count + 1)
+      expect {
+        MiqGroup.seed
+      }.to change { MiqGroup.count }
       expect(MiqGroup.last.name).to eql('EvmRole-test_role')
       expect(MiqGroup.last.sequence).to eql(1)
     end


### PR DESCRIPTION
per request from @matthewd add sequence and guuid to miq groups the right way

This is already part of #5186

/cc @matthewd let me know if you like this
/cc @gmcculloug fyi