### PR TITLE
Speed up vmdb table specs

### DIFF
--- a/spec/factories/vmdb_table.rb
+++ b/spec/factories/vmdb_table.rb
@@ -2,9 +2,9 @@ FactoryGirl.define do
   factory :vmdb_table do
   end
 
-  factory :vmdb_table_evm do
+  factory :vmdb_table_evm, :parent => :vmdb_table, :class => "VmdbTableEvm" do
   end
 
-  factory :vmdb_table_text do
+  factory :vmdb_table_text, :parent => :vmdb_table, :class => "VmdbTableText" do
   end
 end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -1,34 +1,6 @@
 require "spec_helper"
 
 describe VmdbTable do
-  context "#capture_metrics" do
-    before(:each) do
-      MiqDatabase.seed
-      VmdbDatabase.seed
-      # works with VmdbTableEvm, VmdbIndex(often not present), but not VmdbTableText
-      @table = VmdbTable.where(:type => 'VmdbTableEvm').first
-      @table.capture_metrics
-    end
-
-    it "populates vmdb_metrics columns" do
-      metrics = @table.vmdb_metrics
-      metrics.length.should == 0
-
-      @table.capture_metrics
-      metrics = @table.vmdb_metrics
-      metrics.length.should_not == 0
-
-      metric = metrics.first
-      columns = %w( size rows pages percent_bloat wasted_bytes otta table_scans sequential_rows_read
-                    index_scans index_rows_fetched rows_inserted rows_updated rows_deleted rows_hot_updated rows_live
-                    rows_dead timestamp
-                )
-      columns.each do |column|
-        metric.send(column).should_not be_nil
-      end
-    end
-  end
-
   context "#seed_indexes" do
     before(:each) do
       @db = VmdbDatabase.seed_self


### PR DESCRIPTION
Improve VmdbTableEvm#capture_metrics and VmdbIndex#capture_specs by removing the seeding and collapsing related specs.

Previously these were SQL intensive specs with 19890 SQL statements across them
Total time savings: 14s down to 1.44s

See individual commits for the breakdown.
@jrafanie Please review
