### PR TITLE
Add spinner when selecting catalog type

### DIFF
--- a/app/views/catalog/_st_form.html.haml
+++ b/app/views/catalog/_st_form.html.haml
@@ -15,6 +15,6 @@
                        :class    => "selectpicker")
           :javascript
             miqInitSelectPicker();
-            miqSelectPickerEvent('st_prov_type', "#{url}")
+            miqSelectPickerEvent('st_prov_type', "#{url}", {beforeSend: true, complete: true})
   - else
     = render :partial => "form"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1275707
Fixed issue when no spinner was shown at selecting catalog page in Services - Catalog items.
Using https://github.com/ManageIQ/manageiq/pull/4606#issuecomment-144856333