### PR TITLE
Require gettext_i18n_rails version 1.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "spice-html5-rails"
 gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 
 # Needed by the REST API
-gem "gettext_i18n_rails",             "~>1.3.0"
+gem "gettext_i18n_rails",             "~>1.3.1"
 gem "jbuilder",                       "~>2.3.1"
 gem "paperclip",                      "~>4.3.0"
 gem "rails-i18n",                                                     :git => "git://github.com/svenfuchs/rails-i18n.git", :branch => "master"


### PR DESCRIPTION
This version contains

    https://github.com/grosser/gettext_i18n_rails/pull/145

which we need to be able to correctly create gettext catalogs with comments included.