### PR TITLE
Fix nil string in component status error column

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -22,12 +22,11 @@ module EmsContainerHelper::TextualSummary
   end
 
   def textual_group_component_statuses
-    labels = [_("Name"), _("Type"), _("Status"), _("Error")]
+    labels = [_("Name"), _("Healthy"), _("Error")]
     h = {:labels => labels}
     h[:values] = @record.container_component_statuses.collect do |cs|
       [
         cs.name,
-        cs.condition,
         cs.status,
         (cs.error || "")
       ]

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -439,7 +439,9 @@ module ManageIQ::Providers::Kubernetes
         :condition => component_condition.type,
         :status    => component_condition.status,
         :message   => component_condition.message,
-        :error     => component_condition.error
+        # workaround for handling Kubernetes issue: "nil" string is returned in component status error
+        # https://github.com/kubernetes/kubernetes/issues/16721
+        :error     => (component_condition.error unless component_condition.error == "nil")
       )
 
       new_result


### PR DESCRIPTION
Make sure the value in these cases is an empty string.

Currently only "Healthy" component condition type is supported.
Therefor I changed The column name to "Healthy" and the content
to its status.

fixes #5218

before:
![fix_nil_error_before](https://cloud.githubusercontent.com/assets/6347577/10869229/8e3e02d6-80b1-11e5-8a25-a6ff8ddadd9d.png)

after:
![fix_nil_error_after](https://cloud.githubusercontent.com/assets/6347577/10869230/9874e148-80b1-11e5-8bde-9a2a3bc1250a.png)
