### PR TITLE
Properly preload virtual columns on the main and subtables via associations

### DIFF
--- a/lib/extensions/ar_to_model_hash.rb
+++ b/lib/extensions/ar_to_model_hash.rb
@@ -106,15 +106,15 @@ module ToModelHash
     reflection && reflection.collection?
   end
 
-  def to_model_hash_build_preload(options, parent = nil)
+  def to_model_hash_build_preload(options, parent_class = self.class)
     columns  = ((options && options[:columns]) || [])
     includes = ((options && options[:include]) || {})
 
-    # Preload virtual columns on self, not for included tables' columns
-    result = parent.nil? ? columns.select {|c| self.class.virtual_column?(c)} : []
+    result = columns.select { |c| parent_class.virtual_column?(c) }
 
     result += includes.collect do |k, v|
-      sub_result = to_model_hash_build_preload(v, k)
+      parent_class = parent_class.reflections[k.to_s].klass
+      sub_result = to_model_hash_build_preload(v, parent_class)
       sub_result.blank? ? k : {k => sub_result}
     end
   end

--- a/lib/extensions/ar_to_model_hash.rb
+++ b/lib/extensions/ar_to_model_hash.rb
@@ -113,8 +113,8 @@ module ToModelHash
     result = columns.select { |c| parent_class.virtual_column?(c) }
 
     result += includes.collect do |k, v|
-      parent_class = parent_class.reflections[k.to_s].klass
-      sub_result = to_model_hash_build_preload(v, parent_class)
+      association_class = parent_class.reflections_with_virtual[k.to_sym].klass
+      sub_result        = to_model_hash_build_preload(v, association_class)
       sub_result.blank? ? k : {k => sub_result}
     end
   end

--- a/lib/extensions/ar_to_model_hash.rb
+++ b/lib/extensions/ar_to_model_hash.rb
@@ -106,13 +106,15 @@ module ToModelHash
     reflection && reflection.collection?
   end
 
-  def to_model_hash_build_preload(options)
+  def to_model_hash_build_preload(options, parent = nil)
     columns  = ((options && options[:columns]) || [])
     includes = ((options && options[:include]) || {})
 
-    result  = columns.select { |c| self.class.virtual_column?(c) }
+    # Preload virtual columns on self, not for included tables' columns
+    result = parent.nil? ? columns.select {|c| self.class.virtual_column?(c)} : []
+
     result += includes.collect do |k, v|
-      sub_result = to_model_hash_build_preload(v)
+      sub_result = to_model_hash_build_preload(v, k)
       sub_result.blank? ? k : {k => sub_result}
     end
   end

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -5,39 +5,39 @@ describe ToModelHash do
     let(:test_disk_class)     { Class.new(ActiveRecord::Base) { self.table_name = "test_disks" } }
     let(:test_hardware_class) { Class.new(ActiveRecord::Base) { self.table_name = "test_hardwares" } }
     let(:test_vm_class)       { Class.new(ActiveRecord::Base) { self.table_name = "test_vms" } }
-    let(:test_os_class)       { Class.new(ActiveRecord::Base) { self.table_name = "test_operating_systems"} }
+    let(:test_os_class)       { Class.new(ActiveRecord::Base) { self.table_name = "test_operating_systems" } }
     let(:fixed_options)       { test_vm_class.send(:to_model_hash_options_fixup, @test_to_model_hash_options) }
     let(:mocked_preloader)    { double }
 
     before do
       silence_stream($stdout) do
         ActiveRecord::Schema.define do
-          create_table :test_vms, :force => true  do |t|
+          create_table :test_vms, :force => true do |t|
             t.string :name
           end
 
-          create_table :test_hardwares, :force => true  do |t|
+          create_table :test_hardwares, :force => true do |t|
             t.integer :bitness
             t.integer :test_vm_id
           end
 
-          create_table :test_disks, :force => true  do |t|
+          create_table :test_disks, :force => true do |t|
             t.integer :num_disks
             t.integer :something
             t.integer :test_hardware_id
           end
 
-          create_table :test_operating_systems, :force => true  do |t|
+          create_table :test_operating_systems, :force => true do |t|
             t.string :name
           end
         end
       end
 
