### PR TITLE
Automate methods can access categories and entries

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_classification.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_classification.rb
@@ -5,5 +5,10 @@ module MiqAeMethodService
     expose :category
     expose :name
     expose :to_tag
+    expose :entries
+
+    def self.categories
+      wrap_results(Classification.categories)
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+include AutomationSpecHelper
+
+describe MiqAeMethodService::MiqAeServiceClassification do
+  before do
+    @cat1 = FactoryGirl.create(:classification_department_with_tags)
+    @cat2 = FactoryGirl.create(:classification_cost_center_with_tags)
+    @cat_array = Classification.categories.collect(&:name)
+    @tags_array = @cat2.entries.collect(&:name)
+  end
+
+  let(:user) { FactoryGirl.create(:user_with_group) }
+
+  def setup_model(method_script)
+    create_ae_model_with_method(:method_script => method_script,
+                                :name          => 'VITALSTATISTIX',
+                                :ae_namespace  => 'OBELIX',
+                                :ae_class      => 'ASTERIX',
+                                :instance_name => 'DOGMATIX',
+                                :method_name   => 'GETAFIX')
+  end
+
+  def invoke_ae
+    MiqAeEngine.instantiate("/OBELIX/ASTERIX/DOGMATIX", user)
+  end
+
+  it "get a list of categories" do
+    setup_model("$evm.root['result'] = $evm.vmdb('Classification').categories")
+    cats = invoke_ae.root('result')
+    expect(cats.collect(&:name)).to match_array(@cat_array)
+  end
+
+  it "check the tags" do
+    script = <<-'RUBY'
+      categories = $evm.vmdb('Classification').categories
+      cc = categories.detect { |c| c.name == 'cc' }
+      $evm.root['result'] = cc.entries
+    RUBY
+    setup_model(script)
+    tags = invoke_ae.root('result')
+    expect(tags.collect(&:name)).to match_array(@tags_array)
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
@@ -2,22 +2,22 @@ require 'spec_helper'
 
 describe MiqAeMethodService::MiqAeServiceClassification do
   before do
-    @cat1 = FactoryGirl.create(:classification_department_with_tags)
-    @cat2 = FactoryGirl.create(:classification_cost_center_with_tags)
-    @cat_array = Classification.categories.collect(&:name)
-    @tags_array = @cat2.entries.collect(&:name)
+    FactoryGirl.create(:classification_department_with_tags)
+    @cc_cat = FactoryGirl.create(:classification_cost_center_with_tags)
   end
 
   let(:user) { FactoryGirl.create(:user_with_group) }
   let(:categories) { MiqAeMethodService::MiqAeServiceClassification.categories }
 
   it "get a list of categories" do
-    expect(categories.collect(&:name)).to match_array(@cat_array)
+    cat_array = Classification.categories.collect(&:name)
+    expect(categories.collect(&:name)).to match_array(cat_array)
   end
 
   it "check the tags" do
+    tags_array = @cc_cat.entries.collect(&:name)
     cc = categories.detect { |c| c.name == 'cc' }
     tags = cc.entries
-    expect(tags.collect(&:name)).to match_array(@tags_array)
+    expect(tags.collect(&:name)).to match_array(tags_array)
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_classification_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-include AutomationSpecHelper
 
 describe MiqAeMethodService::MiqAeServiceClassification do
   before do
@@ -10,34 +9,15 @@ describe MiqAeMethodService::MiqAeServiceClassification do
   end
 
   let(:user) { FactoryGirl.create(:user_with_group) }
-
-  def setup_model(method_script)
-    create_ae_model_with_method(:method_script => method_script,
-                                :name          => 'VITALSTATISTIX',
-                                :ae_namespace  => 'OBELIX',
-                                :ae_class      => 'ASTERIX',
-                                :instance_name => 'DOGMATIX',
-                                :method_name   => 'GETAFIX')
-  end
-
-  def invoke_ae
-    MiqAeEngine.instantiate("/OBELIX/ASTERIX/DOGMATIX", user)
-  end
+  let(:categories) { MiqAeMethodService::MiqAeServiceClassification.categories }
 
   it "get a list of categories" do
-    setup_model("$evm.root['result'] = $evm.vmdb('Classification').categories")
-    cats = invoke_ae.root('result')
-    expect(cats.collect(&:name)).to match_array(@cat_array)
+    expect(categories.collect(&:name)).to match_array(@cat_array)
   end
 
   it "check the tags" do
-    script = <<-'RUBY'
-      categories = $evm.vmdb('Classification').categories
-      cc = categories.detect { |c| c.name == 'cc' }
-      $evm.root['result'] = cc.entries
-    RUBY
-    setup_model(script)
-    tags = invoke_ae.root('result')
+    cc = categories.detect { |c| c.name == 'cc' }
+    tags = cc.entries
     expect(tags.collect(&:name)).to match_array(@tags_array)
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1254953

Added a new class method categories to return an array of
MiqAeService::MiqAeClassification objects.
e.g. $evm.vmdb('Classification').categories

Exposed the entries method in the MiqAeService::MiqAeClassification
to access the entries in a category.