### PR TITLE
[WIP] Add POC parallel vmdb tests implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ env:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
+  - RAILS_ENV=test
+  - PARALLEL_TEST_PROCESSORS=2
   matrix:
-  - TEST_SUITE=vmdb
+  - TEST_SUITE=vmdb PARALLEL='^spec/(controllers|helpers|initializers|javascripts|lib|mailers|models|presenters|requests|routing|services|task_helpers|tools|views)'
   - TEST_SUITE=automation
   - TEST_SUITE=migrations
   - TEST_SUITE=self_service SPA_UI=self_service
@@ -39,9 +41,11 @@ before_script:
 - '[[ -z "$SPA_UI" ]] || npm install'
 - '[[ -z "$SPA_UI" ]] || npm version'
 - '[[ -z "$SPA_UI" ]] || popd'
-- '[[ -z "$TEST_SUITE" ]] || bundle exec rake test:$TEST_SUITE:setup'
+- '[[ -z "$TEST_SUITE" ]] || [[ -n "$PARALLEL" ]] || bundle exec rake test:$TEST_SUITE:setup'
+- '[[ -z "$TEST_SUITE" ]] || [[ -z "$PARALLEL" ]] || bundle exec parallel_test -e "bundle exec rake test:$TEST_SUITE:setup"'
 script:
-- bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}
+- '[[ -z "$TEST_SUITE" ]] || [[ -n "$PARALLEL" ]] || bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}'
+- '[[ -z "$TEST_SUITE" ]] || [[ -z "$PARALLEL" ]] || bundle exec rake parallel:spec["$PARALLEL"]'
 notifications:
   webhooks:
     urls:

--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ unless ENV['APPLIANCE']
 
   group :development, :test do
     gem "rspec-rails",      "~>2.14.0"
+    gem "parallel_tests"
   end
 end
 

--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -31,4 +31,4 @@ production:
 test: &test
   <<: *base
   pool: 3
-  database: vmdb_test
+  database: vmdb_test<%= ENV['TEST_ENV_NUMBER'] %>


### PR DESCRIPTION
https://github.com/grosser/parallel_tests

parallel_tests will automatically divide the test files in N groups and
run each group of test files in a separate process using a different database.

Note, N is the number of processors on the machine or the
PARALLEL_TEST_PROCESSORS environment variable.

The reason to do this is to use all CPU cores available to us and in
the case of travis containers, we get [2 CPU cores](http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments).

Locally, on SSD, the vmdb suite goes from ~21 minutes to ~11 minutes
when utilizing 2 CPU cores.

To do this:
* database.yml must be changed to dynamically name the db based on an
environment variable that parallel_tests sets internally (TEST_ENV_NUMBER).
Note, if you run locally using the changed database.yml, it will work because
the "single" core default for our project is the same vmdb_test we've always
used.

* We have to run our database setup through parallel_test so it can
setup each of the N databases: `parallel_test -e "bundle exec rake test:vmdb:setup"`.

* Finally, we have to provide the spec file patterns directly to parallel_tests
so it knows what spec files need to be divided into N groups.


#### Before

```
...
Finished in 21 minutes 17 seconds
10191 examples, 0 failure, 3 pending

Randomized with seed 10983
```

#### After

```
# Initial output showing the parallelized tests:
2 processes for 704 specs, ~ 352 specs per process
...

# First process statistics
Finished in 10 minutes 21 seconds
5460 examples, 0 failure, 1 pending
...

# Second process statistics
Finished in 10 minutes 31 seconds
4731 examples, 0 failures, 2 pending
...

# Total suite statistics
Randomized with seed 4955

10191 examples, 1 failure, 3 pendings

Took 649 seconds (10:49)
```