-      test_disk_class.belongs_to     :test_hardware, :anonymous_class => test_hardware_class
-      test_hardware_class.has_many   :test_disks,    :anonymous_class => test_disk_class
-      test_hardware_class.belongs_to :test_vm,       :anonymous_class => test_vm_class
-      test_vm_class.has_one          :test_hardware, :anonymous_class => test_hardware_class, :dependent => :destroy
-      test_vm_class.has_one          :test_operating_system, :anonymous_class => test_os_class, :dependent => :destroy
+      test_disk_class.belongs_to     :test_hardware,         :anonymous_class => test_hardware_class
+      test_hardware_class.has_many   :test_disks,            :anonymous_class => test_disk_class
+      test_hardware_class.belongs_to :test_vm,               :anonymous_class => test_vm_class
+      test_vm_class.has_one          :test_hardware,         :anonymous_class => test_hardware_class, :dependent => :destroy
+      test_vm_class.has_one          :test_operating_system, :anonymous_class => test_os_class,       :dependent => :destroy
 
       # we're testing the preload of associations, skip the recursive .to_model_hash
       ActiveRecord::Base.any_instance.stub(:to_model_hash_recursive)

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -8,20 +8,22 @@ describe ToModelHash do
     let(:fixed_options)       { test_vm_class.send(:to_model_hash_options_fixup, @test_to_model_hash_options) }
 
     before do
-      ActiveRecord::Schema.define do
-        create_table :test_vms, force: true  do |t|
-          t.string :name
-        end
+      silence_stream($stdout) do
+        ActiveRecord::Schema.define do
+          create_table :test_vms, force: true  do |t|
+            t.string :name
+          end
 
-        create_table :test_hardwares, force: true  do |t|
-          t.integer :bitness
-          t.integer :test_vm_id
-        end
+          create_table :test_hardwares, force: true  do |t|
+            t.integer :bitness
+            t.integer :test_vm_id
+          end
 
-        create_table :test_disks, force: true  do |t|
-          t.integer :num_disks
-          t.integer :something
-          t.integer :test_hardware_id
+          create_table :test_disks, force: true  do |t|
+            t.integer :num_disks
+            t.integer :something
+            t.integer :test_hardware_id
+          end
         end
       end
 

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -1,52 +1,90 @@
 require "spec_helper"
 
 describe ToModelHash do
-  class TestVm < ActiveRecord::Base
-    has_one        :test_hardware, :dependent => :destroy
-    virtual_column :bitness,   :type => :integer, :uses => :test_hardware
-    virtual_column :num_disks, :type => :integer, :uses => {:test_hardware => :test_disks}
-  end
-
-  class TestHardware < ActiveRecord::Base
-    has_many   :test_disks
-    belongs_to :test_vm
-  end
-
-  class TestDisk < ActiveRecord::Base
-    belongs_to :test_hardware
-  end
-
-  let(:test_to_model_hash_options) do
-    {
-      "cols"    => ["name"],
-      "include" =>
-        {"test_hardware" =>
-          {
-            "columns" => ["bitness"],
-            "include" => {"test_disk" => {"columns" => ["num_disks"]}}
-          }
-        }
-    }
-  end
-
-  it "to_model_hash_build_preload" do
-    ActiveRecord::Schema.define do
-      create_table :test_vms, force: true  do |t|
-        t.string :name
+  context "to_model_hash_build_preload" do
+    before do
+      class TestVm < ActiveRecord::Base
+        has_one :test_hardware, :dependent => :destroy
       end
 
-      create_table :test_hardwares, force: true  do |t|
-        t.integer :bitness
-        t.integer :test_vm_id
+      class TestHardware < ActiveRecord::Base
+        has_many   :test_disks
+        belongs_to :test_vm
       end
 
-      create_table :test_disks, force: true  do |t|
-        t.integer :num_disks
-        t.integer :test_hardware_id
+      class TestDisk < ActiveRecord::Base
+        belongs_to :test_hardware
+      end
+
+      ActiveRecord::Schema.define do
+        create_table :test_vms, force: true  do |t|
+          t.string :name
+        end
+
+        create_table :test_hardwares, force: true  do |t|
+          t.integer :bitness
+          t.integer :test_vm_id
+        end
+
+        create_table :test_disks, force: true  do |t|
+          t.integer :num_disks
+          t.integer :test_hardware_id
+        end
       end
     end
 
