### PR TITLE
Only push to coveralls upstream

### DIFF
--- a/gems/manageiq_foreman/spec/spec_helper.rb
+++ b/gems/manageiq_foreman/spec/spec_helper.rb
@@ -5,10 +5,9 @@ begin
 rescue LoadError
 end
 
-begin
+if ENV["TRAVIS"]
   require 'coveralls'
   Coveralls.wear!
-rescue LoadError
 end
 
 require 'vcr'

--- a/gems/pending/Rakefile
+++ b/gems/pending/Rakefile
@@ -1,12 +1,13 @@
 require_relative './bundler_setup'
 
-begin
-  require 'coveralls/rake/task'
-rescue LoadError
-else
-  Coveralls::RakeTask.new
-end
-
 Dir[File.join(GEMS_PENDING_ROOT, "lib/tasks/**/*.rake")].sort.each { |ext| load ext }
 
-task :default => [:spec, :test, 'coveralls:push']
+task :default do
+  Rake::Task["spec"].invoke
+  Rake::Task["test"].invoke
+  if ENV["TRAVIS"]
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task["coveralls:push"].invoke
+  end
+end

--- a/gems/pending/spec/spec_helper.rb
+++ b/gems/pending/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require_relative '../bundler_setup'
 
-require 'coveralls'
-Coveralls.wear_merged! do
-  add_filter("/spec/")
+if ENV["TRAVIS"]
+  require 'coveralls'
+  Coveralls.wear_merged! { add_filter("/spec/") }
 end
 
 require 'rspec/autorun'
@@ -24,7 +24,7 @@ RSpec.configure do |config|
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
   end
 
-  if ENV["CI"]
+  if ENV["TRAVIS"]
     config.after(:suite) do
       require "spec/coverage_helper.rb"
     end

--- a/gems/pending/test/test_helper.rb
+++ b/gems/pending/test/test_helper.rb
@@ -1,8 +1,8 @@
 require_relative "../bundler_setup"
 
-require 'coveralls'
-Coveralls.wear_merged! do
-  add_filter("/test/")
+if ENV["TRAVIS"]
+  require 'coveralls'
+  Coveralls.wear_merged! { add_filter("/test/") }
 end
 
 require 'minitest/autorun'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 
-if ENV["CI"]
+if ENV["TRAVIS"]
   require 'coveralls'
   Coveralls.wear!('rails') { add_filter("/spec/") }
 end
@@ -82,7 +82,7 @@ RSpec.configure do |config|
   config.after(:each) do
     EvmSpecHelper.clear_caches
   end
-  if ENV["CI"] && ENV["TEST_SUITE"] == "vmdb"
+  if ENV["TRAVIS"] && ENV["TEST_SUITE"] == "vmdb"
     config.after(:suite) do
       require Rails.root.join("spec/coverage_helper.rb")
     end


### PR DESCRIPTION
Other test environments that don't have access to push to coveralls throw an error at the end of the test, so only push to coveralls in the Travis environment for upstream