### PR TITLE
Fix server tab styling

### DIFF
--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -19,20 +19,15 @@
     .form-group
       %label.col-md-2.control-label
         = _("Resides on VM")
-      .col-md-8{:style => "padding: 0px"}
-        %table{:cellpadding => "0", :cellspacing => "0"}
-          %tr
-            - vm = @selected_server.vm
-            - if vm
-              %td.image.pointer{:onclick => "DoNav('/vm/show/#{vm.id}');", :title => _("Click to view this VM")}
-                %img{:align => "left", :height => "20", :src => "/images/icons/new/vm.png", :width => "20"}/
-              %td.pointer.hover-text{:class => cycle('row0', 'row1'), :onclick => "DoNav('/vm/show/#{vm.id}');",
-                :title => _("Click to view this VM")}
-                = h(vm.name)
-            - else
-              .col-md-8
-                %p.form-control-static
-                  = _("Not Available")
+      .col-md-8
+        - vm = @selected_server.vm
+        - if vm
+          %span.fa.fa-desktop.pointer{:onclick => "DoNav('/vm/show/#{vm.id}')",
+                                      :title   => _("Click to view this VM")}
+            = h(vm.name)
+        - else
+          %span.fa.fa-desktop
+            = _("Not Available")
     .form-group
       %label.col-md-2.control-label
         = _("Company Name")


### PR DESCRIPTION
* replace misaligned image with font awesome icon and markup

Old:
<img width="557" alt="screen shot 2015-11-02 at 2 16 07 pm" src="https://cloud.githubusercontent.com/assets/1287144/10891483/409fa44c-816c-11e5-956a-167132ab74f6.png">

New:
<img width="575" alt="screen shot 2015-11-02 at 2 06 17 pm" src="https://cloud.githubusercontent.com/assets/1287144/10891454/0db75408-816c-11e5-8cc1-1a4650622f3d.png">