-    options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-    expect(TestVm.new.send(:to_model_hash_build_preload, options)).to eq [{:test_hardware => [:test_disk]}]
+    after do
+      Object.send(:remove_const, :TestVm)
+      Object.send(:remove_const, :TestHardware)
+      Object.send(:remove_const, :TestDisk)
+    end
+
+    it "virtual_column" do
+      test_to_model_hash_options = {
+        "cols" => ["bitness"]
+      }
+
+      TestVm.virtual_column :bitness,   :type => :integer, :uses => :test_hardware
+
+      options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+      expect(TestVm.new.send(:to_model_hash_build_preload, options)).to eq [:bitness]
+    end
+
+    it "virtual_column and include association column" do
+      test_to_model_hash_options = {
+        "cols"    => ["bitness"],
+        "include" => {"test_hardware" => {"columns" => ["test_vm_id"]}}
+      }
+
+      TestVm.virtual_column :bitness, :type => :integer, :uses => :test_hardware
+
+      options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+      expect(TestVm.new.send(:to_model_hash_build_preload, options)).to match_array [:bitness, :test_hardware]
+    end
+
+    it "virtual column matches included association column" do
+      test_to_model_hash_options = {
+        "include" => {"test_hardware" => {"columns" => ["bitness"]}}
+      }
+
+      TestVm.virtual_column :bitness, :type => :integer, :uses => :test_hardware
+
+      options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+      expect(TestVm.new.send(:to_model_hash_build_preload, options)).to eq [:test_hardware]
+    end
+
+    it "virtual column on included association" do
+      # TODO: This fails if following one of the other tests that add a virtual column to TestVm.
+      # It appears the .parent_class object_id (in to_model_hash_build_preload) is the same
+      # across tests, is the remove_const not working in the after?
+      test_to_model_hash_options = {
+        "include" => {"test_hardware" => {"columns" => ["num_disks"]}}
+      }
+
+      TestHardware.virtual_column :num_disks, :type => :integer, :uses => :test_disks
+
+      options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+      expect(TestVm.new.send(:to_model_hash_build_preload, options)).to match_array [{:test_hardware => [:num_disks]}]
+    end
   end
 end

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -12,16 +12,16 @@ describe ToModelHash do
     before do
       silence_stream($stdout) do
         ActiveRecord::Schema.define do
-          create_table :test_vms, force: true  do |t|
+          create_table :test_vms, :force => true  do |t|
             t.string :name
           end
 
-          create_table :test_hardwares, force: true  do |t|
+          create_table :test_hardwares, :force => true  do |t|
             t.integer :bitness
             t.integer :test_vm_id
           end
 
-          create_table :test_disks, force: true  do |t|
+          create_table :test_disks, :force => true  do |t|
             t.integer :num_disks
             t.integer :something
             t.integer :test_hardware_id

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -54,6 +54,17 @@ describe ToModelHash do
       expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to eq [{:test_hardware => [:test_disks]}]
     end
 
+    it "columns included from different associations" do
+      @test_to_model_hash_options = {
+        "include" =>  {
+          "test_hardware" => {"columns" => ["bitness"]},
+          "test_disks"    => {"columns" => ["something"]}
+        }
+      }
+
+      expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to match_array [:test_hardware, :test_disks]
+    end
+
     context "virtual columns" do
       it "virtual column on main table" do
         @test_to_model_hash_options = {

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -5,6 +5,7 @@ describe ToModelHash do
     let(:test_disk_class)     { Class.new(ActiveRecord::Base) { self.table_name = "test_disks" } }
     let(:test_hardware_class) { Class.new(ActiveRecord::Base) { self.table_name = "test_hardwares" } }
     let(:test_vm_class)       { Class.new(ActiveRecord::Base) { self.table_name = "test_vms" } }
+    let(:fixed_options)       { test_vm_class.send(:to_model_hash_options_fixup, @test_to_model_hash_options) }
 
     before do
       ActiveRecord::Schema.define do
@@ -30,63 +31,76 @@ describe ToModelHash do
       test_vm_class.has_one          :test_hardware, :anonymous_class => test_hardware_class, :dependent => :destroy
     end
 
-    it "virtual_column" do
-      test_to_model_hash_options = {
-        "cols" => ["bitness"]
-      }
-
-      test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
-
-      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to eq [:bitness]
-    end
-
-    it "virtual_column and include association column" do
-      test_to_model_hash_options = {
-        "cols"    => ["bitness"],
-        "include" => {"test_hardware" => {"columns" => ["test_vm_id"]}}
-      }
-
-      test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
-
-      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to match_array [:bitness, :test_hardware]
-    end
-
-    it "virtual column matches included association column" do
-      test_to_model_hash_options = {
+    it "included column" do
+      @test_to_model_hash_options = {
         "include" => {"test_hardware" => {"columns" => ["bitness"]}}
       }
 
-      test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
-
-      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to eq [:test_hardware]
+      expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to eq [:test_hardware]
     end
 
-    it "virtual column on included association" do
-      test_to_model_hash_options = {
-        "include" => {"test_hardware" => {"columns" => ["num_disks"]}}
+    it "nested included columns" do
+      @test_to_model_hash_options = {
+        "include" => {
+          "test_hardware" => {
+            "columns" => ["bitness"],
+            "include" => {"test_disks" => {"columns" => ["num_disks"]}}
+          }
+        }
       }
 
-      test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks
-
-      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to match_array [{:test_hardware => [:num_disks]}]
+      expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to eq [{:test_hardware => [:test_disks]}]
     end
 
-    it "virtual and regular column includes from different associations" do
-      test_to_model_hash_options = {
-        "include" => [
-          {"test_hardware" => {"columns" => ["num_disks"]}},
-          {"test_disks"    => {"columns" => ["something"]}}
-        ]
-      }
+    context "virtual columns" do
+      it "virtual column on main table" do
+        @test_to_model_hash_options = {
+          "cols" => ["bitness"]
+        }
 
-      test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks
+        test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
+        expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to eq([:bitness])
+      end
 
-      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
-      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to match_array [{:test_hardware => [:num_disks]}]
+      it "virtual column and included column" do
+        @test_to_model_hash_options = {
+          "cols"    => ["bitness"],
+          "include" => {"test_hardware" => {"columns" => ["test_vm_id"]}}
+        }
+
+        test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
+        expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to match_array [:bitness, :test_hardware]
+      end
+
+      it "virtual column matches included association column" do
+        @test_to_model_hash_options = {
+          "include" => {"test_hardware" => {"columns" => ["bitness"]}}
+        }
+
+        test_vm_class.virtual_column :bitness, :type => :integer, :uses => :test_hardware
+        expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to eq [:test_hardware]
+      end
+
+      it "included association virtual column " do
+        @test_to_model_hash_options = {
+          "include" => {"test_hardware" => {"columns" => ["num_disks"]}}
+        }
+
+        test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks
+        expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to match_array [{:test_hardware => [:num_disks]}]
+      end
+
+      it "virtual and regular column included from different associations" do
+        @test_to_model_hash_options = {
+          "include" =>  {
+            "test_hardware" => {"columns" => ["num_disks"]},
+            "test_disks"    => {"columns" => ["something"]}
+          }
+        }
+
+        test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks
+        expect(test_vm_class.new.send(:to_model_hash_build_preload, fixed_options)).to match_array [{:test_hardware => [:num_disks]}]
+      end
     end
   end
 end

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe ToModelHash do
+  class TestVm < ActiveRecord::Base
+    has_one        :test_hardware, :dependent => :destroy
+    virtual_column :bitness,   :type => :integer, :uses => :test_hardware
+    virtual_column :num_disks, :type => :integer, :uses => {:test_hardware => :test_disks}
+  end
+
+  class TestHardware < ActiveRecord::Base
+    has_many   :test_disks
+    belongs_to :test_vm
+  end
+
+  class TestDisk < ActiveRecord::Base
+    belongs_to :test_hardware
+  end
+
+  let(:test_to_model_hash_options) do
+    {
+      "cols"    => ["name"],
+      "include" =>
+        {"test_hardware" =>
+          {
+            "columns" => ["bitness"],
+            "include" => {"test_disk" => {"columns" => ["num_disks"]}}
+          }
+        }
+    }
+  end
+
+  it "to_model_hash_build_preload" do
+    ActiveRecord::Schema.define do
+      create_table :test_vms, force: true  do |t|
+        t.string :name
+      end
+
+      create_table :test_hardwares, force: true  do |t|
+        t.integer :bitness
+        t.integer :test_vm_id
+      end
+
+      create_table :test_disks, force: true  do |t|
+        t.integer :num_disks
+        t.integer :test_hardware_id
+      end
+    end
+
+    options = TestVm.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+    expect(TestVm.new.send(:to_model_hash_build_preload, options)).to eq [{:test_hardware => [:test_disk]}]
+  end
+end

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -19,6 +19,7 @@ describe ToModelHash do
 
         create_table :test_disks, force: true  do |t|
           t.integer :num_disks
+          t.integer :something
           t.integer :test_hardware_id
         end
       end
@@ -66,6 +67,20 @@ describe ToModelHash do
     it "virtual column on included association" do
       test_to_model_hash_options = {
         "include" => {"test_hardware" => {"columns" => ["num_disks"]}}
+      }
+
+      test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks
+
+      options = test_vm_class.send(:to_model_hash_options_fixup, test_to_model_hash_options)
+      expect(test_vm_class.new.send(:to_model_hash_build_preload, options)).to match_array [{:test_hardware => [:num_disks]}]
+    end
+
+    it "virtual and regular column includes from different associations" do
+      test_to_model_hash_options = {
+        "include" => [
+          {"test_hardware" => {"columns" => ["num_disks"]}},
+          {"test_disks"    => {"columns" => ["something"]}}
+        ]
       }
 
       test_hardware_class.virtual_column :num_disks, :type => :integer, :uses => :test_disks


### PR DESCRIPTION
Fixes an issue seen in #5205 where:
1) the main table has a virtual column with the same name as an included association's column even if 
we're not using the main table's column
2) included association's virtual columns were not being preloaded
