### PR TITLE
Azure discovery support, Azure regions as separate EMSes

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -190,6 +190,14 @@ ManageIQ.angularApplication.controller('emsCommonFormController', ['$http', '$sc
     $scope.afterGet = true;
   });
 
+  $scope.isRegionSupported = function() {
+    if ($scope.emsCommonModel.emstype === 'ec2' || $scope.emsCommonModel.emstype === 'azure') {
+      return true;
+    }
+
+    return false;
+  };
+
   init();
 }]);
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -755,7 +755,7 @@ module ApplicationController::CiProcessing
     if session[:type] == "hosts"
       @discover_type = Host.host_discovery_types
     else
-      @discover_type = ExtManagementSystem.ems_discovery_types
+      @discover_type = ExtManagementSystem.ems_infra_discovery_types
     end
     discover_type = []
     @discover_type_checked = []        # to keep track of checked items when start button is pressed

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -150,6 +150,7 @@ class EmsCloudController < ApplicationController
 
     if @ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
       azure_tenant_id = @ems.azure_tenant_id
+      provicer_region = @ems.provider_region
       client_id       = @ems.authentication_userid ? @ems.authentication_userid : ""
       client_key      = @ems.authentication_password ? @ems.authentication_password : ""
     end

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -150,7 +150,6 @@ class EmsCloudController < ApplicationController
 
     if @ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)
       azure_tenant_id = @ems.azure_tenant_id
-      provicer_region = @ems.provider_region
       client_id       = @ems.authentication_userid ? @ems.authentication_userid : ""
       client_key      = @ems.authentication_password ? @ems.authentication_password : ""
     end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -756,6 +756,7 @@ module EmsCommon
     end
     @ems_types = Array(model.supported_types_and_descriptions_hash.invert).sort_by(&:first)
     @amazon_regions = get_amazon_regions
+    @azure_regions = get_azure_regions
     @google_regions = list_google_regions
     @openstack_infra_providers = retrieve_openstack_infra_providers
     @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
@@ -764,6 +765,14 @@ module EmsCommon
   def get_amazon_regions
     regions = {}
     ManageIQ::Providers::Amazon::Regions.all.each do |region|
+      regions[region[:name]] = region[:description]
+    end
+    regions
+  end
+
+  def get_azure_regions
+    regions = {}
+    ManageIQ::Providers::Azure::Regions.all.each do |region|
       regions[region[:name]] = region[:description]
     end
     regions

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -84,6 +84,10 @@ class EmsEvent < EventStream
     add(ems_id, ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, ems_id))
   end
 
+  def self.add_azure(ems_id, event)
+    add(ems_id, ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, ems_id))
+  end
+
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, "event_type must be set in event" if event_type.nil?

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -112,10 +112,15 @@ class ExtManagementSystem < ActiveRecord::Base
 
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
 
-  EMS_DISCOVERY_TYPES = {
+  EMS_INFRA_DISCOVERY_TYPES = {
     'vmware'    => 'virtualcenter',
     'microsoft' => 'scvmm',
     'redhat'    => 'rhevm',
+  }
+
+  EMS_CLOUD_DISCOVERY_TYPES = {
+    'azure'  => 'azure',
+    'amazon' => 'ec2',
   }
 
   def self.create_discovered_ems(ost)
@@ -274,8 +279,12 @@ class ExtManagementSystem < ActiveRecord::Base
     EmsRefresh.queue_refresh(self)
   end
 
-  def self.ems_discovery_types
-    EMS_DISCOVERY_TYPES.values
+  def self.ems_infra_discovery_types
+    EMS_INFRA_DISCOVERY_TYPES.values
+  end
+
+  def self.ems_cloud_discovery_types
+    EMS_CLOUD_DISCOVERY_TYPES.values
   end
 
   def disconnect_inv

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -109,7 +109,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
       new_emses << create_discovered_region("Azure-eastus", clientid, clientkey, azure_tenant_id, all_ems_names)
     end
 
-    EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?  # PUT BACK BEFORE PR
+    EmsRefresh.queue_refresh(new_emses) unless new_emses.blank? # PUT BACK BEFORE PR
 
     new_emses
   end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -109,7 +109,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
       new_emses << create_discovered_region("Azure-eastus", clientid, clientkey, azure_tenant_id, all_ems_names)
     end
 
-    EmsRefresh.queue_refresh(new_emses) unless new_emses.blank? # PUT BACK BEFORE PR
+    EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?
 
     new_emses
   end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -24,6 +24,10 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     false
   end
 
+  def description
+    ManageIQ::Providers::Azure::Regions.find_by_name(provider_region)[:description]
+  end
+
   def self.raw_connect(clientid, clientkey, azuretenantid)
     ::Azure::Armrest::ArmrestService.configure(
       :client_id  => clientid,
@@ -72,5 +76,81 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     vm.update_attributes!(:raw_power_state => "VM starting")
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  # Discovery
+
+  # Create EmsAzure instances for all regions with instances
+  # or images for the given authentication.  Created EmsAzure instances
+  # will automatically have EmsRefreshes queued up.  If this is a greenfield
+  # discovery, we will at least add an EmsAzure for eastus
+  def self.discover(clientid, clientkey, azure_tenant_id)
+    new_emses = []
+
+    all_emses = includes(:authentications)
+    all_ems_names = all_emses.index_by(&:name)
+
+    known_emses = all_emses.select { |e| e.authentication_userid == clientid }
+    known_ems_regions = known_emses.index_by(&:provider_region)
+
+    config     = raw_connect(clientid, clientkey, azure_tenant_id)
+    azure_vmm  = ::Azure::Armrest::VirtualMachineService.new(config)
+
+    azure_vmm.locations.each do |region|
+      region = region.delete(' ').downcase
+      next if known_ems_regions.include?(region)
+      next if vms_in_region(azure_vmm, region).count == 0 # instances
+      # TODO: Check if images are == 0 and if so then skip
+      new_emses << create_discovered_region(region, clientid, clientkey, azure_tenant_id, all_ems_names)
+    end
+
+    # at least create the Azure-eastus region.
+    if new_emses.blank? && known_emses.blank?
+      new_emses << create_discovered_region("Azure-eastus", clientid, clientkey, azure_tenant_id, all_ems_names)
+    end
+
+    EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?  # PUT BACK BEFORE PR
+
+    new_emses
+  end
+
+  def self.discover_queue(clientid, clientkey, azure_tenant_id)
+    MiqQueue.put(
+      :class_name  => name,
+      :method_name => "discover_from_queue",
+      :args        => [clientid, MiqPassword.encrypt(clientkey), azure_tenant_id]
+    )
+  end
+
+  def self.vms_in_region(azure_vmm, region)
+    azure_vmm.list_all.select { |vm| vm['location'] == region }
+  end
+
+  def self.discover_from_queue(clientid, clientkey, azure_tenant_id)
+    discover(clientid, MiqPassword.decrypt(clientkey), azure_tenant_id)
+  end
+
+  def self.create_discovered_region(region_name, clientid, clientkey, azure_tenant_id, all_ems_names)
+    name = "Azure-#{region_name}"
+    name = "Azure-#{region_name} #{clientid}" if all_ems_names.key?(name)
+
+    while all_ems_names.key?(name)
+      name_counter = name_counter.to_i + 1 if defined?(name_counter)
+      name = "Azure-#{region_name} #{name_counter}"
+    end
+
+    new_ems = self.create!(
+      :name            => name,
+      :provider_region => region_name,
+      :zone            => Zone.default_zone,
+      :uid_ems         => azure_tenant_id
+    )
+    new_ems.update_authentication(
+      :default => {
+        :userid   => clientid,
+        :password => clientkey
+      }
+    )
+    new_ems
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -56,9 +56,9 @@ module ManageIQ::Providers
         series = []
         begin
           series = @vmm.series(@ems.provider_region)
-        rescue ::Azure::Armrest::BadGatewayException,
-               ::Azure::Armrest::GatewayTimeoutException,
-               ::Azure::Armrest::BadRequestException
+        rescue ::Azure::Armrest::BadGatewayException, ::Azure::Armrest::GatewayTimeoutException,
+               ::Azure::Armrest::BadRequestException => err
+          _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
         end
         process_collection(series, :flavors) { |s| parse_series(s) }
       end

--- a/app/models/manageiq/providers/azure/regions.rb
+++ b/app/models/manageiq/providers/azure/regions.rb
@@ -2,115 +2,115 @@ module ManageIQ
   module Providers::Azure
     module Regions
       REGIONS = {
-        "westus"      => {
+        "westus" => {
           :name        => "westus",
           :description => "US West",
         },
-        "eastus"      => {
+        "eastus" => {
           :name        => "eastus",
           :description => "US East",
         },
-        "australiaeast"      => {
+        "australiaeast" => {
           :name        => "australiaeast",
           :description => "Australia East",
         },
-        "australiasoutheast"      => {
+        "australiasoutheast" => {
           :name        => "australiasoutheast",
           :description => "Australia South East",
         },
-        "centralus"      => {
+        "centralus" => {
           :name        => "centralus",
           :description => "Central US",
         },
-        "eastus2"      => {
+        "eastus2" => {
           :name        => "eastus2",
           :description => "East US2",
         },
-        "northcentralus"      => {
+        "northcentralus" => {
           :name        => "northcentralus",
           :description => "North Central US",
         },
-        "southcentralus"      => {
+        "southcentralus" => {
           :name        => "southcentralus",
           :description => "South Central US",
         },
-        "northeurope"      => {
+        "northeurope" => {
           :name        => "northeurope",
           :description => "North Eurpoe",
         },
-        "westeurope"      => {
+        "westeurope" => {
           :name        => "westeurope",
           :description => "West Eurpoe",
         },
-        "eastasia"      => {
+        "eastasia" => {
           :name        => "eastasia",
           :description => "East Asia",
         },
-        "southeastasia"      => {
+        "southeastasia" => {
           :name        => "southeastasia",
           :description => "South East Asia",
         },
-        "japaneast"      => {
+        "japaneast" => {
           :name        => "japaneast",
           :description => "Japan East",
         },
-        "japanwest"      => {
+        "japanwest" => {
           :name        => "japanwest",
           :description => "Japan West",
         },
-        "brazilsouth"      => {
+        "brazilsouth" => {
           :name        => "brazilsouth",
           :description => "Brazil South",
         },
-        "westindia"      => {
+        "westindia" => {
           :name        => "westindia",
           :description => "West India",
         },
-        "southindia"      => {
+        "southindia" => {
           :name        => "southindia",
           :description => "South India",
         },
-        "centralindia"      => {
+        "centralindia" => {
           :name        => "centralindia",
           :description => "Central India",
         },
-        "westus(partner)"      => {
+        "westus(partner)" => {
           :name        => "westus(partner)",
-          :description => "West US (partner)",
+          :description => "West US (Partner)",
         },
-        "eastus2(stage)"      => {
+        "eastus2(stage)" => {
           :name        => "eastus2(stage)",
-          :description => "East US2(stage)",
+          :description => "East US2 (Stage)",
         },
-        "northcentralus(stage)"      => {
+        "northcentralus(stage)" => {
           :name        => "northcentralus(stage)",
-          :description => "North Central US (stage)",
+          :description => "North Central US (Stage)",
         },
-        "global"      => {
+        "global" => {
           :name        => "global",
           :description => "Global",
         },
-        "msftwestus"      => {
+        "msftwestus" => {
           :name        => "msftwestus",
           :description => "MSFT West US",
         },
-        "msfteastus"      => {
+        "msfteastus" => {
           :name        => "msfteastus",
           :description => "MSFT East US",
         },
-        "msfteastasia"      => {
+        "msfteastasia" => {
           :name        => "msfteastasia",
           :description => "MSFT East Asia",
         },
-        "msftnortheurope"      => {
+        "msftnortheurope" => {
           :name        => "msftnortheurope",
           :description => "MSFT North Europe",
         },
-        "eastasia(stage)"      => {
+        "eastasia(stage)" => {
           :name        => "eastasia(stage)",
           :description => "East Asia (Stage)",
         },
-        "centralus(stage)"      => {
+        "centralus(stage)" => {
           :name        => "centralus(stage)",
           :description => "Central US (Stage)",
         },
@@ -124,7 +124,7 @@ module ManageIQ
         REGIONS.keys
       end
 
-       def self.find_by_name(name)
+      def self.find_by_name(name)
         REGIONS[name]
       end
     end

--- a/app/models/manageiq/providers/azure/regions.rb
+++ b/app/models/manageiq/providers/azure/regions.rb
@@ -1,0 +1,132 @@
+module ManageIQ
+  module Providers::Azure
+    module Regions
+      REGIONS = {
+        "westus"      => {
+          :name        => "westus",
+          :description => "US West",
+        },
+        "eastus"      => {
+          :name        => "eastus",
+          :description => "US East",
+        },
+        "australiaeast"      => {
+          :name        => "australiaeast",
+          :description => "Australia East",
+        },
+        "australiasoutheast"      => {
+          :name        => "australiasoutheast",
+          :description => "Australia South East",
+        },
+        "centralus"      => {
+          :name        => "centralus",
+          :description => "Central US",
+        },
+        "eastus2"      => {
+          :name        => "eastus2",
+          :description => "East US2",
+        },
+        "northcentralus"      => {
+          :name        => "northcentralus",
+          :description => "North Central US",
+        },
+        "southcentralus"      => {
+          :name        => "southcentralus",
+          :description => "South Central US",
+        },
+        "northeurope"      => {
+          :name        => "northeurope",
+          :description => "North Eurpoe",
+        },
+        "westeurope"      => {
+          :name        => "westeurope",
+          :description => "West Eurpoe",
+        },
+        "eastasia"      => {
+          :name        => "eastasia",
+          :description => "East Asia",
+        },
+        "southeastasia"      => {
+          :name        => "southeastasia",
+          :description => "South East Asia",
+        },
+        "japaneast"      => {
+          :name        => "japaneast",
+          :description => "Japan East",
+        },
+        "japanwest"      => {
+          :name        => "japanwest",
+          :description => "Japan West",
+        },
+        "brazilsouth"      => {
+          :name        => "brazilsouth",
+          :description => "Brazil South",
+        },
+        "westindia"      => {
+          :name        => "westindia",
+          :description => "West India",
+        },
+        "southindia"      => {
+          :name        => "southindia",
+          :description => "South India",
+        },
+        "centralindia"      => {
+          :name        => "centralindia",
+          :description => "Central India",
+        },
+        "westus(partner)"      => {
+          :name        => "westus(partner)",
+          :description => "West US (partner)",
+        },
+        "eastus2(stage)"      => {
+          :name        => "eastus2(stage)",
+          :description => "East US2(stage)",
+        },
+        "northcentralus(stage)"      => {
+          :name        => "northcentralus(stage)",
+          :description => "North Central US (stage)",
+        },
+        "global"      => {
+          :name        => "global",
+          :description => "Global",
+        },
+        "msftwestus"      => {
+          :name        => "msftwestus",
+          :description => "MSFT West US",
+        },
+        "msfteastus"      => {
+          :name        => "msfteastus",
+          :description => "MSFT East US",
+        },
+        "msfteastasia"      => {
+          :name        => "msfteastasia",
+          :description => "MSFT East Asia",
+        },
+        "msftnortheurope"      => {
+          :name        => "msftnortheurope",
+          :description => "MSFT North Europe",
+        },
+        "eastasia(stage)"      => {
+          :name        => "eastasia(stage)",
+          :description => "East Asia (Stage)",
+        },
+        "centralus(stage)"      => {
+          :name        => "centralus(stage)",
+          :description => "Central US (Stage)",
+        },
+      }
+
+      def self.all
+        REGIONS.values
+      end
+
+      def self.names
+        REGIONS.keys
+      end
+
+       def self.find_by_name(name)
+        REGIONS[name]
+      end
+    end
+  end
+end

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -26,6 +26,7 @@
                      options_for_select([["<#{_('Choose>')}", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-if"                       => "newRecord",
                      "ng-model"                    => "emsCommonModel.emstype",
+                     "ng-change"                   => "providerTypeChanged()",
                      "required"                    => "",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
@@ -39,17 +40,24 @@
             = @emstype_display
 
 
-    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "emsCommonModel.emstype == 'ec2'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.provider_region.$invalid}", "ng-if" => "isRegionSupported()", "ng-switch" => "", "on" => "emsCommonModel.emstype"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _('Region')
       .col-md-8
         = select_tag('provider_region',
                      options_for_select([["<#{_('Choose')}>", nil]] + Array(@amazon_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
                      "ng-model"                    => "emsCommonModel.provider_region",
+                     "ng-switch-when"              => "ec2",
                      "required"                    => "",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
-
+        = select_tag('provider_region',
+                     options_for_select([["<#{_('Choose')}>", nil]] + Array(@azure_regions.invert).sort_by { |desc, _name| desc }, disabled: ["<#{_('Choose')}>", nil]),
+                     "ng-model"                    => "emsCommonModel.provider_region",
+                     "ng-switch-when"              => "azure",
+                     "required"                    => "",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
     .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'openstack'"}
       %label.col-md-2.control-label{"for" => "textInput-markup"}
         = _('Hostname (or IPv4 or IPv6 address)')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,6 +638,7 @@ Vmdb::Application.routes.draw do
         listnav_search_selected
         panel_control
         protect
+        provider_type_field_changed
         quick_search
         sections_field_changed
         show

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -140,6 +140,7 @@ FactoryGirl.define do
   end
 
   factory :ems_azure_with_authentication, :parent => :ems_azure do
+    azure_tenant_id "ABCDEFGHIJABCDEFGHIJ0123456789AB"
     after :create do |x|
       x.authentications << FactoryGirl.create(:authentication)
     end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -34,14 +34,23 @@ describe ExtManagementSystem do
     described_class.supported_types.should match_array(all_types)
   end
 
-  it ".ems_discovery_types" do
+  it ".ems_infra_discovery_types" do
     expected_types = [
       "scvmm",
       "rhevm",
       "virtualcenter"
     ]
 
-    expect(described_class.ems_discovery_types).to match_array(expected_types)
+    expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
+  end
+
+  it ".ems_cloud_discovery_types" do
+    expected_types = [
+      "ec2",
+      "azure",
+    ]
+
+    expect(described_class.ems_cloud_discovery_types).to match_array(expected_types)
   end
 
   context "with two small envs" do

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -41,8 +41,150 @@ describe ManageIQ::Providers::Azure::CloudManager do
       end
 
       it "handles incorrect password" do
-        ManageIQ::Providers::Azure::CloudManager.stub(:raw_connect).and_raise(Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
+        ManageIQ::Providers::Azure::CloudManager.stub(:raw_connect).and_raise(
+          Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Incorrect credentials*/)
+      end
+    end
+  end
+
+  context ".discover" do
+    AZURE_PREFIX = /Azure-(\w+)/
+
+    before do
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+
+      @user              = "0123456789ABCDEFGHIJ"
+      @pass              = "ABCDEFGHIJKLMNO1234567890abcdefghijklmno"
+      @tenant_id         = "0123456789ABCDEFGHIJ0123456789AB"
+      @another_user      = "testuser"
+      @another_password  = "secret"
+      @another_tenant_id = "ABCDEFGHIJABCDEFGHIJ0123456789AB"
+    end
+
+    def recorded_discover(example)
+      cassette_name = example.description.tr(" ", "_").delete(",").underscore
+      VCR.use_cassette(
+        "#{described_class.name.underscore}/discover/#{cassette_name}",
+        :allow_unused_http_interactions => true) do
+        ManageIQ::Providers::Azure::CloudManager.discover(@user, @pass, @tenant_id)
+      end
+    end
+
+    def assert_region(ems, name)
+      ems.name.should eq(name)
+      ems.provider_region.should eq(name[AZURE_PREFIX, 1])
+      ems.auth_user_pwd.should eq([@user, @pass])
+      ems.azure_tenant_id.should eq(@tenant_id)
+    end
+
+    def assert_region_on_another_account(ems, name)
+      ems.name.should eq(name)
+      ems.provider_region.should eq(name[AZURE_PREFIX, 1])
+      ems.auth_user_pwd.should eq([@another_user, @another_password])
+      ems.azure_tenant_id.should eq(@another_tenant_id)
+    end
+
+    def create_factory_ems(name, region)
+      ems = FactoryGirl.create(:ems_azure, :name => name, :provider_region => region)
+      cred = {
+        :userid   => @user,
+        :password => @pass,
+      }
+      ems.update_attributes(:azure_tenant_id => @tenant_id)
+      ems.authentications << FactoryGirl.create(:authentication, cred)
+    end
+
+    it "with no existing records" do
+      found = recorded_discover(example)
+      found.count.should eq(2)
+
+      emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
+      emses.count.should eq(2)
+      assert_region(emses[0], "Azure-eastus")
+      assert_region(emses[1], "Azure-westus")
+    end
+
+    it "with some existing records" do
+      create_factory_ems("Azure-eastus", "eastus")
+
+      found = recorded_discover(example)
+      found.count.should eq(1)
+
+      emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
+      emses.count.should eq(2)
+      assert_region(emses[0], "Azure-eastus")
+      assert_region(emses[1], "Azure-westus")
+    end
+
+    it "with all existing records" do
+      create_factory_ems("Azure-eastus", "eastus")
+      create_factory_ems("Azure-westus", "westus")
+
+      found = recorded_discover(example)
+      found.count.should eq(0)
+
+      emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
+      emses.count.should eq(2)
+      assert_region(emses[0], "Azure-eastus")
+      assert_region(emses[1], "Azure-westus")
+    end
+
+    context "with records from a different account" do
+      it "with the same name" do
+        FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus", :provider_region => "westus")
+
+        found = recorded_discover(example)
+        found.count.should eq(2)
+
+        emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
+        emses.count.should eq(3)
+        assert_region(emses[0], "Azure-eastus")
+        assert_region_on_another_account(emses[1], "Azure-westus")
+        assert_region(emses[2], "Azure-westus #{@user}")
+      end
+
+      it "with the same name and backup name" do
+        FactoryGirl.create(
+          :ems_azure_with_authentication,
+          :name            => "Azure-westus",
+          :provider_region => "westus")
+        FactoryGirl.create(
+          :ems_azure_with_authentication,
+          :name            => "Azure-westus #{@user}",
+          :provider_region => "westus")
+
+        found = recorded_discover(example)
+        found.count.should eq(2)
+
+        emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
+        emses.count.should eq(4)
+
+        assert_region(emses[0], "Azure-eastus")
+        assert_region_on_another_account(emses[1], "Azure-westus")
+        assert_region_on_another_account(emses[2], "Azure-westus #{@user}")
+        assert_region(emses[3], "Azure-westus 1")
+      end
+
+      it "with the same name, backup name, and secondary backup name" do
+        FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus", :provider_region => "westus")
+        FactoryGirl.create(
+          :ems_azure_with_authentication,
+          :name            => "Azure-westus #{@user}",
+          :provider_region => "westus")
+        FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus 1", :provider_region => "westus")
+
+        found = recorded_discover(example)
+        found.count.should eq(2)
+
+        emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
+        emses.count.should eq(5)
+
+        assert_region(emses[0], "Azure-eastus")
+        assert_region_on_another_account(emses[1], "Azure-westus")
+        assert_region_on_another_account(emses[2], "Azure-westus #{@user}")
+        assert_region_on_another_account(emses[3], "Azure-westus 1")
+        assert_region(emses[4], "Azure-westus 2")
       end
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://login.windows.net/a50f9983-d1a2-4a8d-be7d-123456789012/oauth2/token
     body:
       encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-ee920016983b&client_secret=5YcZ1lwRmNPWgo82X%2F1l97Fe4VaBGi%2BH55tm4WLuGoQ%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012"&client_secret=0+dVmFpJLU0T9gqFWDkWnX9MY3FPb5l1123456789012%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Length:
       - '188'
       Content-Type:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 88c2ebd1-7e99-4f85-8353-769ea8bd6e01
+      - b1ec6cb5-a2d7-4d66-a3dc-c3dc24c9f3e3
       Client-Request-Id:
-      - 8d010433-c66f-4dae-b027-84dc32da6edd
+      - 2e09feee-65c5-429e-b593-bd6cdb434282
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_49
+      - ESTSFE_IN_30
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -47,18 +47,18 @@ http_interactions:
       Set-Cookie:
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Thu, 22 Oct 2015 17:57:59 GMT
+      - Mon, 02 Nov 2015 17:48:40 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1445540281","not_before":"1445536381","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446490120","not_before":"1446486220","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ"}'
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:01 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -71,11 +71,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -96,17 +96,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - b30760f4-91fc-4362-ba7a-7ae574dca164
+      - 15114ead-75ad-4c54-a31f-906c17fffb1c
       X-Ms-Correlation-Request-Id:
-      - b30760f4-91fc-4362-ba7a-7ae574dca164
+      - 15114ead-75ad-4c54-a31f-906c17fffb1c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175803Z:b30760f4-91fc-4362-ba7a-7ae574dca164
+      - EASTUS:20151102T174841Z:15114ead-75ad-4c54-a31f-906c17fffb1c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:58:03 GMT
+      - Mon, 02 Nov 2015 17:48:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -118,7 +118,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:04 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -131,11 +131,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -158,15 +158,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 54c36c49-c0f6-4754-8fda-600d21fe93d7
+      - 5a301861-644a-4f9a-ad24-d452ea0983e2
       X-Ms-Correlation-Request-Id:
-      - 54c36c49-c0f6-4754-8fda-600d21fe93d7
+      - 5a301861-644a-4f9a-ad24-d452ea0983e2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175805Z:54c36c49-c0f6-4754-8fda-600d21fe93d7
+      - EASTUS:20151102T174841Z:5a301861-644a-4f9a-ad24-d452ea0983e2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:58:04 GMT
+      - Mon, 02 Nov 2015 17:48:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -184,208 +184,208 @@ http_interactions:
         1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
         gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
         bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
-        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
-        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdaXj//od7I9K/h5o1
+        8DZ2wt0MaGAialUXP+Be6G0fGfTRQ6+uyvy4aYqLJQhyWxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyWpLqD0/3Z8p2VG1J0ezxaEMuSh
+        rXp+7BDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUGKAP5L0FE7hSU/mD
         wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
-        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
-        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjVzqkVwg9juNgiDdtH/iA0iRus5Gbb
+        BYaxpOCx3ziMu/V6OamqHqv/f3Y8Qfbm/5ujIhwG0O+hccs+uJe4HDzJ2il8
+        LR8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8fykhQUYNGWYOi/BfDpnkMFg
         /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        35in4pI8RDddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
         dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
-        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
+        oJ+7lDXLnmdv8yFJfs+ON/bVkCNKec+fg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4zz
+        gT4GANzDaZGtKHOPpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnAgx4+GgDV
         Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        D7L79D/HvxvpcpJRZp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
         MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
-        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
-        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
-        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
-        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
-        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
-        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
-        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
-        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
-        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
-        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
-        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
-        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
-        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
-        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
-        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
-        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
-        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
-        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
-        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
-        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
-        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
-        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
-        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
-        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
-        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
-        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
-        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
-        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
-        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
-        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
-        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
-        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
-        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
-        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
-        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
-        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
-        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
-        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
-        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
-        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
-        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
-        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
-        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
-        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
-        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
-        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
-        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
-        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
-        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
-        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
-        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
-        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
-        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
-        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
-        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
-        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
-        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF2Yoe22yK0h96duuyXE4t/EP9wb+Jz+
-        F/u8WA5Apy+GYOErB445a5hH7k7Laj2b5auyuiaN8COmsd06HkHL4AOLx88n
-        piGqDOi7H7EItww+sHhsZhFHcCY5afqIBTi9pDFQpE4d+HMCWL1ZshB6s+Rw
-        24BsnF7uN6acI5rQI3iFYYUf8btKRv4aXZkPOswjnIE37B/ojv6Qvizt8an5
-        K0piMrO8SMGE7VCJ3S6OI0CqDZ5XFDJNnlvx2NQN4RYXmfcBy4DttBJUxxjP
-        8qyldTJAp39tzwDYw+Xctb0RE+ocmHjcSSjQuz48MiCXxYze+3oAGaQ/KnJx
-        dFTkaxcXc7ZEfp+A1cOC/NhVtSRmQ2sfDZ+PoygRtel/jtrAz/5B/wPpCcVO
-        f1f5BMr7h9QbOa9YlaaGH95ZDH5W5nVbx/LCLF0EX4WXf9sggNpMRZpl2Zdx
-        kWM0sX/gbfpDYHoD0rfDj/Am/cbKJ/jCqTA0CT5gMECCPg10zBDJiFCOZPS/
-        AZKt26qZEuGavG2L5cWPKKfEupFyFEov25Z+75IsBrYLdhdrxeYP+SbWhwVL
-        Td3vhCgGiYHfpi/5YyN4l2589T4rEwL5xm4s8K8F9lP/D/pfvA/wMcXg+ez0
-        3Yo46fWPuDlKTPpfnH6U+bpYVg0trP88JJ3pQRKADqD5G5jpH0NUfjBE2EXe
-        1sX0aX5eLAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHf
-        K7/+yYwMAcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok
-        5JZhfwyWf5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S
-        7W6TT+v8R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E4X9LoYeVSPIkf4
-        7AA5xqID1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfV
-        VbdrZeyAC4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1
-        /RGws8/z+r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxq
-        v8jqt3m7KunzL2vKkpCDSFB8pNBXD83sos7zaBqeCRPOJCiN34aGwALMOHZ6
-        eW9iKCSGFR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4T
-        fhT8wfAClsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbT
-        s5fHsxl90xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOS
-        fjBJlVNf59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8
-        yq5/RNtvhLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3
-        QFhHwpCcP4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKN
-        qOsfCi7rJrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdW
-        dXAT+xc3U71hhdZ8IG8GioLbhB8FfzC8/68pEp+yr/P6spjmL+vqsqCEVpfC
-        P4tYzJbND6plj4s/uiirSVbGx0890f/2bwX37vHPHmR6ftaAn7w4/uL0Zw36
-        yzevftZgf/F7/6yBfvN7v/lZg/361U9+07BJms/Pi+kiW5Kerld1dV5Ewswb
-        etnf3jvY2MsUFumNdPWFdHWDcXrPLrnTgcxw1RbULUP+9nqCsfnYAWYPXwsJ
-        rQO0nALcoBHjqtf9xkoYGpd+p99up835XdX//DW6Mh909LbodLxh/0B39If0
-        Za0MPjV/RUm9v73zkPQjkZgIPEilu8s+kX9EtgGysTCA/Zl2m2TAEUlxch8w
-        yhgKfdofr//b/0+oRi/FHTuPKIqD+4BRBOr0aX98/m//n6QS08lKIRHJab0v
-        Dbmy8mzZFBdzdkl9mgJcj8rI2jAwtA6oDMxl1DciSOr53vbeDjWlP8jB2qW1
-        aPvHDv2PUCfEO103bVWTYVBsT6rleXHRxSLa3SagZbF8+yarL3Ievg/KDigK
-        szuEwQ6ICELnLvwoWILExNg4dRQ5cg+A6PcGIL3+G1K207pYSbe3QIFGtkv/
-        o6b0B7ES/W+z9xv0cJc8hPdyvz+kL0tbavUesfT7dWn+jC9Y3F7c+UvX7Gtq
-        FGmlwqWv279EawC8/QMN6I+OrokrQPepgsDL6dlyxvhzS/uXQUr+/mYo3QST
-        68gckvxno682u2BRo/e/+a6gYn52INOsC/+/F/iNuuU1OR+zdZnXBNHvDUB6
-        /f90NZlWZTmQcxZWNYzC3Cs8FHwkrSwLM8vZv8CHRn74XXCq+YCbMgxuxr8F
-        TC9/4Ev6oyMBAQ5oQr+xQPaEwH3A7wID+pR/V+530MzfQED/iE4FzewBTcXX
-        m1wlmemTRyDoBB9JK0tKRsn+hbEZOvK7GJb5gJsyDG7Gvwkt8Y39A1/SH/8v
-        JyyTdoDX86yeAmef8oDUm4uGW2qCqTcfjJQ/XvptI/V5jBivoTi/p7/Lm2bg
-        DIzbhx/JFAAs/eEoCUD0wcCcbCAcKYeD7d2H1Fj+2KPwWf4gkj7Yvre7/dKS
-        lAjaoQ8pjSmt7DN5ELhsiFmGev8aHX7NnnicMaA0OXGJ2wiJcaY/eAA38BsT
-        6Mka8P2+AbKHjYWB1j42/el2H/CMg7PoUzPrzC9oGfzGMgn+od/pt9txHb+r
-        fMpfoyvzQYfphEPxhv0D3dEf0peVBnxq/opSmhhC4xkibYdKlhGYVF+LGwgy
-        z+Gmbgi392UNgtQBy4DttBJUjzV+UUmt/U4B6/ZoBETUuYlMnU578IXMRvAR
-        A+Pf9C3zm840g/enPphe+QPt6Q+BbhHr8IhjXG3uPuAm6IM+NciJ/lL8zB/c
-        UP+KzgZNAP3P2QQzK/Q/zArNSYfKjrA/IrL+wQ31r2+YyHenNBQW2YKY/kcU
-        1z+4of71zVDcqsoNWlJwsOMSJAyejmA/IvhtCN6QvScQ1PBHJOY/uKH+9Y2S
-        +O4sa7NJ1vxIgfwwiI2f5Md+OflpRP6X//8kOpHjZ5Xo70v0bLYolgW4gNLg
-        P2Jz+wc31L++WTYPKG6XSyj5Hkk1C052nIKUwdsR8EcT8D4TQB8T5bNJmT8l
-        9Ff57OmPtDz9jY7sH9xQ//qmqT+t6Bcm/4/oTn+jI/sHN9S/vlm6F4sVYU/t
-        f0Rp/oMb6l8/G5Q+fYd/f6TfCTkhsuJn/uCG+tc3S39C+Uc0F8IqfuYPbqh/
-        fbM0Py/q/Cory5rW+H5EcPsHN9S/vlmCm8j0dT5d15RweVmVxfRHmS7q2vzB
-        DfWvn13af5G3dTH9EentH9xQ//pmSZ+tZ5TQXV78iN3pb3Rk/+CG+tc3S3N4
-        7ItFvpzls9OSMCmmL6uq/BHp7R/cUP/6ZklvNM2PGB+fKokVP/MHN9S/frao
-        P62WSyQlq+WP6E9/oyP7BzfUv3626N/8yNIqhRU/8wc31L9+toiP377Imrc/
-        0j6gsuJn/uCG+tcPcQLu/ijQQkf2D26of32z02A+Xv3I56GO7B/cUP/6Zgme
-        i4/5I3qjI/sHN9S/vll6r5vs4keq5IdBaehx0egL9mOe5ue0Eigk75Bfhmnw
-        ZIIJXsFHGGTwG88Gj4Y/7TdW+jIsEMN84OiEZsEHti19agAKdbQr8wc3tH/J
-        COxEcUv7VzCl8gca0B/BhG4i/3tR+ucPfX849PV19M8RiQW85Sh+w/4lQ0Zz
-        +wca0B/B+BUjMLcB6/he33Yf2Lb0qUHLcDug2z+4of71TZJ49nOmLwS8JS+/
-        Yf8S+qK5/QMN6I//zxDb6Yu2Wv3EOq/JxSbYAYm5Vzto6dZg5gimNA2+EOoF
-        HzEw/k3fMr8pZRg8hm8+COgqf6A9/SHQLWIdmjuKanP3ATdBH/SpQU7oqPiZ
-        P7ih/rWJxB9iER3d7/4i+nn9Jn8HvH40A/wHN9S/vs4M8Bwss0XerLIpJuCL
-        YlpXTXXejl+3VU0OIL3hzxHg9mdNmh5Pp9V62V9XxfA8Ouo82N/TrdctvX2H
-        PuOxcUv+zVKO2yq5ecigjfkgILn8gbfpD6G/ISDD5bfDj4I/5BXb8deZsug8
-        3N/e+XR79z69In/Q/9yk8Cx0aEr9y2J1l5zfDPioc//NgJ7O8+nbF8RTx5dZ
-        UWaToqQEHb3+zffU4bu70B7FtDcsYR+eXjCG/Kaf9dnPzn2HFfgFZTk72eYD
-        YTs0sX8AGP0hUAIe47fDj/Am/caCEXzhGAxNgg8YDJCgTwM+jRKXBJ7+B5m/
-        PR3VvdgQjgApQRTDld/0s5+HlGXaDmnTOs8Wx8usvCbnDXT05wCgIrOCVyi3
-        99PVBC8EhA+GAoJ0yKkjFhrZr4R+aEB/8Fv8Pg8O4zVE5w8idNSvBQzepz+k
-        i35b/s3RFJ8FH3Af6JQ+DYjs5mmDXbu/vbsDohtd8dD/41P/D/qf+4Mnyvxx
-        j/6w+oU/pK/pf5hKmsjOdDjyd6YCdHAkNrjz8DFo+u1HUyF/0P/cH0xo80cw
-        FRupT15g1WbdSfi5Q4xo6KT0LhHpYlkhPnudt1iW7SLqTYj+5jGHITZ/LR9Z
-        fsEUu782zpI2ZijmG/6Dm4e9CP8AFfsHXqY/8JnhMn4RDGI+cLyDZsEHtm2c
-        W4i69L+4iBEIj5bvYXz0t5+3pGRi+oZnYQ1Ps16taPgE1yc2QPTIT/SIu5xK
-        wGC0jFv4UfAHhu6ILADsn/wlN8OYg994DoV6+MT+gVfoj85s8U9QyFAT75jf
-        HSHxafCBfS9OWRL8B0TZ7Zcq+L42IHITsTukUyqT3L/N+wGQjD4gDyMQfhT8
-        geE6egkA+yd/yc0wsOC3/y+QjwkY59bLollnZdOuZ0VFr/lUBvAe3TNxWanp
-        1yA4hiW/gTryW9BAwIRkt3/x20oqBg56mA+E6Ghi/8Db9EdnBhxNuXGUnCTk
-        9D9nhpic9Mne9t6nRE4iZpwqd1d19dP5FL3+/KUO08dnNueTfzefUGufdoDZ
-        o2ZTtBQKUdopX0q/HXJ2cAamZqD8OxNLRom/7R86ZCHjJsoy5LAF3nUN+C/+
-        nJv6pA7eQvf0G+uIL14/e8Mo0AfmT/0++FPh8AcdvDqz439g8aBP8SVBDeJB
-        /gygvc8cqt6HjKGxxaaF+Zt70b+ivEE654B4g5rKH9BK9o9beoB79o/97d1d
-        7w8PAP1B/+vzIP0PCo84MMpTTVlRtP0jzvoRZ33TnFUsmzZbUgqHXvgRS6Fb
-        x0FoGXxg8aBP8SVB/RFL9VhKlNWPGOtrMhaDQa8ev/BnAO195lD1PmQMhXVc
-        C/M3j1b/GmYsmlueaGKS/5cxlmWpH1lC+qCDl9NSaBl8YPGgT/ElQf0Rd/W4
-        q6O2fsRj9EEHL8dSaBl8YPGgT/ElQf0Rj3k8tlpPyqKZU8ryK1o0+xFLmW4d
-        B6Fl8IHFgz7FlwT1RyzlsRSxEy0gIGORyfp5CYL+iK3QreMitAw+sHjQp/iS
-        oP6IrTy2kj9OKhpPVf5IUZluHQOhZfCBxYM+xZcE9UccBSZSjrLqiQY6ffsj
-        ljLdOg5Cy+ADiwd9ii8J6o9YymMp8qXa13Dbj5umuFjmszfVt8kYviBjSC//
-        iL3QreMmtAw+sHjQp/iSoP5/mr1iLCJRHVwkcMWTgtBYXvxI+ZhuHTOgZfCB
-        xYM+xZcE9f+n3CEx/494xHzQwcuxBFoGH1g86FN8SVD/f8cjRIRaueBHHCHd
-        OgZAy+ADiwd9ii8J6v+nOYL/+AZdlmlet8V5QVz0ozUR261jH7QMPrB40Kf4
-        kqD+iJ88fqI04mVeP8vqxY/YyXTruActgw8sHvQpviSoP2Inn53gEFGzHzES
-        unV8g5bBBxYP+hRfEtQfMVKXkcSzpsY/Yid067gHLYMPLB70Kb4kqD+37ETT
-        S6zx/xp2qtfLtlj0VNP/G2Qiiq+w/yJv62L6/0mkn+bnxbIQlP8/hT6rHB3E
-        /4dR//8i/Z0rqoP4/zDq/1+kPzNRnU+rxSJfzhTh//ch/x5a//9HY7nIqzq/
-        YEz/vzwMYTJqvigoLTabAeVwPD/y7/7/6d/FuAE5c8qVny4vi7pakqT+/8Xb
-        dzOHT4MPLBD6FF/yK94M8WeA733m+vE+ZLxkslwL8zf3on9941Np/ngPDXHb
-        6b+7WJdt8aoq85dVVf6IG/gzwPc+c/14HzJeMt+uhfmbe9G//j/FDVdV/Tav
-        f8QKmGH+DPC9z1w/3oeMl0y2a2H+5l70r/9PsYL41V02+P/gEP4/GBpEBxMo
-        ah3b//9G9P+T2fIUqQ7s/2fD+f/JPHV4sFg2bbac/r8ycXn7oO99BqrT+fNu
-        wP/v5t8PG7ovrXbcBOrnwSh1dn9+jfb/L7y8yJbkUs++3R8+vesP60fBCD5z
-        /XgfMl4SbrgW5m/uRf/6fwNrRLlglq/K6hrT/txOeTj9/29A/fZcXTQqz7lj
-        6GW2yLPLrCizSQlu+v/u6KZl1jTF9ItqUpT5a1qXKUgv0Wv/3x0RofoFKyJM
-        1PF0WtFadkOv+SP6f50CYt3BCoIwNWLfU0CcBWcNwV/xn/p98KfC4Q86itGp
-        LLQMPmDtAjzoU3xJUH9udBizwnY9pdbe34YBbj3nd6fVcplPZc5/NP/SrZtu
-        tAw+sHjQp/iSoP7/Zf6Pp/9/SYjynLoX+U/9PvhT4fAHHbzcjKNl8IHFgz7F
-        lwT1/9ssQJ/6fOD//iOe8PByLICWwQcWD/oUXxLU/8/zxI/m3sPLTTVaBh9Y
-        POhTfElQ/z8/9/zPjxjAw8vNN1oGH1g86FN8SVD/v88ABONHE49u3TyjZfCB
-        xYM+xZcE9f/7E+9Z/x8xgenWzTlaBh9YPOhTfElQ/9/JBMwGSMo0q2wKHniR
-        X73Ky2I6Pn75Bb3kcwig9nlG2YTaBlwhtDIYM1EF3eAjHh7/xhTh3+RNS2Vu
-        Yv9iGCAsU48+4Pf49ygFKD2yQyOmhvyHSX70hv06X84u6mI2Pl1Qcoqa+8ME
-        sFsP3CE0hC2PUn9jXuQh8qcy9oBEDCP8KPhDXrEEYlj2L5E09GX/QAP6oyO1
-        jnW1sfuAm2AQcQpTNgo8FSXqeko5seYJZerfNuOTMs/qp08Itk9JgOnRdpa1
-        2SRr6MsOcTtYB4QA4pvpLATAJ/YPpYYQMQAnH1lKcpeggukCb7qv+S9+L0Y4
-        /1Ptnr/0e4wSl9iV/gfiEmk7RJqWBJOaE7Af0YhphP/+H4F7U20QVAEA
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b1VnwIk59FtGgW30/hfEO4
+        xHBhhj3hcM0lKr42WoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
+        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
+        TYxE/9tEXXr1Ylk15O++ztuW7GuPvEDEo4oSTohgsOOv5SNLCcbU/tUZPX/J
+        bwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSGipf5gxvqXzeQ
+        lwk8YAFmkAqf+Hi9Nx2UQDsvSvquQ36DIRMDYwl+G5oLQT34iIfGv0l7OzX8
+        hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIYTosqje7my9mq
+        KshlJ8g/otatqXWX1n0uCnr5R1R7H6pNCW61mFGq8ke020g7wlDcE/o8Emz6
+        tPpg2Hd1ovTPH2JXljP075/DrlWg9a+fS0R8GdHPvkl0buOPf1AHdrzfKNr5
+        7CJfVrONVv0GoAx2wLOQhWMK7VfrFrrB7x2QevjI/ICOPYygB4wasSrAfMBf
+        Eq72N9ZrUC30O/0mGssblMIIPwr+kFesWmNY9i9RXejL/oEG9MfX0WMGGfHk
+        HB7mb4C2fwAOYZjupVuvW0oOIkEkuJrX6Evz1cDcSSrLxDc8kfwHOYvBH1jm
+        oSmmCe7ME7P7UztZG5j+ZwsDj1PuNmXVl2amk7IHkxekNh/wlzzN+tuP+IW/
+        +qHN1t26Ih+GXvzRnMnfAG3/ABzC8P+Vc3ZjviOKD3VE//s6HX0w+MuibtdZ
+        +QUlOmnppAtOaK0sxlOE6TIf8JfMKvrbj3iOv4pOwu15jv7n/hhkwCmNn21K
+        0Zu1r9l/rJfoOvXXhG/+GBxShxd/vme3+HfLgaZj8zc6sn8ADqH0AexJ80L/
+        u928iOoZ1nEGHfpYf/vRtCjtzZDNa/Sl+eobmpbeZHQ7pO9lCMFHiqr7jaeM
+        R8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB/dGZbUd7bew+4CbokT7l3y29
+        DZLmb4C2fwAOof+zNBk0vHgEGoV0e2VJ/3N/DGpO/89vCIHbxK4v8vaqqrEG
+        HCIQiV2VWfWNLo4yOcpAPKeYX/MBf+kYj6Yp5M3uLNJHDCP8KPhDXrFsybDs
+        X8KX6Mv+gQb0x/8HmDQ6meaPTQxEa//57Gz1o6n5f9nUvI8LFoIM/hiEf5G1
+        +VV2/Xq9WtFo8tlTWuCekhD/rHVIM/leqjIEG/xB/3N/aIfc5Ua19bqtapol
+        etHHDB32cKW0KJoeT6fVmhYT6BUfYeEJFQVmJbCV+YC/ZJbW3362ZOMm2fj/
+        vGzQ/3a3J3mLrtwn9g+deJr2zuz9bIsOJ/qUm5RF3j/ZF/YV/DHYcYct70J5
+        R4RWJolZ0M0D/SEzG3wkuhTzaP/Ay/QHPjMszS+CPcwHjnPQLPjAtqVP+XfL
+        LaZj8zc6sn8AjqCkv7HUdJnJfmQtAwOxfwUcHyU8kZf+937kVRd7OPL5pnv6
+        xuEL2J/FAUgHHwz2/bMboeTwHzHAs6LpeZ8fBrFY0Pi/WZBVc/azAPTnzuze
+        fokr89QnJX26qBqdQB/rb6wdWPb504iGCD5ihRB+JK2s5mBY9i/uRXUdvwuF
+        Zj4QNYkm9g+8TX84Lajfug8sFPr0Zi3F07B7n9rKH/S/3e1VTS5afkVEJ5J3
+        CKhxlkkK0Is/ot8H0O9u/q7NlwLxR6T8MFKSff9a6VwMhH6n3yLECj5i7MOP
+        pJUlIsOyf3EvSkF+F8QwHwgV0cT+gbfpD0dB/dZ9YKHQpzeTlLQn/Q/a82bq
+        iWEdttwyGB6z/vYj4inxXk+zMiee+3lPMhLZDxFhS8cfaUUZrFDxmyFp+PmP
+        6PpN0XUpGeezZZvX5+SZ/oiy3xRlw89/ROkPp7SjVki5bxj6XSJPPBQUkjFl
+        9bcfTdEQES8Xr4sf/IjJiWJfl4LrJpLkkAHxuPW3HxFwiICr9aQsmjnBo7ft
+        x4ALnGTs+tuPiBgSkdCOq8CvA547iOe+nmZtdlItl/kUA/GRAOweWlNpSl1/
+        kS1JOvozC8phQobwPAhRI8Q6XThoP2uQnYF5lTfrsh94fXBXvPLygii+Yb3l
+        fXvhfoZn8Vk2pVw3OvFxAbgedjPbvJ++tlj1JAoiIF/obyyz0iiQRIZgXwuE
+        oyPZ/GH4ssgferB/AB79gc+MyPKLkD75YICCuztEQWrNf+w89P8Abe0fD+gP
+        S2jzIf2v/yGSyeGH+9u7e7EP0XX3w+GEQDAjXzsTFZkL+chOBkjp/upMDX/J
+        bwUg+OsQqswLurZ/4GX6A5/JnOiLN0wSUYT+dxuifM0EkxAgwF4+slQA5u6v
+        /5fThBWLJ+436JgofOJj+l+HO/kT+p/5cLDz4x+s6/yDMWD5oKb442dBNGPY
+        O3a6fk0jWWA6/t+JKXGimKcuj/9cochIDpue59lbiI4/CiDXGxdmAG3Naiy9
+        449OBIXlNjpQ1aqED2HTAe3ghDC/PiDnJFCLiJNwA2SGvZlkx8usvCYlD8jU
+        h8UCwHp4ZV+PZsoc3lwSWgOg75r5eU0y8nUn6b067KzO/xC7ukuebJtRXqjv
+        wf5wer1LkVH7OmveVG8pVf2zgIODF8L+cIBfSzJu04OF+zUhMszNMsesTdD9
+        ngGwh4uZQmrrY/JNzIwBffe8qPOrrCxfrUtC4pvvyMELYX84wP9PsgC1kayv
+        3ydA9bAg9+Dm8E0niD7uOJT8xbB7R+b1gIJ1D2lCuYPAWdV+ez0Brj9LXXKn
+        g3R6Q47r82xCgH28AK2HKVGnh2bHyVX0GG+4xN5vkQHo78z5xpHGJ/YPvDg4
+        zPvbez470CA7+OZLWheolgty3f8/hTd1916CEUI0fh39D85JH7yD+DWgbwTo
+        VEUXtiEYfay/MelAJ/rd/BYldW+mhMRoYv/A27elN49gQByq6Rrc8vQJQfYH
+        CWi9YcOFmmSNtfj0TjBkICWD60gwf2H/wkCkGf+mg+yN2qUj0Sz4wLalT02c
+        erakzAL9zd91/jJtqNMhmlFQekDt6Q/6jf4X56QOBaBFfx5SgQYwwPQ8RIL/
+        /5ex8+iHRGdBzu6r/IJcXaEGvewTCqB7pJvxWz26XZTVJCs3oeYCXWTkCDVC
+        rAO7rVbP88u8FMx+dvpg50E62OQ+fCN9IYiQrl7l02pBeorEjwH9bPR2SXxF
+        8HPTo5vXs+V5VS/4VwLzzfd8kVPMRD2/bqpX+S9ak6TQO998NyR61Au/+eHg
+        uYMBwbimzynwf3672L+cNqu6+mlaeEHzAK9OuhJKwKgG/p2E2dhD/G3/gLKh
+        P0QFeZJvPrJ6iCGHLfCua8B/8efcFArHYBC8he7pNzbxX7x+9oZRoA/Mn/p9
+        8KfC4Q86eDk9h5bBBxaPwemi/+1uZ+VqDujyEWaw89G9/keYWnIbikviReM9
+        dL6LfDjJ2w4IgcocMjzXyBZgta3q5yh+NO3cMvjA4vH/+Wkvq/Vslq/K6poU
+        +o9k3nbr5hotgw8sHv9fnHwa3YDZ+dFUc8vgA4vH4FQzuc2sbDTEp5c0Bsq0
+        UAf+nABWb5YshN4sOdw2IBunl/uNKeeIJvQIXmFY4Uf8rpKRv0ZX5oMO8whn
+        4A37B7qjP6QvS3t8av6KkpjkhheZmLAdKrH3y0EfSLXBAY5CpslzK1abuiHc
+        4iLzPmAZsJ1WguoY41metbTOCej0r+0ZAHu4nLu2N2JCnQMTjzsJBXrXh0eG
+        4LKY0XtfDyCD9EdFnqaOikKe4mLOFsXvE7B6WFA4saqWxGxo7aPh83EUJaI2
+        /c9RG/jZP+h/ID2h2OnvKp+0xHg/pN4ohqgLGvg30VkMflbmdVvH8vosXQRf
+        hZd/2yCA2kxFmmXZl3GRYzSxf+Bt+kNgegPSt8OP8Cb9xson+MKpMDQJPmAw
+        QII+hY6xOmaIZEQoRzL6X4dkhmTrtmqmRLgmb9tiefEjyimxbqQcZTSWbUu/
+        d0l2G7C7WOs3f8g3sT4c2LALQ4cPHIIF6dLFr95nZUkg39iNBf61wH7q/0H/
+        i/cBPqZUSD47fbciTnr9I26OEpP+F6cf5SQvllXTFtOfh6QzPZjUrAFo/gZm
+        +scQlR8MEXaRt3UxfZqfF8tCaPkjupq/gZn+8d50LauLHxEVyBmA5m9gpn/c
+        QFQmq++zOk/898qvfzIjQ0DwfLoDRm8mLtGwNwMRymCM8pt8aYnPKNu/uJlS
+        nocKKpgP+MsYKbll2B+D5d9kzvCu/QNf0h+O4Pqt+4Ahom/6NJiBIbL6lmp3
+        b3v3oRcfEKWjZLvb5NM6/xH53pt8NNj3cyo2gecOBiShWoJwfu8A2sPnLbXT
+        1dcuRh7Vo8gRPjtAjrHogHVwQphfH5Dz9agFWPD9IDPsOKmeVxfFlKARXNsz
+        APRwuarqt+dlddXtWhk74MLgD2ag8Ht5xXI/+NL9xYRX1ud3wY/mA27KMLiZ
+        /xvNVIfR5Q98TX8E7OzzvH7vPuAm6DQ+88SWCGYtJzJ70oedXBpRvENBGp7M
+        4Y9IeDsSMhHjbPtFVr/N21VJn39ZUwaInF+C4hMcffWmILuo8zy6VMAYhyQG
+        CfDb0BBYOTGOnV5oEuITfQMkhhUf74u8hQASPL8vgOj1flnU7Tor9Y0uCnZU
+        dtLpt6/PTPJmQDZuE34U/MHwAl7DJ/YPdE5/fJO89un27n16Rf6g/zke4w9J
+        T3YYj6ahQ9TVelIW07OXx7MZfdMQ5X9E1m+ArEth0rNlm9fnxPM/Ius3Qtay
+        ymZPsjJbTgk6vfYjkn4wSZVTX+fTdU1LNJ/X1Xr1I9J+I6QlUrb5m2xC+Wx6
+        6UcE/WCChh7A55Rhvcquf0Tbb4S2IOGPKPuzQdlptVzmUyHijwj6DRA0W63I
+        Z2Uq/ohTabBENiLkN0BYR8KQnD+MLl0m6Oe29/dbc/xGcTiZ59O3T5fNC4qU
+        jy+zoswmRUk+GcGyjajrHwou6ya76LktP2s9f63UwgePNn9H3zbNKxKt/KSo
+        p+uiN++iJXyJpt9EHVjVwU3sX9xM9YYVWvOBvBkoCm4TfhT8wfD+v6ZIfMq+
+        zuvLYpq/rKvLghJaXQr/LGIxWzY/qJY9Lv7ooqwmWTk4fvrf/q3g3j3+2YNM
+        z88a8JMXx1+c/qxBf/nm1c8a7C9+75810G9+7zc/a7Bfv/rJbxo2SfP5eTFd
+        ZEvS0/Wqrs6LSJh5Qy/723sHG3uZwiK9ka6+kK5uME7v2SV3OpAZrtqCumXI
+        315PMDYfO8Ds4WshoXWAllOAGzRiXPW631gJQ+PS7/Tb7bQ5v6v6n79GV+aD
+        jt4WnY437B/ojv6QvqyVwafmryip97d3HpJ+JBITgQepdHfZJ/KPyDZANhYG
+        sD/TbpMMOCIpTu4DRhlDoU/74/V/+/8J1YhCJS1ivSnymkD9iEwDZKKX4v6v
+        RxTFwX3AKAJ1+rQ/Pv+3/09SielklRURyRmHLw25svJs2RQXc/bcfZoCXI/K
+        SG4xMLQOqAzMZdQ3IkhW7N723g41pT/ID93d3nV/7ND/CHVCvNN101Y12U/F
+        9qRanhcXXSyi3W0CSpL19k1WX+Q8fB+UHVAUZncIgx0QEYTOXfhRsASJibFx
+        6ijA5h4A0e8NQHr9N2STpnWxkm5vgQKNbJf+R03pD2Il+t/mICHo4S45Uu8V
+        pXxIX5a21Oo9Ug7v16X5M76uc3tx5y9ds6+pUaSVCpe+bv8SrQHw9g80oD86
+        uiauAN2nCgIvp2fLGePPLe1fBin5+5uhdBNMriNzSPKfjb7a7IJFjd7/5ruC
+        ivnZgUyzLvz/XuA36pbX5KPN1iW7Gn5vANLr/6erybQqy4HUvLCqYRTmXuGh
+        4CNpZVmYWc7+BT408sPvglPNB9yUYXAz/i1gevkDX9IfHQkIcEAT+o0FsicE
+        7gN+FxjQp/y7cr+DZv4GAvpHdCpoZg9oKr7e5CrJTJ88AkEn+EhaWVIySvYv
+        jM3Qkd/FsMwH3JRhcDP+TWiJb+wf+JL++H85YZm0A7yeZ/UUOPuUB6TeXDTc
+        UvNwvflgpPzx0m8bqc9jxHgNxfk9/V3eNANnYNw+/EimAGDpD0dJAKIPBuZk
+        A+FIORxs7z6kxvLHHmUZ5A8i6YPte7vbLy1JiaAd+pDSmL5V8iC+2xDaDfX+
+        NTr8mj3xOGNAaXLiErcREuNMf/AAbuA3JtCTNeD7fQNkDxsLA619bPrT7T7g
+        GQdn0adm1plf0DL4jWUS/EO/02+34zp+V/mUv0ZX5oMO0wmH4g37B7qjP6Qv
+        Kw341PwVpTQxhMYzRNoOlSwjMKm+FjcQZJ7DTd0Qbu/LGgSpA5YB22klqB5r
+        /KKSWvudAtbt0RAi8hwx/SPTplMefCEzEXykbc1vOrcM1J/sYELlD7SnPwSm
+        zmc4uz0ecYyrL7sPuAl6pE8NgqK/FKb5gxvqX9HZoAmg/zmbYGaF/odZoTnp
+        UNkR9kdE1j+4of71DRP57pQGxiJbENP/iOL6BzfUv74ZiltVuUFLCg5MJ0HA
+        4MgfYTT0248IfjuCN2TvCQQ1LKufbRLTQJSiPA4M2HwgVMVY7R9Kpf/fkPju
+        LGuzSdb8SIH8MIiNn+THfjn5aUT+lz8i+g+D6NlsUSwLIERp8B9R3P7BDfWv
+        n0WK2+USSr5HUs2CE9NNEDI480cYHf32owl4vwmgj4ny2aTMnxL6q3z29Eda
+        nv5mmOYPbqh/fdPUn1b0C5P/R3Snvxmm+YMb6l/fLN2LxYrGQu1/RGn+gxvq
+        Xz8blD59h39/pN8JQSGywjR/cEP965ulP6H8I5oLYRWm+YMb6l/fLM3Pizq/
+        ysqypjW+HxHc/sEN9a9vluAmMn2dT9c1JVxeVmUx/VGmi2CaP7ih/vWzS/sv
+        8rYupj8ivf2DG+pf3yzps/WMErrLix+xO/3NMM0f3FD/+mZpDo99sciXs3x2
+        WhImxfRlVZU/Ir39gxvqX98s6Y2m+RHj41MlscI0f3BD/etni/rTarlEUrJa
+        /oj+9DfDNH9wQ/3rZ4v+zY8srVJYYZo/uKH+9bNFfPz2Rda8/ZH2AZUVpvmD
+        G+pfP8QJuPujQIthmj+4of71zU6D+Xj1I58HMM0f3FD/+mYJnouP+SN6M0zz
+        BzfUv75Zeq+b7GJQlRAY6dkg52j2I0q/L6Whx0WjL9iPeZqf00qgMPePGF3/
+        4Ib6188u+X9EdPsHN9S/vlmi+9r8R3Snvxmm+YMb6l8/63Sf/UjdcOcM0/zB
+        DfWvb3YGnLppq9VPrPOa3HZ6+0d05z+4of71s0/3u7+Ifl6/yd8Brx/NAP/B
+        DfWvrzMDPAfLbJE3q2yKCfiimNZVU52349dtVZNTSW/4cwS4/VmTpsfTabVe
+        9tdqMTyPqjoX9vd063VLb9+hz3hs3JJ/s5Tjtkp8HjJoYz4IJkD+wNv0h8yG
+        ISDD5bfDj4I/5BXb8deZsug83N/e+XR79z69In/Q/9yk8Cx0aEr9ywJ4l5zf
+        DPhowPDNgJ7O8+nbF8RTx5dZUWaToqSkH73+zffU4bu70B7FtDcsYR+eXjCG
+        /Kaf9dnPzn2HFfgFZTk72eYDYTs0sX8AGP0hUAIe47fDj/Am/caCEXzhGAxN
+        gg8YDJCgTwM+jRKXBJ7+B5m/PR3V59gQ4gApQRTDld/0s5+HlGXaDmnTOs8W
+        x8usvCaPDnT05wCgIrOCVyhf+NPVBC8EhA+GAoJ0yKkjFhrZr4R+aEB/8Fv8
+        Pg8O4zVE5w8idNSvBQzepz+ki35b/s3RFJ8FH3Af6JQ+DYjs5mmDXbu/vbsD
+        ohtd8dD/41P/D/qf+4Mnyvxxj/6w+oU/pK/pf5hKmsjOdDjyd6YCdHAkNrjz
+        8DFo+u1HUyF/0P/cH0xo80cwFRupT15g1WbdSfi5Q4xo6KT0LhHpYlkhaHud
+        t1jq7SLqTYj+5jGHITZ/LR9ZfsEUu782zpI2ZijmG/6Dm4e9CP8AFfsHXqY/
+        8JnhMn4RDGI+cLyDZsEHtm2cW4i69L+4iBEIj5bvYXz0tx+R0pKSxhZ3H2VA
+        dvT8F6MfjAWo0G8eQe0bMjI0oD8shmY0/EFIFzQ1X8vL6JT+EMD9tvybowI+
+        Cz7gPtApfbpx9qJU26gVDugPK+7mw9uoCvqN/oe54NnwnYCFdQKa9WpFY6Y3
+        /NkCYu8xfxGq8ejDj4I/QG83gQLA/slfcjMQOviNp1+mDJ/YP/AK/dGhPf/E
+        tJjJxjvmdzd7+DT4wL43NF87D4iy2y87swLNTOQmYndIp1QmHfw27wejMvqA
+        PIxA+FHwB4br6CUA7J/8JTfDwILf/r9APiZgnFsvi2adlU27nhUVveZTGcB7
+        dM8kfKCmX4PgGJb8BurIb0EDAROS3f7FbyupGDjoYT4QoqOJ/QNv0x+dGXA0
+        5cZRcpKQ0/86OoI+2dve+5TIScSMU+Xuqq5+Op+i15+/1GH6+Mzm4qPv5hNq
+        7dMOMHvUbIqWwlJKAeZL6bdDzg7OwNQMlH9nYsko8bf9Q4csZNxEWYYctsC7
+        rgH/xZ9zU5/UwVvonn5jHfHF62dvGAX6wPyp3wd/Khz+oINXZ3b8Dywe9Cm+
+        JKhBbM6fAbT3mUPV+5AxFMvqWpi/uRf9K8obpHNgXamp/AGtZP+4jYmlP/bs
+        H/vbu7veHx4A+oP+1+dB+h8UHnFglKeasqLMx88KZ4HwMl2GaDyv8pGdQSFg
+        0IIJbhvwX/w5N8WM8rTRB8FbPJ80cZaz3IvMOfp98KfC4Q86eDlGQsvgA4sH
+        fYovCeqPOKvHWcWyabMlpdPohR8pK3TrOAgtgw8sHvQpviSoP2KpHkuJsvoR
+        Y/2Isb5hxrIs9SNLSB908HLMhJbBBxYP+hRfEtQfcVePuzpq60c8Rh908HIs
+        hZbBBxYP+hRfEtQf8ZjHY6v1pCyaOaWPv6IFzB+xlOnWcRBaBh9YPOhTfElQ
+        f8RSHksRO9FiDjIW2WVWlNmkBEF/xFbo1nERWgYfWDzoU3xJUH/EVh5byR8n
+        FY2nKn+kqEy3joHQMvjA4kGf4kuC+iOOAhMpR1n1RAOdvv0RS5luHQehZfCB
+        xYM+xZcE9Ucs5bEU+VLta7jtx01TXCzz2Zvq22QMX5AxpJd/xF7o1nETWgYf
+        WDzoU3xJUP8/zV4xFpGoDi4SuOJJQWgsL36kfEy3jhnQMvjA4kGf4kuC+v9T
+        7pCY/0c8Yj7o4OVYAi2DDywe9Cm+JKj/v+MRIkKtXPAjjpBuHQOgZfCBxYM+
+        xZcE9f/THMF/fIMuyzSv2+K8IC760ZqI7daxD1oGH1g86FN8SVB/xE8eP1Ea
+        8TKvn2X14v/T7ERzQ7P1I3bCH44b6A/6n/uDucD88bPDTnCIqNmP9BK6dXyD
+        lsEHFg/6FF8S1B8xUpeRxLOmxj9iJ3TruActgw8sHvQpviSoP2Inj53q9bIt
+        Fj3V9P+GQUTxFfZf5G1dTP8/ifTT/LxYFoLy/6fQZ5Wjg/j/MOr/X6S/c0V1
+        EP8fRv3/i/RnJqrzabVY5MuZIvz/PuTfQ+v//2gsF3lV5xeM6f+XhyFMRs0X
+        BaXFZjOgHI7nR/7d/z/9uxg3IGdOufLT5WVRV0uS1P+/ePtu5vBp8IEFQp/i
+        S37FmyH+DPC9z1w/3oeMl0yWa2H+5l70r298Ks0f76Ehbjv9dxfrsi1eVWX+
+        sqrKH3EDfwb43meuH+9Dxkvm27Uwf3Mv+tf/p7jhqqrf5vWPWAEzzJ8BvveZ
+        68f7kPGSyXYtzN/ci/71/ylWEL+6ywb/HxzC/wdDg+hgAkWtY/v/34j+fzJb
+        niLVgf3/bDj/P5mnDg8Wy6bNltP/VyYubx/0vc9AdTp/3g34/938+2FD96XV
+        jptA/TwYpc7u/9dH+36j/eHz8s/OLC+yJbnUs2/3J5ve9Zn3R8EIPnP9eB8y
+        XhJuuBbmb+5F//p/gwKIcsEsX5XVNab9uZ3ycPr/34D67bm6aFR75Y6hl9ki
+        zy6zoswmJbjp/7ujm5ZZ0xTTL6pJUeavaV2mIL1Er/1/d0SE6hesiDBRx9Np
+        RWvZ3RH9f1QBcRbcvch/6vfBnwqHP+jg5VQWWgYfWDzoU3xJUH9udBizwnY9
+        pdbe34YBbj3nd6fVcplPZc5/NP/SrZtutAw+sHjQp/iSoP7/Zf6Pp/9/SYjy
+        nLoX+U/9PvhT4fAHHbzcjKNl8IHFgz7FlwT1/9ssQJ/6fOD//iOe8PByLICW
+        wQcWD/oUXxLU/1/xxI/4wMPLTTtaBh9YPOhTfElQ/z/PBz+aew8vN9VoGXxg
+        8aBP8SVB/f/83PM/P2IADy8332gZfGDxoE/xJUH9/z4DEIwfTTy6dfOMlsEH
+        Fg/6FF8S1P/vT7xn/X/EBKZbN+doGXxg8aBP8SVB/X8nEzAbIDnXrLIpeOBF
+        fvUqL4vp+PjlF/SSzyGA2ucZZRNqG3CF0MpgzEQVdIOPeHj8G1OEf5M3LZW5
+        if2LYYCwTD36gN/j36MUoDTZDo2YGvIfJgnWG/brfDm7qIvZ+HRBSUpq7g8T
+        wG49cIfQELY8Sv2NeZGHyJ/K2AMSMYzwo+APecUSiGHZv0TS0Jf9Aw3oj47U
+        OtbVxu4DboJBxClMWUnwVJSo6ynlRpsntGLzthmflHlWP31CsH1KAkyPtrOs
+        zSZZQ192iNvBOiAEEN9MZyEAPrF/KDWEiAE4+chSkrsEFUwXeNN9zX/xezHC
+        +Z9q9/yl32OUuMSu9D8Ql0jbIdK0JJjUnID9iEZMI/z3/wDHRGTWqVsBAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:05 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -395,11 +395,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -409,8 +409,6 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Content-Encoding:
@@ -419,58 +417,38 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14965'
+      X-Ms-Request-Id:
+      - 54772dc2-869a-4bc2-abd1-845d9d3bdd48
+      X-Ms-Correlation-Request-Id:
+      - 54772dc2-869a-4bc2-abd1-845d9d3bdd48
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174841Z:54772dc2-869a-4bc2-abd1-845d9d3bdd48
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986529
-      X-Ms-Request-Id:
-      - 2d65500b-6173-4192-973f-5400ca103752
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - e767dca9-3c13-4498-b3bc-6403b3b15dbc
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175807Z:e767dca9-3c13-4498-b3bc-6403b3b15dbc
       Date:
-      - Thu, 22 Oct 2015 17:58:07 GMT
+      - Mon, 02 Nov 2015 17:48:40 GMT
+      Content-Length:
+      - '411'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:07 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaEast/vmSizes?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -480,11 +458,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -507,243 +485,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 091802a0-1b0c-486e-b544-8402406ccb3e_130838230597826529
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - eb810908-94f9-4c2f-84d6-af6c8e7ece29
+      - 6106f0cc-4a5d-4919-ba62-80f48376896f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - 4c6e20c1-6fb9-4a32-8d4b-5310333c9547
+      - 67e36000-327c-479e-9167-023c21c6bb18
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175809Z:4c6e20c1-6fb9-4a32-8d4b-5310333c9547
+      - EASTUS:20151102T174841Z:67e36000-327c-479e-9167-023c21c6bb18
       Date:
-      - Thu, 22 Oct 2015 17:58:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPfeQxu/3iQv34RZ6WhcfyjfpFV5vUlYPCy/
-        9jj2Dh586rUKBtIZY38g7yH1rzeJikeun5WB3Ky/3kPoX28SFI9eX3sk9x/s
-        BXLtj+Rm9fU+Mv96d5OYeP187bF08fXHcvOsvA9//aybla669YfSHWZ/KO/D
-        YD/rZqWnbP2xdMfZH8v7sdgmcflG7Mre3sN7DzxAwWh6Q+0Px9oV/Pj+b5z8
-        kv8HuPmU0+sWAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/AustraliaSoutheast/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 8715c671-2daf-41e8-8620-678553d8fd7c_130897065565810249
-      X-Ms-Request-Id:
-      - c6460e9c-be3e-4229-9308-a6cb4835fc55
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - ed5af7d3-d46c-4c73-8d4d-2ebb488dc203
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175812Z:ed5af7d3-d46c-4c73-8d4d-2ebb488dc203
-      Date:
-      - Thu, 22 Oct 2015 17:58:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPeMNsaP7//GyS/5fwCX/T1ikxAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - d0384330-e545-43f0-a33e-6355987bc2f8_130816036987436826
-      X-Ms-Request-Id:
-      - c3a54711-3794-4bde-9dc4-6e808330d09d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - 98be3c97-54c5-485e-b898-ae6252ec2bbb
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175813Z:98be3c97-54c5-485e-b898-ae6252ec2bbb
-      Date:
-      - Thu, 22 Oct 2015 17:58:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2nj397/cxGb/nzIsm4fi
-        Ifq1h7JR+L9R27J5LB7NvvZYNkr/zYrsPaR/f/NgPKJ97cFslP+bVdn7yP/9
-        zaP52dcAN6uz91IAN2gAD9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0E
-        Z/cGNfCzLjk3s9r7SM7uDYrgZ1903sd44sf3f+Pkl/w/CZ7UhtAXAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 5fa1386c-1d91-425c-ab50-72c755980c82
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - 75fc3085-4066-4d86-8bbb-3b683574e175
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175815Z:75fc3085-4066-4d86-8bbb-3b683574e175
-      Date:
-      - Thu, 22 Oct 2015 17:58:15 GMT
+      - Mon, 02 Nov 2015 17:48:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -764,2207 +519,7 @@ http_interactions:
         Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
         93/j5Jf8PzIr3UrFEwAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733957
-      X-Ms-Request-Id:
-      - 470a14aa-72e4-40fa-a65f-025efc874504
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - d66929f1-68e2-4c2a-9b39-36f9ccb2d7c0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175817Z:d66929f1-68e2-4c2a-9b39-36f9ccb2d7c0
-      Date:
-      - Thu, 22 Oct 2015 17:58:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVfn8Z1tc7j28t+cTJRjLzTx2
-        e3H5/GdbWh4cfLp/z2sWjORmFru9tHz+sy0su/cfEOV9dP2h3ILB3kNcPv9Z
-        l5Z7u5TA2PMR9kezt/fw3gOvm8ho3kdcNuXxfeb42qP5lJLG+/d9hP3R7N8/
-        eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv/7Zlv6eVPhD6Q6zP5T3kP7XP9vi
-        3xMJfyi9cfbH8j7S//pnXfx7IuGPpjfU/mjeR/pf/6yL/8PdB/d3fFbyR9Mb
-        an807yH9T4eln9p9ExFlJ9jyh/JNBpQbZd/D8muPY+/gwadeq2AgnTH2B/I+
-        E7JJ8j1y/awM5ObQ5fY67OlGsffo9bVHQhY/0Lj+SG42LO+hwUhKfraNZBdf
-        fyw3z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr
-        2TOE/mh6Q+0Px1pJ/Pj+b5z8kv8HQYPc6yMmAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 7c62b12c-d882-44db-9576-141ebc6501ac_130899364108068887
-      X-Ms-Request-Id:
-      - d9eec5c5-71d1-4de4-a866-a959b9081741
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - ff91b8be-8f98-4b42-ab7e-df6cdbfc6e93
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175819Z:ff91b8be-8f98-4b42-ab7e-df6cdbfc6e93
-      Date:
-      - Thu, 22 Oct 2015 17:58:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x89yZpi+vsf73w0cl+tF5O8/vL8pKrzhtrsuq+q5mnRvH1d/CA/W37xBN/t
-        7D+4f3/PtaBXqnU9zTvt9nb2D3Zcq0W+qOpr/e7BpwfeN9m7p1mb4fWTar1s
-        6ftd+fKXaKPBMez+LI9hf+fhp0Nj2H3w0AMQGcSefHnjIPY2DMLr4WsP4tPd
-        /f2hQdy7f7DvfdUfxL58eeMg7m0YhNfD1x7E7t7ewTA77d7ATwfy5Y2j2N8w
-        Cq+Hrz2Kvf37D4YZav/evU+97/rD2P1Uvh0ex+s2W86yevb/cfF2w/jZlnCw
-        ztAwPlzC3Th+toV8997B3s+ilLuB/GwL+t7D3YPBgWC2vK/6A7lR0N1AfrZl
-        /dPdh/f3hgbyzcr6/Q1D8RD92kPZyFw3D+U9uOvTDSP5WeeuvYNPH3ggIiN5
-        D/Z6sGEkP+vsdf/BvX2PXJGRvA97HfwsD+Xew91Qrn/2hvJww1B2PS7+2RnL
-        7u7+pwf+lx82mN1NNt7r5mdnMN/sxOxuNPT/H5uZpxsH47762mO5v7u3MyT7
-        Nxr723stT3/WvZYdsitDA7nR2N/erjz9Wfda4A0PDeRmC3l7u/L0Z9tt4ZB3
-        aCQ3W8j3kpJNYuJ187XHsruJvW6elffgr91NkvKzzmA3T8t7MNjuJln5Weew
-        b9SqPN3dJC3fiFU52H04rIpvYVXuvYc23v39Lzex2f+nDMvmoXiIfu2hbBT+
-        b9S2bB6LR7OvPZaN0n+zInsP6d/fPBiPaF97MBvl/2ZV9j7yf3/zaH72NcDN
-        6uy9FMANGsBD9msPZ6PY3Mxq7yE3uzcoAY9uX3s0GwXnZl57D8HZvUEN/KxL
-        zs2s9j6Ss3uDIvjZF51v2Hi+3uRsfhOms2NS/KF8k5bz9aZZ8bD82uPYO3jw
-        qdcqGEhnjP2BvIf4v97kZ3rk+lkZyM2K7D1E//UmL9Oj19ceyf0He4Fo+yO5
-        WYm9j9i/3t0kJl4/X3ssXXz9sdw8K+/DXz/rMVlX4/pD6Q6zP5T3YbDbxWQf
-        MJSesvXH0h1nfyzvx2KbxOUbsSt7ew/vPfAABaPpDbU/nPewK5//bMvLvYf3
-        9nyiBGO5mctuLzCf/2yLy4ODT/fvec2CkdzMY7eXl883WRZv5r/2SHZJIdNg
-        XLtgKLdgsPeQl89/1qXl3u4+xuPaBaPpyVJ/NO8jLpuWKn3m+Nqj+ZSW+Pbv
-        +wj7o9m/f/DABxIZzafvITIbnUqvm689mq5Y+GMhFvzmhH+jW+lh8LVH0pMK
-        fyjdYfaH8h7Sv9Gx9DD42kPpiYQ/lN44+2N5H+nf6Ft+I+LfEwl/NL2h9kfz
-        PtL/+mdd/B/uPri/47OSP5reUPujsdKPH9//jZNf8v8A3CFRZlUpAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthCentralUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - fc40acc7-ed1e-42ad-b741-4062ad55bf5e_130898654873913886
-      X-Ms-Request-Id:
-      - e45e9abd-87e7-4733-911c-a8a594d9b8aa
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - caae8cd1-feaf-47a7-8573-35114f388fe7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175821Z:caae8cd1-feaf-47a7-8573-35114f388fe7
-      Date:
-      - Thu, 22 Oct 2015 17:58:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
-        4YahfCPzsnEst5iX9xnM7iZv3uvmZ2cw3+zE7G7Syf/vmhn8+P5vnPyS/wen
-        09MGxRMAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthEurope/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - bb344ebd-a325-41d8-9824-737950975d04_130892630132998905
-      X-Ms-Request-Id:
-      - 5a4de30c-bc9a-4a95-8924-a3a9291488ce
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - 97d743ed-76be-4871-839d-a934f955853d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175823Z:97d743ed-76be-4871-839d-a934f955853d
-      Date:
-      - Thu, 22 Oct 2015 17:58:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPdur42PDzYMxuvla4/l3sPdUOX6Y/lGJ+b4
-        4YahfCPzsnEst5iX9xnM7iZv3uvmZ2cw3+zE7G7Syf/vmhn8+P5vnPyS/wen
-        09MGxRMAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestEurope/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 7147639b-1e2e-4238-a5eb-b3bdfc3af2dc_130890872509982066
-      X-Ms-Request-Id:
-      - 35f46c98-90e8-47e3-af1a-34dfa4f02b94
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - c2536e4c-a7b3-4313-8fd3-bc84049982bb
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175826Z:c2536e4c-a7b3-4313-8fd3-bc84049982bb
-      Date:
-      - Thu, 22 Oct 2015 17:58:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2vj1Jnn5JsxKR+P6Q/km
-        rcrrTcLiYfm1x7F38OBTr1UwkM4Y+wN5D6l/vUlUPHL9rAzkZv31HkL/epOg
-        ePT62iO5/2AvkGt/JDerr/eR+de7m8TE6+drj6WLrz+Wm2flffjrZ92sdNWt
-        P5TuMPtDeR8G+1k3Kz1l64+lO87+WN6PxTaJyzdiV/b2Ht574AEKRtMban84
-        72FXPv/Zlpd7D+/t+UQJxnIzl91eYD7/2RaXBwef7t/zmgUjuZnHbi8vn/+s
-        SwspZBqMaxcM5RYM9h7y8vnPurTc26XU0Z6PsD+aniz1R/M+4rIpd+Qzx9ce
-        zaeUc9m/7yPsj2b//sEDH0hkNJ++h8hsdCq9br72aLpi4Y+FWPCbE/6NbqWH
-        wdceSU8q/KF0h9kfyntI/0bH0sPgaw+lJxL+UHrj7I/lfaR/o2/5jYh/TyT8
-        0fSG2h/N+0j/65918X+4++D+js9K/mh6Q+2P5j2k//hgw2A8DvjaY7n3cDeM
-        t/yx3Cwy78Fmxw83DGWIyxiNb2Qs36zMHO9uWn/0uvn/wsRsjMf+3zUz+PH9
-        3zj5Jf8PaKNq1RgiAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130829004095261533
-      X-Ms-Request-Id:
-      - 2c72fd13-c61f-4f16-a0c5-eadb6f66a557
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - e658b347-2c13-462e-bd1b-83d82a17b5ba
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175829Z:e658b347-2c13-462e-bd1b-83d82a17b5ba
-      Date:
-      - Thu, 22 Oct 2015 17:58:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
-        EAAA
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SoutheastAsia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5766a2f8-6aed-48ac-b876-204ebc3aecb8_130895095482829976
-      X-Ms-Request-Id:
-      - 579880de-eea4-42e4-a1a5-bfbaa51b9c94
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - ae20e312-a978-4e0f-bc41-49c8d00dd3ba
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175831Z:ae20e312-a978-4e0f-bc41-49c8d00dd3ba
-      Date:
-      - Thu, 22 Oct 2015 17:58:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPfeQxu/3iQv34RZ6WhcfyjfpFV5vUlYPCy/
-        9jj2Dh586rUKBtIZY38g7yH1rzeJikeun5WB3Ky/3kPoX28SFI9eX3sk9x/s
-        BXLtj+Rm9fU+Mv96d5OYeP187bF08fXHcvOsvA9//aybla669YfSHWZ/KO/D
-        YD/rZqWnbP2xdMfZH8v7sdgmcflG7Mre3sN7DzxAwWh6Q+0Px9oV/Pj+b5z8
-        kv8HuPmU0+sWAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanEast/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 7d6892c1-2e0d-495d-9582-fb397c5a0378_130816136595468190
-      X-Ms-Request-Id:
-      - 300f9a14-12e3-4f3f-8cd1-ff7615202cc7
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - 534414fa-e16c-4e9b-9585-7cfaf949b696
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175833Z:534414fa-e16c-4e9b-9585-7cfaf949b696
-      Date:
-      - Thu, 22 Oct 2015 17:58:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfaMK9+BneSj3Hu6GVPeH8k2oKTeUhxuGsutR
-        7GdnLLu7+58e+F9+2GB2N+ldr5ufncF8sxOzu1H//n9sZp6+3jga99XXHkxH
-        TflDuVEP32hMvHH8bBuUvYMHn3qtgoF0xtgfyI0GxRvIz7ZR2TSQm7XxjUbF
-        G8nPtmG5/2AvkGt/JDd7v+8nJZvExOvna4+li68/lptn5X34a3eTpHjk/NpD
-        6apbfyjdYfaH8j4MtrtJVr4JDuspW38s3XH2x/J+LLZJXL4Ru7K39/DeAw9Q
-        MJreUPvDufce+niTvHwTZuX+7t7OkE/5TdqVTcLiYfm1x7G7Q2mVoYF8k3Zl
-        k6h41PraA+HId2ggN2uw9xD7TXLiketrj4Tj36GR3KzA3kfodzeJidfN1x7L
-        7ib2unlW3oO/ftbNykYGu3la3oPBftbNykYO+2bNys++VTnYfTisit/HquDH
-        93/j5Jf8PypEh9UdGgAA
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/JapanWest/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - fc53dbcb-0031-4257-b5fa-88f40bc084fc_130816135595421386
-      X-Ms-Request-Id:
-      - 210b8e6b-ae3b-46ae-acba-db53ff5aea1f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - c08b49dd-e46a-4422-ac6d-6789ec37ca13
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175835Z:c08b49dd-e46a-4422-ac6d-6789ec37ca13
-      Date:
-      - Thu, 22 Oct 2015 17:58:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nrn23Z6BDdH8mNXHWjaHjj+NkWj72D
-        B596rYKBdMbYH8iN4uEN5GdbRDYN5GbeulFEvJH8bIvJ/Qd7gZXzR3KzLX8/
-        KdkkJl4/X3ssXXz9sdw8K+/DX7ubJMUj59ceStf58IfSHWZ/KO/DYLubZOWb
-        4LDd3f1PDzxAwVi64+yP5f1YbJO47Hrz/7VHs7f38N4DD1Awmt5Q+8O59x76
-        eJO8fBNm5f7u3s6Qhfwm7comYfGw/Nrj2N2hIHFoIN+kXdkkKh61vvZA2I8f
-        GsjNGuw9xH6TnHjk+tojYW9+aCQ3K7D3EfrdTWLidfO1x7K7ib1unpX34K+f
-        dbOykcFunpb3YLCfdbOykcO+WbPys29VDnYfDqvi97Eq+PH93zj5Jf8P0E9I
-        R+sWAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/BrazilSouth/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - cb2bae3e-e017-4b5a-ac71-b7f357d0fb91_130838121219235396
-      X-Ms-Request-Id:
-      - 1b5903ea-9f6d-4056-8cf9-f6d24c521fb0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - 7f6ebc9a-d2c5-45c6-a7b4-be56c4ad9a9c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175837Z:7f6ebc9a-d2c5-45c6-a7b4-be56c4ad9a9c
-      Date:
-      - Thu, 22 Oct 2015 17:58:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fu
-        DhnzoYHcyFg3iocbyM+2hLC+HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ
-        183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk5Wedw74JH8sbyyZp2fVm
-        /2sP5mD34bAq3t3d//TAI1lkNPeMNsaP7//GyS/5fwCX/T1ikxAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestIndia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - dd46c806-9cad-4822-b97d-085c3af2c320
-      X-Ms-Correlation-Request-Id:
-      - dd46c806-9cad-4822-b97d-085c3af2c320
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175839Z:dd46c806-9cad-4822-b97d-085c3af2c320
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:38 GMT
-      Content-Length:
-      - '463'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''WestIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/SouthIndia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - 222b177a-73b4-4fd1-ad03-fa0cb9dfa95b
-      X-Ms-Correlation-Request-Id:
-      - 222b177a-73b4-4fd1-ad03-fa0cb9dfa95b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175840Z:222b177a-73b4-4fd1-ad03-fa0cb9dfa95b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:40 GMT
-      Content-Length:
-      - '464'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''SouthIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralIndia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - efe9ef07-62f0-46f8-bf1f-9fc30828aae6
-      X-Ms-Correlation-Request-Id:
-      - efe9ef07-62f0-46f8-bf1f-9fc30828aae6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175842Z:efe9ef07-62f0-46f8-bf1f-9fc30828aae6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:41 GMT
-      Content-Length:
-      - '466'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''CentralIndia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/WestUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986529
-      X-Ms-Request-Id:
-      - 2ae8a354-3ffa-4e68-9c6f-754e8126fa5e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - 37e0553f-f6ff-4617-8977-5cf8ce43408b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175844Z:37e0553f-f6ff-4617-8977-5cf8ce43408b
-      Date:
-      - Thu, 22 Oct 2015 17:58:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastUS2/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 772c4f26-4447-4b91-947d-0c7008c93042_130815979149733957
-      X-Ms-Request-Id:
-      - 6bcc5d5b-96a4-4519-bd0b-1540c570aa5b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Correlation-Request-Id:
-      - 4116fd7d-3fad-4100-bdc7-455a691d6de0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175846Z:4116fd7d-3fad-4100-bdc7-455a691d6de0
-      Date:
-      - Thu, 22 Oct 2015 17:58:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVfn8Z1tc7j28t+cTJRjLzTx2
-        e3H5/GdbWh4cfLp/z2sWjORmFru9tHz+sy0su/cfEOV9dP2h3ILB3kNcPv9Z
-        l5Z7u5TA2PMR9kezt/fw3gOvm8ho3kdcNuXxfeb42qP5lJLG+/d9hP3R7N8/
-        eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv/7Zlv6eVPhD6Q6zP5T3kP7XP9vi
-        3xMJfyi9cfbH8j7S//pnXfx7IuGPpjfU/mjeR/pf/6yL/8PdB/d3fFbyR9Mb
-        an807yH9T4eln9p9ExFlJ9jyh/JNBpQbZd/D8muPY+/gwadeq2AgnTH2B/I+
-        E7JJ8j1y/awM5ObQ5fY67OlGsffo9bVHQhY/0Lj+SG42LO+hwUhKfraNZBdf
-        fyw3z8r78NfPekTZNYT+ULrD7A/lfRjsZz2i7BlCfyzdcfbH8n4stklcvhEr
-        2TOE/mh6Q+0Px1pJ/Pj+b5z8kv8HQYPc6yMmAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/NorthCentralUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 7c62b12c-d882-44db-9576-141ebc6501ac_130899364108068887
-      X-Ms-Request-Id:
-      - 754ce6d1-0ba9-4136-912b-a57630ba73fa
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Correlation-Request-Id:
-      - ec5f8fa1-18c9-4b9d-8918-8ab5b52bb13e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175852Z:ec5f8fa1-18c9-4b9d-8918-8ab5b52bb13e
-      Date:
-      - Thu, 22 Oct 2015 17:58:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x89yZpi+vsf73w0cl+tF5O8/vL8pKrzhtrsuq+q5mnRvH1d/CA/W37xBN/t
-        7D+4f3/PtaBXqnU9zTvt9nb2D3Zcq0W+qOpr/e7BpwfeN9m7p1mb4fWTar1s
-        6ftd+fKXaKPBMez+LI9hf+fhp0Nj2H3w0AMQGcSefHnjIPY2DMLr4WsP4tPd
-        /f2hQdy7f7DvfdUfxL58eeMg7m0YhNfD1x7E7t7ewTA77d7ATwfy5Y2j2N8w
-        Cq+Hrz2Kvf37D4YZav/evU+97/rD2P1Uvh0ex+s2W86yevb/cfF2w/jZlnCw
-        ztAwPlzC3Th+toV8997B3s+ilLuB/GwL+t7D3YPBgWC2vK/6A7lR0N1AfrZl
-        /dPdh/f3hgbyzcr6/Q1D8RD92kPZyFw3D+U9uOvTDSP5WeeuvYNPH3ggIiN5
-        D/Z6sGEkP+vsdf/BvX2PXJGRvA97HfwsD+Xew91Qrn/2hvJww1B2PS7+2RnL
-        7u7+pwf+lx82mN1NNt7r5mdnMN/sxOxuNPT/H5uZpxsH47762mO5v7u3MyT7
-        Nxr723stT3/WvZYdsitDA7nR2N/erjz9Wfda4A0PDeRmC3l7u/L0Z9tt4ZB3
-        aCQ3W8j3kpJNYuJ187XHsruJvW6elffgr91NkvKzzmA3T8t7MNjuJln5Weew
-        b9SqPN3dJC3fiFU52H04rIpvYVXuvYc23v39Lzex2f+nDMvmoXiIfu2hbBT+
-        b9S2bB6LR7OvPZaN0n+zInsP6d/fPBiPaF97MBvl/2ZV9j7yf3/zaH72NcDN
-        6uy9FMANGsBD9msPZ6PY3Mxq7yE3uzcoAY9uX3s0GwXnZl57D8HZvUEN/KxL
-        zs2s9j6Ss3uDIvjZF51v2Hi+3uRsfhOms2NS/KF8k5bz9aZZ8bD82uPYO3jw
-        qdcqGEhnjP2BvIf4v97kZ3rk+lkZyM2K7D1E//UmL9Oj19ceyf0He4Fo+yO5
-        WYm9j9i/3t0kJl4/X3ssXXz9sdw8K+/DXz/rMVlX4/pD6Q6zP5T3YbDbxWQf
-        MJSesvXH0h1nfyzvx2KbxOUbsSt7ew/vPfAABaPpDbU/nPewK5//bMvLvYf3
-        9nyiBGO5mctuLzCf/2yLy4ODT/fvec2CkdzMY7eXl883WRZv5r/2SHZJIdNg
-        XLtgKLdgsPeQl89/1qXl3u4+xuPaBaPpyVJ/NO8jLpuWKn3m+Nqj+ZSW+Pbv
-        +wj7o9m/f/DABxIZzafvITIbnUqvm689mq5Y+GMhFvzmhH+jW+lh8LVH0pMK
-        fyjdYfaH8h7Sv9Gx9DD42kPpiYQ/lN44+2N5H+nf6Ft+I+LfEwl/NL2h9kfz
-        PtL/+mdd/B/uPri/47OSP5reUPujsdKPH9//jZNf8v8A3CFRZlUpAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/global/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - e4c36732-8e98-40ef-8cf0-2db072582fe8
-      X-Ms-Correlation-Request-Id:
-      - e4c36732-8e98-40ef-8cf0-2db072582fe8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175854Z:e4c36732-8e98-40ef-8cf0-2db072582fe8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:54 GMT
-      Content-Length:
-      - '460'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''global'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTWestUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - 09c7ae2e-bfe2-4bee-9e62-e7157338e6e5
-      X-Ms-Correlation-Request-Id:
-      - 09c7ae2e-bfe2-4bee-9e62-e7157338e6e5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175856Z:09c7ae2e-bfe2-4bee-9e62-e7157338e6e5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:56 GMT
-      Content-Length:
-      - '464'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''MSFTWestUS'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - 167405a9-35b1-427c-badc-ee20831dbbd1
-      X-Ms-Correlation-Request-Id:
-      - 167405a9-35b1-427c-badc-ee20831dbbd1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175857Z:167405a9-35b1-427c-badc-ee20831dbbd1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:56 GMT
-      Content-Length:
-      - '464'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''MSFTEastUS'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTEastAsia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - 4027cb31-12ec-4f77-8b43-7a8e717e72fe
-      X-Ms-Correlation-Request-Id:
-      - 4027cb31-12ec-4f77-8b43-7a8e717e72fe
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175858Z:4027cb31-12ec-4f77-8b43-7a8e717e72fe
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:58 GMT
-      Content-Length:
-      - '466'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''MSFTEastAsia'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:58:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/MSFTNorthEurope/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Failure-Cause:
-      - gateway
-      X-Ms-Request-Id:
-      - cba766f5-0d9a-4080-8e92-319b0e47d600
-      X-Ms-Correlation-Request-Id:
-      - cba766f5-0d9a-4080-8e92-319b0e47d600
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175859Z:cba766f5-0d9a-4080-8e92-319b0e47d600
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:58:59 GMT
-      Content-Length:
-      - '469'
-    body:
-      encoding: UTF-8
-      string: '{"error":{"code":"NoRegisteredProviderFound","message":"No registered
-        resource provider found for location ''MSFTNorthEurope'' and API version ''2015-06-15''
-        for type ''locations/vmSizes''. The supported api-versions are ''2015-05-01-preview,
-        2015-06-15''. The supported locations are ''eastus, eastus2, westus, centralus,
-        northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia,
-        japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth''."}}'
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/EastAsia/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 87669224-8edb-4099-85ed-2799f5f9b5ce_130829004095261533
-      X-Ms-Request-Id:
-      - 902e990b-b17c-4dac-8f28-342773ef0112
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 3ef3e26a-d949-4b3c-9c32-defd6ef898de
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175902Z:3ef3e26a-d949-4b3c-9c32-defd6ef898de
-      Date:
-      - Thu, 22 Oct 2015 17:59:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuWe0MX58/zdOfsn/A9q7uECT
-        EAAA
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/CentralUS/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - d0384330-e545-43f0-a33e-6355987bc2f8_130816036987436826
-      X-Ms-Request-Id:
-      - a38308c8-0c44-4f3c-aa17-c366b5f4cda0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Correlation-Request-Id:
-      - c000f70c-ace8-478d-a131-161d60890536
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175904Z:c000f70c-ace8-478d-a131-161d60890536
-      Date:
-      - Thu, 22 Oct 2015 17:59:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2nj397/cxGb/nzIsm4fi
-        Ifq1h7JR+L9R27J5LB7NvvZYNkr/zYrsPaR/f/NgPKJ97cFslP+bVdn7yP/9
-        zaP52dcAN6uz91IAN2gAD9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0E
-        Z/cGNfCzLjk3s9r7SM7uDYrgZ1903sd44sf3f+Pkl/w/CZ7UhtAXAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - d2291cb4-f297-4eeb-b3df-1cc278fa78b1
-      X-Ms-Correlation-Request-Id:
-      - d2291cb4-f297-4eeb-b3df-1cc278fa78b1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175906Z:d2291cb4-f297-4eeb-b3df-1cc278fa78b1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:06 GMT
-      Content-Length:
-      - '387'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH99OIbf/yX/D22hnRl1BQAA
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - fbd30d21-43a0-48e6-a766-c893ee59f232
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 6fc3bd31-7948-4b2d-8391-eab2e5a2e596
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175907Z:6fc3bd31-7948-4b2d-8391-eab2e5a2e596
-      Date:
-      - Thu, 22 Oct 2015 17:59:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/jizJrz6t68dVqlrX502qRFcuTar1sqd39UaThs2xdtmG7e367
-        y6Ju11n5RTadF0vuTpGRx+sbz0fFjFp8dLdZT5ppXazaolo2d/c/3Tvfy84P
-        tvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz2f7B/bt13lTrepp/XlfrVXP35Nun
-        z7Zfvvry6V0a62Uxy+vm7hfFtK6a6rwdn1SL1brN73awc2995OP1S7wB/b8O
-        5Zdfvn7z+avT19tPT38yxNr98X3zqxvJN4j2PD/ffllXs41oZ5dZUWaToiza
-        69d529w9Dj/Y+8ihtswW4NqPNjRpr1fc5OaOvJfKapphnHgxz5p23SjBmFRE
-        pF/y/wAyNDwxNwMAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - abbe54f5-d36c-4751-a8eb-7fd7eb8fdaec
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - 9c90d07b-1bd2-4394-8ce8-6c8cd9ab523b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175909Z:9c90d07b-1bd2-4394-8ce8-6c8cd9ab523b
-      Date:
-      - Thu, 22 Oct 2015 17:59:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/jizJrz6t68dVqlrX502qRFcuTar1sqd39UaThs2xdtmG7e367
-        y6Ju11n5RTadF0vuTpGRx+sbz0fFjFp8dLdZT5ppXazaolo2d/c/3Tvfy84P
-        tvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz2f7B/bt13lTrepp/XlfrVXP35Msv
-        Xn715vQnv3h9lwZ7Wczyurn7RTGtq6Y6b8cn1WK1bvO7HfTunnz79Nnr01c/
-        efpq9yMftV/ijen/fVifvnr5/yFsvzj7ib0QXffH982vbgjfIL6C0E9+0WzE
-        N7vMijKbFGXRXr/O2+bucfjB7kcOt2W2gIB9tKFJe73iJjd35L1UVtMMA8WL
-        eda060YpZuhiJ/VHsmzI2UHv7uuXpyfbP/nFjlJOHkM/ef5finJH97g//l8p
-        Hovr40v6xeNeIxX9b75hYcAPoskv+X8Ar+8O+u8GAAA=
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 28ed9487-1227-475d-a17f-f36155ad3f7e
-      X-Ms-Correlation-Request-Id:
-      - 28ed9487-1227-475d-a17f-f36155ad3f7e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175910Z:28ed9487-1227-475d-a17f-f36155ad3f7e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:10 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 26930df0-76c4-4cec-a6cb-f1802dd8c5eb
-      X-Ms-Correlation-Request-Id:
-      - 26930df0-76c4-4cec-a6cb-f1802dd8c5eb
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175912Z:26930df0-76c4-4cec-a6cb-f1802dd8c5eb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:12 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 8f2dd463-d6c2-42e4-a9fa-9a3c8bd9e9ee
-      X-Ms-Correlation-Request-Id:
-      - 8f2dd463-d6c2-42e4-a9fa-9a3c8bd9e9ee
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175913Z:8f2dd463-d6c2-42e4-a9fa-9a3c8bd9e9ee
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:13 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - d6dd7fa2-db08-4fd2-afe3-51878570feca
-      X-Ms-Correlation-Request-Id:
-      - d6dd7fa2-db08-4fd2-afe3-51878570feca
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175917Z:d6dd7fa2-db08-4fd2-afe3-51878570feca
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:16 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 81f236cd-081c-4002-b99e-691c3ca0613e
-      X-Ms-Correlation-Request-Id:
-      - 81f236cd-081c-4002-b99e-691c3ca0613e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175918Z:81f236cd-081c-4002-b99e-691c3ca0613e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:18 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/availabilitySets?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 1637df3c-3228-4625-80be-27a797e55161
-      X-Ms-Correlation-Request-Id:
-      - 1637df3c-3228-4625-80be-27a797e55161
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175920Z:1637df3c-3228-4625-80be-27a797e55161
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:19 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 260e77ae-4d8a-4809-a2a1-b7cbfd0596a6
-      X-Ms-Correlation-Request-Id:
-      - 260e77ae-4d8a-4809-a2a1-b7cbfd0596a6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175922Z:260e77ae-4d8a-4809-a2a1-b7cbfd0596a6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 22 Oct 2015 17:59:21 GMT
-      Content-Length:
-      - '387'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH99OIbf/yX/D22hnRl1BQAA
-    http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:22 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -2977,11 +532,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3000,17 +555,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14973'
       X-Ms-Request-Id:
-      - 4596a1f3-3d9c-4a96-913a-7e724c4c0628
+      - 8ddf5551-e545-4581-b091-b01b9ecec3d1
       X-Ms-Correlation-Request-Id:
-      - 4596a1f3-3d9c-4a96-913a-7e724c4c0628
+      - 8ddf5551-e545-4581-b091-b01b9ecec3d1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175923Z:4596a1f3-3d9c-4a96-913a-7e724c4c0628
+      - EASTUS:20151102T174842Z:8ddf5551-e545-4581-b091-b01b9ecec3d1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:23 GMT
+      - Mon, 02 Nov 2015 17:48:41 GMT
       Content-Length:
       - '1446'
     body:
@@ -3050,7 +605,7 @@ http_interactions:
         ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
         b2cOFgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:24 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3063,11 +618,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3086,17 +641,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14972'
       X-Ms-Request-Id:
-      - fc46e38f-83e1-459f-91b1-6e29ff4bea3c
+      - 3dcf0781-cd80-4e98-b9ee-f7aee37979db
       X-Ms-Correlation-Request-Id:
-      - fc46e38f-83e1-459f-91b1-6e29ff4bea3c
+      - 3dcf0781-cd80-4e98-b9ee-f7aee37979db
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175925Z:fc46e38f-83e1-459f-91b1-6e29ff4bea3c
+      - EASTUS:20151102T174842Z:3dcf0781-cd80-4e98-b9ee-f7aee37979db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:25 GMT
+      - Mon, 02 Nov 2015 17:48:41 GMT
       Content-Length:
       - '1791'
     body:
@@ -3143,7 +698,7 @@ http_interactions:
         fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
         lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:25 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3156,11 +711,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3179,17 +734,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14971'
       X-Ms-Request-Id:
-      - 584ea95a-c8fa-4eef-b574-cf22953c8e84
+      - 0dd58274-8355-412f-9352-95c4b840245c
       X-Ms-Correlation-Request-Id:
-      - 584ea95a-c8fa-4eef-b574-cf22953c8e84
+      - 0dd58274-8355-412f-9352-95c4b840245c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175926Z:584ea95a-c8fa-4eef-b574-cf22953c8e84
+      - EASTUS:20151102T174842Z:0dd58274-8355-412f-9352-95c4b840245c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:26 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '133'
     body:
@@ -3199,7 +754,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:27 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3212,11 +767,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3235,17 +790,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14975'
       X-Ms-Request-Id:
-      - e12653a8-69b6-47aa-aa4a-36b148a95f49
+      - 2a8b9a2e-6488-4b6d-9a3c-8c3fe627320d
       X-Ms-Correlation-Request-Id:
-      - e12653a8-69b6-47aa-aa4a-36b148a95f49
+      - 2a8b9a2e-6488-4b6d-9a3c-8c3fe627320d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175928Z:e12653a8-69b6-47aa-aa4a-36b148a95f49
+      - EASTUS:20151102T174842Z:2a8b9a2e-6488-4b6d-9a3c-8c3fe627320d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:27 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '133'
     body:
@@ -3255,7 +810,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:28 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3268,11 +823,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3291,17 +846,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14981'
       X-Ms-Request-Id:
-      - 3bb4d8f5-fa9e-4cb5-a579-3e52ddb9238b
+      - a9599ab7-015a-402c-97ed-139364b1f31b
       X-Ms-Correlation-Request-Id:
-      - 3bb4d8f5-fa9e-4cb5-a579-3e52ddb9238b
+      - a9599ab7-015a-402c-97ed-139364b1f31b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175929Z:3bb4d8f5-fa9e-4cb5-a579-3e52ddb9238b
+      - EASTUS:20151102T174843Z:a9599ab7-015a-402c-97ed-139364b1f31b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:29 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '1160'
     body:
@@ -3334,7 +889,7 @@ http_interactions:
         a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
         dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:29 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3347,11 +902,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3370,17 +925,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14992'
       X-Ms-Request-Id:
-      - 071be2bb-3b54-4b53-a098-d004702f31d7
+      - 0ea2a3b7-70aa-4d09-b667-ac28434fc3d9
       X-Ms-Correlation-Request-Id:
-      - 071be2bb-3b54-4b53-a098-d004702f31d7
+      - 0ea2a3b7-70aa-4d09-b667-ac28434fc3d9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175930Z:071be2bb-3b54-4b53-a098-d004702f31d7
+      - EASTUS:20151102T174843Z:0ea2a3b7-70aa-4d09-b667-ac28434fc3d9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:30 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '133'
     body:
@@ -3390,7 +945,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:31 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3403,11 +958,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3426,17 +981,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14964'
       X-Ms-Request-Id:
-      - 4ed801c1-ccaa-4c14-b486-e1d430633971
+      - 611864d7-0efc-4216-a251-ce4aeeb7cdf4
       X-Ms-Correlation-Request-Id:
-      - 4ed801c1-ccaa-4c14-b486-e1d430633971
+      - 611864d7-0efc-4216-a251-ce4aeeb7cdf4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175932Z:4ed801c1-ccaa-4c14-b486-e1d430633971
+      - EASTUS:20151102T174843Z:611864d7-0efc-4216-a251-ce4aeeb7cdf4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:32 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '133'
     body:
@@ -3446,7 +1001,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:32 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -3459,11 +1014,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3482,17 +1037,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14972'
       X-Ms-Request-Id:
-      - 8feea206-f5b9-4985-9a95-707e00873bad
+      - e47ef8e7-9912-417a-ae86-1f7a6b701925
       X-Ms-Correlation-Request-Id:
-      - 8feea206-f5b9-4985-9a95-707e00873bad
+      - e47ef8e7-9912-417a-ae86-1f7a6b701925
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175934Z:8feea206-f5b9-4985-9a95-707e00873bad
+      - EASTUS:20151102T174843Z:e47ef8e7-9912-417a-ae86-1f7a6b701925
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:33 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '1084'
     body:
@@ -3524,7 +1079,7 @@ http_interactions:
         vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
         IA8AAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:34 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
@@ -3537,11 +1092,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3560,17 +1115,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14963'
       X-Ms-Request-Id:
-      - e49790e3-d70f-44db-ab69-88e487dbd108
+      - 1c1c5ee5-5172-4c41-9640-3febf39b316e
       X-Ms-Correlation-Request-Id:
-      - e49790e3-d70f-44db-ab69-88e487dbd108
+      - 1c1c5ee5-5172-4c41-9640-3febf39b316e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175935Z:e49790e3-d70f-44db-ab69-88e487dbd108
+      - EASTUS:20151102T174843Z:1c1c5ee5-5172-4c41-9640-3febf39b316e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:35 GMT
+      - Mon, 02 Nov 2015 17:48:42 GMT
       Content-Length:
       - '502'
     body:
@@ -3589,7 +1144,7 @@ http_interactions:
         Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
         PiqhoAIAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:36 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
@@ -3602,11 +1157,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3625,17 +1180,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14952'
       X-Ms-Request-Id:
-      - 6133d1e7-f491-42b7-82dc-23e0e82934e7
+      - 443c066a-c448-405d-b310-690dbbc4a932
       X-Ms-Correlation-Request-Id:
-      - 6133d1e7-f491-42b7-82dc-23e0e82934e7
+      - 443c066a-c448-405d-b310-690dbbc4a932
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175937Z:6133d1e7-f491-42b7-82dc-23e0e82934e7
+      - EASTUS:20151102T174844Z:443c066a-c448-405d-b310-690dbbc4a932
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:37 GMT
+      - Mon, 02 Nov 2015 17:48:43 GMT
       Content-Length:
       - '1685'
     body:
@@ -3680,7 +1235,7 @@ http_interactions:
         Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
         jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:38 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
@@ -3693,11 +1248,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3716,17 +1271,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14971'
       X-Ms-Request-Id:
-      - 7c049848-d9f7-43af-b269-2b4981432a41
+      - 9b23b094-347d-47fa-8395-d62f34d938cf
       X-Ms-Correlation-Request-Id:
-      - 7c049848-d9f7-43af-b269-2b4981432a41
+      - 9b23b094-347d-47fa-8395-d62f34d938cf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175939Z:7c049848-d9f7-43af-b269-2b4981432a41
+      - EASTUS:20151102T174844Z:9b23b094-347d-47fa-8395-d62f34d938cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:39 GMT
+      - Mon, 02 Nov 2015 17:48:43 GMT
       Content-Length:
       - '501'
     body:
@@ -3745,7 +1300,7 @@ http_interactions:
         WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
         IniEAgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:39 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:42 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
@@ -3780,18 +1335,20 @@ http_interactions:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:09B0:9B86B8B:5637A1FC
       Content-Length:
       - '358'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 22 Oct 2015 17:59:42 GMT
+      - Mon, 02 Nov 2015 17:48:44 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-jfk1023-JFK
+      - cache-jfk1024-JFK
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -3800,8 +1357,10 @@ http_interactions:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
+      X-Fastly-Request-Id:
+      - 4f478c50bb64fe7ece468ff3dc4cb9f7e080adf7
       Expires:
-      - Thu, 22 Oct 2015 18:04:42 GMT
+      - Mon, 02 Nov 2015 17:53:44 GMT
       Source-Age:
       - '0'
     body:
@@ -3836,7 +1395,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:42 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
@@ -3849,11 +1408,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -3872,17 +1431,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14962'
       X-Ms-Request-Id:
-      - f5894f46-adc6-48d8-a064-d665fe6de742
+      - b8104a71-26fb-411c-b365-38ccda341d03
       X-Ms-Correlation-Request-Id:
-      - f5894f46-adc6-48d8-a064-d665fe6de742
+      - b8104a71-26fb-411c-b365-38ccda341d03
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175944Z:f5894f46-adc6-48d8-a064-d665fe6de742
+      - EASTUS:20151102T174844Z:b8104a71-26fb-411c-b365-38ccda341d03
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:43 GMT
+      - Mon, 02 Nov 2015 17:48:44 GMT
       Content-Length:
       - '493'
     body:
@@ -3900,7 +1459,7 @@ http_interactions:
         AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
         +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:44 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
@@ -3935,18 +1494,20 @@ http_interactions:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:09AA:5BA6A17:5637A1FD
       Content-Length:
       - '1004'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 22 Oct 2015 17:59:46 GMT
+      - Mon, 02 Nov 2015 17:48:45 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-jfk1027-JFK
+      - cache-jfk1023-JFK
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -3955,8 +1516,10 @@ http_interactions:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
+      X-Fastly-Request-Id:
+      - 2730f22fa63a0f22b01466eb80ad56822f6ccf9a
       Expires:
-      - Thu, 22 Oct 2015 18:04:46 GMT
+      - Mon, 02 Nov 2015 17:53:45 GMT
       Source-Age:
       - '0'
     body:
@@ -3993,7 +1556,7 @@ http_interactions:
             }
 
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:46 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
@@ -4006,11 +1569,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4029,17 +1592,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14977'
       X-Ms-Request-Id:
-      - a88afd68-6b30-4839-baad-2dab0ac18847
+      - d235e333-5fee-4e74-a066-d224dccd3560
       X-Ms-Correlation-Request-Id:
-      - a88afd68-6b30-4839-baad-2dab0ac18847
+      - d235e333-5fee-4e74-a066-d224dccd3560
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175947Z:a88afd68-6b30-4839-baad-2dab0ac18847
+      - EASTUS:20151102T174845Z:d235e333-5fee-4e74-a066-d224dccd3560
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:47 GMT
+      - Mon, 02 Nov 2015 17:48:44 GMT
       Content-Length:
       - '1505'
     body:
@@ -4080,7 +1643,7 @@ http_interactions:
         DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
         VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:48 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -4115,18 +1678,20 @@ http_interactions:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
+      X-Github-Request-Id:
+      - C71B4C14:09B0:9B86CD4:5637A1FD
       Content-Length:
       - '1902'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 22 Oct 2015 17:59:53 GMT
+      - Mon, 02 Nov 2015 17:48:45 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-jfk1032-JFK
+      - cache-jfk1028-JFK
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -4135,8 +1700,10 @@ http_interactions:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
+      X-Fastly-Request-Id:
+      - 41e92fa5555f711965f8d8fc5f5bc25f5757317f
       Expires:
-      - Thu, 22 Oct 2015 18:04:53 GMT
+      - Mon, 02 Nov 2015 17:53:45 GMT
       Source-Age:
       - '0'
     body:
@@ -4481,7 +2048,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:53 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
@@ -4494,11 +2061,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4517,17 +2084,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14979'
       X-Ms-Request-Id:
-      - 8f7d6098-50e8-48f9-92b0-fe200a64ce56
+      - 634f4366-21af-40ba-a3a4-52f972943563
       X-Ms-Correlation-Request-Id:
-      - 8f7d6098-50e8-48f9-92b0-fe200a64ce56
+      - 634f4366-21af-40ba-a3a4-52f972943563
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175954Z:8f7d6098-50e8-48f9-92b0-fe200a64ce56
+      - EASTUS:20151102T174845Z:634f4366-21af-40ba-a3a4-52f972943563
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:54 GMT
+      - Mon, 02 Nov 2015 17:48:45 GMT
       Content-Length:
       - '1307'
     body:
@@ -4564,7 +2131,7 @@ http_interactions:
         miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
         AAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:55 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
@@ -4577,11 +2144,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4600,17 +2167,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14981'
       X-Ms-Request-Id:
-      - 33cbd020-8d5c-4625-a0ab-dc60b6d98471
+      - bf8400ec-9327-4c62-bdaf-86ceff84f873
       X-Ms-Correlation-Request-Id:
-      - 33cbd020-8d5c-4625-a0ab-dc60b6d98471
+      - bf8400ec-9327-4c62-bdaf-86ceff84f873
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175955Z:33cbd020-8d5c-4625-a0ab-dc60b6d98471
+      - EASTUS:20151102T174845Z:bf8400ec-9327-4c62-bdaf-86ceff84f873
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Thu, 22 Oct 2015 17:59:55 GMT
+      - Mon, 02 Nov 2015 17:48:45 GMT
       Content-Length:
       - '1090'
     body:
@@ -4642,10 +2209,10 @@ http_interactions:
         557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
         /h+BjiSEdgwAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:56 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4655,11 +2222,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4680,20 +2247,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - cf9233d9-8314-40ea-81f0-fb76317a524b
+      - 6203b526-a0f8-4000-a36e-9d51c17a0b02
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 20e81798-27e8-4ee3-920a-b9eccd8a8cb5
+      - bd8987ac-9706-41f6-ae37-83403d5ccfe5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175957Z:20e81798-27e8-4ee3-920a-b9eccd8a8cb5
+      - EASTUS:20151102T174846Z:bd8987ac-9706-41f6-ae37-83403d5ccfe5
       Date:
-      - Thu, 22 Oct 2015 17:59:56 GMT
+      - Mon, 02 Nov 2015 17:48:45 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4702,41 +2269,21 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
         5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
         d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/1oMr0/3bl3
-        vrv96Xk+3d6f7t/ffri3k2/vnc/u59NPpw93s/z3/ch7ub1e8Vhv7Np7p6ym
-        GQaO9/Ksadf+lzSaVV63Rd7Q15am8sVl0dBrxfLidZu13O3r9XSa57PcGw81
-        taRaC7l3H+5/+uBBvrv94OBgZ3v//izbnjx8kG1Pzw/O7+9NJrNP750HALLZ
-        jGA0r1fZFN14aLgvX9b5efGO0VQOMM9HuzvjvfHOeOfu7qcf+V993/3xS/zu
-        iBuWeduDFHRLzQxfzfLzbF22PsZ4/l/DW3cJA4zn7hCiH8Jx8oAbomwiD76+
-        JbPIE04qGts53NuPNC9WJ9XyvLhY18zJQCKYOnl6eOH5YU8TzQR+ni3bvD4n
-        fm7uTvEevTK7v7dztzsS+mDKH+wGrCuPz7Xm+X/pIFdV014QrO1Zfrl/7z4N
-        6//d43zx+7z6/D2H2GRl3pxXBGPdHBzQgN5nhN2PPN2EJ/je+8M2088MpSx1
-        rJY6qRardZv/5Be+dv/GyOWgbyRaT0fZ1zykfHU0fZg9PPh0trd9kNM/ZDZm
-        ZCruP9iGJsJH+f17O746+v+GAZw+3M/Od3bI4j3cOd/e3z2YbD98SKbwfLKb
-        3Xvw8NPznQ4AVYcfYAD5v//PGkDLJl+Tu+4SDhjRrUzg+/KcPOCHKKPIg69v
-        yS7yhNOKxnYWoyaQhodRv86n67por5ly9FYPEWr6w56XGGrU7uwn9P2+QvS5
-        UZ7/l5h4QfiWA/Zsw6L4RVN5d3d/71MyBeFg6IMNtqFHjP/3jhO+TJPXl3m9
-        e/DpPRrW/0/H6eZz7+D+/4/HuVpP2rxp9+//f8Az/bpjzOvV/Z3/93ukX3t8
-        xKt7D/Ye0Hj+Xz5A0h1fJ7Sw722ThamWs237HY3wfYbc/chzj/AE33t/2Gb6
-        mSGdJZd1lBbXP/ni9I0z3t8g7W7HHF0PqYeQ7wdNdnams+nO/vYOGa3t/Yz8
-        1YcPCI/pXj77NJ/sPHh4nvl+0P83fO/dT3f3ptO9g+2HO5/SqPbvnW9n558+
-        3P50b/9gl9zx3ez+bgBA/bD/l/rer7n5doAynv+XsNZd6p/wa+4O4vkhHCcP
-        uCHKJvLg61syizzhpKKxncOo591VMvRGMHXy9PDC80OfJZoD/LQasrm7LKb/
-        P7btNLpdGsz7jK77kSeoeILvvT9sM/3MUMlSxopss6LMKoTD8dIPnVJdaY3h
-        5Evmvdm9/fP9853tew8/3aW08N5kezLbu7c92T3f2f90Os3uTfZ9yfz/hi3Y
-        PyByfjo9p/h+52B7P783I31zL9/e3Tm/P53t7e/uHuwFAFQz/MgWfE3uukso
-        EIq3NAfvy3TygCGinCIPvr4lv8gTzisa22n8/6E54Kn6GlqzR4f/9w/xfc1e
-        9yNPavEE33t/2Gb6mSGVJY+VXwrUsh+sa8qHaRP67hsjlwW+kVpdybVveSj5
-        Inr/fnawO5vcJw06oVzpA8pkH+SsUB+Sj53tnd+/H+RKf1bsQlTa30POP7Kk
-        Urtw/+Dg0we7GQUFkykpnoNJtk2f7G0/uD/dPXi4v7+3e/5pAEBVxAfYhV1W
-        KD87dmEo6S2DvUvQfm556y5hgPHcKjv/vhwnD7ghyiby4OtbMos84aSisZ3D
-        //caBUdwHu7ANNFM4KenMClB9uD++y5o9mjw/9rh0XsHn75vTr77kSeqeILv
-        vT9sM/2Mf9CHv+T/AQazL9/EJAAA
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/1o9vDe/u7B
+        vWw7f7BLmOx/em/74XR3ur2fne/ku7v75wf709/3I+/l9nrFY72xa++dsppm
+        GDjey7OmXftf0mhWed0WeUNfW5rKF5dFQ68Vy4vXbdZyt6/X02mez3JvPNTU
+        kmot5N59uP/pgwf57vaDg4Od7f37s2x78vBBtj09Pzi/vzeZzD69dx4AyGYz
+        gtG8XmVTdOOh4b58WefnxTtGUznAPB/t7oz3xjvjnbu7n37kf/V998cv8bsj
+        bljmbQ9S0C01M3w1y8+zddn6GOP5fw1v3SUMMJ67Q4h+CMfJA26Isok8+PqW
+        zCJPOKlobOdwbz/SvFidVMvz4mJdMycDiWDq5OnhheeHPU00E/h5tmzz+pz4
+        ubk7xXv0yuz+3s7d7kjogyl/sBuwrjw+15rn/6WDXFVNe0Gwtmf55f69+zSs
+        /3eP88Xv8+rz9xxik5V5c14RjHVzcEADep8Rdj/ydBOe4HvvD9tMP+Mf9OEv
+        +X8AsdVUNRQHAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:58 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4746,11 +2293,442 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8ec09b80-90d0-4fc7-8c78-c907d0a2a6e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Correlation-Request-Id:
+      - 71c1845c-ea83-4b23-a2ba-094efe6f6796
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174846Z:71c1845c-ea83-4b23-a2ba-094efe6f6796
+      Date:
+      - Mon, 02 Nov 2015 17:48:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14968'
+      X-Ms-Request-Id:
+      - e9bc1924-57da-43c8-bcf7-2ea1a2e1bb6d
+      X-Ms-Correlation-Request-Id:
+      - e9bc1924-57da-43c8-bcf7-2ea1a2e1bb6d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174846Z:e9bc1924-57da-43c8-bcf7-2ea1a2e1bb6d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:45 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - b9768fa9-a549-4772-abe1-5992095441bf
+      X-Ms-Correlation-Request-Id:
+      - b9768fa9-a549-4772-abe1-5992095441bf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174846Z:b9768fa9-a549-4772-abe1-5992095441bf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4101a507-1633-49cc-8105-2955b452b8a6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - fd2c3f00-f25b-44ea-83e6-5c12cd9f9e3a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174847Z:fd2c3f00-f25b-44ea-83e6-5c12cd9f9e3a
+      Date:
+      - Mon, 02 Nov 2015 17:48:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14951'
+      X-Ms-Request-Id:
+      - 65323b12-f18d-40c6-a34d-a25e10e8ec93
+      X-Ms-Correlation-Request-Id:
+      - 65323b12-f18d-40c6-a34d-a25e10e8ec93
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174847Z:65323b12-f18d-40c6-a34d-a25e10e8ec93
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14971'
+      X-Ms-Request-Id:
+      - c26927de-cc34-464f-a32e-ca2ed194c858
+      X-Ms-Correlation-Request-Id:
+      - c26927de-cc34-464f-a32e-ca2ed194c858
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174847Z:c26927de-cc34-464f-a32e-ca2ed194c858
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14973'
+      X-Ms-Request-Id:
+      - c25e09e5-db9b-4d33-be64-18e848e8f2a5
+      X-Ms-Correlation-Request-Id:
+      - c25e09e5-db9b-4d33-be64-18e848e8f2a5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174847Z:c25e09e5-db9b-4d33-be64-18e848e8f2a5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4773,20 +2751,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 93dd445a-b6ff-4838-8c32-e250febda980
+      - 82c63701-d54b-428d-8d8b-d9a04c5df1ff
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14972'
       X-Ms-Correlation-Request-Id:
-      - 349e9ac7-2368-4b52-8a1c-af95d7cda76b
+      - 2efa3916-999d-48d2-9e17-64e856ff60de
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T175959Z:349e9ac7-2368-4b52-8a1c-af95d7cda76b
+      - EASTUS:20151102T174847Z:2efa3916-999d-48d2-9e17-64e856ff60de
       Date:
-      - Thu, 22 Oct 2015 17:59:59 GMT
+      - Mon, 02 Nov 2015 17:48:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4796,65 +2774,32 @@ http_interactions:
         8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
         Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
         /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP35Nunz7Zfvvry6V0axGUxy+vm7hfFtK6a6rwdn1SL1brN73bQae4e/+Tx
-        2fPjJ2fPz978Pq9P3+x95LD7Jf445lk9u8rq/GVdnRcliBeO43LxuvgBPv7o
-        dZstZ9T69z/eGQLWtFWdXQzCKhb05av8PK/z5bT3NTVYrSdl0czzmr77aDrP
-        z7cxSKDn0x7PR9U5gXHN8vqS/uw2at6uTZPJdVX2vqd3GpoYtCmzNm9ab2Dh
-        0Khx1TwtmrfUtot11by5XmE4Hz0vlut3vV6W2YK/PSE0tok2s16LaZ1T918y
-        l6Dls7panIFYvZaXc/BVBwP6fF0X9PlH87ZdPbp7FwMmbpnd393bGU/KajKe
-        VnU+viqWs+qqGS/z9i4BIt6idozRmP4Mxt4dPXUxzabzYnmBbl6RTHy3Lto8
-        eCd846NZ1magGETue993X/nNiHbUfZRZpsLZ9YvN1Psomy2K5VfEAIbMk7pa
-        ZhfzptOuxNycVMvz4mJdZ0rpoEtqNCuabFLmL7Omuarq2fG6nefLtpia9udZ
-        2eT+O/5g6P0mp6lsN46YiE+g39JIzLDNR2dLGu55NoWS+t4v/gga5BtRIIZw
-        UQXyQvq+28OBmWibXpnd39v56Jd8PxgEfXxZQHSIIUgvECMQ4V+vp9M8n+WO
-        k9w7HxmkaGxGPeMJJoCH/ENUmpdF3a6z8osMjE0jdpTK37X5EuPzXzujTy7m
-        bTP+yS+eFtnFsmqIMxrSti1RobGDpmGbX7/vxv//lqE5qdiklz5qVaPdCNl7
-        p6ysnHyUZ0279r9clRm+8Obb9g9G66rnW5oCMOJsPYX51UZiCEwLnQnDh7Z3
-        vLfZITifnt+bTfPp9vnkYLa9//D8/vbD2cF0e7J7P59Nz88f7OxPA0w6Fphg
-        eGDp+x8yA3TQ+f+DQ2AH+V2xY69lrr3+8DjPYHMz9Q32dnYOtl/tbb9+udtr
-        Qq9BB6DZN+IeKEK9fowgvCSNckGzvf00v+w1IsNCOPzwfQQfqf8PuAk+uiFl
-        bu0pKAlu8hWIeGIDf/KL4wvyEqhJW6/zABY1y5fwKMiTqBYEafrVigbMWgeN
-        /bb+gOm9/z+5EiszKbP8cv/e/a43MXPWlICbsbgG1GRSVa1ndLvfUwuhMw2U
-        CeuBx2MU0VfvKQIh47o/AvQJhDACsT3pRGJ36uL/886QL0j///OH/NE58b9B
-        E39TXpF8Z/jBzjoYabNTcrD76YOHD6Y7259O7hF9pnu72wf5HuUrDmZ7Dz+d
-        Hczy3T3XNb3Y8QIIhgeWvv/mZuHLL15+9eb0J794vXEaOvj0vJJdpQ0eQx88
-        X8sruT8ETJXBEKz380qgRKK+KR7njEizja4ImnT9YDzfuB+yOU0BNATRvkdE
-        JokQ+AadEOGLy0Wze+/hXlwHixviYfX/AS/EwzakzK2dkJ+/6Qoh5U9+QW5D
-        RJMMOxkezQ8+vdf1MRgWpIi4glQEcQPR/v9NRvp2CrRjZ/xB/7/aSH/w6Jx4
-        bFZU35SNdl/+fy1zMZ3u7pJDu7f9abaXbe+f36OkxcEk286ns08/PX94sHv/
-        4Ocqc3E7Lujg87PrJAwC+0adhJNsSZpnmgWcgsc5CF9N1st2vTlZsbs/3tkf
-        39t+/uZ1rwm9BtlHsx+Ck3D66mXvO7Il1PHPhXNA2Px/wCkgLENK/MgZuFFj
-        CAnf3xnI69X9nV6igWFASogLSAXQ7BPN/7/vBBBj/f/Q+NOonBjEFY8z9jdB
-        896JGHv5zky7nVzwy2Zb++mDnU/3pwcPKAx/+IDIMXm4nT38lOLz/en92f5k
-        cj7bvee6phc7to1geGDp+x820Tv4/Oza2h/OMsH/72ztF2c/EWR18PwcGlug
-        8/8Baws0Q1r8yNzeqDSEhu9vbhfFL9p7sPfg54m9BWv9/9DgYlhOEgbUz8+5
-        yZ19SoZg58H+9uwgJ4Kcn59vT3Kyuwf79MXOp7OdbM9LB9CL8+z9LdXg6vg3
-        aqksCX+yaIhwr9v1rKh83PE4qzW0fKwG62C8u30KkVzVRZNvv+i1+6at1hA+
-        HuMoawQTgufn1nwZrH7WrZj/jcfk5vmoXGPwOwEEPJaEgEaG5m2PgNSmS8LT
-        xaq9jrTDICMEpG++LgktVhECdgmCxyfii2rZm2NqAXAQw8+fUKPd8OsuwN5Q
-        lI67nXb0RZeOniIzz/8L6Bhzp/rDpo7ek473wq+tzcEz5HO8l4NlBClE5NZ+
-        lhLkJk+LTIJ4ET/5xfEF+VjUJLbEny/hj5EfVi0I0vSrFZGXrQga+2398dJ7
-        36QjRqha6/WLf8noI5j0b8SiC6G/lmOm87a7v/fpzx//TL/a/f+nm6ZfeXJn
-        NV3822/IaXNfthnRieRACWQ4xPIBWMtKgvuYvjB+XJ7tPsizvf3tbJbNtvf3
-        p/e2s4ODh9s7O/v3zid7u/cfngfa+v/9qZMvfp/jn6SUic8+Pv7z7L390KeD
-        6ZefHT9UPbqBxEjXER1opu7o3s7u3varve2nZOSmpLUjLeltSCZa/1Ac0qqB
-        eex9TeqfencOwIf6os0qn+7qBO1usv+Cz07E+odjpx48y//+buiQWbu9rceQ
-        tn/yi52QIn1DT7/SpPLHnaY6+P8f2Xrom29E3Qit39+286RQpnOna9ZnzqZ5
-        w3ANqMmkqlrP9HW/pxZCYhoj09QDj8fon6/el/FDnnV/BPgzGcAExPGkC4nT
-        qY+Nbgnm4oep+ztWk0ceyodVOpGvviFrLN8ZKtj5A/k2m96dyf1sL9s/396d
-        fUqrFruzfDvb3Ztu39ud7TzY/fTh3qd7ge77ken1gSmDD8H6ken1HisFYup6
-        X5M2pt5/zkxvLIERjp16+H+H6fW8eTw/Mr3fiLoRWn9907v7I9OLufjZ1/1O
-        93dMJI98+yd9+bBKJ/LVz7Xpnc7Od7LzBw+37+3sU9Q7e3Bv++F0en/74P79
-        3cnuw9mUljZc1/TiPLut6XqSNcX0h7XIbumnin/AIL2v3do5gN16/dKbMnl+
-        6AbrdVbmzXlFuuKr171GpMkIh2/ObC2v64uHuwf7ccEVi+Uj9P8Bs+WjG1Kl
-        b7p+3qSHoSu/Cbv14vd59fn7Wiw7H+vm4OD/LWZrM+OH7Or+CFBnMmD6idlv
-        Z7EMMTGGn/0c9uBcDRieQND/35y+/qCBOVG/QeN+wxYbP0iMf8n/A4SpY14w
-        SAAA
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+qxVNOX1gmcK98pHBiYZmtDOegP484h+i
+        zrws6nadlV9k4GsasHsrf9fmSwzPf+2MPrmYt834J794WmQXy6ohxmhI2WLM
+        jR00Ddv8+n03/v+3DM0JxSa19FGrCu1GyN47ZWXF5KM8a9q1/+WqzPCFN9+2
+        f/BZVzvf0hKAD2frKayvNhI7YFroTBg+tL3jvc3+wPn0/N5smk+3zycHs+39
+        h+f3tx/ODqbbk937+Wx6fv5gZ38aYNIxwATDA0vf/5AZoIPO/x/8ATvI74oZ
+        ey1z7fWHxzkGm5upa7C3s3Ow/Wpv+/XL3V4Teg06AM2+Ee9AEer1YwThJWmU
+        C5rt7af5Za8R2RXC4YfvIvhI/X/AS/DRDSlza0dBSXCTq0DEExP4k18cX5CT
+        QE3aep0HsKhZvoRDQY5EtSBIU7aRrHXQ2G/rD5je+/+TJ7EykzLLL/fv3e86
+        EzNnTQm4GYtrQE0mVdV6Rrf7PbUQOtNAmbAeeDxGEX31niIQMq77I0CfQAgj
+        ENuTTiR2py5er6fTPJ8RQqale+f/E86QL0j///OH/NE58b9BE39TXpF8x1Qh
+        0f4l/w+d9qoxuxAAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 17:59:59 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/CHEF-PROD/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4864,11 +2809,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4891,20 +2836,479 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 9e49207a-3345-4307-b40c-42ae1d54e5ba
+      - 8ba8176c-645f-4d81-a8ec-3a2729aa2119
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14950'
       X-Ms-Correlation-Request-Id:
-      - b8b3bff7-c266-45e9-898c-5adc813fe3f8
+      - 01fc5541-bf92-4626-bdea-aa01a8db73c6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180001Z:b8b3bff7-c266-45e9-898c-5adc813fe3f8
+      - EASTUS:20151102T174848Z:01fc5541-bf92-4626-bdea-aa01a8db73c6
       Date:
-      - Thu, 22 Oct 2015 18:00:01 GMT
+      - Mon, 02 Nov 2015 17:48:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14967'
+      X-Ms-Request-Id:
+      - 3afbf9a8-6d08-4e9e-a79c-3ee93fb79126
+      X-Ms-Correlation-Request-Id:
+      - 3afbf9a8-6d08-4e9e-a79c-3ee93fb79126
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174848Z:3afbf9a8-6d08-4e9e-a79c-3ee93fb79126
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14970'
+      X-Ms-Request-Id:
+      - 0091dd26-2b2f-44e9-b2dc-c0de558ade06
+      X-Ms-Correlation-Request-Id:
+      - 0091dd26-2b2f-44e9-b2dc-c0de558ade06
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174848Z:0091dd26-2b2f-44e9-b2dc-c0de558ade06
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - b269f1d7-bd32-4cda-97ca-b7109fd0709e
+      X-Ms-Correlation-Request-Id:
+      - b269f1d7-bd32-4cda-97ca-b7109fd0709e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174848Z:b269f1d7-bd32-4cda-97ca-b7109fd0709e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - fdaeeaed-9106-4bfa-81c2-fdcebd4dd239
+      X-Ms-Correlation-Request-Id:
+      - fdaeeaed-9106-4bfa-81c2-fdcebd4dd239
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174848Z:fdaeeaed-9106-4bfa-81c2-fdcebd4dd239
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14957'
+      X-Ms-Request-Id:
+      - 21af6d53-f653-4908-9b9a-3bc1d389d659
+      X-Ms-Correlation-Request-Id:
+      - 21af6d53-f653-4908-9b9a-3bc1d389d659
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174849Z:21af6d53-f653-4908-9b9a-3bc1d389d659
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 02 Nov 2015 17:48:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
+      X-Ms-Request-Id:
+      - c4d5a0d2-bf9b-4abe-ba6c-35f2fedf5b5d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14969'
+      X-Ms-Correlation-Request-Id:
+      - f1fb4b98-50a4-4ae7-a604-4bbd24fd8f49
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174849Z:f1fb4b98-50a4-4ae7-a604-4bbd24fd8f49
+      Date:
+      - Mon, 02 Nov 2015 17:48:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Mon, 02 Nov 2015 17:48:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
+      X-Ms-Request-Id:
+      - 63699b7b-3f63-4966-b72d-cb815fa43c97
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14970'
+      X-Ms-Correlation-Request-Id:
+      - e88dc0a0-3755-4b49-a63f-222d5b511679
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151102T174849Z:e88dc0a0-3755-4b49-a63f-222d5b511679
+      Date:
+      - Mon, 02 Nov 2015 17:48:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4914,15 +3318,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvf2
-        3uwePNrZebSz+wn+3fnINP4l8sv38eOXMAhg+hYYKlUsTT5aZgL1ZJ6fbxNZ
-        Zq7PKDW9d/FsoGiznk7zfJZ7EPE4ip4tz6vOd4RmSFAfbDoEMaDMzsH27sGb
-        3YeP9ncf7d4b797b3du9v9+hENHF/MpU0r+/z3A/yt+1+RKdAgUduR21pdgX
-        xbSumuq8HZ9R44t524x/8ounRXaxrJq2mDav87YlrBvt1O+gT1gH/r0IOkTM
-        9yfkABHvf/ro3s743u7Bg929BwERhbGimFdXeY2e87v1eokOvW5ujTBJinlb
-        GgkBf+Pkl/w/1DSzZ1oEAAA=
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3t3f2
+        3uw+eLR/8Gj/4Sc7O492dj4yjX+J/PJ9/PglDAKYvgWGShVLk4+WmUA9mefn
+        20SWmeszSk3vXTwbKNqsp9M8n+UeRDyOomfL86rzHaEZEtQHmw5BHKDM7qP7
+        u+P7B7v37t/b7VCI6GJ+ZSrp399nuB/l79p8iU6Bgo7cjtpS7ItiWldNdd6O
+        z6jxxbxtxj/5xdMiu1hWTVtMm9d52xLWjXbqd9AnrAM/TNA1ZIj+cqMfomWf
+        jix/eFeaCFdEu62u8hrv5Xfr9RKde2Bv3R2xuXlbGsnof+Pkl/w/vwZWuxcE
+        AAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:01 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
@@ -4935,11 +3339,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -4958,24 +3362,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"46c9c6e9-fce9-4b85-a25f-053a43fa9dda"
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dbf79919-c57e-47a2-b940-dff7d32ce264
+      - 035f992d-32e9-4713-8ad4-b416a2ed659c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14949'
       X-Ms-Correlation-Request-Id:
-      - 78eabcc4-0d2b-4022-8f29-6e586f1a520d
+      - d195c5f3-009f-4975-aeb0-ed8b9b9ceacb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180003Z:78eabcc4-0d2b-4022-8f29-6e586f1a520d
+      - EASTUS:20151102T174849Z:d195c5f3-009f-4975-aeb0-ed8b9b9ceacb
       Date:
-      - Thu, 22 Oct 2015 18:00:02 GMT
+      - Mon, 02 Nov 2015 17:48:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4984,20 +3388,20 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
         0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
         Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9j+dPpx+mj/cPp/S
-        P/uTg/vb2d59QuX+vWz/3nn2cDbLft+P9MX2esXjvEW/+kZZTTOMGW/lWdOu
-        zReE0Sqv24JaPkqZivLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qZmlzFqou3fw
-        6eT8/s697Wx3d7q9v3f/4fZk53y2fb736b3d6UF+b29n175crE6q5Xlxsa4Z
-        MXT/PfkqNXjgsXNarKbc3kLA8/+uab3bHRN9EEP66867PJid3pTJg69uMXHy
-        UOPikpqcvTyezYgagPbR7s54b7wz3h9sWhpO+iJv5xVT/+k1zVEx7b6ynpTF
-        lN6wwANUqcUPee46CNHc2fc+8jH7JeE4CD2adcL05xj9y6Ju11mpf/pvEQaE
-        YXN3lp9n67INB+P+sL/qL9/XcX40Wzav87YllglmST6vLwkd+vh7pjl9ka1W
-        ZZHPnobfy9eGeh8tsqlSmr79aGdne+fp9r3j7d3d7YNPtx/cM9zyUb7MJiVx
-        1rOqvsrqGWFB7c+zsslNCxochvw6n67ror1mqlEbh+gPeSZi+HjvKv0tIUh2
-        Fll9TSi29doOSqfzi2w6L5YQ0x/6cE6qxWrd5oaxFBPvLTMQ/KB/fsn/A5qN
-        DjBkBwAA
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:03 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
@@ -5010,11 +3414,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5033,24 +3437,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"a7883c39-700f-4d10-af79-b733641b9812"
+      - W/"98077b54-1aca-4f76-aec9-c6bdf31d49f2"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ceb36122-7a66-4eca-9467-a30c14122eb3
+      - 18d06f93-d8a6-4a36-8dc1-fd6a9edbf387
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14968'
       X-Ms-Correlation-Request-Id:
-      - 9a93cf0a-82e3-4105-90a3-f8941cc0975a
+      - 4186e49a-4755-44e9-a678-67ef0d0c42ba
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180004Z:9a93cf0a-82e3-4105-90a3-f8941cc0975a
+      - EASTUS:20151102T174850Z:4186e49a-4755-44e9-a678-67ef0d0c42ba
       Date:
-      - Thu, 22 Oct 2015 18:00:03 GMT
+      - Mon, 02 Nov 2015 17:48:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5059,18 +3463,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
         vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
         P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/yh4cHNyb3nu4/WBn53yb
-        et7Zzs4fPNyePLh379P93cnDg9293/cjfbG9XvEIb9GpvlFW0wwDxlt51rRr
-        8wWNYJXXbUEtH6VMP/nwsmioebG8eN1mLXf2ej2d5vksV+ypGfUgZFkLaWc7
-        92Y7uw9m259OdoiWB3vn2w/3ppPth7uTbHJv5969g50H9uVipTjizd17D8a7
-        9+6Pd/fuj/d2bRs7mtLg/0Xezol+9MrTa5rnYmrbFrMyf1Ms8mrdni2/KJbr
-        loe0b79fnVTL8+JiXTMg+kpHi+8Y4t0fFmcs5efZss3r82xKnDHFe/TK7P7e
-        zt0Opg19MOUPdj8SjH8JftA/v+T/Ad/gzfDwAgAA
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/eniw8+DB5P7+9m42zbb3
+        zx98up3l04fb008ns/N7u7P9h+d7v+9H+mJ7veIR3qJTfaOsphkGjLfyrGnX
+        5gsawSqv24JaPkqZfvLhZdFQ82J58brNWu7s9Xo6zfNZrthTM+pByLIW0s52
+        7s12dh/Mtj+d7BAtD/bOtx/uTSfbD3cn2eTezr17NEb7crFSHPHm/s74wafj
+        3YcPxw8ObAs7ltJg/0Xezol69MLTa5rlYmrbFrMyf1Ms8mrdni2/KJbrlge0
+        b79fnVTL8+JiXTMg+krHiu8Y4t0fFl8s5efZss3r82xKfDHFe/TK7P7ezt0O
+        pg19MOUPdj8SjH8JftA/v+T/AbZb5zfuAgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:04 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/CHEF-PROD/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5080,11 +3484,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5107,20 +3511,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 3df2ea6b-6779-4952-9ceb-443c7c220037
+      - 2faa0af3-ba15-4bf2-bdb7-c68a008cda43
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14948'
       X-Ms-Correlation-Request-Id:
-      - 3f3e2454-a10f-44f7-b18f-80bd3463acaf
+      - d80ed96a-71ba-49bd-8a4e-6894d9fc9649
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180006Z:3f3e2454-a10f-44f7-b18f-80bd3463acaf
+      - EASTUS:20151102T174850Z:d80ed96a-71ba-49bd-8a4e-6894d9fc9649
       Date:
-      - Thu, 22 Oct 2015 18:00:06 GMT
+      - Mon, 02 Nov 2015 17:48:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5130,18 +3534,18 @@ http_interactions:
         pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723t7b3YPHu3sPNr59BP8u/OR
-        afxL5Jfv48cvYRBA6i2QUQLY4X+0zATqy6ppL6jr7af5pes2SjvvdTwb6Nes
-        p9M8n+UzBxGPo9/Z8rzqfEeYhuTzwaZDEAPi7Dzc3r3/ZvdTosyj3Xvj+/v7
-        uzsH+x0iEWnMr0wo/fv7DPejSVW1T4vsYklkKabAQ8dMo102VZm/ntZ5vmzm
-        VfukrCZf1QU1+Wjetqvm0d2703l+vqqr2f3dvZ3xhL4fT6s6H18Vy1l11YyX
-        eXsXHcxcB9sr+gn6z7bPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/Pz
-        Bzv707v+dI1v88a4sQiPJ4sVk0F5I3/X0hdEYAxTZ1lHS98aBvmimNZVU523
-        4zNqfDFvm/FPfuGR6HXetjRDDUMm2PihxOwzkQP/XswzxDjvzzQ9htkjhnn4
-        CAL1cHz/we7Bwf5ewDBCqxjmX75Gt/ldkuC8zsriB0E/t8aYlIAPQRoO9/qy
-        usprvE2EaqvVil7RttTofTo1b0sjmbbfOPkl/w/GK76iqgUAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR/55OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+rJr2grrefppfum6jtPNex7OB
+        fs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoEsUec3Tc7+yDOzs54996n9/f2
+        HnaIRKQxvzKh9O/vM9yPJlXVPi2yiyWRpZgCDx0zjXbZVGX+elrn+bKZV+2T
+        spp8VRfU5KN5266aR3fvTuf5+aquZvd393bGE/p+PK3qfHxVLGfVVTNe5u1d
+        dDBzHWyv6CfoP9s+n57fm03z6fb55GC2vf/w/P72w9nBdHuyez+fTc/PH+zs
+        T+/60zW+zRvjxiI8nixWTAbljfxdS18QgTFMnWUdLX1rGOSLYlpXTXXejs+o
+        8cW8bcY/+YVHotd529IMNQyZYOOHErPPRA78ezHPEOO8P9NsZpiDe/v39z4N
+        GEZoFcP8y9foNr9LEpzXWVn8IOjn1hiTEvAhSMPhXl9WV3mNt/O7szwry2pK
+        v37djn0I0lCm7zdOfsn/A1RYqtiyBQAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:06 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
@@ -5154,11 +3558,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5177,24 +3581,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"46048ef2-d999-4c80-9536-733a15783368"
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6a4954e3-5bfd-43ea-930e-7d074ff9aa42
+      - 2f3fc274-ebda-412d-9179-f4e786b66e2e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - 2fb6670b-c59e-4a0e-bc69-b2002107562d
+      - 9a37c23c-7b38-46b0-91fd-27db7f16757d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180008Z:2fb6670b-c59e-4a0e-bc69-b2002107562d
+      - EASTUS:20151102T174850Z:9a37c23c-7b38-46b0-91fd-27db7f16757d
       Date:
-      - Thu, 22 Oct 2015 18:00:07 GMT
+      - Mon, 02 Nov 2015 17:48:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5203,20 +3607,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
         3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
         e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/a/3Rn/yA/
-        39uePXz4cHt/erCz/fD+vU+3H9y7l+3ef3Bw796nB7/vR/pie73i0d6ia32j
-        rKYZho238qxp1+YLGscqr9uCWj5KmZby4WXRUPNiefG6zVru7PV6Os3zWT6T
-        N6kZDUiIsxYC72b57r3J7mT74GD/wfb+wwf725MH+/e37+eT6flk595k8vDA
-        vlysTqrleXGxrhkxdP89+So1eOCxM1usptx+10DA8/+6mb3bHRZ9EMP76069
-        PJig3qzJg69uMXfyUOPikpqcvTyezWgQgPbR7s54b7wzViY1j9e0NMz0Rd7O
-        K56Ap9c0TcW0+8p6UhZTesMCD1ClFj/k6esgRNP30kzf0/zyIx+5XxIOhTCk
-        uSdkf45HcFnU7Tor9U//LcKAMGzuzvLzbF224WDcH/ZX/eX7Os6PZsvmdd62
-        xDXBRMnn9SWhQx9/zzSnL7LVqizy2dPwe/naUO+jRTZVYtO3H+3sbO883b53
-        vL27t31A/3tiGOajfJlNSmKuZ1V9ldUzwoLan2dlk5sWNDgM+XU+XddFe81U
-        ozYO0R/yTMTwifKTpQVJ0CKrrwnLtl7bcemMfpFN58USwvpDH9FJtVit29zw
-        lmISHwt+0D+/5P8Br0Ap9XYHAAA=
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:08 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
@@ -5229,11 +3632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5252,24 +3655,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"0055b621-9718-4519-bcec-bd46e5bd2d63"
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 28d467d7-625d-4611-85f9-07c9a4b5b8a7
+      - 1d610be7-5a5a-4772-b2b3-b4828296038e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14981'
       X-Ms-Correlation-Request-Id:
-      - c3460a05-873a-44bb-82ee-7092941374bc
+      - 56aa7334-0f00-4b4a-8d64-cc558502fd60
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180009Z:c3460a05-873a-44bb-82ee-7092941374bc
+      - EASTUS:20151102T174850Z:56aa7334-0f00-4b4a-8d64-cc558502fd60
       Date:
-      - Thu, 22 Oct 2015 18:00:09 GMT
+      - Mon, 02 Nov 2015 17:48:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5278,18 +3681,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
         GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
         g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vRzs79+5NP
-        93a3Hz7YPdjev7/7cHsyzafbk9n+p/n9yWxv9um93/cjfbG9XvE4b9GvvlFW
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
         0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/bl
-        YqU44s39nfHu7v74/s54xzawQykN8l/k7bzinp5e01QXU9u2mJX5m2KRV+v2
-        bPlFsVy3PJ59+/3qpFqeFxfrmgHRVzpUfMcQ7/6wOGMpP8+WbV6fZ1PijJXh
-        jFl+uX/v/t0Osg19MOUPdj8SpH8JftA/v+T/AdJgKPX2AgAA
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:10 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5299,11 +3702,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5326,20 +3729,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 7e80013a-ce37-42dc-9767-d805960a46be
+      - 4e463239-77fe-45a3-a5f0-5e86e40a3004
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14978'
       X-Ms-Correlation-Request-Id:
-      - f977be49-7a85-4a37-9332-a0ee421cd3d8
+      - a1131d13-3531-4b93-8b3d-a0e360060105
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180012Z:f977be49-7a85-4a37-9332-a0ee421cd3d8
+      - EASTUS:20151102T174851Z:a1131d13-3531-4b93-8b3d-a0e360060105
       Date:
-      - Thu, 22 Oct 2015 18:00:12 GMT
+      - Mon, 02 Nov 2015 17:48:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5349,15 +3752,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723t7b3YPHu3sPNq99wn9u7Pz
-        kWn8S+SX7+PHL2EQQOotkFEC2OF/tMwE6nSenzd5fZnXu67XKOm8t/FsIF+z
-        nk7zfJbPHEQ8jnxny/Oq8x0hGlLPB5sOQQxos3Owvfvwze6DR/sHj/bujw/u
-        H3y693C/QyOijPmV6aR/f5/hfpS/a3OaApoGgqojt6O2NPuimNZVU5234zNq
-        fDFvm/FPfvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcSMSH9/fu
-        7e3sBUQU1opiXl3lNXrO787yrCyrKf3qd3VrpEk0fAjSUAj5Gye/5P8BO4tm
-        ak8EAAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR/95OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBO5/l5k9eXeb3reo2Sznsbzwby
+        NevpNM9n+cxBxOPId7Y8rzrfEaIh9Xyw6RDEHm123+zsP9q/92j//njnwf0H
+        +ztdGhFlzK9MJ/37+wz3o/xdm9MU0DQQVB25HbWl2RfFtK6a6rwdn1Hji3nb
+        jH/yi6dFdrGsmraYNq/ztiWsG+3U76BPWAf+vQg6RMz3J+RGIu7u7d0/+PRe
+        QERhrSjm1VVeo+f87izPyrKa0q9+V7dGmkTDhyANhZC/cfJL/h9aydE4TwQA
+        AA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:13 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
@@ -5370,11 +3773,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5393,24 +3796,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"75c8137e-2e25-4d12-b6ac-26b79404804e"
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 02e1ada9-0b9f-490a-b7e0-a3695498439c
+      - 5bd4ae42-2a3a-4796-b6fe-961ad4b05b0f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14975'
       X-Ms-Correlation-Request-Id:
-      - f1a04561-8e62-47fb-b5fb-356572748e42
+      - 6ba36243-7458-45e1-8d59-6f6e7e49a2ad
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180014Z:f1a04561-8e62-47fb-b5fb-356572748e42
+      - EASTUS:20151102T174851Z:6ba36243-7458-45e1-8d59-6f6e7e49a2ad
       Date:
-      - Thu, 22 Oct 2015 18:00:14 GMT
+      - Mon, 02 Nov 2015 17:48:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5419,21 +3822,21 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
         73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
         O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96MH96cHu
-        PUJkL9+7v039721PPs2m23ufTh483N/ZP9jZz3/fj/TF9nrFg71Fz/pGWU0z
-        DBtv5VnTrs0XNIxVXrcFtXyUMinlw8uioebF8uJ1m7Xc2ev1dJrns3wmb1Iz
-        S5y1EHiS7872ZvuT7eze3nR7nwa0PTnfmW3TuD699/BBtjeb5PblYnVSLc+L
-        i3XNiKH778lXqcEDj53YYjXl9rsGAp7/183s3e6w6IMY3l936uXBBPVmTR58
-        dYu5k4caF5fU5Ozl8WxGBAG0j3Z3xvjv/mDT0jDTF3k7r3gCnl7TNBXTzis0
-        K0Qv+j7AkL74Yc/aZVG366zUP4PXCAfCsbk7y8+zddl+5GP6S9wf9lf95fs6
-        0o9my+Z13rZEbBDPDlQ+B1fg4++Z5vRFtlqVRT57Gn4vX/8SbfZRvswmJdH6
-        WVVfZfWMoFOr86xsctOCkMZYXufTdV2010wPauMQ+GHTOIYQtTv7CX1/V0lr
-        x6iT8kU2nRdLcOkPH3f92vCHohLItMEaP+ifX/L/AJpJF8xuBgAA
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:15 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5443,11 +3846,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5470,20 +3873,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 42a4042e-16f3-46ed-b0bd-a2a61804817c
+      - d7ce7aa2-f04f-4371-b54f-cb7f8dd47b10
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14970'
       X-Ms-Correlation-Request-Id:
-      - ea0b5765-1c07-4858-9444-bac3ff04eb00
+      - 7c20ce1f-fce6-414a-bf38-cce1b7d7a518
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180016Z:ea0b5765-1c07-4858-9444-bac3ff04eb00
+      - EASTUS:20151102T174851Z:7c20ce1f-fce6-414a-bf38-cce1b7d7a518
       Date:
-      - Thu, 22 Oct 2015 18:00:15 GMT
+      - Mon, 02 Nov 2015 17:48:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5493,15 +3896,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723t7b3YPHu3sPNr99BP6d2fn
-        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1NNXL11vUZJ5b+HZQLZmPZ3m+Syf
-        OYh4HNnOludV5ztCMKSaDzYdghjQZOfh9t7Bm939R/sPH+3cG9/7dG93/+B+
-        hzZEEfMr00f//j7D/Sh/1+ZEeiI/QdWR21FbWn1RTOuqqc7b8Rk1vpi3zfgn
-        v3haZBfLqmmLafM6b1vCutFO/Q76hHXg34ugQ8R8f0JuJOL+7sO9nYPdgIjC
-        UjHMv3yNbvO7xMx5nZXFD4J+bo0xyYMPQRoO9/qyusprvJ3fneVZWVZT+vXr
-        duxDkIYyfb9x8kv+HwQWyIu9BAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR/95OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKCevnrpeouSzHsLzwayNevpNM9n
+        +cxBxOPIdrY8rzrfEYIh1Xyw6RDEHk123+zsP9q/92j//njn052dgwf3O7Qh
+        iphfmT769/cZ7kf5uzYn0hP5CaqO3I7a0uqLYlpXTXXejs+o8cW8bcY/+cXT
+        IrtYVk1bTJvXedsS1o126nfQJ6wD/14EHSLm+xNyIxF39/buH3x6LyCisFQM
+        8y9fo9v8LjFzXmdl8YOgn1tjTPLgQ5CGw72+rK7yGm/nd2d5VpbVlH79uh37
+        EKShTN9vnPyS/wdgfsCKvQQAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:16 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
@@ -5514,11 +3917,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5537,24 +3940,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"86704d65-b5ba-4259-9777-a1500522eddb"
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 336e3d5a-8241-4b28-836c-88b655f8a9d0
+      - d0eb02a4-4ee8-430d-939b-5634d00f61b5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14969'
       X-Ms-Correlation-Request-Id:
-      - 6ead9898-c295-4d01-89f1-153a61f5be02
+      - 195adcf3-e01a-4bf1-b266-2677b8cb0ed0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180018Z:6ead9898-c295-4d01-89f1-153a61f5be02
+      - EASTUS:20151102T174851Z:195adcf3-e01a-4bf1-b266-2677b8cb0ed0
       Date:
-      - Thu, 22 Oct 2015 18:00:17 GMT
+      - Mon, 02 Nov 2015 17:48:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5563,19 +3966,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
         PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
         2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+3508OmDnf3Zp/e3J/cn
-        2fb+3v2H2w8fPHiwne3e39m5v7eXz2aT3/cjfbG9XvHgbtGjvlFW0wzDxVt5
-        1rRr8wWhv8rrtqCWj1ImnXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJshbC
-        fprtfjp7MDvYvv8wPydKns+2H04z+nNn8un92afTSZ7t2JeL1Um1PC8u1jUj
-        hu6/J1+lBg88diKL1ZTb7xoIeP5fM6N3u8OhD2L4ft0plwcT05stefDVLeZM
-        HmpcXFKTs5fHsxkRAtA+2t0Z47+DwaalYaIv8nZeMeGfXtP0FNPuK+tJWUzp
-        DQs8QJVa/LCnrYMRTdvpq5cf+Uj9knAIhBlNNSH5c435ZVG366zUP4PXCAfC
-        sbk7y8+zddmGw3F/2F/1l+/rSD+aLZvXedsSvwRTJJ/Xl4QPffw905y+yFar
-        sshnT8Pv5WtDv4/yZTYpiV2eVfVVVs8IOrU6z8omNy0IaYzldT5d10V7zfSg
-        Ng6BHzaNYwj5HGLHppPxRTadF0sI2A8fZ/3a8IWiEmCLH/TPL/l/AK9xKi8J
-        BwAA
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:18 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
@@ -5588,11 +3991,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5615,20 +4018,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - cd7ce981-d618-4b2e-a23e-95576b6bdb8f
+      - 568b6432-59e7-4ccc-8ca4-c4bd6f9e3cc5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14968'
       X-Ms-Correlation-Request-Id:
-      - 98c5e595-3776-4a8e-b454-b6a712d0e585
+      - 5f37f4bb-04bc-4813-ace3-4cd7f345b89f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180020Z:98c5e595-3776-4a8e-b454-b6a712d0e585
+      - EASTUS:20151102T174852Z:5f37f4bb-04bc-4813-ace3-4cd7f345b89f
       Date:
-      - Thu, 22 Oct 2015 18:00:19 GMT
+      - Mon, 02 Nov 2015 17:48:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5645,10 +4048,10 @@ http_interactions:
         O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
         MQDoSbwCAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:20 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5658,11 +4061,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5685,20 +4088,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 3f671e9f-9315-4c79-86a1-46f81ff1e8f9
+      - 97198937-1323-45d5-9e69-21744429ea97
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14961'
       X-Ms-Correlation-Request-Id:
-      - 3e92a133-f3dd-4618-b979-f6e39f02d562
+      - ded11791-262a-4690-9f9d-7e58d707b49c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180021Z:3e92a133-f3dd-4618-b979-f6e39f02d562
+      - EASTUS:20151102T174852Z:ded11791-262a-4690-9f9d-7e58d707b49c
       Date:
-      - Thu, 22 Oct 2015 18:00:21 GMT
+      - Mon, 02 Nov 2015 17:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5708,14 +4111,14 @@ http_interactions:
         pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723t7b3YPHu3sPNrb/YT+3dn5
-        yDT+JfLL9/HjlzAIIPUWyCgB7PA/WmYC9Yuzn9hz3UVp5r2GZwPdmvV0muez
-        fOYg4nF0O1ueV53vCMOQbD7YdAhiQJSdg+293Te79x/df/Bo/8H403v7Bzu7
-        DzvEIZKYX5lA+vf3Ge5H+bs2J9oT/QmqjtyO2hGrmNZVU5234zNqfDFvm/FP
-        fvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcTMSHD+7t7dwPiCg8
-        FcW8uspr9JzfneVZWVZT+tXv6tZIk0z4EKShEPI3Tn7J/wPV1v3OSAQAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR/75OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
+        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQewRZffNzv6j/XuP9u+Pdx7cf7C/s9sh
+        DpHE/MoE0r+/z3A/yt+1OdGe6E9QdeR21I5YxbSumuq8HZ9R44t524x/8oun
+        RXaxrJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkRiLu7u3dP/j0XkBE4ako
+        5tVVXqPn/O4sz8qymtKvfle3RppkwocgDYWQv3HyS/4fR1XYwUgEAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:22 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
@@ -5728,11 +4131,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5751,24 +4154,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"1a1612b0-f799-4f42-b0b2-71e25bb22be5"
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b94e151f-e5ef-486e-a884-f2ad1a2ce1ca
+      - 0816e639-8fb9-4ccb-813c-9ae1bbb36d69
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - 7b4fccda-af59-4075-adc8-acf1ef372f61
+      - 25a2fc57-7ada-43d3-b44b-6c202815bb32
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180023Z:7b4fccda-af59-4075-adc8-acf1ef372f61
+      - EASTUS:20151102T174852Z:25a2fc57-7ada-43d3-b44b-6c202815bb32
       Date:
-      - Thu, 22 Oct 2015 18:00:22 GMT
+      - Mon, 02 Nov 2015 17:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5777,19 +4180,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
         xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
         2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P9rNdj/d3ZvsbJ8/
-        ePhwe/98f297sjPZ236wm+/dn0z29ib5/d/3I32xvV7x8G7Rpb5RVtMM48Vb
-        eda0a/MF4b/K67aglo9SJp58eFk01LxYXrxus5Y7e72eTvN8ls/kTWpmqbIW
-        yu5P8wf39vfvb093pve39/P8fDv79OB8+2E2+zTPs+mD/b379uVidVItz4uL
-        dc2IofvvyVepwQOPncpiNeX2uwYCnv/3TOnd7njogxjCX3fO5cHM9KZLHnx1
-        i0mThxoXl9Tk7OXxbEaUALSPdnfG+O/hYNPScNEXeTuvmPJPr2l+imn3lfWk
-        LKb0hgUeoEotftjz1sGI5u2Ls5/Y+8jH6peEYyDUaLIJy59r1C+Lul1npf4Z
-        vEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blhgmmCP5vL4kfOjj75nm
-        9EW2WpVFPnsafi9fG/p9lC+zSUn88qyqr7J6RtCp1XlWNrlpQUhjLK/z6bou
-        2mumB7VxCPywaRxDiNo5FrGD09n4IpvOiyVE7IePtH5tGENRoRYeuvhB//yS
-        /wcxvijwDwcAAA==
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:24 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
@@ -5802,11 +4205,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5829,20 +4232,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a2baf837-be63-4aac-ab9a-1338e55be8d0
+      - 6b2864ea-4c47-4d70-b658-27ecc989d73c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14956'
       X-Ms-Correlation-Request-Id:
-      - 2f53e2f4-612b-485c-b938-c7c93e108467
+      - 8ff04a59-0ace-4343-9fd5-e7588a553280
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180026Z:2f53e2f4-612b-485c-b938-c7c93e108467
+      - EASTUS:20151102T174852Z:8ff04a59-0ace-4343-9fd5-e7588a553280
       Date:
-      - Thu, 22 Oct 2015 18:00:26 GMT
+      - Mon, 02 Nov 2015 17:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5859,10 +4262,10 @@ http_interactions:
         McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
         D8aATOm/AgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:26 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5872,11 +4275,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5899,20 +4302,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 5a736413-88e5-46bc-8105-e05240092fea
+      - b1d4710c-3f5a-41cf-9cf8-970e31eadfa7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - b2844804-a415-42dc-a7bf-2143fe9272e6
+      - c0343c56-05f7-4769-9e79-a8d20c1f9f14
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180027Z:b2844804-a415-42dc-a7bf-2143fe9272e6
+      - EASTUS:20151102T174853Z:c0343c56-05f7-4769-9e79-a8d20c1f9f14
       Date:
-      - Thu, 22 Oct 2015 18:00:26 GMT
+      - Mon, 02 Nov 2015 17:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5921,16 +4324,16 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
         6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
         Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        e3tvdg8e7ew82nvwCf27s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqF2c/
-        cVItVus233W9RknnvY1nA/ma9XSa57N85iDiceQ7W55Xne8I0ZB6Pth0CGJA
-        m52D7b0HoM39Tx/tPhjf/3Tv/sHeww6NiDLmV6YT/a0g7egsbWZZmxFeb///
-        RZmD8e7Ow/1Pd/e+AcrsuV5/flEGP77PcD/K37U5iS2JLkHVkdtRW4p9UUzr
-        qqnO2/EZNb6Yt834J794WmQXy6ppi2nzOm9bwrrRTv0O+oR14N+LoEPEfH9C
-        bibig92HD/fuB0Tss5LFvLrKa/Sc353lWVlWU/rV7+rWSJM69SFIQyHkb5z8
-        kv8H+z4WzkgGAAA=
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
+        O3tvdh882j94dP/eJzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQP3i
+        7CdOqsVq3ea7rtco6by38WwgX7OeTvN8ls8cRDyOfGfL86rzHSEaUs8Hmw5B
+        7NFm983O/qP9vUf3H4wf7H766d7OQYdGRBnzK9OJ/laQdnSWNrOszQivt/+/
+        o8y9vb2Hu/e/AcrsuV5/flEGP77PcD/K37U5iS2JLkHVkdtRW4p9UUzrqqnO
+        2/EZNb6Yt834J794WmQXy6ppi2nzOm9bwrrRTv0O+oR14N+LoEPEfH9Cbibi
+        w/0H9x/sBkTss5LFvLrKa/Sc353lWVlWU/rV7+rWSJM69SFIQyHkb5z8kv8H
+        2PH2UkgGAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:28 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
@@ -5943,11 +4346,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -5966,24 +4369,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"ea35794f-6fea-4201-819f-b29fa3a501e8"
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1757db2b-e5e6-48f4-b162-50edf5dbb674
+      - dbfe25fc-9a50-4ee8-ab90-39f626c13841
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 92914a0d-7be7-4453-a614-aae4462e5725
+      - c1009853-206d-47ea-ac8b-90536f261616
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180031Z:92914a0d-7be7-4453-a614-aae4462e5725
+      - EASTUS:20151102T174853Z:c1009853-206d-47ea-ac8b-90536f261616
       Date:
-      - Thu, 22 Oct 2015 18:00:30 GMT
+      - Mon, 02 Nov 2015 17:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5992,19 +4395,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
         79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
         e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3l27/6Dh/vn
-        25+e59n2/t7O7vbB7sPz7cnew/PsXnZ/Zzc/+H0/0hfb6xUP9hY96xtlNc0w
-        bLyVZ027Nl/QMFZ53RbU8lHKpJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8Sc0s
-        cdZC4L2Hk73Zvb3p9oMH+f72/vk0J/Q//XT7wSQ7yB6cH3y6t7tjXy5WJ9Xy
-        vLhY14wYuv+efJUaPPDYiS1WU26/ayDg+X/dzN7tDos+iOH9dadeHkxQb9bk
-        wVe3mDt5qHFxSU3OXh7PZkQQQPtod2eM//YHm5aGmb7I23nFE/D0mqapmHZf
-        WU/KYkpvWOABqtTihz19HYxo+r44+wl9d/cjH7lfEg6FMKSpJ2R/rkdwWdTt
-        Oiv1z+A1woFwbO7O8vNsXbbhcNwf9lf95fs60o9my+Z13rbEN8FUyef1JeFD
-        H3/PNKcvstWqLPLZ0/B7+drQ76N8mU1KYptnVX2V1TOCTq3Os7LJTQtCGmN5
-        nU/XddFeMz2ojUPgh03jGELUrscpdow6KV9k03mxhMD98HHXrw1/KCrUoo81
-        ftA/v+T/AZ9s1+g5BwAA
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:31 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
@@ -6017,11 +4420,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6044,20 +4447,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bbcdc28a-9a65-44d4-93a1-2237a106659a
+      - c0402740-61d3-4f1d-970e-223623d80802
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - 32705312-e3b5-479a-9f70-2eb52ed69939
+      - e7eacd31-8e99-4e64-afdd-235bfb950a21
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180032Z:32705312-e3b5-479a-9f70-2eb52ed69939
+      - EASTUS:20151102T174853Z:e7eacd31-8e99-4e64-afdd-235bfb950a21
       Date:
-      - Thu, 22 Oct 2015 18:00:32 GMT
+      - Mon, 02 Nov 2015 17:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6074,10 +4477,10 @@ http_interactions:
         OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
         +EH//JL/B0wm3MTUAgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:33 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -6087,11 +4490,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6114,40 +4517,39 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 5178f5d1-db54-4deb-9f09-4f86997d117e
+      - 75dea3e1-aacb-422d-a51e-22072c498c5e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14978'
       X-Ms-Correlation-Request-Id:
-      - ecfb9a80-d0ac-4577-9cf0-4341d2714cd6
+      - 63d54c0a-5194-4bc9-915f-e62c96773ae2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180034Z:ecfb9a80-d0ac-4577-9cf0-4341d2714cd6
+      - EASTUS:20151102T174853Z:63d54c0a-5194-4bc9-915f-e62c96773ae2
       Date:
-      - Thu, 22 Oct 2015 18:00:34 GMT
+      - Mon, 02 Nov 2015 17:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50d74wXh39+HB+MG9+x/x
-        a9SsabN23eQNNfiefJQaEHg+mlaznL776GVdXRaAVCwvXtM7+d1mPZ3m+Syf
-        GVh4Pirzy7zEC2fL8yr4ZlY0NIRrvLxGdx+9yrPZddBkkTdNdsH9fb7Om5ZH
-        kBZNWq+X6DjNlrM0o25XLf5a5lfptFqeFxfrOmsJt2YcgGuLBcPa29m9v727
-        s72392b34NHOzqN7+5/Qvzs7H5nGv0R++T5+/BIGAXTfAk2liqXJR8tMoFYN
-        mrgOo6T0XsTzvuSkNwYJSt8RAiFJfbDpEMSALDsPt/d23+w+fLR//9G93fH+
-        /v2de7sd6hBNzK9MIf37+wz2o0lVtU+L7GJZNW0xBRo6ZBrssqnK/PW0zvNl
-        M6/aJ2U1+aouqMlH87ZdNY/u3m1W+XS3aaua5n13PKEG42lV5+OrYjmrrprx
-        Mm/vooeZ62Eb71wudrbzbPdBnu3tb2ezbLa9vz+9t50dHDzc3tnZv3c+2du9
-        //B8jzvY/skvdsa3aT1uLK7jyWLFFFB+6M+uDpO+e69ZHZrR95/NoZl8+Gjn
-        YLxPUr5zby+YShlKFPPqKq/Rc35XZc3r5tYI/+QXRlJNh/hBPPNL/h/fOgWp
-        4QQAAA==
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR//5OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
+        PnMQ8TjKnS3Pq853hEBIOB9sOgSxR5bdNzv7IMv+p+OdvU8f7t7rUIdoYn5l
+        Cunf32ewH02qqn1aZBfLqmmLKdDQIdNgl01V5q+ndZ4vm3nVPimryVd1QU0+
+        mrftqnl0926zyqe7TVvVNLO74wk1GE+rOh9fFctZddWMl3l7Fz3MXA/beOdy
+        sbOdZ7sP8mxvfzubZbPt/f3pve3s4ODh9s7O/r3zyd7u/Yfne9zB9k9+sTO+
+        TetxY3EdTxYrpoDyQ392dZj03XvN6tCMvv9sbp7Jg4f7n97bC6ZShhLFvLrK
+        a/Sc353lWVlWU/rV7+rWSJNo+hCkofDLb5z8kv8HLShyKs8EAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:35 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
@@ -6160,11 +4562,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6183,24 +4585,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"b02efa6d-5d26-454e-bffe-91d2a5417b8e"
+      - W/"2ce2d8c8-8577-42d9-a3a9-8e30dc1607bf"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ea79fffd-f66e-4ca5-9963-abf0ab8a33a5
+      - ca7c8a76-779b-4dcc-9021-d0ba063bcd8d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14947'
       X-Ms-Correlation-Request-Id:
-      - 5a098982-76c4-4f26-a104-854c2a5d3bdb
+      - e1bad053-ebc2-42fd-b7f2-740bd696413f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180036Z:5a098982-76c4-4f26-a104-854c2a5d3bdb
+      - EASTUS:20151102T174854Z:e1bad053-ebc2-42fd-b7f2-740bd696413f
       Date:
-      - Thu, 22 Oct 2015 18:00:35 GMT
+      - Mon, 02 Nov 2015 17:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6209,24 +4611,23 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
         FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
         Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9FkZy8/zz6dbd+f
-        7X26vX9/P9+enJ/n2w93Z3vZ/f3dB5OD/Pf9SF9sr1c8xFt0qm+U1TTDiPFW
-        njXt2nxBI1jldVtQy0cpE1A+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzdFkL
-        be8fPJzu7jzYJzrOdmkMk8n2w72DB9uT7MH5p59O92ks7uVidVItz4uLdc2I
-        ofvvyVepwQOPnc5iNeX2uwYCnv83Terd7ojogxjKX3fW5cHc9CZMHnx1i2mT
-        hxoXl9Tk7OXxbEa0ALSPdnfG+O/+YNPS8NEXeTuvmPZPr2mGimnnFZoQIhV9
-        H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWVzZ5k
-        Zbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog/BES
-        gcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sbORDO4P+7n+
-        Yij00WzZvM7bluQQtLCDl8/rS8KAPv6eaU5fZKtVWeSzp+H38rXhxY8W2VQn
-        jr79aGdne+fp9r3j7d3d7YcPt+/dMyL4Ub7MJiWJ67OqvsrqGWFB7c+zsslN
-        C5LoRVZf08dtvbafqqx8kU3nxRLKwyH+w5ot/dqIraKi8+UmhulN//yS/wdN
-        rPcB8wcAAA==
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9HeNN+bHUwPtg/u
+        P3iwvb83e7id3csebh/k93Zm091Pdx5Mzn/fj/TF9nrFQ7xFp/pGWU0zjBhv
+        5VnTrs0XNIJVXrcFtXyUMgHlw8uioebF8uJ1m7Xc2ev1dJrns3wmb1IzS5e1
+        0Pb+wcPp7s6DfaLjbHd7//5ksv1w7+DB9iR7cP7pp9P9h0RP+3KxOqmW58XF
+        umbE0P335KvU4IHHTmexmnL7XQMBz/+bJvVud0T0QQzlrzvr8mBuehMmD766
+        xbTJQ42LS2py9vJ4NiNaANpHuztj/Hd/sGlp+OiLvJ1XTPun1zRDxbTzCk0I
+        kYq+DzCkL37YE3ZZ1O06K/VPna6ffHH65i6hQCg2d1/zz+3dj3xMf0k4nLLK
+        Zk+yMltO8/pJNn2bL2dKtpdVVYJ2lnfl6QybQPywB+6jrMN+/uTupI/8XR0Q
+        /giJQGTw//z+ME3OlpNqvZy9yNpX65I58/8j9ChCxO++evpy+ye/2NlIBveH
+        /Vx/MRT6aLZsXudtS3IIWtjBy+f1JWFAH3/PNKcvstWqLPLZ0/B7+drw4kf5
+        MpuUJIbPqvoqq2cEnVqdZ2WTmxbK7V9k03mxhPi7rr85en/5xcuv3pz+5Bev
+        o/TW6TCCp6goxR1pmWL0zy/5fwAzzH7ZtQcAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:36 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/COMPUTEVMS/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -6236,11 +4637,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6263,20 +4664,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - 37d138bb-354b-4c90-bf08-7c2f41237dc0
+      - cedffa59-bfa6-4ad2-a0e9-f6566d4f8ba3
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14966'
       X-Ms-Correlation-Request-Id:
-      - f1f9f514-31e4-4a36-ae20-b7201557404e
+      - 0dcb2589-81d4-491f-918b-d19da0db2e8c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180037Z:f1f9f514-31e4-4a36-ae20-b7201557404e
+      - EASTUS:20151102T174854Z:0dcb2589-81d4-491f-918b-d19da0db2e8c
       Date:
-      - Thu, 22 Oct 2015 18:00:36 GMT
+      - Mon, 02 Nov 2015 17:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6286,17 +4687,16 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723t7b3YPHu3sPLr34BP6d2fn
-        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1KpBE9dhlGrei3g2UK5ZT6d5Pstn
-        DiIeR7mz5XnV+Y4QCAnng02HIAZk2Xm4vbf7Zvfho/37j/YOxvfv79/f2etQ
-        h2hifmUK6d/fZ7AfTaqqfVpkF8uqaYsp0NAh02CXTVXmr6d1ni+bedU+KavJ
-        V3VBTT6at+2qeXT3brPKp7tNW9U0s7vjCTUYT6s6H18Vy1l11YyXeXsXPcxc
-        D9t453Kxu70zuZ/tZfvn27uzTx9s7+/O8u1sd2+6fW93tvNg99OHe5/uEV2p
-        8fZPfrE7vk3rcWNxHU8WK6aA8kN/dnWY9N17zerQjL7/bMZmcm/n0f2dR7sP
-        x/sPd+8d7N4PplKGEsW8uspr9Ewot9VqFXRza4RJLM3b0kj45DdOfsn/A4Nc
-        gC/HBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u72zt7b3YfPNo/eHR//5OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
+        PnMQ8TjKnS3Pq853hEBIOB9sOgSxR5bdNzv7IMv+p+O9/fuf7uwcdMhDRDG/
+        Mon07+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAm
+        H83bdtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6Hbbxz
+        uSDMJ/ezvWz/fHt39umD7f3dWb6d7e5Nt+/tznYe7H76cO/TPSIsNd7+yS92
+        x7dpPW4sruPJYsUUUIboT68Ok757r2kdmtL3n87NU/lw7/69g3vBVMpQophX
+        V3mNnvO7szwry2pKv/pd3Rppkk0fgjQUfvmNk1/y/wDvm++Q0AQAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:38 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
@@ -6309,11 +4709,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6332,24 +4732,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"dc2de49e-9c0d-4b01-8be3-2c206480eca6"
+      - W/"ae5753ad-843b-447c-ad44-b9866332d3f2"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c9f5b9d9-094d-40ab-a6d7-7d6b505fbf8c
+      - 0df07641-0f2d-475d-b2b8-0335fb39a179
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14977'
       X-Ms-Correlation-Request-Id:
-      - 356e6be9-a8d6-4f21-94a2-850672e3fedd
+      - 44b8462d-b3a3-4862-9fd5-dfe763707946
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180039Z:356e6be9-a8d6-4f21-94a2-850672e3fedd
+      - EASTUS:20151102T174854Z:44b8462d-b3a3-4862-9fd5-dfe763707946
       Date:
-      - Thu, 22 Oct 2015 18:00:38 GMT
+      - Mon, 02 Nov 2015 17:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6358,21 +4758,20 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
         FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
         Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9FsujfL9x/m2w+n
-        O7Pt/cnO7vbBJL+3vTfd2/l0/2Ann2af/r4f6Yvt9YqHeItO9Y2ymmYYMd7K
-        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
-        7YOd2f2d+/f3tvf2zne39+9/mm9PZnvn2w8nu+e7+b398/N8x75crE6q5Xlx
-        sa4ZMXT/PfkqNXjgsdNZrKbcXoknz/+bJvVud0T0QQzlrzvr8mBuehMmD766
-        xbTJQ42LS2py9vJ4NiNaANpHuztj/Lc/2LQ0fPRF3s4rpv3Ta5qhYtp5hSaE
-        SEXfBxjSFz/sCbss6nadlfqnTtdPvjh9c5dQIBSbu6/55/buRz6mvyQcTlll
-        sydZmS2nef0km77NlzMl28uqKkE7y7vydIZNIH7YA/dR1mE/f3J30kf+rg4I
-        f4REIDL4f35/mCZny0m1Xs5eZO2rdcmc+f8RehQh4ndfPX25/ZNfbCaD+8N+
-        rr8YCn00Wzav87YlOQQt7ODl8/qSMKCPv2ea0xfZalUW+exp+L18bXjxo0U2
-        1Ymjbz/a2dneebp973h7d3f74dPtZ6dGBD/Kl9mkJHF9VtVXWT0jLKj9eVY2
-        uWlBEr3I6mv6uK3X9lOVlS+y6bxYQnk4xH9Ys6VfG7FVVHS+3MQwvemfX/L/
-        ANnGD2/zBwAA
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1GW339w/1422z7Y
+        vzfZ3t9/MN3OZvv725OHB59+eu/e3uze+d7v+5G+2F6veIi36FTfKKtphhHj
+        rTxr2rX5gkawyuu2oJaPUiagfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZumy
+        Fto+2Jnd37l/f297b+98d3v//qf59mS2d779cLJ7vpvf2z8/z3fsy8XqpFqe
+        FxfrmhFD99+Tr1KDBx47ncVqyu2VePL8v2lS73ZHRB/EUP66sy4P5qY3YfLg
+        q1tMmzzUuLikJmcvj2czogWgfbS7M8Z/+4NNS8NHX+TtvGLaP72mGSqmnVdo
+        QohU9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGU
+        VTZ7kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/q
+        gPBHSAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cVmMrg/
+        7Of6i6HQR7Nl8zpvW5JD0MIOXj6vLwkD+vh7pjl9ka1WZZHPnobfy9eGFz/K
+        l9mkJDF8VtVXWT0j6NTqPCub3LRQbv8im86LJcTfdf3N0fvLL15+9eb0J794
+        HaW3TocRPEVFKe5IyxSjf37J/wOqI1T/tQcAAA==
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:39 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
@@ -6385,11 +4784,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6412,43 +4811,40 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130900263689403635
       X-Ms-Request-Id:
-      - d135dd44-11c7-4ae7-ab42-a0b49a285e86
+      - d25214ae-a93b-497f-b9c3-da17f4ce8373
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14976'
       X-Ms-Correlation-Request-Id:
-      - 758ef1db-2ee2-4ed7-8c05-fe364b4ae4ee
+      - deb16708-7834-4022-aee3-f430acf1a421
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180040Z:758ef1db-2ee2-4ed7-8c05-fe364b4ae4ee
+      - EASTUS:20151102T174854Z:deb16708-7834-4022-aee3-f430acf1a421
       Date:
-      - Thu, 22 Oct 2015 18:00:40 GMT
+      - Mon, 02 Nov 2015 17:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
-        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
-        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
-        awm3ZhyAa4sFw9rb2b2/vbuzvbf3Zvfg0c7Oo3v3PqF/d3Y+Mo1/ifzyfX37
-        o/xdmy8x2m9TjyWRkMBEydNer7iLL4ppXTXVeTs+/sG6zsdPi+xiWTVtMW3G
-        Z1n22vs7RJHe1z68mdod7413xjtBS5ko+tbrnj5+z/mhNwZniL4bmCPXRgll
-        f/k+fvwSBoKX3+IlJZTF86NlJvPwOivz5ryqp/lXr13HOrKQBb3X8fxsD9MH
-        mw5B7LLTzv03uw8f7dH/SK72Hzy4v7/fYSsijfmVCaV/C5t9NKmq1ucLO7U0
-        2mVTlfnraZ0TG86r9klZTb6qC2ry0bxtV82ju3eX1/XFw92D/fGEvhtPK2K6
-        q2I5q66a8TJv7wL4zAHfbgztt6ez853s/MHD7Xs7+7Pt/dmDe9sPp9P72wf3
-        7+9Odh/OpvnOg7v+VI1v88a4sciOJ4sVk0D5wgoThqgzrCOlbw1zOAk6o8YX
-        87YZ/+QXHnle5y2E3hMfFp7w1fcQPn77FqL3UbOevA+HnlSLVbUkvSXcdfeH
-        yKCe+nxx95inQB7mOjzCeXj+PyN13qDcPKaWp9Imb+Xdpjlfl2VgUOj1rtDu
-        3n+zs/uI5Pb+wXsJa59cllTvR6YhEr0/eXpjE4V0b//Rzv3xpw/v79x/uBeM
-        UeQxinl1ldfoOb+rptbr5tYI/+QXqXlbGgkBf+Pkl/w/GbnUDKUIAAA=
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
+        O3tvdh882j94dP/+Jzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQH2d
+        lXlzXtXT/KvXrtso7bzX8WygX7OeTvN8ls8cRDyOfmfL86rzHWEaks8Hmw5B
+        7BFn983O/qP9B4/uPxzv7D3Yvb/7oEMkIo35lQmlf3+f4X40qar2aZFdLKum
+        LabAQ8dMo102VZm/ntZ5vmzmVfukrCZf1QU1+Wjetqvm0d27y+v64uHuwf54
+        Qt+Np1Wdj6+K5ay6asbLvL0L4DMHfLsxtN+ezs53svMHD7fv7ezPtvdnD+5t
+        P5xO728f3L+/O9l9OJvmOw/u+lM1vs0b48YiO54sVkwC5Yv8XUtfEHExRJ1h
+        HSl9a5jji2JaV0113o7PqPHFvG3GP/mFR57XedvS7DQMmWDjhxKyz0AO/Hsx
+        zhDTvD/DbGSW3b2dhzsP9wNmEVpFMa+u8ho953dneVaW1ZR+9bu6NdKkA3wI
+        0lAI+Rsnv+T/AThoDsz9BAAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:41 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
@@ -6461,11 +4857,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6484,24 +4880,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"0f3d7eeb-a0a8-4e03-ab82-228f96d8d775"
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 12654b9c-4fad-494d-ae34-2501c9125c48
+      - 94268839-9a5a-4ea4-aff5-c10a53ca41e2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 37f63852-7379-4a09-a225-6ff0f209236b
+      - b8c62f00-d5f9-452a-a93f-0cac856cd86c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180042Z:37f63852-7379-4a09-a225-6ff0f209236b
+      - EASTUS:20151102T174855Z:b8c62f00-d5f9-452a-a93f-0cac856cd86c
       Date:
-      - Thu, 22 Oct 2015 18:00:41 GMT
+      - Mon, 02 Nov 2015 17:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6510,20 +4906,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
         Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
         vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOf83uxBnk+2s53s
-        YHs/37m3nU0O9rb39g7OH346O5g9eHD/9/1IX2yvVzzMW/Ssb5TVNMOA8Vae
-        Ne3afEHDWOV1W1DLRykTUT68LBpqXiwvXrdZy529Xk+neT7LZ/ImNbNkWQtp
-        J9lePr3/MNue3btPY5jtz7az3d3d7elufu/BvZ1PJw8ne/blYnVSLc+Li3XN
-        iKH778lXqcEDj53SYjXl9rsGAp7/F83p3e6A6IMYxl930uXB1PTmSx58dYtZ
-        k4caF5fU5Ozl8WxGpAC0j3Z3xnvjnfGng01Lw0Zf5O28YtI/vaYJKqbdV9aT
-        spjSGxZ4gCq1+OFNXAcXmrjXduK+en328iMfs18SjoPQo3knTH/W0D+Z5+fb
-        L+tqtnEMl0XdrrNS//TfIgwIw+buLD/P1mUbDsb9YX/VX76v4/xotmxe521L
-        LBPMknxeXxI69PH3THP6IlutyiKfPQ2/l68N9T5aZFMlN3370c7O9s7T7XvH
-        26QLjh9sP9w33PJRvswmJXHWs6q+yuoZYUHtz7OyyU0LGhyG/DqfruuivWaq
-        URuH6Dc3E9VitW7zn/yi2TgVMYSo3dlP6Pu7OgWWFiQ+i6y+Jizbem3HpTP6
-        RTadF0tI6s/CiAZFQ1E1bKVIhIJhhoEf9M8v+X8A30qf1WEHAAA=
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:42 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
@@ -6536,11 +4931,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.3.0 x86_64) ruby/2.2.2p95
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDU1MzYzODEsIm5iZiI6MTQ0NTUzNjM4MSwiZXhwIjoxNDQ1NTQwMjgxLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.qmq8eQCB2Vz_JxvHCT5FBa6hb0anzYutJv4ax5N7155KiZhjgSoj8rLmnOVxgcQcEDcGUv0_SFmZU6RpJRTxpMSocWLS_9WSMGy6TMF8ABOOm7ROUUSh8bOwRRAgBh8SHFNAzQGDNKrsiHp6BnaSZPgZufmLP0SoROSYLyQ6YzUGBy59AY1KwoOK5_hYPhX56-YvmQON0v4yxRCIn92ZcQBd7fDhIq5W9aM2lpKs4VeTflcqNFvsyL6zUQMKzc22ZkqTMEhlRGjJJuv76Td5se8FQ3JG6MXKEgJghA8LUgZ_aYHrHfcVMHF-gESz_2s0uEPth3aY1f4ScGOLFjw7eg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDY0ODYyMjAsIm5iZiI6MTQ0NjQ4NjIyMCwiZXhwIjoxNDQ2NDkwMTIwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Gdo3w1M3UO_uX9GBfmme9Zqwy0z9PdJlrKxJ4O_zSfAkGrUmnqbVx-TBBePDfK1oJYKOnVosqdiVix3k_Xz35YvO6j7zfrLapyXTz7uw9n4OnBJfzCDhAOGh1MJfBZbwVEJ2bPQN47rGUq5UlO88akH-oPMEk8foWLSDHVyFamKXljbaPyZ36hOB2vbyR-P9kI-9-ufJSDZjQZaQ2W7LndW8CRC-tndZBDMoumZNzgoV564KEzqCLdoLzR0UQx4VjT6iF6vdtrvKEfVPxX6MxtnESL4gmxtPzA6EiNTdAKJod4Nip4r_54t4ba2YHaSMEYHBTPeSRFSbuQxOBSCLKQ
   response:
     status:
       code: 200
@@ -6559,24 +4954,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"548f14dc-0b70-44ab-8580-4727cca9e120"
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 96a1ca31-7f54-47e1-8751-e1104974efdf
+      - 0b0f1967-d490-4426-82d6-7b8721c72167
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14955'
       X-Ms-Correlation-Request-Id:
-      - 5a1f0bcf-91bc-4006-a4d4-993fa05c29a3
+      - e68274f3-1192-4023-84c2-a0099ea0b6f2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151022T180044Z:5a1f0bcf-91bc-4006-a4d4-993fa05c29a3
+      - EASTUS:20151102T174855Z:e68274f3-1192-4023-84c2-a0099ea0b6f2
       Date:
-      - Thu, 22 Oct 2015 18:00:43 GMT
+      - Mon, 02 Nov 2015 17:48:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6585,13 +4980,13 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
         vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
         d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70f39w/Od/dn
-        0+2dyYOd7f39bLJ9cP+Afnuw92A6zR7mu3s7v+9H+mJ7veJh3qJnfaOsphkG
-        jLfyrGnX5gsaxiqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IGRZC2l3H8z2DvJZtr2XEQX383uz7YcPZpPtycMsm+zPzu8dnJ/bl4uV4og3
-        93fGDz4d7+3eG+/v2RZ2LKXB/ou8nVfc1dNrmupiatsWszJ/Uyzyat2eLb8o
-        luuWB7Rvv1+dVMvz4mJdMyD6SseK7xji3R8CXyzl59myzevzbEp80Vi+WDcH
-        B3c7aDb0wZQ/2P1I0P0l+EH//JL/B3qvVwTwAgAA
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
     http_version: 
-  recorded_at: Thu, 22 Oct 2015 18:00:44 GMT
+  recorded_at: Mon, 02 Nov 2015 17:48:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
@@ -1,0 +1,12116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - 48224f43-c449-4206-a456-3c5f4fcca631
+      Client-Request-Id:
+      - cbaf25dd-6754-4202-ab67-ab51c40b3c4d
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_49
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 28 Oct 2015 16:40:15 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446054015","not_before":"1446050115","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ"}'
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 76c7b732-27f7-4657-93dd-3b6f9b8c403c
+      X-Ms-Correlation-Request-Id:
+      - 76c7b732-27f7-4657-93dd-3b6f9b8c403c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164015Z:76c7b732-27f7-4657-93dd-3b6f9b8c403c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
+      X-Ms-Correlation-Request-Id:
+      - 1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164015Z:1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
+        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
+        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
+        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
+        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
+        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
+        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
+        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
+        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
+        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
+        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
+        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
+        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
+        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
+        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
+        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
+        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
+        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
+        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
+        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
+        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
+        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
+        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
+        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
+        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
+        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
+        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
+        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
+        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
+        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
+        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
+        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
+        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
+        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
+        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
+        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
+        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
+        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
+        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
+        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
+        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
+        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
+        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
+        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
+        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
+        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
+        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
+        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
+        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
+        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
+        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
+        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
+        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
+        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
+        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
+        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
+        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
+        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
+        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
+        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
+        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
+        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
+        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
+        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
+        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
+        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
+        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
+        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
+        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
+        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
+        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
+        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
+        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
+        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
+        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
+        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
+        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
+        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
+        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
+        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
+        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
+        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
+        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
+        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
+        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
+        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
+        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
+        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
+        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
+        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
+        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
+        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
+        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
+        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
+        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
+        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
+        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
+        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
+        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
+        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
+        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
+        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
+        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
+        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
+        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
+        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
+        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
+        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
+        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
+        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
+        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
+        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
+        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
+        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
+        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
+        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
+        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
+        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
+        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
+        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
+        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
+        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
+        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
+        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
+        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
+        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
+        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
+        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
+        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
+        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
+        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
+        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
+        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
+        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
+        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
+        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
+        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
+        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
+        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
+        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
+        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
+        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
+        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
+        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
+        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
+        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
+        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
+        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
+        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
+        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
+        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
+        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
+        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
+        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
+        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
+        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
+        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
+        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
+        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
+        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
+        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
+        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
+        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
+        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
+        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
+        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
+        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
+        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
+        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
+        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
+        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
+        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
+        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
+        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
+        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
+        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
+        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
+        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
+        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
+        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1c3c7072-7657-4a67-b4f1-c023212d96c0
+      - f05a5df5-2265-4f66-9cf1-7ef2ca79f2a7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - c18f3a55-a050-4f63-a912-30383c6d653d
+      X-Ms-Correlation-Request-Id:
+      - c18f3a55-a050-4f63-a912-30383c6d653d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164016Z:c18f3a55-a050-4f63-a912-30383c6d653d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 87f777b7-8843-47ae-83dd-8c08f64503ea
+      - 989e5b7b-fc5c-4ce2-b6a0-613875c7df59
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - c57550c9-705b-44d9-a1ac-d386126b33cf
+      X-Ms-Correlation-Request-Id:
+      - c57550c9-705b-44d9-a1ac-d386126b33cf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164017Z:c57550c9-705b-44d9-a1ac-d386126b33cf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3b831f92-a44c-4e72-a737-c8796d9fcdd8
+      - 6c25c0da-9a0c-48a1-981f-0d45ce86343c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 63abb515-4f8d-40cb-8833-744112c560ac
+      X-Ms-Correlation-Request-Id:
+      - 63abb515-4f8d-40cb-8833-744112c560ac
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164017Z:63abb515-4f8d-40cb-8833-744112c560ac
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4706c265-2f79-4c17-99a5-d96060b04bc0
+      - 8c682b95-8526-48c0-82c6-aa8388e04ed1
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      X-Ms-Correlation-Request-Id:
+      - e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164018Z:e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 507cb549-ae31-4af0-896e-c9d570ff8af5
+      - 8aa62020-b0e6-49dc-8f54-df25d2346ad7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      X-Ms-Correlation-Request-Id:
+      - df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164018Z:df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 81600ec8-4421-4a3f-b21e-15d6252b7337
+      - e869e5d9-0ea1-4ac1-a0cf-cbed4b9905a2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 2d137dae-5f57-45c5-8590-790d3b5d6daf
+      X-Ms-Correlation-Request-Id:
+      - 2d137dae-5f57-45c5-8590-790d3b5d6daf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164019Z:2d137dae-5f57-45c5-8590-790d3b5d6daf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 15661851-8350-4571-b3bc-546cbb6d8033
+      - c6e303cb-b151-436a-a860-b6463b2c5831
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - ee3882db-e389-4290-ab65-984f6ee2e5ff
+      X-Ms-Correlation-Request-Id:
+      - ee3882db-e389-4290-ab65-984f6ee2e5ff
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164019Z:ee3882db-e389-4290-ab65-984f6ee2e5ff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1eee67e0-7a9a-4abb-ab1d-83e1884257a0
+      - 57dc249a-bfd0-48a5-ba92-5e8f31042bb4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 13670aa1-627a-4825-bdba-721c3944ea07
+      X-Ms-Correlation-Request-Id:
+      - 13670aa1-627a-4825-bdba-721c3944ea07
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164020Z:13670aa1-627a-4825-bdba-721c3944ea07
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 031180d6-703f-4664-886c-d9e7499914ec
+      - 4ac2bb9c-4728-4ee2-89a3-6f574ce99189
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      X-Ms-Correlation-Request-Id:
+      - daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164020Z:daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2e31d7b4-f7e1-4751-b920-dfa395ef8e90
+      - e2e62b6c-dbd2-463a-97c8-66d149c16fdc
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - e376da29-4c17-4a04-8877-379d4b12b8a8
+      X-Ms-Correlation-Request-Id:
+      - e376da29-4c17-4a04-8877-379d4b12b8a8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164021Z:e376da29-4c17-4a04-8877-379d4b12b8a8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 85b3cf4b-e2f5-45bf-b3ce-487edaea9615
+      - d2d9f309-4da8-4b20-bbf9-17d1b15cf60d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 614fe18a-218c-4a21-922b-078e0fd45ccb
+      X-Ms-Correlation-Request-Id:
+      - 614fe18a-218c-4a21-922b-078e0fd45ccb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164021Z:614fe18a-218c-4a21-922b-078e0fd45ccb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b72daced-db43-4695-96b5-07212efa3cd0
+      - d54bd2d2-1a40-4160-9554-98bfdaf28a31
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      X-Ms-Correlation-Request-Id:
+      - 71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164021Z:71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8ba4888a-5863-4dfc-b6f7-c55d8583b82c
+      - cbc41774-f4fe-4ec6-9d4c-466cf77eec01
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - f90fa7f9-aaec-4015-8964-4b69958be7ce
+      X-Ms-Correlation-Request-Id:
+      - f90fa7f9-aaec-4015-8964-4b69958be7ce
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164022Z:f90fa7f9-aaec-4015-8964-4b69958be7ce
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2d5b5625-ce3d-4811-a60a-bc690ecac1d2
+      - 4dc67b26-7376-4004-a6e0-c646154d0554
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      X-Ms-Correlation-Request-Id:
+      - 3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164022Z:3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0471516c-b01a-4872-b8e9-ed41001a9ccf
+      - a6d9b41c-f5e4-4cc4-80c9-212a56b2ea65
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      X-Ms-Correlation-Request-Id:
+      - 28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164023Z:28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ca6265b2-e00f-4d03-ad6e-543c4337bf12
+      - f4c2a5db-d6e5-4412-99a1-c5d11ce63af1
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 439e64fb-e4c4-4e53-a38d-3be841c00109
+      X-Ms-Correlation-Request-Id:
+      - 439e64fb-e4c4-4e53-a38d-3be841c00109
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164024Z:439e64fb-e4c4-4e53-a38d-3be841c00109
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4e98c91a-4b9b-474c-aeaa-670cc3cb81a2
+      - c894d597-73e2-453e-9d28-3205f59954ea
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 010e1711-7eaf-492f-a55e-edfa4717c11a
+      X-Ms-Correlation-Request-Id:
+      - 010e1711-7eaf-492f-a55e-edfa4717c11a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164024Z:010e1711-7eaf-492f-a55e-edfa4717c11a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4ef4520f-4cf4-441e-85f0-2b3cd5b0c65b
+      - 7f11af8a-0d71-4912-8ec2-41bb4c671cad
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - 9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      X-Ms-Correlation-Request-Id:
+      - 9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164025Z:9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ba3c227b-2104-46dd-b8dc-0a36fd9644dd
+      - f09247b7-57b9-423c-aa6f-5d87ce9187a1
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      X-Ms-Correlation-Request-Id:
+      - 2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164025Z:2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0a651fd9-4a03-432e-9f3b-a25e38195d3b
+      - d6c58cc8-e17f-48dc-9913-246494345755
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 54e73d93-0909-4b22-9d3b-2e279873f24a
+      X-Ms-Correlation-Request-Id:
+      - 54e73d93-0909-4b22-9d3b-2e279873f24a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164026Z:54e73d93-0909-4b22-9d3b-2e279873f24a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0e852c03-c7a0-4461-828d-85cba50b6397
+      - 2702641b-773e-4827-b811-d3cb19704874
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Request-Id:
+      - 1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      X-Ms-Correlation-Request-Id:
+      - 1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164027Z:1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1d5c2746-f46b-4d22-a0a7-ab0b49ebe35a
+      - 641178bf-00cc-4be3-8e2c-c2e82572c091
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      X-Ms-Correlation-Request-Id:
+      - 5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164027Z:5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2cc0c2b0-14c6-4500-b23c-00744f8d3c0d
+      - 2fcac979-eeb0-446d-b624-007fed7809e6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Request-Id:
+      - 244e6bba-640e-4801-812c-712a3b44900f
+      X-Ms-Correlation-Request-Id:
+      - 244e6bba-640e-4801-812c-712a3b44900f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164027Z:244e6bba-640e-4801-812c-712a3b44900f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ba2fdea3-f817-4352-8a4e-558a29dd1728
+      - ce8161ff-6ee5-4777-895b-fb839b9675e7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - a3f72022-f6e1-4450-b173-20b5c8389a08
+      X-Ms-Correlation-Request-Id:
+      - a3f72022-f6e1-4450-b173-20b5c8389a08
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164028Z:a3f72022-f6e1-4450-b173-20b5c8389a08
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1374e1fc-ee2c-44b9-b3c3-c86a435c688f
+      - df910620-ed92-4f1f-b8bd-90ddfd33b3bf
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 73d91cf3-3533-4547-9da5-87e41be9f2c2
+      X-Ms-Correlation-Request-Id:
+      - 73d91cf3-3533-4547-9da5-87e41be9f2c2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164028Z:73d91cf3-3533-4547-9da5-87e41be9f2c2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1fb010b5-4f3e-47fa-aa73-b72cf652f0a0
+      - d1649780-4af7-4cbe-87ca-8a4b7fcedab5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - b1f63c45-ab83-4418-a760-7f200a292e5b
+      X-Ms-Correlation-Request-Id:
+      - b1f63c45-ab83-4418-a760-7f200a292e5b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164028Z:b1f63c45-ab83-4418-a760-7f200a292e5b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 09d826a7-d798-4471-9f5b-11e1f8502110
+      - 9041d5b0-2270-4ca7-a2fb-f1d4e30dfefd
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 77892022-257c-4d7c-b72d-d854c42aff42
+      X-Ms-Correlation-Request-Id:
+      - 77892022-257c-4d7c-b72d-d854c42aff42
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164030Z:77892022-257c-4d7c-b72d-d854c42aff42
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7f0b7093-1e79-4422-9333-364104e00549
+      - 92a064d4-8e23-4690-b28d-d9f04ca40b27
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 0de7428b-a93d-4498-83a1-16b9ef0caa85
+      X-Ms-Correlation-Request-Id:
+      - 0de7428b-a93d-4498-83a1-16b9ef0caa85
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164030Z:0de7428b-a93d-4498-83a1-16b9ef0caa85
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 13156844-5f89-439d-b494-d119cf4fc156
+      - 7f03d32c-b263-40f2-a783-58030d374c3c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 05901df7-7ff5-4416-b249-0a0e1658fc2a
+      X-Ms-Correlation-Request-Id:
+      - 05901df7-7ff5-4416-b249-0a0e1658fc2a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164031Z:05901df7-7ff5-4416-b249-0a0e1658fc2a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a1d2aabe-423c-4fb7-8cb3-10d12420aa32
+      - dce58fa8-a404-4ec5-925e-1882cbcd46c3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 5267d697-3378-4646-bda2-cf45d88ff474
+      X-Ms-Correlation-Request-Id:
+      - 5267d697-3378-4646-bda2-cf45d88ff474
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164031Z:5267d697-3378-4646-bda2-cf45d88ff474
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5af6c2e6-9826-4ac7-8267-960e165b7698
+      - 7cfd11eb-0e83-40c1-8a77-e34babacf2b4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 1bc44088-e0a9-4256-a48f-49809cb1a7e1
+      X-Ms-Correlation-Request-Id:
+      - 1bc44088-e0a9-4256-a48f-49809cb1a7e1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164031Z:1bc44088-e0a9-4256-a48f-49809cb1a7e1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c4c453dd-dd9e-4311-aca0-7ed6eef3dcc5
+      - e283d19e-010a-4a86-92d7-341ac93e31ce
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 75dc80e4-efaf-4c86-9c72-3e3d7f127871
+      X-Ms-Correlation-Request-Id:
+      - 75dc80e4-efaf-4c86-9c72-3e3d7f127871
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164032Z:75dc80e4-efaf-4c86-9c72-3e3d7f127871
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 211e063e-740d-4123-9286-9e95b689cd5a
+      - cec00229-607e-452c-ab1e-7427a79c67bc
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 6cfbc081-e207-49e7-8457-8aea16f7b076
+      X-Ms-Correlation-Request-Id:
+      - 6cfbc081-e207-49e7-8457-8aea16f7b076
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164032Z:6cfbc081-e207-49e7-8457-8aea16f7b076
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 714c2938-8619-46b6-ac35-2113e9125993
+      - b34c64b9-e31d-4168-94be-caa803c153c2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 19a31545-2415-46a4-9033-8582eec97dc4
+      X-Ms-Correlation-Request-Id:
+      - 19a31545-2415-46a4-9033-8582eec97dc4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164032Z:19a31545-2415-46a4-9033-8582eec97dc4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 20493006-3794-4227-a062-59741d2fcf03
+      - 91a17597-5892-4832-8088-92a3759265ff
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 051c5870-3d8f-4d0b-bab4-070bede3a8e5
+      X-Ms-Correlation-Request-Id:
+      - 051c5870-3d8f-4d0b-bab4-070bede3a8e5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164033Z:051c5870-3d8f-4d0b-bab4-070bede3a8e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1b4c7f49-13aa-4978-8cd0-08679b2f1e68
+      - 4eca1be4-38dd-4f12-b745-d80ba25b903d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14973'
+      X-Ms-Request-Id:
+      - 8d05e6fe-d9ee-4c29-a61b-86b1169fece9
+      X-Ms-Correlation-Request-Id:
+      - 8d05e6fe-d9ee-4c29-a61b-86b1169fece9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164033Z:8d05e6fe-d9ee-4c29-a61b-86b1169fece9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - aaae9c72-63d4-4b63-88fe-1e8021940a8e
+      - d1e8f6e8-ce38-4548-b308-78fc01a0e249
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - b4475355-ced2-4310-9255-a60c33ac77af
+      X-Ms-Correlation-Request-Id:
+      - b4475355-ced2-4310-9255-a60c33ac77af
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164033Z:b4475355-ced2-4310-9255-a60c33ac77af
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 65de5b80-3fff-488d-8964-729c75789999
+      - e02a2d55-4530-4d5e-9687-fbbc798b1f1a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 855cb813-a0d4-4493-b0ae-8f884fe42791
+      X-Ms-Correlation-Request-Id:
+      - 855cb813-a0d4-4493-b0ae-8f884fe42791
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164034Z:855cb813-a0d4-4493-b0ae-8f884fe42791
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7b874385-3c06-4a43-9303-2b3d6b92a1e0
+      - f388c994-f6c6-46f7-96f1-6f5ce33e579f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 0e678c7e-e060-4ffb-a87a-3943dd6864e7
+      X-Ms-Correlation-Request-Id:
+      - 0e678c7e-e060-4ffb-a87a-3943dd6864e7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164034Z:0e678c7e-e060-4ffb-a87a-3943dd6864e7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 246e30ec-5ffa-4791-9840-f00bc7ec80ea
+      - e71d0f2f-88dd-4a0b-a45d-8a714a05f46b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 7239e88f-3e5a-485c-b6cf-8da6aec4dd18
+      X-Ms-Correlation-Request-Id:
+      - 7239e88f-3e5a-485c-b6cf-8da6aec4dd18
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164035Z:7239e88f-3e5a-485c-b6cf-8da6aec4dd18
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7de546ea-6750-4e59-be89-5fcd4af212fe
+      - cfa62301-5cb7-4c7b-aa63-047305c481d9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - c58036cf-3a20-48aa-940e-87fde103865f
+      X-Ms-Correlation-Request-Id:
+      - c58036cf-3a20-48aa-940e-87fde103865f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164035Z:c58036cf-3a20-48aa-940e-87fde103865f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ac1b4cd5-d7c1-4c27-b4c0-742ef2b97766
+      - cd9ecd42-27f0-4dbc-ab97-edb755fe97d5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 8d2549b4-2246-4019-95b7-63bb69a22cdc
+      X-Ms-Correlation-Request-Id:
+      - 8d2549b4-2246-4019-95b7-63bb69a22cdc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164035Z:8d2549b4-2246-4019-95b7-63bb69a22cdc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8d10fb97-7dba-417e-b2d5-4055e0c6850c
+      - a6a12c74-d3fe-4653-ab24-c4334be651e2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - be8bbce6-048d-44b9-995c-2d381c1c5720
+      X-Ms-Correlation-Request-Id:
+      - be8bbce6-048d-44b9-995c-2d381c1c5720
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164036Z:be8bbce6-048d-44b9-995c-2d381c1c5720
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 31d8b4f5-2ce8-477f-9b90-322b5fa397fa
+      - 69bd8006-e58a-45b0-a91e-ce9d7204bf2d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - dd270c39-316e-481b-942c-eb2af077cca2
+      X-Ms-Correlation-Request-Id:
+      - dd270c39-316e-481b-942c-eb2af077cca2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164036Z:dd270c39-316e-481b-942c-eb2af077cca2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - d9b8f599-f7de-46bc-b321-0c65b6156214
+      - dd893989-f430-4fca-b88c-a702c014775f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - 33db4c6d-013e-4b2c-80a9-d59555c31d43
+      X-Ms-Correlation-Request-Id:
+      - 33db4c6d-013e-4b2c-80a9-d59555c31d43
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164036Z:33db4c6d-013e-4b2c-80a9-d59555c31d43
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b47f0af0-9589-4912-b35c-c24e8417f264
+      - f5545e68-9a8e-402b-bbec-71538fc7b7d9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - bb37a462-ac29-42f4-93d2-5052dbc4b7d3
+      X-Ms-Correlation-Request-Id:
+      - bb37a462-ac29-42f4-93d2-5052dbc4b7d3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164037Z:bb37a462-ac29-42f4-93d2-5052dbc4b7d3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1d52bbc1-c469-4e54-b0e1-6acc5ec9f142
+      - 77be3324-40e7-4377-a3b0-6300400cab91
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 3127604c-8745-4d78-9725-960e3616f088
+      X-Ms-Correlation-Request-Id:
+      - 3127604c-8745-4d78-9725-960e3616f088
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164037Z:3127604c-8745-4d78-9725-960e3616f088
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - dd5877f0-bbcd-45f8-b04b-69a117697094
+      - ec4c3b40-c04b-4729-9102-80dd0cf74194
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 74c1c80a-b731-440b-a8d1-9a43d407d580
+      X-Ms-Correlation-Request-Id:
+      - 74c1c80a-b731-440b-a8d1-9a43d407d580
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164037Z:74c1c80a-b731-440b-a8d1-9a43d407d580
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - da3af471-8711-490e-8db4-fe41378b07b0
+      - f82ccdb4-0d8a-453d-9b22-2d42f2cef554
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - bf64ede3-06c5-41ce-b561-17d10b252f37
+      X-Ms-Correlation-Request-Id:
+      - bf64ede3-06c5-41ce-b561-17d10b252f37
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164038Z:bf64ede3-06c5-41ce-b561-17d10b252f37
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2ee64f29-077e-44c3-a7fc-ca83714f909f
+      - 304a1dce-e551-4944-b0f0-fd07a559a017
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 7c337c52-e21d-49c2-9440-9b5eb7562f35
+      X-Ms-Correlation-Request-Id:
+      - 7c337c52-e21d-49c2-9440-9b5eb7562f35
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164038Z:7c337c52-e21d-49c2-9440-9b5eb7562f35
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 35ee161d-fec4-4946-8582-546768e0e611
+      - cc7a5557-d1b6-47b7-b045-e0dff88f814b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
+      X-Ms-Correlation-Request-Id:
+      - c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164039Z:c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 259e416c-9f2a-4544-8ac6-5938ebb3d779
+      - d20ff211-42a7-48ed-aa12-4acfc9ed96f3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 38f8f274-1666-4bb2-ace1-e423caf66e1a
+      X-Ms-Correlation-Request-Id:
+      - 38f8f274-1666-4bb2-ace1-e423caf66e1a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164039Z:38f8f274-1666-4bb2-ace1-e423caf66e1a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4eb78f05-636b-46e9-a65d-775b89d11122
+      - bc8767f8-fa9d-40f9-93f7-47a656a57b06
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - 4d8c7d9b-e664-4ec2-83ed-624b984867c4
+      X-Ms-Correlation-Request-Id:
+      - 4d8c7d9b-e664-4ec2-83ed-624b984867c4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164039Z:4d8c7d9b-e664-4ec2-83ed-624b984867c4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 02e3c921-aba4-46bb-b555-ed8bf09e5e1f
+      - a4ec282f-a33d-47be-a00c-c9e1636329d7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - 4b492f5a-574c-44cc-8cef-91aaae5b3cc3
+      X-Ms-Correlation-Request-Id:
+      - 4b492f5a-574c-44cc-8cef-91aaae5b3cc3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164039Z:4b492f5a-574c-44cc-8cef-91aaae5b3cc3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 766d5181-61fc-43bb-ae1d-a403108fa100
+      - cdc5ac3f-5ebc-417b-81d7-1a677ee9fb65
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 93f8e616-921d-4aff-bd48-3313f47d6773
+      X-Ms-Correlation-Request-Id:
+      - 93f8e616-921d-4aff-bd48-3313f47d6773
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164040Z:93f8e616-921d-4aff-bd48-3313f47d6773
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 21f7d1d3-9dcf-422a-a6ca-a590a8325ffa
+      - 539bbb7c-953c-4b32-a238-b3257d065034
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 83575265-990e-479f-ac30-6dc30b822ec3
+      X-Ms-Correlation-Request-Id:
+      - 83575265-990e-479f-ac30-6dc30b822ec3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164040Z:83575265-990e-479f-ac30-6dc30b822ec3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 40ccd4ad-9a36-413e-85dd-265f611626ab
+      X-Ms-Correlation-Request-Id:
+      - 40ccd4ad-9a36-413e-85dd-265f611626ab
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164040Z:40ccd4ad-9a36-413e-85dd-265f611626ab
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:39 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 326fd145-c626-45c1-8d3e-d7036fec87e4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 003f115f-44f5-4f7f-a2ff-b279023bbd1c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164041Z:003f115f-44f5-4f7f-a2ff-b279023bbd1c
+      Date:
+      - Wed, 28 Oct 2015 16:40:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - b118c723-8584-496d-9141-f49d9e9ad2e0
+      X-Ms-Correlation-Request-Id:
+      - b118c723-8584-496d-9141-f49d9e9ad2e0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164042Z:b118c723-8584-496d-9141-f49d9e9ad2e0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:41 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - aeecf67f-23e8-42ff-be1c-8155ef5c2e50
+      X-Ms-Correlation-Request-Id:
+      - aeecf67f-23e8-42ff-be1c-8155ef5c2e50
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164043Z:aeecf67f-23e8-42ff-be1c-8155ef5c2e50
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:43 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 154e4001-2761-44ce-a6b2-c5eb212d406d
+      X-Ms-Correlation-Request-Id:
+      - 154e4001-2761-44ce-a6b2-c5eb212d406d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164043Z:154e4001-2761-44ce-a6b2-c5eb212d406d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:42 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 648540d2-20a9-45a4-aa29-70266e1c038a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - fd49b1a6-4556-4cce-88d8-84b99e77ffe6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164044Z:fd49b1a6-4556-4cce-88d8-84b99e77ffe6
+      Date:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 31cad604-1ab4-46c0-8ed5-427255bce807
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 151a6b83-e1c3-4943-8c1b-1206b8fa7983
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164044Z:151a6b83-e1c3-4943-8c1b-1206b8fa7983
+      Date:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 817b2975-0f9d-4d9e-89db-58ba9e586a74
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - fd342667-5421-4917-b039-10d1f010d85a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164044Z:fd342667-5421-4917-b039-10d1f010d85a
+      Date:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/82h//5OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+/onnr/P6Mq+f5peu2yjtvNfx
+        bKBfs55O83yWzxxEPI5+Z8vzqvMdYRqSzwebDkGMEef+o/0Hj+7vjx/e+/T+
+        /XtdIhFpzK9MKP37+wz3o0lVtU+L7GJZNW0xBR46ZhrtsqnK/PW0zvNlM6/a
+        J2U1+aouqMlH87ZdNY/u3r3Km3ZaZU07mzT3H366N55Qm/G0qvPxVbGcVVfN
+        eJm3d9HJzHWy3fyisuE52N659zCfTfcOtu/nBzvb+zs7e9uT2f3p9v79h9n+
+        LLu/u3ewf9efsvFt3hg3FunxZLFiUih/5O9a+oKIjKHqTOuI6VvDJF8U07pq
+        qvN2fEaNL+ZtM/7JLzwyvc7blmapYcgEGz+UoH1GcuDfi4GGmOf9GWcz0zx8
+        uLv7cDdgGqFVFPPqKq/Rc353lmdlWU3pV7+rWyNNusCHIA2FkL9x8kv+H4e4
+        yhZABQAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e7a25889-1011-4d07-baeb-669a4ebe093d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - 67ebe139-0a3f-4fff-acc4-70dda96a7af6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164045Z:67ebe139-0a3f-4fff-acc4-70dda96a7af6
+      Date:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
+        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
+        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
+        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
+        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
+        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
+        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
+        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
+        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
+        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
+        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a854afe8-dcf9-4e60-8c41-2a3906957a76
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - 479637dd-22ad-4924-ba41-b2f99c43f33a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164046Z:479637dd-22ad-4924-ba41-b2f99c43f33a
+      Date:
+      - Wed, 28 Oct 2015 16:40:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - e7df7f64-f6f4-4825-b100-1e8228d2dbd9
+      X-Ms-Correlation-Request-Id:
+      - e7df7f64-f6f4-4825-b100-1e8228d2dbd9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164047Z:e7df7f64-f6f4-4825-b100-1e8228d2dbd9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:47 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - b139eef8-aedb-43ad-9286-e5a6327f1c7e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - ac4e5899-4de0-40eb-940d-ea756707f09c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164047Z:ac4e5899-4de0-40eb-940d-ea756707f09c
+      Date:
+      - Wed, 28 Oct 2015 16:40:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 5ce67bbc-f461-4fb5-aa90-476e3e390574
+      X-Ms-Correlation-Request-Id:
+      - 5ce67bbc-f461-4fb5-aa90-476e3e390574
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164047Z:5ce67bbc-f461-4fb5-aa90-476e3e390574
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:47 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
+      X-Ms-Correlation-Request-Id:
+      - 5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164048Z:5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:47 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - 6a055201-21bf-469d-acbf-8351d479ed37
+      X-Ms-Correlation-Request-Id:
+      - 6a055201-21bf-469d-acbf-8351d479ed37
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164048Z:6a055201-21bf-469d-acbf-8351d479ed37
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 397608b1-c617-454a-8e0f-9f33042e56cf
+      X-Ms-Correlation-Request-Id:
+      - 397608b1-c617-454a-8e0f-9f33042e56cf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164048Z:397608b1-c617-454a-8e0f-9f33042e56cf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14972'
+      X-Ms-Request-Id:
+      - 0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
+      X-Ms-Correlation-Request-Id:
+      - 0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164048Z:0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:47 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 1e941426-1cdb-4ff1-a684-056c44f65b78
+      X-Ms-Correlation-Request-Id:
+      - 1e941426-1cdb-4ff1-a684-056c44f65b78
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164048Z:1e941426-1cdb-4ff1-a684-056c44f65b78
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - 56fc0177-711a-4d8d-9190-506b3b52611c
+      X-Ms-Correlation-Request-Id:
+      - 56fc0177-711a-4d8d-9190-506b3b52611c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164049Z:56fc0177-711a-4d8d-9190-506b3b52611c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - f530cf07-7299-473a-a489-c4612766857e
+      X-Ms-Correlation-Request-Id:
+      - f530cf07-7299-473a-a489-c4612766857e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164049Z:f530cf07-7299-473a-a489-c4612766857e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:48 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - 69ca47ed-783f-4bac-9258-d9c030aa813f
+      X-Ms-Correlation-Request-Id:
+      - 69ca47ed-783f-4bac-9258-d9c030aa813f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164049Z:69ca47ed-783f-4bac-9258-d9c030aa813f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:49 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - eb05bb4e-f3c8-4888-935b-0be1c655c425
+      X-Ms-Correlation-Request-Id:
+      - eb05bb4e-f3c8-4888-935b-0be1c655c425
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164049Z:eb05bb4e-f3c8-4888-935b-0be1c655c425
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:48 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 4349b5a7-948d-41b6-8dc9-f074bbd58de7
+      X-Ms-Correlation-Request-Id:
+      - 4349b5a7-948d-41b6-8dc9-f074bbd58de7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164049Z:4349b5a7-948d-41b6-8dc9-f074bbd58de7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:49 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:7988:6055F0A:5630FA92
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:40:50 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1025-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:45:50 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 90c15674-9d8a-40e1-ae56-38c8e6cd2585
+      X-Ms-Correlation-Request-Id:
+      - 90c15674-9d8a-40e1-ae56-38c8e6cd2585
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164050Z:90c15674-9d8a-40e1-ae56-38c8e6cd2585
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:49 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB2E24:3708:BB52466:5630FA92
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:40:50 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2148-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:45:50 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
+      X-Ms-Correlation-Request-Id:
+      - c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164051Z:c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:50 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB2E15:370A:7E463F6:5630FA92
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:40:51 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2120-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:45:51 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 6205a725-39f0-4640-a72a-c4789bd1995f
+      X-Ms-Correlation-Request-Id:
+      - 6205a725-39f0-4640-a72a-c4789bd1995f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164051Z:6205a725-39f0-4640-a72a-c4789bd1995f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:51 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 68c7ab62-0e6d-478f-afb9-c64612837db6
+      X-Ms-Correlation-Request-Id:
+      - 68c7ab62-0e6d-478f-afb9-c64612837db6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164051Z:68c7ab62-0e6d-478f-afb9-c64612837db6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:50 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2abdebd6-457f-4dda-ae10-e26249a43761
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 97b58c48-bf1b-46e0-a794-5a1bc4d87e04
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164052Z:97b58c48-bf1b-46e0-a794-5a1bc4d87e04
+      Date:
+      - Wed, 28 Oct 2015 16:40:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b6b4bb7d-2093-4de9-a698-2e354a4bd709
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Correlation-Request-Id:
+      - 264b9a49-720d-4f05-8486-25fc02838622
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164052Z:264b9a49-720d-4f05-8486-25fc02838622
+      Date:
+      - Wed, 28 Oct 2015 16:40:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 93908a15-2981-4355-a77d-af7df19bf57a
+      X-Ms-Correlation-Request-Id:
+      - 93908a15-2981-4355-a77d-af7df19bf57a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164052Z:93908a15-2981-4355-a77d-af7df19bf57a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:52 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Request-Id:
+      - b75a9d7c-e043-424a-91e8-d8cacde269cd
+      X-Ms-Correlation-Request-Id:
+      - b75a9d7c-e043-424a-91e8-d8cacde269cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:b75a9d7c-e043-424a-91e8-d8cacde269cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:52 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2716546a-e910-4409-827b-e8a187095340
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 42ec9912-5275-4500-bef8-94f2dbe21d0a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:42ec9912-5275-4500-bef8-94f2dbe21d0a
+      Date:
+      - Wed, 28 Oct 2015 16:40:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - 9f88d726-a396-4880-8319-f82ec3b425f8
+      X-Ms-Correlation-Request-Id:
+      - 9f88d726-a396-4880-8319-f82ec3b425f8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:9f88d726-a396-4880-8319-f82ec3b425f8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:52 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Request-Id:
+      - 8a77641d-fc48-411f-a563-4b956da90915
+      X-Ms-Correlation-Request-Id:
+      - 8a77641d-fc48-411f-a563-4b956da90915
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:8a77641d-fc48-411f-a563-4b956da90915
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 05caa0a1-9ea9-4f51-87a0-148b01d846f4
+      X-Ms-Correlation-Request-Id:
+      - 05caa0a1-9ea9-4f51-87a0-148b01d846f4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:05caa0a1-9ea9-4f51-87a0-148b01d846f4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 8d6a51d8-6f7b-471e-b8c0-c1c7c6bcd590
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 174c9088-e99a-4ad5-b70b-f916252654aa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164053Z:174c9088-e99a-4ad5-b70b-f916252654aa
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 982b2f69-ec6f-4c5d-be99-05144b39d013
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Correlation-Request-Id:
+      - 18e484f9-50c4-47ac-95cd-1d392d9acdef
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:18e484f9-50c4-47ac-95cd-1d392d9acdef
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Request-Id:
+      - d6770183-1f1c-4c46-b75d-9deffc6062e5
+      X-Ms-Correlation-Request-Id:
+      - d6770183-1f1c-4c46-b75d-9deffc6062e5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:d6770183-1f1c-4c46-b75d-9deffc6062e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:54 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - 1ee5a629-5a49-4b37-bfd0-49381b3d48a5
+      X-Ms-Correlation-Request-Id:
+      - 1ee5a629-5a49-4b37-bfd0-49381b3d48a5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:1ee5a629-5a49-4b37-bfd0-49381b3d48a5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - 01a0c380-6c5d-4489-bedd-e314b395283f
+      X-Ms-Correlation-Request-Id:
+      - 01a0c380-6c5d-4489-bedd-e314b395283f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:01a0c380-6c5d-4489-bedd-e314b395283f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:53 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - 23ce7140-49ee-4da2-9ae8-f17ff3d42963
+      X-Ms-Correlation-Request-Id:
+      - 23ce7140-49ee-4da2-9ae8-f17ff3d42963
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:23ce7140-49ee-4da2-9ae8-f17ff3d42963
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:54 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Request-Id:
+      - 7eee27e1-14d5-4f17-88de-f55f95ee0737
+      X-Ms-Correlation-Request-Id:
+      - 7eee27e1-14d5-4f17-88de-f55f95ee0737
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164054Z:7eee27e1-14d5-4f17-88de-f55f95ee0737
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:40:54 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 8b056664-e1d0-4bdd-b73f-9f0af509830b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - 863eaa64-f5a9-40d6-8b03-4f4296bf006a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164055Z:863eaa64-f5a9-40d6-8b03-4f4296bf006a
+      Date:
+      - Wed, 28 Oct 2015 16:40:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 887bae6b-da90-426b-aa42-5475bf25b365
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - bc8a4b6f-1192-413e-8cde-dca57167cdc6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164055Z:bc8a4b6f-1192-413e-8cde-dca57167cdc6
+      Date:
+      - Wed, 28 Oct 2015 16:40:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
+        3ux++mh/59H9+5/s7Dza2fnINP4l8sv38eOXMAhg+hYYKlUsTT5aZgL1ZJ6f
+        bxNZZq7PKDW9d/FsoGiznk7zfJZ7EPE4ip4tz6vOd4RmSFAfbDoEMUaZ+4/2
+        Hzy6/+n4wf69/b0Hux0KEV3Mr0wl/fv7DPej/F2bL9EpUNCR21Fbin1RTOuq
+        qc7b8Rk1vpi3zfgnv3haZBfLqmmLafM6b1vCutFO/Q76hHXg34ugQ8R8f0Ju
+        JuLDnXs79x8ERBTGimJeXeU1es7vzvKsLKsp/ep3dWukSVp8CNJQCPkbJ7/k
+        /wEUKcVCYgQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0d712b27-900a-42c0-9b08-e7516f5ddaf1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Correlation-Request-Id:
+      - 09bf8521-45cf-4f4c-91ee-a50dd8905dca
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164055Z:09bf8521-45cf-4f4c-91ee-a50dd8905dca
+      Date:
+      - Wed, 28 Oct 2015 16:40:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
+        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
+        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
+        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
+        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
+        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
+        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
+        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
+        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
+        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
+        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8119c994-9436-4f8e-abea-81085143d2a6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Correlation-Request-Id:
+      - 54ee710f-b139-46fe-8238-188a95d5672d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164056Z:54ee710f-b139-46fe-8238-188a95d5672d
+      Date:
+      - Wed, 28 Oct 2015 16:40:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 26f7ff73-c1a1-41e0-99c8-eb3c7c52823a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Correlation-Request-Id:
+      - 41056eb5-300b-4937-ac06-aabf3f5e4bc1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164056Z:41056eb5-300b-4937-ac06-aabf3f5e4bc1
+      Date:
+      - Wed, 28 Oct 2015 16:40:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+p5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZdW0F9T19tP80nUbpZ33Op4N
+        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHi3H+0/4CIM36w9+DB/kGH
+        RkQZ8yvTSf/+PoP9aFJV7dMiu1gSVYop0NAh02CXTVXmr6d1ni+bedU+KavJ
+        V3VBTT6at+2qeXT37nSen6/qanZ/d29nPKHvx9OqzsdXxXJWXTXjZd7eRQcz
+        18H2in6C/LPt8+n5vdk0n26fTw5m2/sPz+9vP5wdTLcnu/fz2fT8/MHO/vSu
+        P1vj27wxbizC48lixWRQ1sjftfQF0RfD1EnW0dK3hj++KKZ11VTn7fiMGl/M
+        22b8k194JHqdty1NUMOQCTZ+KDH7POTAvxfvDPHN+/PMZn55uHNv5/6DgGGE
+        VjHMv3yNbvO7JMB5nZXFD4J+bo0x6QAfgjQc7vVldZXXeDu/O8uzsqym9OvX
+        7diHIA1l+n7j5Jf8Pz4oY5ixBQAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8338f2f0-c757-4f34-a4b8-0739cde12bdc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14974'
+      X-Ms-Correlation-Request-Id:
+      - bc2e30ef-b89a-4cf4-802b-024eb2ce51f7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164056Z:bc2e30ef-b89a-4cf4-802b-024eb2ce51f7
+      Date:
+      - Wed, 28 Oct 2015 16:40:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
+        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
+        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
+        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
+        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
+        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
+        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
+        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
+        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
+        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
+        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a9e74055-5729-4bd3-a1f8-2f0774bfae9b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14973'
+      X-Ms-Correlation-Request-Id:
+      - a7d00222-ab52-4b00-9067-b6249651776c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164056Z:a7d00222-ab52-4b00-9067-b6249651776c
+      Date:
+      - Wed, 28 Oct 2015 16:40:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - b260a2d9-81d0-4c02-9f90-8192cee1e85b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14971'
+      X-Ms-Correlation-Request-Id:
+      - 87c608d3-5c47-47f4-b7e5-428e857ff54b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164057Z:87c608d3-5c47-47f4-b7e5-428e857ff54b
+      Date:
+      - Wed, 28 Oct 2015 16:40:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+g092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4E6nefnTV5f5vWu6zVKOu9tPBvI
+        16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQY7S5/2h/79H9g/HBvfu7Dz+9
+        16ERUcb8ynTSv7/PcD/K37U5TQFNA0HVkdtRW5p9UUzrqqnO2/EZNb6Yt834
+        J794WmQXy6ppi2nzOm9bwrrRTv0O+oR14N+LoEPEfH9Cbibiwd7u/v79gIjC
+        WlHMq6u8Rs/53VmelWU1pV/9rm6NNImGD0EaCiF/4+SX/D+6hmeETwQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 964fa48f-51a0-4a47-90ac-d37cafd38912
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14973'
+      X-Ms-Correlation-Request-Id:
+      - 17fe1d8d-6f62-48ad-9dc7-c96dd58a79db
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164057Z:17fe1d8d-6f62-48ad-9dc7-c96dd58a79db
+      Date:
+      - Wed, 28 Oct 2015 16:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
+        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
+        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
+        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
+        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
+        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
+        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
+        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
+        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
+        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - f6c431c2-f62f-4e0e-9006-7920bfcdefda
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - 09131a97-d0ff-4328-8e7d-6f1e6805a2d7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164057Z:09131a97-d0ff-4328-8e7d-6f1e6805a2d7
+      Date:
+      - Wed, 28 Oct 2015 16:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+g092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6+uql6y1KMu8tPBvI1qyn0zyf
+        5TMHEY8j29nyvOp8RwiGVPPBpkMQYzS5/2h/79H9++OH+/uf7uwcdGhDFDG/
+        Mn307+8z3I/yd21OpCfyE1QduR21pdUXxbSumuq8HZ9R44t524x/8ounRXax
+        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+3N1/uPtpQERhqRjmX75G
+        t/ldYua8zsriB0E/t8aY5MGHIA2He31ZXeU13s7vzvKsLKsp/fp1O/YhSEOZ
+        vt84+SX/D3Wp62q9BAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 05872d95-33ba-43b6-b181-fe16d47bc93a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14972'
+      X-Ms-Correlation-Request-Id:
+      - 5a98c3f5-bbee-4c78-aa5f-85f501001a8d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164057Z:5a98c3f5-bbee-4c78-aa5f-85f501001a8d
+      Date:
+      - Wed, 28 Oct 2015 16:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
+        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
+        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
+        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
+        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
+        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
+        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
+        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
+        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
+        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 698e9579-14b5-4461-82f4-ed38e100fceb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Correlation-Request-Id:
+      - 3af96e29-6944-4dc1-98f5-0cb3fc1b121d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164058Z:3af96e29-6944-4dc1-98f5-0cb3fc1b121d
+      Date:
+      - Wed, 28 Oct 2015 16:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 68b01d79-9139-41dd-a850-0a0fb7aaf7f0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Correlation-Request-Id:
+      - e7376835-9b63-452e-860e-921534e2ea9f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164058Z:e7376835-9b63-452e-860e-921534e2ea9f
+      Date:
+      - Wed, 28 Oct 2015 16:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+wSc7O492
+        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUD94uwn9lx3UZp5r+HZQLdmPZ3m
+        +SyfOYh4HN3OludV5zvCMCSbDzYdghgjyv1H+3uP7t8fP9zf/3Rnp0scIon5
+        lQmkf3+f4X6Uv2tzoj3Rn6DqyO2oHbGKaV011Xk7PqPGF/O2Gf/kF0+L7GJZ
+        NW0xbV7nbUtYN9qp30GfsA78exF0iJjvT8jNRHy4u/9w99OAiMJTUcyrq7xG
+        z/ndWZ6VZTWlX/2ubo00yYQPQRoKIX/j5Jf8P4KQkFtIBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5bd19a31-c60d-40d3-ae58-23c5bfd26dd0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14970'
+      X-Ms-Correlation-Request-Id:
+      - 9bdd8385-8e51-4650-aee5-c016aa692279
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164058Z:9bdd8385-8e51-4650-aee5-c016aa692279
+      Date:
+      - Wed, 28 Oct 2015 16:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
+        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
+        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
+        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
+        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
+        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
+        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
+        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
+        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
+        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
+        Abt1q/kPBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - aca45686-e743-44ce-8b19-54cd7c5bb26c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14969'
+      X-Ms-Correlation-Request-Id:
+      - df72eb27-58b9-4e63-8ccb-c5f9339d0d9e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164058Z:df72eb27-58b9-4e63-8ccb-c5f9339d0d9e
+      Date:
+      - Wed, 28 Oct 2015 16:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - f5fa37a1-8f1a-4901-b320-e5c7facdcc8a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 2392e244-2247-493b-999c-467d009a8a5f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164059Z:2392e244-2247-493b-999c-467d009a8a5f
+      Date:
+      - Wed, 28 Oct 2015 16:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99tL/z6P7DT3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
+        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
+        GKPN/Uf7e4/ufzre+fThp5/e65CICGN+ZTLR3wrRDs6SZpa1GaH19keEoX/p
+        6RFmz3X6/wvC7O5+uv9g9xaUwY/vM9yP8ndtTkJLgktQdeR21JZiXxTTumqq
+        83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+fkJuJ
+        +Om9ewd7oWrqs5LFvLrKa/Sc353lWVlWU/rV7+rWSJMy9SFIQyHkb5z8kv8H
+        Po1oXkYGAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 14725499-3f1c-4cc5-8a96-bcac14209898
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - 587ca008-7737-4d24-940b-d88c2f09db1e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164059Z:587ca008-7737-4d24-940b-d88c2f09db1e
+      Date:
+      - Wed, 28 Oct 2015 16:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
+        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
+        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
+        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
+        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
+        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
+        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
+        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
+        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
+        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
+        4wf980v+H8QOklQ5BwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 15eaeff7-7948-427a-9984-3e233f322b0c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - bc4bef2b-6d3f-47b7-afc9-15be545a82b7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164059Z:bc4bef2b-6d3f-47b7-afc9-15be545a82b7
+      Date:
+      - Wed, 28 Oct 2015 16:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 4276b1d8-f868-4bc0-94b9-dc92fd814786
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 4d3620ac-1555-409f-af4b-3ab4f6c3e8f4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164059Z:4d3620ac-1555-409f-af4b-3ab4f6c3e8f4
+      Date:
+      - Wed, 28 Oct 2015 16:40:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/+2hn55OdHfr3
+        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1KpBE9dhlGrei3g2UK5ZT6d5Pstn
+        DiIeR7mz5XnV+Y4QCAnng02HIMbIcv/R/oNH9x+M9+4/3Nnd3++Qh4hifmUS
+        6d/fZ7gfTaqqfVpkF8uqaYsp8NAx02iXTVXmr6d1ni+bedU+KavJV3VBTT6a
+        t+2qeXT3brPKp7tNW9U0tbvjCTUYT6s6H18Vy1l11YyXeXsXPcxcD9t453Kx
+        s51nuw/ybG9/O5tls+39/em97ezg4OH2zs7+vfPJ3u79h+d73MH2T36xM75N
+        63FjcR1PFiumgDJEf3p1mPTde03r0JS+/3RunMp7NKL9nfvBVMpQophXV3mN
+        nvO7szwry2pKv/pd3Rppkk0fgjQUfvmNk1/y/wCefpbR0AQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1e0b1ecb-758d-4e6f-9ddd-b0da3746469e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - a426f511-fe39-476e-95fd-89ceae204dc2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164100Z:a426f511-fe39-476e-95fd-89ceae204dc2
+      Date:
+      - Wed, 28 Oct 2015 16:40:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
+        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
+        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
+        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
+        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
+        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
+        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
+        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
+        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
+        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
+        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
+        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 5df7a01b-befa-406e-bc21-34ed65ddc26e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 96b54b3f-af9e-4d9d-8374-b3610e792b68
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164100Z:96b54b3f-af9e-4d9d-8374-b3610e792b68
+      Date:
+      - Wed, 28 Oct 2015 16:41:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/+2hn55OdHfr3
+        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1KpBE9dhlGrei3g2UK5ZT6d5Pstn
+        DiIeR7mz5XnV+Y4QCAnng02HIMbIcv/R/gERZLy7e3Dvwf17HfIQUcyvTCL9
+        +/sM96NJVbVPi+xiWTVtMQUeOmYa7bKpyvz1tM7zZTOv2idlNfmqLqjJR/O2
+        XTWP7t5tVvl0t2mrmqZ2dzyhBuNpVefjq2I5q66a8TJv76KHmethG+9cLna3
+        dyb3s71s/3x7d/bpg+393Vm+ne3uTbfv7c52Hux++nDv0z0iLDXe/skvdse3
+        aT1uLK7jyWLFFFCG6E+vDpO+e69pHZrS95/OzVN5sPPw4cFuMJUylCjm1VVe
+        o+f87izPyrKa0q9+V7dGmmTThyANhV9+4+SX/D9gqnOb0AQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5247b217-9838-435c-ae3c-7daeca345354
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14976'
+      X-Ms-Correlation-Request-Id:
+      - a0637888-4e4c-419a-8e64-a97ec6ae143a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164100Z:a0637888-4e4c-419a-8e64-a97ec6ae143a
+      Date:
+      - Wed, 28 Oct 2015 16:40:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
+        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
+        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
+        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
+        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
+        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
+        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
+        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
+        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
+        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
+        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 6c1254c8-906c-4dee-8412-7b240ee92339
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14975'
+      X-Ms-Correlation-Request-Id:
+      - 46f93e7b-2082-4ffa-827e-f5822bd48a41
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164100Z:46f93e7b-2082-4ffa-827e-f5822bd48a41
+      Date:
+      - Wed, 28 Oct 2015 16:40:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99tL/7aGf3k52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
+        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
+        xohz/9H+g0f3Px0fPHz46cGn+x0iEWnMr0wo/fv7DPejSVW1T4vsYlk1bTEF
+        HjpmGu2yqcr89bTO82Uzr9onZTX5qi6oyUfztl01j+7eXV7XFw93D/bHE/pu
+        PK3qfHxVLGfVVTNe5u1dAJ854NuNof32dHa+k50/eLh9b2d/tr0/e3Bv++F0
+        en/74P793cnuw9k033lw15+q8W3eGDcW2fFksWISKF/k71r6goiLIeoM60jp
+        W8McXxTTumqq83Z8Ro0v5m0z/skvPPK8ztuWZqdhyAQbP5SQfQZy4N+LcYaY
+        5v0ZZiOzPPx0b/fBzkHALEKrKObVVV6j5/zuLM/KsprSr35Xt0aadIAPQRoK
+        IX/j5Jf8P3sJr6L9BAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a30e5d0e-4507-4b0f-9fe7-2fd36ed927a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 352a9ed2-b2ef-4644-947d-be9690628699
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164101Z:352a9ed2-b2ef-4644-947d-be9690628699
+      Date:
+      - Wed, 28 Oct 2015 16:41:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
+        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
+        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
+        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
+        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
+        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
+        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
+        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
+        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
+        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
+        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fc55336f-0a86-4cba-a7dc-42dc58cff07d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14972'
+      X-Ms-Correlation-Request-Id:
+      - b66b6055-bdb9-493d-bf65-01d19ab015ab
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T164101Z:b66b6055-bdb9-493d-bf65-01d19ab015ab
+      Date:
+      - Wed, 28 Oct 2015 16:41:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
@@ -1,0 +1,12116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - 17d509d8-d803-4654-a4f7-29a41ade7e24
+      Client-Request-Id:
+      - d146f1d7-5dd5-4f1e-95fe-cfb8e168a146
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_109
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 28 Oct 2015 16:06:10 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446051970","not_before":"1446048070","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng"}'
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - a5060b69-e7a7-4af7-be59-88f0ea05a152
+      X-Ms-Correlation-Request-Id:
+      - a5060b69-e7a7-4af7-be59-88f0ea05a152
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160611Z:a5060b69-e7a7-4af7-be59-88f0ea05a152
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 7879b2d7-931c-460e-8228-b75549e22f6c
+      X-Ms-Correlation-Request-Id:
+      - 7879b2d7-931c-460e-8228-b75549e22f6c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160612Z:7879b2d7-931c-460e-8228-b75549e22f6c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
+        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
+        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
+        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
+        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
+        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
+        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
+        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
+        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
+        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
+        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
+        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
+        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
+        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
+        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
+        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
+        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
+        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
+        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
+        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
+        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
+        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
+        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
+        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
+        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
+        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
+        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
+        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
+        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
+        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
+        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
+        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
+        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
+        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
+        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
+        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
+        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
+        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
+        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
+        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
+        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
+        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
+        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
+        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
+        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
+        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
+        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
+        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
+        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
+        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
+        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
+        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
+        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
+        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
+        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
+        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
+        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
+        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
+        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
+        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
+        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
+        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
+        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
+        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
+        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
+        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
+        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
+        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
+        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
+        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
+        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
+        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
+        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
+        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
+        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
+        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
+        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
+        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
+        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
+        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
+        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
+        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
+        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
+        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
+        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
+        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
+        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
+        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
+        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
+        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
+        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
+        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
+        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
+        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
+        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
+        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
+        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
+        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
+        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
+        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
+        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
+        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
+        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
+        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
+        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
+        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
+        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
+        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
+        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
+        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
+        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
+        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
+        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
+        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
+        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
+        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
+        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
+        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
+        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
+        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
+        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
+        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
+        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
+        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
+        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
+        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
+        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
+        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
+        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
+        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
+        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
+        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
+        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
+        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
+        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
+        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
+        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
+        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
+        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
+        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
+        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
+        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
+        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
+        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
+        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
+        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
+        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
+        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
+        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
+        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
+        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
+        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
+        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
+        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
+        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
+        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
+        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
+        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
+        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
+        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
+        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
+        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
+        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
+        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
+        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
+        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
+        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
+        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
+        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
+        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
+        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
+        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
+        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
+        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
+        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
+        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
+        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
+        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
+        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
+        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 36eaab47-96b4-426f-8e33-927ea73acfac
+      - 7e598d69-d6c8-40a0-be8f-1d4609ac9929
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - c193768e-be37-43e3-8e83-0689d88958fd
+      X-Ms-Correlation-Request-Id:
+      - c193768e-be37-43e3-8e83-0689d88958fd
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160613Z:c193768e-be37-43e3-8e83-0689d88958fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:12 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 12585c8b-9800-47a7-a345-0032169f8c16
+      - 2d7bd0e2-11ef-4ae5-87f5-8cd1a83e57cd
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - cea7d711-a7d4-49db-8c26-2ab71417e266
+      X-Ms-Correlation-Request-Id:
+      - cea7d711-a7d4-49db-8c26-2ab71417e266
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160613Z:cea7d711-a7d4-49db-8c26-2ab71417e266
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:12 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 30511ba3-c3ae-4283-8d4e-d57744a10b99
+      - b52e8488-603f-42fc-b245-76a856921a89
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 322eeb24-23d8-4898-9227-3a9523296b21
+      X-Ms-Correlation-Request-Id:
+      - 322eeb24-23d8-4898-9227-3a9523296b21
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160614Z:322eeb24-23d8-4898-9227-3a9523296b21
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 24be0c62-6204-4b49-895d-ae51b9c3a94f
+      - 6523826d-9b06-4a0f-b275-3c9f1c265e99
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      X-Ms-Correlation-Request-Id:
+      - 8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160616Z:8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 547abbe1-12db-49e8-a864-f16d4dd37e8a
+      - 8397146a-6a86-48ff-a2c4-cacc28d0662f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      X-Ms-Correlation-Request-Id:
+      - fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160617Z:fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5b230f58-4850-4a13-821b-5da9cd71b85e
+      - 6fe065a5-e44b-4665-b2cf-b863df87c81a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      X-Ms-Correlation-Request-Id:
+      - 18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160617Z:18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:17 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2d451ba9-5ade-4230-9bad-74a35ea2e8d9
+      - 660a9256-d1e4-4a42-97d3-964027ae36af
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 5e23b520-2edf-423b-bd5f-75f6c002f57c
+      X-Ms-Correlation-Request-Id:
+      - 5e23b520-2edf-423b-bd5f-75f6c002f57c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160618Z:5e23b520-2edf-423b-bd5f-75f6c002f57c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c5ce66fe-44db-4d1e-9998-d738296dd038
+      - f5f8d342-f804-4352-909e-8f603230c150
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      X-Ms-Correlation-Request-Id:
+      - 1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160618Z:1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 52d1fec1-6740-4976-9224-a749acf9dd5a
+      - 8044f5bf-7ac2-485c-825f-950b934e0eec
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      X-Ms-Correlation-Request-Id:
+      - 9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160619Z:9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4003aeb5-e9be-41ed-8a28-056b9f0f94fd
+      - b7439c3f-15c7-4cbf-94af-545d27729f37
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      X-Ms-Correlation-Request-Id:
+      - 85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160619Z:85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1009f555-0dd6-4fe1-8903-ed73d5b0585a
+      - 2c056b43-967b-492d-a983-0d31fe5cc854
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      X-Ms-Correlation-Request-Id:
+      - 0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160620Z:0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 314a21c9-fde9-4d21-ba01-1f9c29199046
+      - c283b145-1acf-4fa9-b615-d6b91edda304
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 9041a700-4a73-414f-aa08-459eeced0a32
+      X-Ms-Correlation-Request-Id:
+      - 9041a700-4a73-414f-aa08-459eeced0a32
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160620Z:9041a700-4a73-414f-aa08-459eeced0a32
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b2a6a1ce-eae4-41c9-ba96-60ebb2cdebe5
+      - e0cfe62b-536a-491e-8778-7dad8d3f991e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - e0cc3885-c215-41a8-8820-d753b6080f7b
+      X-Ms-Correlation-Request-Id:
+      - e0cc3885-c215-41a8-8820-d753b6080f7b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160621Z:e0cc3885-c215-41a8-8820-d753b6080f7b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 467f6e57-f833-4d55-a19e-f7e3ab7733d2
+      - b5cbb65b-2a02-4fcf-b72c-b97bea668ee4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 349fb902-e445-424a-ab73-3bdb3b467469
+      X-Ms-Correlation-Request-Id:
+      - 349fb902-e445-424a-ab73-3bdb3b467469
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160622Z:349fb902-e445-424a-ab73-3bdb3b467469
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a700307d-43bd-45fd-9081-844c4615bb20
+      - d7189e1a-b17b-433e-bccf-04b0101be3c5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      X-Ms-Correlation-Request-Id:
+      - 09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160622Z:09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 136248a7-f348-4e58-9c18-3e161554cdaa
+      - 5eb9fb42-22d7-44e8-aa98-5d554a69ac83
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 90fe193b-4d26-4482-881d-608b015cea6f
+      X-Ms-Correlation-Request-Id:
+      - 90fe193b-4d26-4482-881d-608b015cea6f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160622Z:90fe193b-4d26-4482-881d-608b015cea6f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 20760a4d-9a5c-4a02-8d60-ac16ee1116fe
+      - cf6cea42-3b2e-4310-9080-3d7db2aeefa8
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      X-Ms-Correlation-Request-Id:
+      - 23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160623Z:23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9fede14c-481f-4071-b4d3-781761db060d
+      - fc4fb2ca-4a93-49be-a504-5a209cc28d0b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - ba2a2406-0642-47b4-b977-361f58c548f0
+      X-Ms-Correlation-Request-Id:
+      - ba2a2406-0642-47b4-b977-361f58c548f0
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160623Z:ba2a2406-0642-47b4-b977-361f58c548f0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4d8b9c3e-0e0c-4c34-8953-d390fc7eaada
+      - ccdef002-e171-46f5-9ef6-8913d11a5124
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      X-Ms-Correlation-Request-Id:
+      - 8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160624Z:8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 20f2074c-8a50-4e16-963b-a9fe85cbc80d
+      - 76ec443f-cf08-4c79-95b1-5f72b2986e64
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 40719cd3-9bd0-4ef3-945d-147b075a7303
+      X-Ms-Correlation-Request-Id:
+      - 40719cd3-9bd0-4ef3-945d-147b075a7303
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160625Z:40719cd3-9bd0-4ef3-945d-147b075a7303
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - bf5e1016-a7e5-4bc9-8352-903b6a7abc00
+      - fe2ba23e-928b-45f1-bd7e-66743c07357e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 918567fe-3e55-4d94-9a08-9f3220022e84
+      X-Ms-Correlation-Request-Id:
+      - 918567fe-3e55-4d94-9a08-9f3220022e84
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160625Z:918567fe-3e55-4d94-9a08-9f3220022e84
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 948aa5b7-cf4f-4757-a533-604ce0e085ec
+      - e75823d5-3a28-4314-a908-3d1d32f2540a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 5d883e2d-0986-4426-aeed-a16e38eaec5e
+      X-Ms-Correlation-Request-Id:
+      - 5d883e2d-0986-4426-aeed-a16e38eaec5e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160626Z:5d883e2d-0986-4426-aeed-a16e38eaec5e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7eb38320-9542-4901-bbd3-44ecf3534bd6
+      - ddbce0a3-c7ca-42cc-8997-63dbbcf2768b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - ada9dccb-8da4-4d94-8604-2b3864ea9378
+      X-Ms-Correlation-Request-Id:
+      - ada9dccb-8da4-4d94-8604-2b3864ea9378
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160626Z:ada9dccb-8da4-4d94-8604-2b3864ea9378
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - d5209bc4-f182-40e0-8696-4981f0a2d0e4
+      - df063519-b884-40ed-8d70-7b709fa60a52
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      X-Ms-Correlation-Request-Id:
+      - 8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160627Z:8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8edc4da6-7005-4c71-888e-21ee3181278a
+      - d821876d-80c6-40ae-84bf-24eab2b36682
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - c1917c21-5e9f-46e1-852c-1318e10b6484
+      X-Ms-Correlation-Request-Id:
+      - c1917c21-5e9f-46e1-852c-1318e10b6484
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160627Z:c1917c21-5e9f-46e1-852c-1318e10b6484
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 87579a15-c14c-47ba-9f65-029029d9a709
+      - cd2ae45c-cdfd-428b-a078-53673d776883
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      X-Ms-Correlation-Request-Id:
+      - a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160628Z:a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6b0fe660-72f9-4cbe-979a-e6583086fff4
+      - b53c1eea-d7e2-48e4-8096-4c2e5da43774
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      X-Ms-Correlation-Request-Id:
+      - 40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160628Z:40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3e0fb4ca-8a75-477d-ab68-33f439dd14b2
+      - 87c946c8-c8c5-4f44-803c-92a8217f36a4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - d40f9592-d67a-4a4a-b688-330022546dff
+      X-Ms-Correlation-Request-Id:
+      - d40f9592-d67a-4a4a-b688-330022546dff
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160629Z:d40f9592-d67a-4a4a-b688-330022546dff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 555201ee-93d2-4fa7-9e4e-9f34d954a89c
+      - 997c35b5-c40c-48b2-9e9c-ef3cb3d2fa72
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 34811df1-92fb-4868-b0f6-e095ad6d1892
+      X-Ms-Correlation-Request-Id:
+      - 34811df1-92fb-4868-b0f6-e095ad6d1892
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160629Z:34811df1-92fb-4868-b0f6-e095ad6d1892
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1112143b-a4ca-451f-bccd-7cf866f42ce5
+      - a66633b0-193a-4e5f-8e25-4fa0a304feb3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - c42f54cc-a632-4b97-802c-5b950aeac821
+      X-Ms-Correlation-Request-Id:
+      - c42f54cc-a632-4b97-802c-5b950aeac821
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160630Z:c42f54cc-a632-4b97-802c-5b950aeac821
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c22997b4-983b-4582-848c-8ffac2b09d73
+      - eb9f8d71-d065-4200-91c0-e8f980d36774
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 8f2642fd-4200-4780-9a34-b5d2c5503490
+      X-Ms-Correlation-Request-Id:
+      - 8f2642fd-4200-4780-9a34-b5d2c5503490
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160630Z:8f2642fd-4200-4780-9a34-b5d2c5503490
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 54c4fdb6-ca86-4bae-824f-62b8f8a3cb90
+      - d7f20717-0ac3-4c7d-b844-bfd126cc0109
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 5d3a9434-aa7e-4dbb-b0fc-463633c36d09
+      X-Ms-Correlation-Request-Id:
+      - 5d3a9434-aa7e-4dbb-b0fc-463633c36d09
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160631Z:5d3a9434-aa7e-4dbb-b0fc-463633c36d09
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 72f2187f-b0cc-4c36-99e9-1b2cff0f535f
+      - c0a286d2-ce93-4730-8594-0772d92ca023
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 07292aae-25f4-4487-ba85-eeb4bc5c469a
+      X-Ms-Correlation-Request-Id:
+      - 07292aae-25f4-4487-ba85-eeb4bc5c469a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160631Z:07292aae-25f4-4487-ba85-eeb4bc5c469a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b705733e-b2d6-4e8a-ac73-ee9233e8cec4
+      - ba5149d9-e3ae-4fb1-8c68-e001259dd58e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 5583345b-3aed-493f-af77-b0bf11c5becc
+      X-Ms-Correlation-Request-Id:
+      - 5583345b-3aed-493f-af77-b0bf11c5becc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160632Z:5583345b-3aed-493f-af77-b0bf11c5becc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 31988902-18cb-4cf8-9b3f-fd689e028841
+      - bdf3ae49-6f9a-4135-a1f0-561916ebf8d2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 11993a3b-8d8a-439c-8d04-5863d6678216
+      X-Ms-Correlation-Request-Id:
+      - 11993a3b-8d8a-439c-8d04-5863d6678216
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160632Z:11993a3b-8d8a-439c-8d04-5863d6678216
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3c582b99-0ac9-42fa-a2a4-62fa9eefa362
+      - bf6a7f8d-44d7-4c30-9f5c-1cd1fff2ef5f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 738c6eff-0812-4046-b139-c9938878d5d0
+      X-Ms-Correlation-Request-Id:
+      - 738c6eff-0812-4046-b139-c9938878d5d0
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160633Z:738c6eff-0812-4046-b139-c9938878d5d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b7f65517-9b50-402d-a966-09d8faf574f9
+      - ea2ce756-225c-4a35-a646-b44e031fa35d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 542d3b9c-4883-43c5-b3d4-91bb8ea03dff
+      X-Ms-Correlation-Request-Id:
+      - 542d3b9c-4883-43c5-b3d4-91bb8ea03dff
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160633Z:542d3b9c-4883-43c5-b3d4-91bb8ea03dff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b49ffe75-3def-4b70-ae2b-2e2224e0d2b9
+      - cef570fb-9f09-461c-aef0-4588d4bc6175
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 10140cfe-7d77-4dba-9b6f-598485fc08fa
+      X-Ms-Correlation-Request-Id:
+      - 10140cfe-7d77-4dba-9b6f-598485fc08fa
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160634Z:10140cfe-7d77-4dba-9b6f-598485fc08fa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2423044f-8704-405a-8872-f26c05979839
+      - f4ebdd36-3e3d-4bfb-bbde-4aba1bb221c0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - ef6a31f0-7496-4514-8a6d-15a93547e586
+      X-Ms-Correlation-Request-Id:
+      - ef6a31f0-7496-4514-8a6d-15a93547e586
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160634Z:ef6a31f0-7496-4514-8a6d-15a93547e586
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2e63acc3-e08b-4c65-aaab-48b67645940a
+      - f11e54a1-d48d-4069-80a9-d995311517c3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 5752a446-37b9-4283-a689-9b49d1a6e93e
+      X-Ms-Correlation-Request-Id:
+      - 5752a446-37b9-4283-a689-9b49d1a6e93e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160634Z:5752a446-37b9-4283-a689-9b49d1a6e93e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - cd3a1e15-107b-43d7-92bf-5f8cd36a613b
+      - f96dd53f-c46e-4e65-9c11-3d5143173aca
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 4e5460cf-1adb-4d17-a699-37519a2f3e53
+      X-Ms-Correlation-Request-Id:
+      - 4e5460cf-1adb-4d17-a699-37519a2f3e53
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160635Z:4e5460cf-1adb-4d17-a699-37519a2f3e53
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 966ec10d-effb-47e3-92fa-ddf99e7901cc
+      - ad918320-bee5-420f-916b-58fa1fc717fc
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
+      X-Ms-Correlation-Request-Id:
+      - dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160635Z:dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 316c5cbe-6cee-47ad-8bd0-c5c984921ed7
+      - 3d572cba-b640-4d13-ab86-6b270f2cf808
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - c45bba8f-94ba-4b97-b98e-aecdf9e464e2
+      X-Ms-Correlation-Request-Id:
+      - c45bba8f-94ba-4b97-b98e-aecdf9e464e2
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160636Z:c45bba8f-94ba-4b97-b98e-aecdf9e464e2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2e4e5475-08e4-48e4-befa-31cdba71eaa6
+      - c52ad923-d50c-42fe-ac2b-a0d62f338589
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
+      X-Ms-Correlation-Request-Id:
+      - b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160636Z:b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - af5bc45d-3f44-4b39-9ff8-518a3e8d8fb1
+      - eca0c68c-6a51-422c-b808-362e703f5d13
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 3fb07f40-b547-4b56-a88f-660d4bdefa3b
+      X-Ms-Correlation-Request-Id:
+      - 3fb07f40-b547-4b56-a88f-660d4bdefa3b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160637Z:3fb07f40-b547-4b56-a88f-660d4bdefa3b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8ce1cdb1-c471-47ef-98c6-29b6ec0ae02a
+      - f04ea275-6b48-4f6e-8574-d793df6a0580
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - f142d144-fc45-4e6a-8de0-998ef5004ce1
+      X-Ms-Correlation-Request-Id:
+      - f142d144-fc45-4e6a-8de0-998ef5004ce1
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160637Z:f142d144-fc45-4e6a-8de0-998ef5004ce1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7412664a-15a6-4881-b203-30bb1bbee775
+      - fe8a60b1-9ab9-4d56-b577-2db403124ea0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - b739f750-eaf9-489d-a7e5-0654b021372d
+      X-Ms-Correlation-Request-Id:
+      - b739f750-eaf9-489d-a7e5-0654b021372d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160638Z:b739f750-eaf9-489d-a7e5-0654b021372d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6b130eb9-51b5-45df-a708-fd90826d587c
+      - dd36478b-ecbc-4949-9c1a-5e03c4c604e6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 1e4ba712-47ec-411c-9a26-a266f4943997
+      X-Ms-Correlation-Request-Id:
+      - 1e4ba712-47ec-411c-9a26-a266f4943997
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160638Z:1e4ba712-47ec-411c-9a26-a266f4943997
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6afcab65-bed8-4d60-b8ff-dfcfec42313f
+      - b02acd64-ac15-4a87-bf92-54ed0e16bb3d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 291f9210-6bad-4594-956b-17ae442e185b
+      X-Ms-Correlation-Request-Id:
+      - 291f9210-6bad-4594-956b-17ae442e185b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160639Z:291f9210-6bad-4594-956b-17ae442e185b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:38 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0a9f6778-1f00-4850-a044-2b4eb6204992
+      - ad2d65ac-a9a1-486b-9df2-1d0ef9183587
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 56e75b9a-c9fe-4ee2-bdd9-20139756eebc
+      X-Ms-Correlation-Request-Id:
+      - 56e75b9a-c9fe-4ee2-bdd9-20139756eebc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160639Z:56e75b9a-c9fe-4ee2-bdd9-20139756eebc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:38 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 002428ee-2beb-4515-a1f8-f44c3140ff75
+      - 0286f669-0f06-48f0-89e5-645033bb852f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - f311357e-cc31-4c97-acdd-bb4223636ee6
+      X-Ms-Correlation-Request-Id:
+      - f311357e-cc31-4c97-acdd-bb4223636ee6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160639Z:f311357e-cc31-4c97-acdd-bb4223636ee6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 341b92f3-4f19-48bc-bbe6-75b9b45edf03
+      - 7216bf33-6fa5-4ca5-91c1-f7a841c291a2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 7f5a32b5-a38e-4e76-83d1-580ab385e1cc
+      X-Ms-Correlation-Request-Id:
+      - 7f5a32b5-a38e-4e76-83d1-580ab385e1cc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160640Z:7f5a32b5-a38e-4e76-83d1-580ab385e1cc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 976bb79d-6403-460b-b270-f008f6375fb2
+      - c80c8b2c-2800-47f9-9a53-edf1b1e6d11b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - f627bda7-b076-47cf-acd5-2ec3f31bbc84
+      X-Ms-Correlation-Request-Id:
+      - f627bda7-b076-47cf-acd5-2ec3f31bbc84
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160640Z:f627bda7-b076-47cf-acd5-2ec3f31bbc84
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 11d39ccb-0228-4c1c-b6d3-5573b1050714
+      - a580d96c-64e7-4d3b-987b-16ef38cd1fc0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - edffbab1-dc9c-4b76-b0fb-40108a22d60e
+      X-Ms-Correlation-Request-Id:
+      - edffbab1-dc9c-4b76-b0fb-40108a22d60e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160641Z:edffbab1-dc9c-4b76-b0fb-40108a22d60e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7544fffd-5848-4ff3-bd73-15c039f36c36
+      - 7d6d7f91-754e-4cbc-babc-80c224c4923b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 23ccfca2-8278-40c4-9c26-707b967fe9d3
+      X-Ms-Correlation-Request-Id:
+      - 23ccfca2-8278-40c4-9c26-707b967fe9d3
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160641Z:23ccfca2-8278-40c4-9c26-707b967fe9d3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 618081cb-a36e-4418-a054-48d7e993f061
+      - 970c63ec-c32c-4260-8bf2-43316ad61f86
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - c7505d81-5e81-4b04-904a-5d4034e1a4ad
+      X-Ms-Correlation-Request-Id:
+      - c7505d81-5e81-4b04-904a-5d4034e1a4ad
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160642Z:c7505d81-5e81-4b04-904a-5d4034e1a4ad
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
+      X-Ms-Correlation-Request-Id:
+      - 2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160642Z:2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:41 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - ca4bd3f8-c48e-4e72-93a3-d378e8255f2e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - dca3f331-224c-4112-8f7b-2fcb000085eb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160643Z:dca3f331-224c-4112-8f7b-2fcb000085eb
+      Date:
+      - Wed, 28 Oct 2015 16:06:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 1daac3e2-bf34-4fae-bcc0-7f2d893a7526
+      X-Ms-Correlation-Request-Id:
+      - 1daac3e2-bf34-4fae-bcc0-7f2d893a7526
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160644Z:1daac3e2-bf34-4fae-bcc0-7f2d893a7526
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:43 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 75fe929f-1758-40dc-9e00-68e274b55743
+      X-Ms-Correlation-Request-Id:
+      - 75fe929f-1758-40dc-9e00-68e274b55743
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160644Z:75fe929f-1758-40dc-9e00-68e274b55743
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:44 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - ed41f461-51eb-4f9e-8de1-dac1a867f396
+      X-Ms-Correlation-Request-Id:
+      - ed41f461-51eb-4f9e-8de1-dac1a867f396
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160645Z:ed41f461-51eb-4f9e-8de1-dac1a867f396
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:45 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a2a145d4-cc1b-4b58-9838-c7bfaab6d21e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 295dd2b2-599e-439a-99ff-1542292cff9e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160646Z:295dd2b2-599e-439a-99ff-1542292cff9e
+      Date:
+      - Wed, 28 Oct 2015 16:06:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - a04053e9-7a93-4e8b-a64a-1d661e0ebda0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 99566903-55a3-4f30-98c1-7de3f4b19fdf
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160646Z:99566903-55a3-4f30-98c1-7de3f4b19fdf
+      Date:
+      - Wed, 28 Oct 2015 16:06:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 7702a149-7761-434e-9ee9-7c175b38d5ae
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 414b080e-dbe7-429a-b22d-1d41b1c572c7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160646Z:414b080e-dbe7-429a-b22d-1d41b1c572c7
+      Date:
+      - Wed, 28 Oct 2015 16:06:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz6aP9Tz/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATq6594/jqvL/P6aX7puo3Sznsd
+        zwb6NevpNM9n+cxBxOPod7Y8rzrfEaYh+Xyw6RDEGHHuP9p/8Oj+/vjhvU/v
+        37+33yESkcb8yoTSv7/PcD+aVFX7tMgullXTFlPgoWOm0S6bqsxfT+s8Xzbz
+        qn1SVpOv6oKafDRv21Xz6O7dq7xpp1XWtLNJc//hp3vjCbUZT6s6H18Vy1l1
+        1YyXeXsXncxcJ9vNLyobnoPtnXsP89l072D7fn6ws72/s7O3PZndn27v33+Y
+        7c+y+7t7B/t3/Skb3+aNcWORHk8WKyaF8kf+rqUviMgYqs60jpi+NUzyRTGt
+        q6Y6b8dn1Phi3jbjn/zCI9PrvG1plhqGTLDxQwnaZyQH/r0YaIh53p9xNjPN
+        w4e7uw93A6YRWkUxr67yGj3nd2d5VpbVlH71u7o10qQLfAjSUAj5Gye/5P8B
+        DhRlSkAFAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 251d73f2-bf08-4ee3-b8ae-feb28f3aef99
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - b60d9bce-05c1-457e-bc42-53616407fa61
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160647Z:b60d9bce-05c1-457e-bc42-53616407fa61
+      Date:
+      - Wed, 28 Oct 2015 16:06:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
+        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
+        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
+        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
+        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
+        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
+        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
+        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
+        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
+        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
+        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8ca1edf9-2faa-4758-91c6-cf1ce7c5f21f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - dd932738-6f54-41fc-b8f9-34e2420b9cdc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160648Z:dd932738-6f54-41fc-b8f9-34e2420b9cdc
+      Date:
+      - Wed, 28 Oct 2015 16:06:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
+      X-Ms-Correlation-Request-Id:
+      - b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160649Z:b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:49 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 1d87e490-9c3f-44eb-89a4-fb95a0b78746
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 4d5ed352-21c7-4c63-a846-5d8c6ed82770
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160650Z:4d5ed352-21c7-4c63-a846-5d8c6ed82770
+      Date:
+      - Wed, 28 Oct 2015 16:06:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - bba3203c-b17c-4da1-93aa-54c66723b5e5
+      X-Ms-Correlation-Request-Id:
+      - bba3203c-b17c-4da1-93aa-54c66723b5e5
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160650Z:bba3203c-b17c-4da1-93aa-54c66723b5e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:50 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 83d8ee28-1dbe-4880-9cf7-7e1cabec186e
+      X-Ms-Correlation-Request-Id:
+      - 83d8ee28-1dbe-4880-9cf7-7e1cabec186e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160651Z:83d8ee28-1dbe-4880-9cf7-7e1cabec186e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:50 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 16546bdf-6f12-487f-adbd-03248d7cb544
+      X-Ms-Correlation-Request-Id:
+      - 16546bdf-6f12-487f-adbd-03248d7cb544
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160652Z:16546bdf-6f12-487f-adbd-03248d7cb544
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:51 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 26a1172d-902c-47c0-99e6-ebd2705da4a1
+      X-Ms-Correlation-Request-Id:
+      - 26a1172d-902c-47c0-99e6-ebd2705da4a1
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160652Z:26a1172d-902c-47c0-99e6-ebd2705da4a1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:52 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
+      X-Ms-Correlation-Request-Id:
+      - f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160653Z:f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:52 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 943a5b87-3460-4b14-a85e-8a5ed0c82dfe
+      X-Ms-Correlation-Request-Id:
+      - 943a5b87-3460-4b14-a85e-8a5ed0c82dfe
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160653Z:943a5b87-3460-4b14-a85e-8a5ed0c82dfe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:52 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - b575e49c-8fd6-4d7c-801c-903446936585
+      X-Ms-Correlation-Request-Id:
+      - b575e49c-8fd6-4d7c-801c-903446936585
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160653Z:b575e49c-8fd6-4d7c-801c-903446936585
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:53 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - de8d65eb-5133-426b-ad51-0a79d239bc8f
+      X-Ms-Correlation-Request-Id:
+      - de8d65eb-5133-426b-ad51-0a79d239bc8f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160654Z:de8d65eb-5133-426b-ad51-0a79d239bc8f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:53 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - f07ca7ef-f603-48bc-bf64-d0c58a2bce73
+      X-Ms-Correlation-Request-Id:
+      - f07ca7ef-f603-48bc-bf64-d0c58a2bce73
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160654Z:f07ca7ef-f603-48bc-bf64-d0c58a2bce73
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:54 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 2f59938c-48a8-4f81-93d5-4fa09907d149
+      X-Ms-Correlation-Request-Id:
+      - 2f59938c-48a8-4f81-93d5-4fa09907d149
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160655Z:2f59938c-48a8-4f81-93d5-4fa09907d149
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:55 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - fdadf65d-1c1d-45f8-bd45-72d360013ec8
+      X-Ms-Correlation-Request-Id:
+      - fdadf65d-1c1d-45f8-bd45-72d360013ec8
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160656Z:fdadf65d-1c1d-45f8-bd45-72d360013ec8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:55 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:54 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB271C:798A:A033321:5630F211
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:06:56 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6224-ATL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:11:56 GMT
+      Source-Age:
+      - '143'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 59b91a1f-a12a-4191-8828-450d8baa5e16
+      X-Ms-Correlation-Request-Id:
+      - 59b91a1f-a12a-4191-8828-450d8baa5e16
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160657Z:59b91a1f-a12a-4191-8828-450d8baa5e16
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:56 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:55 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB271C:7987:40297FE:5630F211
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:06:57 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6225-ATL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:11:57 GMT
+      Source-Age:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - aa25861b-864b-4e8e-a763-724ffeda7cef
+      X-Ms-Correlation-Request-Id:
+      - aa25861b-864b-4e8e-a763-724ffeda7cef
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160658Z:aa25861b-864b-4e8e-a763-724ffeda7cef
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:57 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB2714:7989:80C0DE5:5630F211
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:06:58 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6235-ATL
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:11:58 GMT
+      Source-Age:
+      - '144'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 2bce695b-68a1-4645-833f-26dd5535490a
+      X-Ms-Correlation-Request-Id:
+      - 2bce695b-68a1-4645-833f-26dd5535490a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160659Z:2bce695b-68a1-4645-833f-26dd5535490a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:58 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - d5b0ff65-80cb-4f81-adfd-df3217f73a12
+      X-Ms-Correlation-Request-Id:
+      - d5b0ff65-80cb-4f81-adfd-df3217f73a12
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160659Z:d5b0ff65-80cb-4f81-adfd-df3217f73a12
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:06:59 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dcdc1567-68db-4c38-8399-d08685c9ed4c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 4e5d4ba2-398d-418c-8b4b-73120b3e88d7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160700Z:4e5d4ba2-398d-418c-8b4b-73120b3e88d7
+      Date:
+      - Wed, 28 Oct 2015 16:07:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - eb84d0a8-1f77-4615-9c63-5c1d378b6378
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 32626507-bd6b-47ac-a822-4bbdebb6dc14
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160701Z:32626507-bd6b-47ac-a822-4bbdebb6dc14
+      Date:
+      - Wed, 28 Oct 2015 16:07:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:06:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - cabc4e2b-ce32-45fb-b482-0794203b5f56
+      X-Ms-Correlation-Request-Id:
+      - cabc4e2b-ce32-45fb-b482-0794203b5f56
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160701Z:cabc4e2b-ce32-45fb-b482-0794203b5f56
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:01 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 52920d62-833b-4b5b-b9f1-a59798d6398d
+      X-Ms-Correlation-Request-Id:
+      - 52920d62-833b-4b5b-b9f1-a59798d6398d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160702Z:52920d62-833b-4b5b-b9f1-a59798d6398d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:01 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5cc90cde-ad20-4316-bbe1-c72e8fd32989
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 790d8656-b833-42db-96fa-c9c8891ad2b8
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160702Z:790d8656-b833-42db-96fa-c9c8891ad2b8
+      Date:
+      - Wed, 28 Oct 2015 16:07:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 4ce7706c-61b4-4def-82e7-e72c0372ec3c
+      X-Ms-Correlation-Request-Id:
+      - 4ce7706c-61b4-4def-82e7-e72c0372ec3c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160703Z:4ce7706c-61b4-4def-82e7-e72c0372ec3c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:02 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - abcd71e8-ee76-4b68-a27e-348be7458b1a
+      X-Ms-Correlation-Request-Id:
+      - abcd71e8-ee76-4b68-a27e-348be7458b1a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160703Z:abcd71e8-ee76-4b68-a27e-348be7458b1a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:02 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - a19654b3-b1cd-497d-a07d-b497f4962a3f
+      X-Ms-Correlation-Request-Id:
+      - a19654b3-b1cd-497d-a07d-b497f4962a3f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160703Z:a19654b3-b1cd-497d-a07d-b497f4962a3f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:03 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 8829c353-1c1b-42e4-857c-f291a88e57a1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 3e35a61d-a4ea-4ee4-8d34-4dbe8b2a91b1
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160704Z:3e35a61d-a4ea-4ee4-8d34-4dbe8b2a91b1
+      Date:
+      - Wed, 28 Oct 2015 16:07:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 00f03466-0269-478c-9910-70160ef2aea1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - da34d54e-bbef-496b-b1f1-2e83fdb55863
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160704Z:da34d54e-bbef-496b-b1f1-2e83fdb55863
+      Date:
+      - Wed, 28 Oct 2015 16:07:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - e06d0d37-cb27-4c50-a337-0b69addcea53
+      X-Ms-Correlation-Request-Id:
+      - e06d0d37-cb27-4c50-a337-0b69addcea53
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160705Z:e06d0d37-cb27-4c50-a337-0b69addcea53
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:04 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
+      X-Ms-Correlation-Request-Id:
+      - 5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160705Z:5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 88816b85-4620-48a9-ae2c-ff0cbb518388
+      X-Ms-Correlation-Request-Id:
+      - 88816b85-4620-48a9-ae2c-ff0cbb518388
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160705Z:88816b85-4620-48a9-ae2c-ff0cbb518388
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 49319d5d-9297-4437-a383-b98d8027d2b1
+      X-Ms-Correlation-Request-Id:
+      - 49319d5d-9297-4437-a383-b98d8027d2b1
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160706Z:49319d5d-9297-4437-a383-b98d8027d2b1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 455ef356-f19e-4c08-89d3-95370decf8c7
+      X-Ms-Correlation-Request-Id:
+      - 455ef356-f19e-4c08-89d3-95370decf8c7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160706Z:455ef356-f19e-4c08-89d3-95370decf8c7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:07:06 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - b9be75f5-7820-4b9b-a458-2eb8a7a9071d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 1eb763da-4edd-413f-a1e0-d38223b6aaeb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160706Z:1eb763da-4edd-413f-a1e0-d38223b6aaeb
+      Date:
+      - Wed, 28 Oct 2015 16:07:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 7c4a00f7-b092-4e7f-bf95-8a124d3e55e4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 7eefa523-29f9-4595-9218-c1dbb2ca677d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160707Z:7eefa523-29f9-4595-9218-c1dbb2ca677d
+      Date:
+      - Wed, 28 Oct 2015 16:07:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
+        3ux++mjnAf3vk52dRzs7H5nGv0R++T5+/BIGAUzfAkOliqXJR8tMoJ7M8/Nt
+        IsvM9Rmlpvcung0UbdbTaZ7Pcg8iHkfRs+V51fmO0AwJ6oNNhyDGKHP/0f6D
+        R/c/HT/Yv7e/92C3QyGii/mVqaR/f5/hfpS/a/MlOgUKOnI7akuxL4ppXTXV
+        eTs+o8YX87YZ/+QXT4vsYlk1bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyM1E
+        fLhzb+d+yGbCWFHMq6u8Rs/53VmelWU1pV/9rm6NNEmLD0EaCiF/4+SX/D9Z
+        37Y6YgQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 81ffed43-3acc-4c03-bee7-ab6f2427e290
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 608d7837-cb19-450f-837b-f51383f2fa68
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160707Z:608d7837-cb19-450f-837b-f51383f2fa68
+      Date:
+      - Wed, 28 Oct 2015 16:07:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
+        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
+        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
+        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
+        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
+        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
+        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
+        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
+        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
+        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
+        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c5463d1f-03f6-428e-a6c3-17ae97ccfb68
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - db735259-fddb-4f8f-aea2-9af9ecfa0c8d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160708Z:db735259-fddb-4f8f-aea2-9af9ecfa0c8d
+      Date:
+      - Wed, 28 Oct 2015 16:07:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - b13bd001-5e77-4243-8b77-b07a2f55d537
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 3cc8c732-29d0-4a36-ab64-f04bdde189e8
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160708Z:3cc8c732-29d0-4a36-ab64-f04bdde189e8
+      Date:
+      - Wed, 28 Oct 2015 16:07:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHOw092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6smraC+p6+2l+6bqN0s57Hc8G
+        +jXr6TTPZ/nMQcTj6He2PK863xGmIfl8sOkQxBhx7j/af/Do/qfjB3sPHuwf
+        dGhElDG/Mp307+8z2I8mVdU+LbKLJVGlmAINHTINdtlUZf56Wuf5splX7ZOy
+        mnxVF9Tko3nbrppHd+9O5/n5qq5m93f3dsYT+n48rep8fFUsZ9VVM17m7V10
+        MHMdbK/oJ8g/2z6fnt+bTfPp9vnkYLa9//D8/vbD2cF0e7J7P59Nz88f7OxP
+        7/qzNb7NG+PGIjyeLFZMBmWN/F1LXxB9MUydZB0tfWv444tiWldNdd6Oz6jx
+        xbxtxj/5hUei13nb0gQ1DJlg44cSs89DDvx78c4Q37w/z2zml4c793buPwgY
+        RmgVw/zL1+g2v0sCnNdZWfwg6OfWGJMO8CFIw+FeX1ZXeY2387uzPCvLakq/
+        ft2OfQjSUKbvN05+yf8DJTk02LEFAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - faccb6cd-d14b-4ffc-8668-b741780bdded
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 74e84b8b-cee2-4629-b878-9ba71d56c6e4
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160709Z:74e84b8b-cee2-4629-b878-9ba71d56c6e4
+      Date:
+      - Wed, 28 Oct 2015 16:07:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
+        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
+        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
+        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
+        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
+        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
+        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
+        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
+        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
+        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
+        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4aba7665-16a1-4f71-b211-cbc92df7dc29
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 151a2396-ff6e-43e4-a09a-793e0690891f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160709Z:151a2396-ff6e-43e4-a09a-793e0690891f
+      Date:
+      - Wed, 28 Oct 2015 16:07:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 8f619ab5-bfdc-4c76-8cb6-de0bfcf0f49e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Correlation-Request-Id:
+      - 7fddf34d-6588-4165-af26-381555d7b9fb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160710Z:7fddf34d-6588-4165-af26-381555d7b9fb
+      Date:
+      - Wed, 28 Oct 2015 16:07:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHuzic7O492
+        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUCdzvPzJq8v83rX9Rolnfc2ng3k
+        a9bTaZ7P8pmDiMeR72x5XnW+I0RD6vlg0yGIMdrcf7S/9+j+wfjg3v3dh5/e
+        69CIKGN+ZTrp399nuB/l79qcpoCmgaDqyO2oLc2+KKZ11VTn7fiMGl/M22b8
+        k188LbKLZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPxYG93f/9+QERh
+        rSjm1VVeo+f87izPyrKa0q9+V7dGmkTDhyANhZC/cfJL/h/2arQOTwQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2039879e-38c9-4861-91b6-67366bd61953
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 11b6d935-500d-4bb7-945f-62e027ab2cf6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160710Z:11b6d935-500d-4bb7-945f-62e027ab2cf6
+      Date:
+      - Wed, 28 Oct 2015 16:07:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
+        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
+        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
+        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
+        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
+        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
+        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
+        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
+        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
+        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - ca9b8cd5-1fd7-43d1-b0a7-edf2bab467c3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - aab48c77-540e-4cdc-9b2f-3daf46240c3e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160711Z:aab48c77-540e-4cdc-9b2f-3daf46240c3e
+      Date:
+      - Wed, 28 Oct 2015 16:07:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu7ic7O492
+        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUA9ffXS9RYlmfcWng1ka9bTaZ7P
+        8pmDiMeR7Wx5XnW+IwRDqvlg0yGIMZrcf7S/9+j+/fHD/f1Pd3YOOrQhiphf
+        mT769/cZ7kf5uzYn0hP5CaqO3I7a0uqLYlpXTXXejs+o8cW8bcY/+cXTIrtY
+        Vk1bTJvXedsS1o126nfQJ6wD/14EHSLm+xNyMxEf7u4/3P00IKKwVAzzL1+j
+        2/wuMXNeZ2Xxg6CfW2NM8uBDkIbDvb6srvIab+d3Z3lWltWUfv26HfsQpKFM
+        32+c/JL/B4KzAfC9BAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 298a213f-cb25-4fea-85e7-6a6848c33cfe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 8ca50672-c605-49b0-8551-a752d24fbe6b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160711Z:8ca50672-c605-49b0-8551-a752d24fbe6b
+      Date:
+      - Wed, 28 Oct 2015 16:07:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
+        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
+        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
+        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
+        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
+        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
+        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
+        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
+        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
+        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 22dbe051-b4fc-4a8a-9e36-4122d494bbfd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 5f24404d-c01a-48e7-b861-f00bbaeec91c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160712Z:5f24404d-c01a-48e7-b861-f00bbaeec91c
+      Date:
+      - Wed, 28 Oct 2015 16:07:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - a04cc63b-73bc-4bbd-84ba-d7e9f9b19146
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - f1124027-a7f7-4d4f-871d-3f3d4f540669
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160712Z:f1124027-a7f7-4d4f-871d-3f3d4f540669
+      Date:
+      - Wed, 28 Oct 2015 16:07:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu3ic7O492
+        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUD94uwn9lx3UZp5r+HZQLdmPZ3m
+        +SyfOYh4HN3OludV5zvCMCSbDzYdghgjyv1H+3uP7t8fP9zf/3Rn56BDHCKJ
+        +ZUJpH9/n+F+lL9rc6I90Z+g6sjtqB2ximldNdV5Oz6jxhfzthn/5BdPi+xi
+        WTVtMW1e521LWDfaqd9Bn7AO/HsRdIiY70/IzUR8uLv/cPfTgIjCU1HMq6u8
+        Rs/53VmelWU1pV/9rm6NNMmED0EaCiF/4+SX/D+5kTjSSAQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9bf08aa0-1e6e-4ffa-9acf-629c2076ceca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - c2368b4c-e5c2-421f-a5c1-6bba0de66a6a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160713Z:c2368b4c-e5c2-421f-a5c1-6bba0de66a6a
+      Date:
+      - Wed, 28 Oct 2015 16:07:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
+        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
+        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
+        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
+        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
+        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
+        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
+        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
+        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
+        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
+        Abt1q/kPBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 09b4be0d-a77f-4463-858e-b13d9c4142b2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 70246e81-7a26-4b35-8bb9-b9414da6ba71
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160713Z:70246e81-7a26-4b35-8bb9-b9414da6ba71
+      Date:
+      - Wed, 28 Oct 2015 16:07:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 28892e7c-e902-4121-9484-a68ebdff94d2
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - fdfb69b9-c55e-488d-afbf-a0bd788cdc24
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160714Z:fdfb69b9-c55e-488d-afbf-a0bd788cdc24
+      Date:
+      - Wed, 28 Oct 2015 16:07:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99tPPg0e7+Jzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQP3i
+        7CdOqsVq3ea7rtco6by38WwgX7OeTvN8ls8cRDyOfGfL86rzHSEaUs8Hmw5B
+        jNHm/qP9vUf3Px3vfPrw00/vdUhEhDG/Mpnob4VoB2dJM8vajNB6+yPC0L/0
+        9Aiz5zr9/wVhdnc/3X+wewvK4Mf3Ge5H+bs2J6ElwSWoOnI7akuxL4ppXTXV
+        eTs+o8YX87YZ/+QXT4vsYlk1bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyM1E
+        /PTevYO9hwER+6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTH0I0lAI+Rsnv+T/
+        Ac3NFXtGBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 307e9823-8dfc-419f-9b81-9418bfc36b93
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 7eec5408-6186-4dda-88aa-b8824d391daa
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160714Z:7eec5408-6186-4dda-88aa-b8824d391daa
+      Date:
+      - Wed, 28 Oct 2015 16:07:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
+        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
+        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
+        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
+        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
+        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
+        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
+        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
+        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
+        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
+        4wf980v+H8QOklQ5BwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 85aa2d8e-3f2f-4360-938f-30fc9ddce941
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Correlation-Request-Id:
+      - bf7241db-1fca-4110-bc91-27c52c807749
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160715Z:bf7241db-1fca-4110-bc91-27c52c807749
+      Date:
+      - Wed, 28 Oct 2015 16:07:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - cfefca26-7c81-4ca9-b686-e964fe51417c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - bdd1f685-4872-44d4-b693-b2defd7e0c0f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160715Z:bdd1f685-4872-44d4-b693-b2defd7e0c0f
+      Date:
+      - Wed, 28 Oct 2015 16:07:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu/U92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
+        +cxBxOMod7Y8rzrfEQIh4Xyw6RDEGFnuP9p/8Oj+g/He/Yc7u/v7HfIQUcyv
+        TCL9+/sM96NJVbVPi+xiWTVtMQUeOmYa7bKpyvz1tM7zZTOv2idlNfmqLqjJ
+        R/O2XTWP7t5tVvl0t2mrmqZ2dzyhBuNpVefjq2I5q66a8TJv76KHmethG+9c
+        Lna282z3QZ7t7W9ns2y2vb8/vbedHRw83N7Z2b93Ptnbvf/wfI872P7JL3bG
+        t2k9biyu48lixRRQhuhPrw6TvnuvaR2a0vefzo1TeY9GtL8TcroMJYp5dZXX
+        6Dm/O8uzsqym9Kvf1a2RJtn0IUhD4ZffOPkl/w9AVy5b0AQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2448004f-6cee-4750-9083-6cb65092da09
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - c0e8d542-6f6e-4a53-bdeb-20ea060ed868
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160716Z:c0e8d542-6f6e-4a53-bdeb-20ea060ed868
+      Date:
+      - Wed, 28 Oct 2015 16:07:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
+        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
+        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
+        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
+        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
+        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
+        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
+        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
+        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
+        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
+        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
+        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - f927e28b-c8d9-4090-9801-1e40ae4f344d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - e76bf218-714c-4de2-b1e2-54f87a7f2f5c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160716Z:e76bf218-714c-4de2-b1e2-54f87a7f2f5c
+      Date:
+      - Wed, 28 Oct 2015 16:07:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHup5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
+        8pmDiMdR7mx5XnW+IwRCwvlg0yGIMbLcf7R/QAQZ7+4e3Htw/16HPEQU8yuT
+        SP/+PsP9aFJV7dMiu1hWTVtMgYeOmUa7bKoyfz2t83zZzKv2SVlNvqoLavLR
+        vG1XzaO7d5tVPt1t2qqmqd0dT6jBeFrV+fiqWM6qq2a8zNu76GHmetjGO5eL
+        3e2dyf1sL9s/396dffpge393lm9nu3vT7Xu7s50Hu58+3Pt0jwhLjbd/8ovd
+        8W1ajxuL63iyWDEFlCH606vDpO/ea1qHpvT9p3PzVB7sPHx4sBtMpQwlinl1
+        ldfoOb87y7OyrKb0q9/VrZEm2fQhSEPhl984+SX/D8rMeNnQBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8058a85f-fd3e-42f9-899e-87e5d853ea7a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 134a201f-f94c-4aa6-b78b-963683f40279
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160717Z:134a201f-f94c-4aa6-b78b-963683f40279
+      Date:
+      - Wed, 28 Oct 2015 16:07:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
+        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
+        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
+        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
+        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
+        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
+        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
+        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
+        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
+        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
+        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 9b58e8d3-4491-4f24-96db-cb1e9363b452
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 7421a78c-7be8-46ba-8d0a-85259f0deea7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160717Z:7421a78c-7be8-46ba-8d0a-85259f0deea7
+      Date:
+      - Wed, 28 Oct 2015 16:07:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99tPPg0e6DT3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfo6
+        K/PmvKqn+VevXbdR2nmv49lAv2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2C
+        GCPO/Uf7Dx7d/3R88PDhpwef7neIRKQxvzKh9O/vM9yPJlXVPi2yi2XVtMUU
+        eOiYabTLpirz19M6z5fNvGqflNXkq7qgJh/N23bVPLp7d3ldXzzcPdgfT+i7
+        8bSq8/FVsZxVV814mbd3AXzmgG83hvbb09n5Tnb+4OH2vZ392fb+7MG97YfT
+        6f3tg/v3dye7D2fTfOfBXX+qxrd5Y9xYZMeTxYpJoHyRv2vpCyIuhqgzrCOl
+        bw1zfFFM66qpztvxGTW+mLfN+Ce/8MjzOm9bmp2GIRNs/FBC9hnIgX8vxhli
+        mvdnmI3M8vDTvd0HOwcBswitophXV3mNnvO7szwry2pKv/pd3Rpp0gE+BGko
+        hPyNk1/y/wBEnenI/QQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 65dd3494-560e-4da5-b6f0-75d73f57ba62
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - f8e95b50-9cd6-4ce1-a8b8-3964f4afa2cc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160718Z:f8e95b50-9cd6-4ce1-a8b8-3964f4afa2cc
+      Date:
+      - Wed, 28 Oct 2015 16:07:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
+        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
+        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
+        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
+        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
+        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
+        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
+        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
+        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
+        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
+        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8d6022e8-ac94-4693-bd11-cf2c023e3085
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - c768133a-2a4d-469c-9cea-5968566e714a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T160718Z:c768133a-2a4d-469c-9cea-5968566e714a
+      Date:
+      - Wed, 28 Oct 2015 16:07:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:07:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
@@ -1,0 +1,12116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - b39e8f21-2830-49b5-aa83-8948651c550c
+      Client-Request-Id:
+      - 0938ec38-8ad3-43a8-a84b-093ead356152
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_89
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 28 Oct 2015 16:35:12 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446053711","not_before":"1446049811","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA"}'
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - fdc1f84a-258e-4901-9651-2a78038f667a
+      X-Ms-Correlation-Request-Id:
+      - fdc1f84a-258e-4901-9651-2a78038f667a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163512Z:fdc1f84a-258e-4901-9651-2a78038f667a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 70ab68dd-8e5a-461d-9900-bf13c2383aae
+      X-Ms-Correlation-Request-Id:
+      - 70ab68dd-8e5a-461d-9900-bf13c2383aae
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163512Z:70ab68dd-8e5a-461d-9900-bf13c2383aae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
+        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
+        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
+        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
+        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
+        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
+        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
+        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
+        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
+        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
+        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
+        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
+        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
+        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
+        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
+        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
+        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
+        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
+        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
+        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
+        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
+        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
+        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
+        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
+        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
+        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
+        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
+        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
+        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
+        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
+        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
+        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
+        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
+        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
+        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
+        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
+        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
+        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
+        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
+        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
+        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
+        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
+        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
+        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
+        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
+        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
+        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
+        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
+        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
+        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
+        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
+        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
+        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
+        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
+        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
+        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
+        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
+        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
+        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
+        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
+        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
+        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
+        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
+        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
+        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
+        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
+        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
+        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
+        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
+        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
+        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
+        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
+        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
+        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
+        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
+        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
+        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
+        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
+        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
+        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
+        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
+        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
+        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
+        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
+        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
+        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
+        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
+        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
+        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
+        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
+        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
+        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
+        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
+        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
+        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
+        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
+        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
+        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
+        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
+        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
+        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
+        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
+        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
+        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
+        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
+        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
+        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
+        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
+        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
+        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
+        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
+        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
+        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
+        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
+        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
+        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
+        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
+        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
+        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
+        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
+        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
+        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
+        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
+        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
+        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
+        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
+        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
+        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
+        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
+        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
+        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
+        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
+        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
+        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
+        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
+        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
+        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
+        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
+        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
+        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
+        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
+        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
+        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
+        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
+        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
+        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
+        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
+        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
+        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
+        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
+        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
+        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
+        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
+        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
+        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
+        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
+        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
+        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
+        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
+        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
+        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
+        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
+        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
+        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
+        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
+        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
+        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
+        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
+        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
+        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
+        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
+        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
+        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
+        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
+        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
+        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
+        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
+        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
+        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
+        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4055ec61-464e-41cf-a4e0-b66575e5db65
+      - b6789cfc-fa6d-4d8c-a904-0453962aaf41
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      X-Ms-Correlation-Request-Id:
+      - d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163513Z:d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:13 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5ad33207-30c7-4558-9104-882c265b968e
+      - d01f2eac-84a6-4e9f-a59a-774e42ead3df
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 32e8ea9e-03df-4e16-af97-690cb43c7bee
+      X-Ms-Correlation-Request-Id:
+      - 32e8ea9e-03df-4e16-af97-690cb43c7bee
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163514Z:32e8ea9e-03df-4e16-af97-690cb43c7bee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:13 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 052b8258-5dcf-4b5c-8778-82c1e7b8c388
+      - cc84a063-74c3-402a-9817-9571610c4557
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      X-Ms-Correlation-Request-Id:
+      - 948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163514Z:948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 411da219-aae5-47fb-8b3a-f120d0bc1018
+      - d3e776db-e155-442b-a01c-e227f94cd9fa
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 726acedc-e819-4b8f-8958-393dd69b25e2
+      X-Ms-Correlation-Request-Id:
+      - 726acedc-e819-4b8f-8958-393dd69b25e2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163515Z:726acedc-e819-4b8f-8958-393dd69b25e2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2de3c3be-d9f2-4e59-be19-aff309740715
+      - a0042f2e-02a0-4f9e-b16a-98257f135b8e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 626f5b30-6806-43ab-93ce-6aa23e0a1557
+      X-Ms-Correlation-Request-Id:
+      - 626f5b30-6806-43ab-93ce-6aa23e0a1557
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163515Z:626f5b30-6806-43ab-93ce-6aa23e0a1557
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 26d86c69-ae1c-4f6e-a469-ffca0b6e793b
+      - 9e3fb8fc-b01b-4bd1-8d78-95accd66ba38
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      X-Ms-Correlation-Request-Id:
+      - ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163515Z:ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 81030e21-165c-4312-a6e6-61ddcb952c16
+      - 9342e3c4-b3b7-42a4-b817-93256a304834
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - adfa98ab-a603-4cb3-96e4-bf407341295d
+      X-Ms-Correlation-Request-Id:
+      - adfa98ab-a603-4cb3-96e4-bf407341295d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163516Z:adfa98ab-a603-4cb3-96e4-bf407341295d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1889017a-7ebe-4ed8-bc39-294884d47133
+      - a04922aa-d079-4c02-b990-8888e85bb883
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      X-Ms-Correlation-Request-Id:
+      - 49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163516Z:49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4a5d1820-c8e0-425d-8a96-347c09855276
+      - ffefb4bd-4af8-4b20-8bd5-8c7866f6801b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      X-Ms-Correlation-Request-Id:
+      - b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163517Z:b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 178db479-30dd-4c5f-9aa1-81ae45110963
+      - c84a0da7-e88b-45ea-8f7c-b05ed0cc40fa
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - d9fd9fed-838c-4f45-95f0-b03238b651fb
+      X-Ms-Correlation-Request-Id:
+      - d9fd9fed-838c-4f45-95f0-b03238b651fb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163517Z:d9fd9fed-838c-4f45-95f0-b03238b651fb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:17 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3484f69b-91ac-4ca4-8abc-543d8dcb7348
+      - 507bf603-b939-4d45-8bb8-b5880a12f20c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      X-Ms-Correlation-Request-Id:
+      - 3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163518Z:3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:17 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0298137a-c9cb-431d-bea8-ea912ce5be29
+      - 6da9b6aa-7941-4bd0-8006-4971b238addb
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      X-Ms-Correlation-Request-Id:
+      - fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163518Z:fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:17 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - af08601d-7c19-4ceb-ad93-734e74a0c8bb
+      - f432093b-4591-4a2c-9c42-40410a6819ba
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - f56124bd-185a-45a4-ace9-f976d423504d
+      X-Ms-Correlation-Request-Id:
+      - f56124bd-185a-45a4-ace9-f976d423504d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163518Z:f56124bd-185a-45a4-ace9-f976d423504d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 664c9290-8822-402a-ac70-f381e2dcc5db
+      - ec1f1ed7-7d8d-47cf-9f4f-7d74d901ea06
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 37f90733-3fa7-459f-8f28-377de512f4b0
+      X-Ms-Correlation-Request-Id:
+      - 37f90733-3fa7-459f-8f28-377de512f4b0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163519Z:37f90733-3fa7-459f-8f28-377de512f4b0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b38d86d1-ada7-4beb-ba97-284cc0d2a7f8
+      - e373c89a-90b0-4793-ae53-0a7fada4bf56
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      X-Ms-Correlation-Request-Id:
+      - 5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163519Z:5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 459b7940-f6b3-4d8d-bae2-dc873312c6f6
+      - c7dfc2c1-16f5-46a5-9681-fe471252f5b0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 902d217e-12f9-408f-9ee5-b4f381177923
+      X-Ms-Correlation-Request-Id:
+      - 902d217e-12f9-408f-9ee5-b4f381177923
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163520Z:902d217e-12f9-408f-9ee5-b4f381177923
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 690ef100-c3ce-4a13-8d13-4a1e7572dbe9
+      - acc9b5ee-6ddc-4c91-8d67-a09e0b88e3b1
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 62825ca9-f5ae-434d-b91e-299e6d672659
+      X-Ms-Correlation-Request-Id:
+      - 62825ca9-f5ae-434d-b91e-299e6d672659
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163520Z:62825ca9-f5ae-434d-b91e-299e6d672659
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c4187aec-3877-4f8d-be1b-acab3d0aaa5a
+      - d3a088dc-ac2e-4ef1-9fdb-bce80d272a63
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - caeb980b-5d87-4923-9ba4-a7cf9e608958
+      X-Ms-Correlation-Request-Id:
+      - caeb980b-5d87-4923-9ba4-a7cf9e608958
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163521Z:caeb980b-5d87-4923-9ba4-a7cf9e608958
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 148cfa8a-9557-40fa-a63b-474f1f4539fc
+      - 381ac3ce-bda2-4a4b-8c6c-b327f45d75dd
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 685be522-4a05-4065-ac32-147365cf3bbb
+      X-Ms-Correlation-Request-Id:
+      - 685be522-4a05-4065-ac32-147365cf3bbb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163521Z:685be522-4a05-4065-ac32-147365cf3bbb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9df83c59-0174-431e-9832-8e510494d6f0
+      - a1c1892e-7654-4c12-bfa5-a5720eef5f9b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - e9fbef01-5e9c-46a2-a619-f0816dec6834
+      X-Ms-Correlation-Request-Id:
+      - e9fbef01-5e9c-46a2-a619-f0816dec6834
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163521Z:e9fbef01-5e9c-46a2-a619-f0816dec6834
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1dc04ce0-4c5a-4f55-b2ec-f1c2b74837e8
+      - d51c902c-5ea9-4d22-968a-ecb7a32d9cd8
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      X-Ms-Correlation-Request-Id:
+      - 28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163521Z:28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a1b82cc7-bc18-4d47-92cc-ac25c9200519
+      - cd031bad-d667-4882-9cef-57ed6ed304be
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - db63827e-d942-4821-801d-67e7cabaa018
+      X-Ms-Correlation-Request-Id:
+      - db63827e-d942-4821-801d-67e7cabaa018
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163522Z:db63827e-d942-4821-801d-67e7cabaa018
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2214f903-00cc-4796-b1bb-ce387bcc5f88
+      - 846f5f81-081f-4c9c-a04c-00c1f32c2702
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 83cefac5-3e04-4517-a417-01a5d043d636
+      X-Ms-Correlation-Request-Id:
+      - 83cefac5-3e04-4517-a417-01a5d043d636
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163522Z:83cefac5-3e04-4517-a417-01a5d043d636
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1da230e6-6c4f-4b8e-94c8-d2577fe29a1c
+      - 21fdecd5-1467-45e0-88fb-3bb79ddd8b63
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      X-Ms-Correlation-Request-Id:
+      - 40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163522Z:40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 718aa02e-4f88-4923-b263-81312ee87bc6
+      - ffcbdde9-3d49-4b4b-b7d6-2a94c7293013
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 72355828-b324-47e6-ba10-b62286f72691
+      X-Ms-Correlation-Request-Id:
+      - 72355828-b324-47e6-ba10-b62286f72691
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163523Z:72355828-b324-47e6-ba10-b62286f72691
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 495503a1-ded9-44df-beee-a9b28bbdf39d
+      - 7797e931-ade0-43a5-b97b-c19a8e1622c6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 6d479355-4d12-44f5-b283-e1b562de6c8c
+      X-Ms-Correlation-Request-Id:
+      - 6d479355-4d12-44f5-b283-e1b562de6c8c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163523Z:6d479355-4d12-44f5-b283-e1b562de6c8c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 05030f81-6084-4c7e-89ef-4d1441edfbf1
+      - 07280be1-60ff-4dbd-8239-676336718b95
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - f69996aa-8bae-4e64-9ca7-34e81e49805a
+      X-Ms-Correlation-Request-Id:
+      - f69996aa-8bae-4e64-9ca7-34e81e49805a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163524Z:f69996aa-8bae-4e64-9ca7-34e81e49805a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 669552b1-97ab-4933-871d-dc59833a3c04
+      - eca59a27-35ec-4f0e-9a71-3ac9066d872e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - f87e28d6-06f5-46d2-9984-7b121d66ea21
+      X-Ms-Correlation-Request-Id:
+      - f87e28d6-06f5-46d2-9984-7b121d66ea21
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163524Z:f87e28d6-06f5-46d2-9984-7b121d66ea21
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2f72bf7b-47f9-4ba6-b8fb-aafcdae04763
+      - f7a557e0-94d7-4661-a577-18d716cddba4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 5b25c3ba-4b78-410a-bd33-e4b8438d6373
+      X-Ms-Correlation-Request-Id:
+      - 5b25c3ba-4b78-410a-bd33-e4b8438d6373
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163524Z:5b25c3ba-4b78-410a-bd33-e4b8438d6373
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - e418c967-748e-4db8-badd-ef5890509926
+      - e8d84987-2a06-4497-94b9-fc159e8fad2e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
+      X-Ms-Correlation-Request-Id:
+      - e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163525Z:e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 025ec6d2-27cf-4743-af9d-9ac343a59e70
+      - 909de84d-91d3-4647-bb48-2db2f36b050b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - fc468091-c04b-4115-8ae9-f44dfc6779a2
+      X-Ms-Correlation-Request-Id:
+      - fc468091-c04b-4115-8ae9-f44dfc6779a2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163525Z:fc468091-c04b-4115-8ae9-f44dfc6779a2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8e1b4905-26a8-4d3c-9ab7-0f594de3026a
+      - cfe55d83-aadd-4271-80c4-d6bcdbad1727
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - ca7900c8-be9e-438a-98e4-7090f5d49e73
+      X-Ms-Correlation-Request-Id:
+      - ca7900c8-be9e-438a-98e4-7090f5d49e73
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163525Z:ca7900c8-be9e-438a-98e4-7090f5d49e73
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7e06919f-af25-4210-9f48-3bef8955dd49
+      - c5321f65-7577-4319-bca2-bedb983273fd
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 2531a42f-8a62-4a68-b21b-9e3fb1c29828
+      X-Ms-Correlation-Request-Id:
+      - 2531a42f-8a62-4a68-b21b-9e3fb1c29828
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163526Z:2531a42f-8a62-4a68-b21b-9e3fb1c29828
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 764d4ed2-3313-42c5-9b30-155b9a14ca1c
+      - b5d8980c-7b0f-4906-b7b2-4f794954ef8c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - b13d017e-73ef-48c6-a342-cd9ac584511b
+      X-Ms-Correlation-Request-Id:
+      - b13d017e-73ef-48c6-a342-cd9ac584511b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163526Z:b13d017e-73ef-48c6-a342-cd9ac584511b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c80fca4a-f35e-45ac-9ae2-cb68266d1ba0
+      - cae0dc70-2768-4efb-9069-afcb7e2b1384
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 13bee540-4b2e-4979-8667-1de3768494cd
+      X-Ms-Correlation-Request-Id:
+      - 13bee540-4b2e-4979-8667-1de3768494cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163527Z:13bee540-4b2e-4979-8667-1de3768494cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8438fbee-8dbf-49e4-8a49-4408b854e858
+      - de213cc7-1b22-42c7-add4-180bb406fc87
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - f1253a95-0260-4994-b719-ea6171b08116
+      X-Ms-Correlation-Request-Id:
+      - f1253a95-0260-4994-b719-ea6171b08116
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163527Z:f1253a95-0260-4994-b719-ea6171b08116
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 247dcbc1-3f09-4cd7-a8bd-fdc2c63d1bd8
+      - 36769973-b620-47b1-b4c2-253d109334f2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 0f84083b-a4ff-4fa9-b17f-28db20a3beb5
+      X-Ms-Correlation-Request-Id:
+      - 0f84083b-a4ff-4fa9-b17f-28db20a3beb5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163527Z:0f84083b-a4ff-4fa9-b17f-28db20a3beb5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 21faa11f-b26e-4f61-a3a8-d70b994ad7fc
+      - 348a800f-3470-4276-96c0-6bc5aa0dda99
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
+      X-Ms-Correlation-Request-Id:
+      - 37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163528Z:37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 326885f6-a81b-44f9-8eea-8bdbfd4817c5
+      - 7ff36c85-7bf3-433a-abfa-0a6ea1b81248
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - e68c66c1-a183-4601-89a8-6af0f1e42097
+      X-Ms-Correlation-Request-Id:
+      - e68c66c1-a183-4601-89a8-6af0f1e42097
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163528Z:e68c66c1-a183-4601-89a8-6af0f1e42097
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6fc0d724-7dd5-4ab7-a014-9ec639f244b1
+      - 8f9b11f6-9c33-4a01-90db-1be9c84e8d39
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 1d0a2192-0fb6-484f-80c6-d6ef1549900b
+      X-Ms-Correlation-Request-Id:
+      - 1d0a2192-0fb6-484f-80c6-d6ef1549900b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163528Z:1d0a2192-0fb6-484f-80c6-d6ef1549900b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a1181ec5-8b7f-49a8-9456-33faae3193b5
+      - a681ad7b-5261-47e0-9779-086bc9ee0590
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 663bccf7-4aa5-45d3-954a-78d5f44a5be1
+      X-Ms-Correlation-Request-Id:
+      - 663bccf7-4aa5-45d3-954a-78d5f44a5be1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163528Z:663bccf7-4aa5-45d3-954a-78d5f44a5be1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9739e587-4fd4-4501-a768-6faef4ca4ab4
+      - e1a6abbb-e6ce-4fcc-9b47-50a22e7c9e26
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
+      X-Ms-Correlation-Request-Id:
+      - 7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163529Z:7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5e7f236c-639f-4238-bcd4-1877fd2d91f3
+      - 709f00ab-44ae-4797-9d5a-b2c96baa09e3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 45f994eb-c61f-4ea6-86cb-d29524dbe7a2
+      X-Ms-Correlation-Request-Id:
+      - 45f994eb-c61f-4ea6-86cb-d29524dbe7a2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163529Z:45f994eb-c61f-4ea6-86cb-d29524dbe7a2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5082126d-c149-4561-8cb4-35250ca24b90
+      - 6438087f-faa0-4386-8db5-375b28adf7e2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 70009eac-3d02-440c-a14c-c9060f9a5fe7
+      X-Ms-Correlation-Request-Id:
+      - 70009eac-3d02-440c-a14c-c9060f9a5fe7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163529Z:70009eac-3d02-440c-a14c-c9060f9a5fe7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 009f48f2-82f3-4ea2-a8e9-38e7bd8ab450
+      - 16b4c993-a424-4248-bc43-b8a5bbf0c2a6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 58cd2784-0404-44b5-a019-484e88c3d157
+      X-Ms-Correlation-Request-Id:
+      - 58cd2784-0404-44b5-a019-484e88c3d157
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163530Z:58cd2784-0404-44b5-a019-484e88c3d157
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6d3bbb41-89a7-4657-9ee2-9a2b725b4b03
+      - ab68b57d-dbad-4aa6-8ccb-bde0f16899c5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 840ea5ea-4561-444b-9424-097d08d44f79
+      X-Ms-Correlation-Request-Id:
+      - 840ea5ea-4561-444b-9424-097d08d44f79
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163531Z:840ea5ea-4561-444b-9424-097d08d44f79
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1a34292f-9fc3-459a-88c1-61351378c8ea
+      - cb389b18-077b-407a-9f2a-a4a6c19cc559
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 69bfa40a-6df5-48b1-af99-7c89a939aad2
+      X-Ms-Correlation-Request-Id:
+      - 69bfa40a-6df5-48b1-af99-7c89a939aad2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163531Z:69bfa40a-6df5-48b1-af99-7c89a939aad2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 29ff17dd-14b9-4594-944b-c743ef5cfba5
+      - effc15c2-6673-4562-90e0-9c380ecd94f6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 88be2c30-1bfd-4456-9e71-6379da82e428
+      X-Ms-Correlation-Request-Id:
+      - 88be2c30-1bfd-4456-9e71-6379da82e428
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163531Z:88be2c30-1bfd-4456-9e71-6379da82e428
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4679a377-2faa-4861-9ccd-a82451a34886
+      - c8a4bb1d-207e-4cca-94e4-38e31bd1ae4e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - bb472d9a-3c6d-41de-b346-13b965e20bf9
+      X-Ms-Correlation-Request-Id:
+      - bb472d9a-3c6d-41de-b346-13b965e20bf9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163532Z:bb472d9a-3c6d-41de-b346-13b965e20bf9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 092a0d5a-38be-40cd-8b7d-cacbf0bdaa42
+      - 58599eab-ddc2-401c-944b-974e4fa62d74
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - fe203b1f-42b1-413e-95e9-66d6089f5698
+      X-Ms-Correlation-Request-Id:
+      - fe203b1f-42b1-413e-95e9-66d6089f5698
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163532Z:fe203b1f-42b1-413e-95e9-66d6089f5698
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2fbd4d26-9755-44c3-91ab-9ec99ae47c64
+      - 55195397-7a31-4da8-8182-d4793f15ad14
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 7e6cef3e-b380-4313-a646-8f1e2f028c03
+      X-Ms-Correlation-Request-Id:
+      - 7e6cef3e-b380-4313-a646-8f1e2f028c03
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163532Z:7e6cef3e-b380-4313-a646-8f1e2f028c03
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5753d44c-e9a2-448e-bd0b-4f48617c3658
+      - b1d8a212-2f65-4ebc-8b2a-e2d60af7709c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - eff311e4-1f58-440b-88e6-63a6ffe866c9
+      X-Ms-Correlation-Request-Id:
+      - eff311e4-1f58-440b-88e6-63a6ffe866c9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163532Z:eff311e4-1f58-440b-88e6-63a6ffe866c9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3d8dfc2f-926a-49b9-81b6-a467f3a28325
+      - 53b26ff1-434c-4008-a0a6-86c717c30c75
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - bc14ecba-0e41-4251-a1d7-709fd835f10b
+      X-Ms-Correlation-Request-Id:
+      - bc14ecba-0e41-4251-a1d7-709fd835f10b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163533Z:bc14ecba-0e41-4251-a1d7-709fd835f10b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8227915a-6a4b-489d-b6a8-da449e769d5e
+      - ed36c2b4-1af8-46ed-af3a-22ed9c46809f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - c750862b-7fd1-44ae-a81a-eb531bb718dd
+      X-Ms-Correlation-Request-Id:
+      - c750862b-7fd1-44ae-a81a-eb531bb718dd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163533Z:c750862b-7fd1-44ae-a81a-eb531bb718dd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0e5ec959-4bc2-42ce-8178-21ea5d72c27a
+      - 62337c8f-150d-4038-bae1-696d3773088e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 982272c5-9fda-4a5e-a564-d8b2277ca0e7
+      X-Ms-Correlation-Request-Id:
+      - 982272c5-9fda-4a5e-a564-d8b2277ca0e7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163534Z:982272c5-9fda-4a5e-a564-d8b2277ca0e7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 640edb2e-5c6f-4317-9512-6c3a5c45e8fa
+      - 952f6ed6-9834-4592-ac87-275532909f23
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 3b5378f0-65a8-403d-86d2-87181206a495
+      X-Ms-Correlation-Request-Id:
+      - 3b5378f0-65a8-403d-86d2-87181206a495
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163534Z:3b5378f0-65a8-403d-86d2-87181206a495
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 09f95b24-449b-47f2-8935-db264754b8b0
+      X-Ms-Correlation-Request-Id:
+      - 09f95b24-449b-47f2-8935-db264754b8b0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163534Z:09f95b24-449b-47f2-8935-db264754b8b0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:33 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 04a64a8e-7c81-4725-a6f9-fa4f4e69e411
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - b83d38e3-22e9-49a0-b063-d765f5927c49
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163535Z:b83d38e3-22e9-49a0-b063-d765f5927c49
+      Date:
+      - Wed, 28 Oct 2015 16:35:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 7ff7ce68-baaa-4be5-ad7c-cf91989b6393
+      X-Ms-Correlation-Request-Id:
+      - 7ff7ce68-baaa-4be5-ad7c-cf91989b6393
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163535Z:7ff7ce68-baaa-4be5-ad7c-cf91989b6393
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:35 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - bd11ea49-f967-4f1b-ac0e-90302d37b392
+      X-Ms-Correlation-Request-Id:
+      - bd11ea49-f967-4f1b-ac0e-90302d37b392
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163536Z:bd11ea49-f967-4f1b-ac0e-90302d37b392
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:36 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 3b6626d1-b82c-4be6-b631-e24411982be3
+      X-Ms-Correlation-Request-Id:
+      - 3b6626d1-b82c-4be6-b631-e24411982be3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163537Z:3b6626d1-b82c-4be6-b631-e24411982be3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:37 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f5a65b0e-4c64-4326-967a-c154738263d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - caf71346-a236-4cb0-a264-53d12b709a6e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163538Z:caf71346-a236-4cb0-a264-53d12b709a6e
+      Date:
+      - Wed, 28 Oct 2015 16:35:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 13b71b5e-8a0f-46e6-914f-8f35126ada1d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - e20162a1-82d8-4d65-872d-1b28b8f3898c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163538Z:e20162a1-82d8-4d65-872d-1b28b8f3898c
+      Date:
+      - Wed, 28 Oct 2015 16:35:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 3a3bf562-6aab-44cd-b337-f5dddb10e376
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - eebdd6c5-388d-463a-b56b-d3e473bf5a01
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163539Z:eebdd6c5-388d-463a-b56b-d3e473bf5a01
+      Date:
+      - Wed, 28 Oct 2015 16:35:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qN7B5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19U88f53Xl3n9NL903UZp572O
+        ZwP9mvV0muezfOYg4nH0O1ueV53vCNOQfD7YdAhijDj3H+0/eHR/f/zw3qf3
+        79/b7xCJSGN+ZULp399nuB9Nqqp9WmQXy6ppiynw0DHTaJdNVeavp3WeL5t5
+        1T4pq8lXdUFNPpq37ap5dPfuVd600ypr2tmkuf/w073xhNqMp1Wdj6+K5ay6
+        asbLvL2LTmauk+3mF5UNz8H2zr2H+Wy6d7B9Pz/Y2d7f2dnbnszuT7f37z/M
+        9mfZ/d29g/27/pSNb/PGuLFIjyeLFZNC+SN/19IXRGQMVWdaR0zfGib5opjW
+        VVOdt+Mzanwxb5vxT37hkel13rY0Sw1DJtj4oQTtM5ID/14MNMQ87884m5nm
+        4cPd3Ye7AdMIraKYV1d5jZ7zu7M8K8tqSr/6Xd0aadIFPgRpKIT8jZNf8v8A
+        0+Qg/UAFAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1305ec3a-96b5-4e9f-9a1d-07bfc7c8abb2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 56938193-f9ba-4159-aaaf-792f69dffe9f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163539Z:56938193-f9ba-4159-aaaf-792f69dffe9f
+      Date:
+      - Wed, 28 Oct 2015 16:35:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
+        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
+        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
+        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
+        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
+        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
+        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
+        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
+        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
+        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
+        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1bd32c05-3887-4377-bca0-885aa39cb0ab
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - aa318178-192d-4efc-ae8a-ebe5c0857d20
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163539Z:aa318178-192d-4efc-ae8a-ebe5c0857d20
+      Date:
+      - Wed, 28 Oct 2015 16:35:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - a0228457-aaab-4bbd-ac5c-f4bd9485a737
+      X-Ms-Correlation-Request-Id:
+      - a0228457-aaab-4bbd-ac5c-f4bd9485a737
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163541Z:a0228457-aaab-4bbd-ac5c-f4bd9485a737
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:40 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - fd2bdb71-e08b-43f3-a6a4-079392d8ae5f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 6c16ede5-d04d-4a4e-83d3-f1bba231e171
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163541Z:6c16ede5-d04d-4a4e-83d3-f1bba231e171
+      Date:
+      - Wed, 28 Oct 2015 16:35:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - e283ed4f-6375-409f-b812-bc4b8e8a43e7
+      X-Ms-Correlation-Request-Id:
+      - e283ed4f-6375-409f-b812-bc4b8e8a43e7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163541Z:e283ed4f-6375-409f-b812-bc4b8e8a43e7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:41 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - 2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
+      X-Ms-Correlation-Request-Id:
+      - 2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:41 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 47800d9b-5e8c-4ce2-a334-a57f8a501b7b
+      X-Ms-Correlation-Request-Id:
+      - 47800d9b-5e8c-4ce2-a334-a57f8a501b7b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:47800d9b-5e8c-4ce2-a334-a57f8a501b7b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:42 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
+      X-Ms-Correlation-Request-Id:
+      - ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:42 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 9d0b5d92-1db1-4d8b-86aa-d77198191c82
+      X-Ms-Correlation-Request-Id:
+      - 9d0b5d92-1db1-4d8b-86aa-d77198191c82
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:9d0b5d92-1db1-4d8b-86aa-d77198191c82
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:42 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 66f926f4-f1a7-4d24-9390-138110c30948
+      X-Ms-Correlation-Request-Id:
+      - 66f926f4-f1a7-4d24-9390-138110c30948
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:66f926f4-f1a7-4d24-9390-138110c30948
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:41 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - f6a8c87b-d575-4ec7-a906-efa6b75aae0d
+      X-Ms-Correlation-Request-Id:
+      - f6a8c87b-d575-4ec7-a906-efa6b75aae0d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163542Z:f6a8c87b-d575-4ec7-a906-efa6b75aae0d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:42 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
+      X-Ms-Correlation-Request-Id:
+      - 8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163543Z:8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:42 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 23f699f5-ff98-4f06-94ce-2ed344863e2d
+      X-Ms-Correlation-Request-Id:
+      - 23f699f5-ff98-4f06-94ce-2ed344863e2d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163543Z:23f699f5-ff98-4f06-94ce-2ed344863e2d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:43 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - d9bcf0a0-e299-4170-b255-daccc22c18c8
+      X-Ms-Correlation-Request-Id:
+      - d9bcf0a0-e299-4170-b255-daccc22c18c8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163543Z:d9bcf0a0-e299-4170-b255-daccc22c18c8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:43 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 0a73ee52-36df-4ac9-bff5-69e6573f4bb1
+      X-Ms-Correlation-Request-Id:
+      - 0a73ee52-36df-4ac9-bff5-69e6573f4bb1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163543Z:0a73ee52-36df-4ac9-bff5-69e6573f4bb1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:43 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:798A:A0FADFD:5630F960
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1026-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - a1c918cc-8d01-4827-a81e-271aa1502353
+      X-Ms-Correlation-Request-Id:
+      - a1c918cc-8d01-4827-a81e-271aa1502353
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163544Z:a1c918cc-8d01-4827-a81e-271aa1502353
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:798A:A0FAE4F:5630F960
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1022-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:40:44 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 4ffa3527-ecd4-4409-a4e6-1efd22dad066
+      X-Ms-Correlation-Request-Id:
+      - 4ffa3527-ecd4-4409-a4e6-1efd22dad066
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163544Z:4ffa3527-ecd4-4409-a4e6-1efd22dad066
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C14:798C:C1F0B2F:5630F961
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 16:35:45 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1034-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Wed, 28 Oct 2015 16:40:45 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 5bae7a51-a5e8-4783-b81c-492f00999206
+      X-Ms-Correlation-Request-Id:
+      - 5bae7a51-a5e8-4783-b81c-492f00999206
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163545Z:5bae7a51-a5e8-4783-b81c-492f00999206
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 46fea4fd-0b8a-483d-969c-13977010a540
+      X-Ms-Correlation-Request-Id:
+      - 46fea4fd-0b8a-483d-969c-13977010a540
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163545Z:46fea4fd-0b8a-483d-969c-13977010a540
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:44 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 101a9c84-8ebd-4853-b7c3-aa083f7066d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 2518967b-b860-4345-95b8-e6fca829f4c9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163545Z:2518967b-b860-4345-95b8-e6fca829f4c9
+      Date:
+      - Wed, 28 Oct 2015 16:35:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dc410e58-a6c2-48f9-b6c2-1d9cb13efe2f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 8b56cf27-d50b-41ad-9a94-2cb16294f6d5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163546Z:8b56cf27-d50b-41ad-9a94-2cb16294f6d5
+      Date:
+      - Wed, 28 Oct 2015 16:35:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 3512e777-491f-42bc-a105-aa944c12e419
+      X-Ms-Correlation-Request-Id:
+      - 3512e777-491f-42bc-a105-aa944c12e419
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163546Z:3512e777-491f-42bc-a105-aa944c12e419
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 494f7047-5430-4802-9a96-c07c45aea8d7
+      X-Ms-Correlation-Request-Id:
+      - 494f7047-5430-4802-9a96-c07c45aea8d7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163546Z:494f7047-5430-4802-9a96-c07c45aea8d7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:45 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b4dadbef-3594-4414-b7d1-a575393a1888
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Correlation-Request-Id:
+      - 3995dfab-7667-4777-937e-6e3425df12fd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:3995dfab-7667-4777-937e-6e3425df12fd
+      Date:
+      - Wed, 28 Oct 2015 16:35:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 02d81947-1c4f-46a5-8e54-4b16c72aa1d2
+      X-Ms-Correlation-Request-Id:
+      - 02d81947-1c4f-46a5-8e54-4b16c72aa1d2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:02d81947-1c4f-46a5-8e54-4b16c72aa1d2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 176cec38-9e89-482e-aa11-010fa2859d36
+      X-Ms-Correlation-Request-Id:
+      - 176cec38-9e89-482e-aa11-010fa2859d36
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:176cec38-9e89-482e-aa11-010fa2859d36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 20a46daa-4a2f-42c4-8888-533a8bbf9c6d
+      X-Ms-Correlation-Request-Id:
+      - 20a46daa-4a2f-42c4-8888-533a8bbf9c6d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:20a46daa-4a2f-42c4-8888-533a8bbf9c6d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 3b309668-d0e8-42d1-8404-9b1b8eb5cf9f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 48d142fe-f7e9-475b-8615-d05dd56ae176
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:48d142fe-f7e9-475b-8615-d05dd56ae176
+      Date:
+      - Wed, 28 Oct 2015 16:35:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - e4ad777c-58b2-43c7-801b-56a91339a6e4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - f114ae20-1eb3-415c-9f10-a7bd5df153c0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163547Z:f114ae20-1eb3-415c-9f10-a7bd5df153c0
+      Date:
+      - Wed, 28 Oct 2015 16:35:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - adc9b1a9-5408-4453-9cff-f48491fc38c5
+      X-Ms-Correlation-Request-Id:
+      - adc9b1a9-5408-4453-9cff-f48491fc38c5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163548Z:adc9b1a9-5408-4453-9cff-f48491fc38c5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
+      X-Ms-Correlation-Request-Id:
+      - 7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163548Z:7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - c7a36473-f8b5-4c47-a545-4f761a9ddcff
+      X-Ms-Correlation-Request-Id:
+      - c7a36473-f8b5-4c47-a545-4f761a9ddcff
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163548Z:c7a36473-f8b5-4c47-a545-4f761a9ddcff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 0bbc39e4-7210-45a7-9158-51050b165706
+      X-Ms-Correlation-Request-Id:
+      - 0bbc39e4-7210-45a7-9158-51050b165706
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163548Z:0bbc39e4-7210-45a7-9158-51050b165706
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 38d52d9f-f615-46f8-aae5-bf2c2c6f44af
+      X-Ms-Correlation-Request-Id:
+      - 38d52d9f-f615-46f8-aae5-bf2c2c6f44af
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163549Z:38d52d9f-f615-46f8-aae5-bf2c2c6f44af
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 16:35:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - c6d569a1-dbc9-422e-9e1d-fb7ce164b920
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - ff414aba-3a8c-4efa-997c-439c5cba3de6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163549Z:ff414aba-3a8c-4efa-997c-439c5cba3de6
+      Date:
+      - Wed, 28 Oct 2015 16:35:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 5ad34d38-9321-4caf-bdad-56a58cf6d427
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 3bafaf9d-0f1e-400c-ac33-4b6305b44350
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163549Z:3bafaf9d-0f1e-400c-ac33-4b6305b44350
+      Date:
+      - Wed, 28 Oct 2015 16:35:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
+        3ux++uje/Uf7Dz/Z2Xm0s/ORafxL5Jfv48cvYRDA9C0wVKpYmny0zATqyTw/
+        3yayzFyfUWp67+LZQNFmPZ3m+Sz3IOJxFD1bnled7wjNkKA+2HQIYowyRJYH
+        j+5/On6wf29/78Fuh0JEF/MrU0n//j7D/Sh/1+ZLdAoUdOR21JZiXxTTumqq
+        83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+fkJuJ
+        +HDn3s79BwERhbGimFdXeY2e87uzPCvLakq/+l3dGmmSFh+CNBRC/sbJL/l/
+        AFVnufNiBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b48acc42-b5c4-49f6-a4e5-99febefa4b72
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 2f8a8312-9db5-4bb9-a640-4b459fab41d8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163549Z:2f8a8312-9db5-4bb9-a640-4b459fab41d8
+      Date:
+      - Wed, 28 Oct 2015 16:35:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
+        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
+        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
+        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
+        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
+        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
+        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
+        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
+        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
+        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
+        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 383a01b0-b9f9-42f3-ba07-0707415b1010
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - cef6388d-4892-4e5f-b8ee-e4231bbeeaba
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163550Z:cef6388d-4892-4e5f-b8ee-e4231bbeeaba
+      Date:
+      - Wed, 28 Oct 2015 16:35:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 7a78382d-f73e-4d29-ab60-71ee3b3d60c0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 2de87afb-e51d-4643-98c4-bd0f0e3b1d6f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163550Z:2de87afb-e51d-4643-98c4-bd0f0e3b1d6f
+      Date:
+      - Wed, 28 Oct 2015 16:35:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7O5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZdW0F9T19tP80nUbpZ33Op4N
+        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHi3H+0/+DR/U/HD/YePNg/
+        6NCIKGN+ZTrp399nsB9Nqqp9WmQXS6JKMQUaOmQa7LKpyvz1tM7zZTOv2idl
+        NfmqLqjJR/O2XTWP7t6dzvPzVV3N7u/u7Ywn9P14WtX5+KpYzqqrZrzM27vo
+        YOY62F7RT5B/tn0+Pb83m+bT7fPJwWx7/+H5/e2Hs4Pp9mT3fj6bnp8/2Nmf
+        3vVna3ybN8aNRXg8WayYDMoa+buWviD6Ypg6yTpa+tbwxxfFtK6a6rwdn1Hj
+        i3nbjH/yC49Er/O2pQlqGDLBxg8lZp+HHPj34p0hvnl/ntnMLw937u3cfxAw
+        jNAqhvmXr9FtfpcEOK+zsvhB0M+tMSYd4EOQhsO9vqyu8hpv53dneVaW1ZR+
+        /bod+xCkoUzfb5z8kv8HFSfU3LEFAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 818f9bee-4bfc-4c3e-b661-8b289659e01f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - b78ff9b3-09e5-4f3d-8c11-de6de0e6ce50
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163550Z:b78ff9b3-09e5-4f3d-8c11-de6de0e6ce50
+      Date:
+      - Wed, 28 Oct 2015 16:35:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
+        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
+        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
+        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
+        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
+        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
+        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
+        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
+        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
+        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
+        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e5341f67-2dc7-4655-9d70-bdb1fd510db3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - cf5bd45b-52fb-4713-b022-9e18c946f64a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163550Z:cf5bd45b-52fb-4713-b022-9e18c946f64a
+      Date:
+      - Wed, 28 Oct 2015 16:35:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - dc52f23d-fd1e-4064-8c9b-d4d01f2da3e5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 6015b3ae-3c37-41fe-b950-692b01f3d818
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163550Z:6015b3ae-3c37-41fe-b950-692b01f3d818
+      Date:
+      - Wed, 28 Oct 2015 16:35:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7u5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
+        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcgxmhz/9H+3qP7B+ODe/d3H356
+        r0Mjooz5lemkf3+f4X6Uv2tzmgKaBoKqI7ejtjT7opjWVVOdt+Mzanwxb5vx
+        T37xtMgullXTFtPmdd62hHWjnfod9AnrwL8XQYeI+f6E3EzEg73d/f37ARGF
+        taKYV1d5jZ7zu7M8K8tqSr/6Xd0aaRINH4I0FEL+xskv+X8AbbuwKk8EAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 66f1bfbe-8fdb-4ec3-b873-c1ed6178101c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 0d2d0997-48ad-42ef-b75b-03ab02e7b505
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163551Z:0d2d0997-48ad-42ef-b75b-03ab02e7b505
+      Date:
+      - Wed, 28 Oct 2015 16:35:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
+        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
+        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
+        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
+        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
+        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
+        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
+        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
+        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
+        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - d8ea530a-ec5a-4e84-b381-c1886dcfe5b5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 18b37675-16a6-41f6-b797-0bf87bb366a6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163551Z:18b37675-16a6-41f6-b797-0bf87bb366a6
+      Date:
+      - Wed, 28 Oct 2015 16:35:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7u5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19NVL11uUZN5beDaQrVlPp3k+
+        y2cOIh5HtrPledX5jhAMqeaDTYcgxmhy/9H+3qP798cP9/c/3dk56NCGKGJ+
+        Zfro399nuB/l79qcSE/kJ6g6cjtqS6svimldNdV5Oz6jxhfzthn/5BdPi+xi
+        WTVtMW1e521LWDfaqd9Bn7AO/HsRdIiY70/IzUR8uLv/cPfTgIjCUjHMv3yN
+        bvO7xMx5nZXFD4J+bo0xyYMPQRoO9/qyusprvJ3fneVZWVZT+vXrduxDkIYy
+        fb9x8kv+HwQKKZK9BAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8b4ac921-d852-4e98-90aa-303733cb6505
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - a3a253c9-98e8-4a79-b9d2-11932024fd98
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163551Z:a3a253c9-98e8-4a79-b9d2-11932024fd98
+      Date:
+      - Wed, 28 Oct 2015 16:35:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
+        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
+        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
+        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
+        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
+        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
+        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
+        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
+        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
+        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e024db5b-7142-4795-b75b-8a733b20ee33
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 14fa4e40-a182-4ea8-94a7-dbe2a719937a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163552Z:14fa4e40-a182-4ea8-94a7-dbe2a719937a
+      Date:
+      - Wed, 28 Oct 2015 16:35:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - fb65ef3b-bb2b-427b-ae87-64f1165bec9e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - e1d479b6-5910-4aa1-ae25-49b3da9d1193
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163552Z:e1d479b6-5910-4aa1-ae25-49b3da9d1193
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7e5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1i7Of2HPdRWnmvYZnA92a9XSa
+        57N85iDicXQ7W55Xne8Iw5BsPth0CGKMKPcf7e89un9//HB//9OdnYMOcYgk
+        5lcmkP79fYb7Uf6uzYn2RH+CqiO3o3bEKqZ11VTn7fiMGl/M22b8k188LbKL
+        ZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPx4e7+w91PAyIKT0Uxr67y
+        Gj3nd2d5VpbVlH71u7o10iQTPgRpKIT8jZNf8v8Az+rfIkgEAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f394664f-e438-4d0c-83d4-f08eae338047
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 2fd79f35-a3be-46df-8100-c63959a0921d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163552Z:2fd79f35-a3be-46df-8100-c63959a0921d
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
+        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
+        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
+        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
+        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
+        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
+        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
+        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
+        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
+        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
+        Abt1q/kPBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0fadf0e4-d3e1-44f1-95af-7e1387012b1c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 366bc2ec-83b2-4a23-8c63-d6e147ca9932
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163552Z:366bc2ec-83b2-4a23-8c63-d6e147ca9932
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - c95e5fa6-c9e6-4ff9-8ff3-79daef94d2f4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 93602e43-392c-400a-baf0-639229364e07
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163553Z:93602e43-392c-400a-baf0-639229364e07
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99dO/+o/v3PtnZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOoX
+        Zz9xUi1W6zbfdb1GSee9jWcD+Zr1dJrns3zmIOJx5Dtbnled7wjRkHo+2HQI
+        Yow29x/t7z26/+l459OHn37aJRERxvzKZKK/FaIdnCXNLGszQuvtjwhD/9LT
+        I8ye6/T/F4TZ3f10/8HuLSiDH99nuB/l79qchJYEl6DqyO2oLcW+KKZ11VTn
+        7fiMGl/M22b8k188LbKLZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPx
+        03v3DvYeBkTss5LFvLrKa/Sc353lWVlWU/rV7+rWSJMy9SFIQyHkb5z8kv8H
+        gIQAUkYGAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3437bb92-cbae-411b-b60a-7d814f254d2e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 4d853835-5d59-4d5b-9001-e81c3f5df695
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163553Z:4d853835-5d59-4d5b-9001-e81c3f5df695
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
+        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
+        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
+        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
+        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
+        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
+        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
+        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
+        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
+        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
+        4wf980v+H8QOklQ5BwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 242c2427-2a2b-4068-8724-5b3a796de0d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 7fee3a7f-2aca-4331-9c92-1bfcb837be50
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163553Z:7fee3a7f-2aca-4331-9c92-1bfcb837be50
+      Date:
+      - Wed, 28 Oct 2015 16:35:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - cd43f277-1ef9-4fc8-a3c2-70aec1f6b309
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - 064b0ba4-8650-48e7-9836-f2653cb7f410
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163554Z:064b0ba4-8650-48e7-9836-f2653cb7f410
+      Date:
+      - Wed, 28 Oct 2015 16:35:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7+5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
+        8pmDiMdR7mx5XnW+IwRCwvlg0yGIMbLcf7T/4NH9B+O9+w93dve75CGimF+Z
+        RPr39xnuR5Oqap8W2cWyatpiCjx0zDTaZVOV+etpnefLZl61T8pq8lVdUJOP
+        5m27ah7dvdus8ulu01Y1Te3ueEINxtOqzsdXxXJWXTXjZd7eRQ8z18M23rlc
+        7Gzn2e6DPNvb385m2Wx7f396bzs7OHi4vbOzf+98srd7/+H5Hnew/ZNf7Ixv
+        03rcWFzHk8WKKaAM0Z9eHSZ9917TOjSl7z+dG6fyHo1of+d+MJUylCjm1VVe
+        o+f87izPyrKa0q9+V7dGmmTThyANhV9+4+SX/D/UjH3+0AQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 000b2115-ed40-4792-b194-2d5c8795d785
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - c927dc59-9d5f-4c1a-a61a-d5b471499c76
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163554Z:c927dc59-9d5f-4c1a-a61a-d5b471499c76
+      Date:
+      - Wed, 28 Oct 2015 16:35:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
+        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
+        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
+        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
+        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
+        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
+        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
+        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
+        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
+        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
+        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
+        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 3a8da927-36ca-4cb7-9260-29357f2a4290
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 8f930bc1-50c5-49cf-ab37-d051d4a0c310
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163554Z:8f930bc1-50c5-49cf-ab37-d051d4a0c310
+      Date:
+      - Wed, 28 Oct 2015 16:35:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP79z/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
+        5TMHEY+j3NnyvOp8RwiEhPPBpkMQY2S5/2j/gAgy3t09uPfg/r0OeYgo5lcm
+        kf79fYb70aSq2qdFdrGsmraYAg8dM4122VRl/npa5/mymVftk7KafFUX1OSj
+        eduumkd37zarfLrbtFVNU7s7nlCD8bSq8/FVsZxVV814mbd30cPM9bCNdy4X
+        u9s7k/vZXrZ/vr07+/TB9v7uLN/Odvem2/d2ZzsPdj99uPfpHhGWGm//5Be7
+        49u0HjcW1/FksWIKKEP0p1eHSd+917QOTen7T+fmqTzYefjwYDeYShlKFPPq
+        Kq/Rc353lmdlWU3pV7+rWyNNsulDkIbCL79x8kv+Hzmf2UXQBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f90bbfa3-f657-4637-893d-4c8bef8f8bfd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - ea022cee-a771-4b99-b524-d728c23fa788
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163555Z:ea022cee-a771-4b99-b524-d728c23fa788
+      Date:
+      - Wed, 28 Oct 2015 16:35:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
+        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
+        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
+        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
+        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
+        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
+        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
+        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
+        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
+        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
+        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 0ba580ca-792e-4766-9c53-ea38523453f4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 4fcfd892-c30e-404a-816f-09c268668d93
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163555Z:4fcfd892-c30e-404a-816f-09c268668d93
+      Date:
+      - Wed, 28 Oct 2015 16:35:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdj99dO/+o/v3P9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOrr
+        rMyb86qe5l+9dt1Gaee9jmcD/Zr1dJrns3zmIOJx9Dtbnled7wjTkHw+2HQI
+        Yow49x/tP3h0/9PxwcOHnx58ut8hEpHG/MqE0r+/z3A/mlRV+7TILpZV0xZT
+        4KFjptEum6rMX0/rPF8286p9UlaTr+qCmnw0b9tV8+ju3eV1ffFw92B/PKHv
+        xtOqzsdXxXJWXTXjZd7eBfCZA77dGNpvT2fnO9n5g4fb93b2Z9v7swf3th9O
+        p/e3D+7f353sPpxN850Hd/2pGt/mjXFjkR1PFismgfJF/q6lL4i4GKLOsI6U
+        vjXM8UUxraumOm/HZ9T4Yt4245/8wiPP67xtaXYahkyw8UMJ2WcgB/69GGeI
+        ad6fYTYyy8NP93Yf7BwEzCK0imJeXeU1es7vzvKsLKsp/ep3dWukSQf4EKSh
+        EPI3Tn7J/wO1T9eJ/QQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a5d5625d-65ab-4441-aa58-199c806fa09a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 1f249566-21e7-4e7b-867f-6edb102eab7c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163555Z:1f249566-21e7-4e7b-867f-6edb102eab7c
+      Date:
+      - Wed, 28 Oct 2015 16:35:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
+        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
+        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
+        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
+        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
+        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
+        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
+        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
+        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
+        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
+        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bf50c0ba-aa07-42d7-b3dd-85fb44261f5b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 4aa8785b-9227-4f8c-b4a8-ec6c146d059d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T163555Z:4aa8785b-9227-4f8c-b4a8-ec6c146d059d
+      Date:
+      - Wed, 28 Oct 2015 16:35:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
@@ -1,0 +1,12121 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - 669df257-2019-486f-a423-3441d0e67f71
+      Client-Request-Id:
+      - b21c05ea-847e-4a48-b306-7a96d4c3743a
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_169
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 28 Oct 2015 19:19:37 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446063578","not_before":"1446059678","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw"}'
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - de60da71-c68b-4a3b-b225-4dbd043df410
+      X-Ms-Correlation-Request-Id:
+      - de60da71-c68b-4a3b-b225-4dbd043df410
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191939Z:de60da71-c68b-4a3b-b225-4dbd043df410
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - f0dcbf0a-84ee-4c7b-9782-171298bdad86
+      X-Ms-Correlation-Request-Id:
+      - f0dcbf0a-84ee-4c7b-9782-171298bdad86
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191939Z:f0dcbf0a-84ee-4c7b-9782-171298bdad86
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
+        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
+        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
+        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
+        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
+        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
+        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
+        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
+        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
+        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
+        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
+        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
+        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
+        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
+        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
+        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
+        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
+        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
+        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
+        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
+        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
+        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
+        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
+        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
+        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
+        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
+        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
+        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
+        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
+        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
+        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
+        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
+        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
+        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
+        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
+        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
+        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
+        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
+        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
+        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
+        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
+        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
+        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
+        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
+        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
+        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
+        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
+        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
+        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
+        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
+        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
+        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
+        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
+        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
+        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
+        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
+        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
+        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
+        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
+        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
+        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
+        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
+        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
+        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
+        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
+        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
+        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
+        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
+        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
+        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
+        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
+        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
+        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
+        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
+        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
+        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
+        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
+        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
+        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
+        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
+        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
+        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
+        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
+        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
+        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
+        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
+        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
+        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
+        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
+        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
+        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
+        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
+        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
+        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
+        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
+        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
+        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
+        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
+        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
+        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
+        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
+        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
+        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
+        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
+        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
+        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
+        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
+        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
+        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
+        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
+        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
+        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
+        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
+        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
+        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
+        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
+        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
+        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
+        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
+        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
+        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
+        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
+        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
+        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
+        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
+        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
+        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
+        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
+        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
+        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
+        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
+        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
+        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
+        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
+        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
+        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
+        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
+        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
+        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
+        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
+        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
+        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
+        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
+        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
+        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
+        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
+        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
+        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
+        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
+        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
+        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
+        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
+        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
+        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
+        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
+        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
+        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
+        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
+        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
+        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
+        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
+        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
+        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
+        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
+        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
+        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
+        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
+        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
+        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
+        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
+        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
+        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
+        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
+        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
+        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
+        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
+        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
+        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
+        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
+        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6933ed3f-bfb4-4d51-b1a0-18b66c555d13
+      - b966e9d1-7fee-4b19-9f2f-699df508dbc5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      X-Ms-Correlation-Request-Id:
+      - 4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191940Z:4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9e740c5d-1f88-4f6f-91d0-c56aad946f5a
+      - ed99c12f-b638-447b-b264-2829643152ff
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 8899c01e-3dd2-4161-be99-41cc468daec9
+      X-Ms-Correlation-Request-Id:
+      - 8899c01e-3dd2-4161-be99-41cc468daec9
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191940Z:8899c01e-3dd2-4161-be99-41cc468daec9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 341fea8b-3676-4439-910b-54875609799f
+      - 9971fac6-34bb-4272-8265-5910c142c257
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 759caae1-ffd8-44a3-9b03-b695155fb720
+      X-Ms-Correlation-Request-Id:
+      - 759caae1-ffd8-44a3-9b03-b695155fb720
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191941Z:759caae1-ffd8-44a3-9b03-b695155fb720
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a2b20e03-45de-4c3c-84c3-33d7242eb5aa
+      - beffef60-1e11-4b45-9099-e30beeb71dc6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 12ef3095-99cf-44aa-85c3-587857269507
+      X-Ms-Correlation-Request-Id:
+      - 12ef3095-99cf-44aa-85c3-587857269507
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191941Z:12ef3095-99cf-44aa-85c3-587857269507
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0f7f9138-4f89-4dd0-99c4-af9b685485db
+      - 73a1fe34-16c4-4abd-90bc-d5ce2786a46d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      X-Ms-Correlation-Request-Id:
+      - e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191942Z:e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 85c448c7-8270-43bd-8b7c-a7e4781b9c86
+      - c9945f4d-0ce1-4f40-9434-a25d00b013c4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 50103b33-2a67-41b6-8738-8b2bd33f02f8
+      X-Ms-Correlation-Request-Id:
+      - 50103b33-2a67-41b6-8738-8b2bd33f02f8
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191942Z:50103b33-2a67-41b6-8738-8b2bd33f02f8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:42 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 565d50bb-7d96-4b2d-8894-da26984d9e20
+      - c69053be-7a1d-48a6-9c8c-5e40f4a5d73c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 3c035387-2614-4b19-b89d-09b1c89c32d6
+      X-Ms-Correlation-Request-Id:
+      - 3c035387-2614-4b19-b89d-09b1c89c32d6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191943Z:3c035387-2614-4b19-b89d-09b1c89c32d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:43 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 57d6ae26-c402-4217-ab1d-e0924b3aa975
+      - 6d4dbcd7-d68b-4e10-bc88-e40a93acd4b3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      X-Ms-Correlation-Request-Id:
+      - b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191943Z:b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:43 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4a7addd3-f388-4359-afd8-ca164b5ed523
+      - fcfa7692-9dfd-4bc1-9c4e-cf4241c15742
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      X-Ms-Correlation-Request-Id:
+      - a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191944Z:a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:44 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0ce5ce3b-112b-4764-a28d-7b0309ef893a
+      - f5236d2d-2892-487d-94e5-6e9c4702c0be
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      X-Ms-Correlation-Request-Id:
+      - 9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191944Z:9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:44 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5debab3b-f053-4b7d-be91-555dc236d109
+      - 6062636b-95cc-4871-852f-2d599d48526a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      X-Ms-Correlation-Request-Id:
+      - 69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191945Z:69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:44 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9d945e6d-1051-45b2-96c6-e25f6e7543c8
+      - a7e4edf6-993c-4330-bdf2-c09a403ac500
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 862d8063-2253-4c1d-8de1-ab7bd27a317d
+      X-Ms-Correlation-Request-Id:
+      - 862d8063-2253-4c1d-8de1-ab7bd27a317d
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191945Z:862d8063-2253-4c1d-8de1-ab7bd27a317d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a7a8ebb0-f2ed-4c72-b4ce-b0e36732cc98
+      - bfb9183d-f28e-4d0c-aa87-60fd28bb60bf
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 31627ad1-01c5-4711-aa7f-c441b2799036
+      X-Ms-Correlation-Request-Id:
+      - 31627ad1-01c5-4711-aa7f-c441b2799036
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191946Z:31627ad1-01c5-4711-aa7f-c441b2799036
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 72e9a2fc-a479-47f4-9b6c-93c3f1f5ce32
+      - 94e9df99-7926-48e5-9ef3-3baccd6ee09d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 156c5a4e-67e2-4d0f-8382-2d462752fedc
+      X-Ms-Correlation-Request-Id:
+      - 156c5a4e-67e2-4d0f-8382-2d462752fedc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191946Z:156c5a4e-67e2-4d0f-8382-2d462752fedc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 695e7b69-943b-42ad-85f1-21b8bdf8da8b
+      - 940104d5-2eac-4744-bdda-b7d9fe3ec327
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - a63405f0-3425-4e93-9e96-dd07fa213327
+      X-Ms-Correlation-Request-Id:
+      - a63405f0-3425-4e93-9e96-dd07fa213327
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191947Z:a63405f0-3425-4e93-9e96-dd07fa213327
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:46 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3b6cfb33-5011-4fb3-83ba-3d0f7bb6ac85
+      - bb7cce66-6fb0-4684-b694-4d2ea8ea3a28
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      X-Ms-Correlation-Request-Id:
+      - c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191947Z:c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:46 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b064a2a9-008b-4980-8378-78bd1559b539
+      - eb514984-df49-482c-a92f-317f12e1076c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 7963625b-190c-4f8c-89a8-a68735abf28a
+      X-Ms-Correlation-Request-Id:
+      - 7963625b-190c-4f8c-89a8-a68735abf28a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191947Z:7963625b-190c-4f8c-89a8-a68735abf28a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:47 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 94ceef14-f880-42e1-93e6-30505510e58f
+      - c945bb07-4dce-4645-bcdc-43acf22508ae
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 58e70409-647e-4fca-ab94-68e407c983cb
+      X-Ms-Correlation-Request-Id:
+      - 58e70409-647e-4fca-ab94-68e407c983cb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191948Z:58e70409-647e-4fca-ab94-68e407c983cb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6602dcbe-6f91-46b9-b72c-2ea31dbec408
+      - bcb4d331-45e0-4035-8c3e-dfa52d386a4e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      X-Ms-Correlation-Request-Id:
+      - be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191948Z:be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2f1e6a92-6397-40b8-ac63-e47c9934e44a
+      - 53e9ffff-680b-48c0-b2b9-b6a6b655242b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 40acab8e-b389-47c4-8422-b8e5d6d4e915
+      X-Ms-Correlation-Request-Id:
+      - 40acab8e-b389-47c4-8422-b8e5d6d4e915
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191949Z:40acab8e-b389-47c4-8422-b8e5d6d4e915
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 150f8efa-c5d1-4767-aaeb-63cc43159962
+      - 526754cd-6a9d-48e8-8f10-93cb5b689b7f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 420db90a-e9d3-4762-b07d-deba63ef25af
+      X-Ms-Correlation-Request-Id:
+      - 420db90a-e9d3-4762-b07d-deba63ef25af
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191949Z:420db90a-e9d3-4762-b07d-deba63ef25af
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 621c6887-a5df-4627-b792-5581c79b84ff
+      - af733721-5503-44fd-879e-550d3d39f60f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      X-Ms-Correlation-Request-Id:
+      - aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191950Z:aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7fb583fa-cbce-40e9-87a3-56e7daa892eb
+      - add3ddeb-9068-4311-9e73-caf17740ab11
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 75b0003e-437f-41d3-91da-41d20d537754
+      X-Ms-Correlation-Request-Id:
+      - 75b0003e-437f-41d3-91da-41d20d537754
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191950Z:75b0003e-437f-41d3-91da-41d20d537754
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 841bcbc1-3c6b-4e59-aac5-7568f1e97cc3
+      - dc9b1e7e-7a78-4c9b-9ecd-1a9fdee7db4f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 98e4e652-e133-4f4c-895c-0eee20e77257
+      X-Ms-Correlation-Request-Id:
+      - 98e4e652-e133-4f4c-895c-0eee20e77257
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191951Z:98e4e652-e133-4f4c-895c-0eee20e77257
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:50 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c684822c-0623-4cd9-99a9-404260673598
+      - e1fd97f0-d332-4726-9b38-5fb5ffb1582f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      X-Ms-Correlation-Request-Id:
+      - a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191951Z:a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:50 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 19108cbf-604c-419a-b468-ef3243367a76
+      - 5ac6068c-3921-4933-978b-3a190afdc23e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 59269398-cc5a-456b-a0d0-23d0215b06d6
+      X-Ms-Correlation-Request-Id:
+      - 59269398-cc5a-456b-a0d0-23d0215b06d6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191951Z:59269398-cc5a-456b-a0d0-23d0215b06d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 34222713-f9f9-42b9-b0bb-cd0f1720dd32
+      - 91fb1d60-071d-439a-9525-a7192de0d4b7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 6fd69513-a47e-4e68-8849-91f6454c9d36
+      X-Ms-Correlation-Request-Id:
+      - 6fd69513-a47e-4e68-8849-91f6454c9d36
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191952Z:6fd69513-a47e-4e68-8849-91f6454c9d36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 35430d78-6f6f-4978-a9cb-dba50cb640b6
+      - 46a4077b-e823-41aa-b674-64c453ac8324
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - f8c04792-d503-497b-8705-63f05e795176
+      X-Ms-Correlation-Request-Id:
+      - f8c04792-d503-497b-8705-63f05e795176
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191952Z:f8c04792-d503-497b-8705-63f05e795176
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:52 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4c70f70e-4722-4832-a74b-41e17b6b8109
+      - df61b42a-81d0-476c-a2ae-3bf7c84ae223
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - bc0b837f-91f0-4a74-b089-7b4bcdee8a16
+      X-Ms-Correlation-Request-Id:
+      - bc0b837f-91f0-4a74-b089-7b4bcdee8a16
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191953Z:bc0b837f-91f0-4a74-b089-7b4bcdee8a16
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:53 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9bb8d6f8-4765-4e61-8a8c-ca817656924b
+      - d43ce9a2-a487-4075-ba83-cee7d4aefd13
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - fb139d56-8ded-44de-976d-74f1e63e78c3
+      X-Ms-Correlation-Request-Id:
+      - fb139d56-8ded-44de-976d-74f1e63e78c3
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191953Z:fb139d56-8ded-44de-976d-74f1e63e78c3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:53 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 329cbb91-1b7a-49fd-be3e-8b8446b036c6
+      - 6adee14d-cd3f-4820-ba76-a34b553bab73
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 637be055-3456-4f8a-8008-9f9bbd84087f
+      X-Ms-Correlation-Request-Id:
+      - 637be055-3456-4f8a-8008-9f9bbd84087f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191954Z:637be055-3456-4f8a-8008-9f9bbd84087f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:54 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4484bd8d-87dd-421a-a66e-15ac283d990a
+      - 55a7ceae-1de7-4a18-bc7a-7397bd46799d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 008e3e12-72a1-4f09-82bb-879be6541a9b
+      X-Ms-Correlation-Request-Id:
+      - 008e3e12-72a1-4f09-82bb-879be6541a9b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191954Z:008e3e12-72a1-4f09-82bb-879be6541a9b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:54 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b13bbb51-3a06-43b7-84d2-6132d21910c9
+      - f1151bd0-0ec0-421a-8f4b-d88c39a41d38
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - ec492f1a-8680-41b2-9dbf-7a6f95819220
+      X-Ms-Correlation-Request-Id:
+      - ec492f1a-8680-41b2-9dbf-7a6f95819220
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191955Z:ec492f1a-8680-41b2-9dbf-7a6f95819220
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:54 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5b11a1d3-56a9-4720-9c10-b4ee7e970e04
+      - b8e7d553-dc1b-4d48-be92-2fc7ad0286d4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - d7c69587-1b64-4f2d-b0d5-f9633c74f089
+      X-Ms-Correlation-Request-Id:
+      - d7c69587-1b64-4f2d-b0d5-f9633c74f089
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191955Z:d7c69587-1b64-4f2d-b0d5-f9633c74f089
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:55 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 09ce85ce-658d-404c-b7b0-c7b4ec1259e1
+      - c3a8fa72-d221-4ec3-a621-6b2022ac9d31
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
+      X-Ms-Correlation-Request-Id:
+      - dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191955Z:dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:54 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8fdcd4c7-496a-4eac-a99a-43ba6c86af3b
+      - f606289d-f812-432f-8b67-27f5285eba89
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 5e0ad678-1022-489f-a754-dfdbbbd38cc9
+      X-Ms-Correlation-Request-Id:
+      - 5e0ad678-1022-489f-a754-dfdbbbd38cc9
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191956Z:5e0ad678-1022-489f-a754-dfdbbbd38cc9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:56 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - c8d7abf3-e899-4692-beb6-6238b0147982
+      - d1897261-eab3-4840-b386-44df89caabce
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - f34edfb0-4b57-44d0-9073-999af01749a7
+      X-Ms-Correlation-Request-Id:
+      - f34edfb0-4b57-44d0-9073-999af01749a7
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191956Z:f34edfb0-4b57-44d0-9073-999af01749a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:56 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 32e9269e-5825-44f7-8945-cb4717496fdc
+      - 7dedc152-863b-49d9-9f08-bd71deb06e7a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 5128e35a-129d-48ed-ab67-6ac6b6b49a63
+      X-Ms-Correlation-Request-Id:
+      - 5128e35a-129d-48ed-ab67-6ac6b6b49a63
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191957Z:5128e35a-129d-48ed-ab67-6ac6b6b49a63
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:57 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 097b1f80-8667-40fc-bfc1-c3af72099684
+      - a9304fed-5761-4b3f-9c14-71d312339d69
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - a081a150-1356-497b-a4f4-a989de24fd46
+      X-Ms-Correlation-Request-Id:
+      - a081a150-1356-497b-a4f4-a989de24fd46
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191957Z:a081a150-1356-497b-a4f4-a989de24fd46
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:56 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0b2746f0-804b-4739-a714-8f18279e478c
+      - ea9acc9c-3798-4eec-926d-7c87e4577ac5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 9ddca1ea-3766-49cc-a558-ec44ea0a19fd
+      X-Ms-Correlation-Request-Id:
+      - 9ddca1ea-3766-49cc-a558-ec44ea0a19fd
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191958Z:9ddca1ea-3766-49cc-a558-ec44ea0a19fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:57 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 25cb347b-337d-4e5a-9267-b2ab29ac686a
+      - 435ded7a-b068-4d82-9379-a784b544506d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
+      X-Ms-Correlation-Request-Id:
+      - 3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191958Z:3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:58 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4f3025b1-f413-4092-9811-923580bb6de4
+      - 826832f7-c150-4aa8-a3e5-a08e5a195763
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - dcbc238f-36a7-4a4c-9453-c1cb5750ae91
+      X-Ms-Correlation-Request-Id:
+      - dcbc238f-36a7-4a4c-9453-c1cb5750ae91
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191959Z:dcbc238f-36a7-4a4c-9453-c1cb5750ae91
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:58 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 35d7c0b2-b2e1-450b-a10a-8bc043263a61
+      - 786a81f8-ce8c-4fe5-a336-489194bae608
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - bd19b5dc-4ebe-4007-8453-2241c59dbc62
+      X-Ms-Correlation-Request-Id:
+      - bd19b5dc-4ebe-4007-8453-2241c59dbc62
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191959Z:bd19b5dc-4ebe-4007-8453-2241c59dbc62
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:58 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 27666057-d157-4248-9a8c-69994f066884
+      - 39ea6e39-ec29-4010-b827-3ba0b62cd567
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
+      X-Ms-Correlation-Request-Id:
+      - ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T191959Z:ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:59 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1752f800-7094-40e6-8f6b-b29295662d76
+      - 467bc159-ba1d-4ea4-b4b4-1668a3811abc
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 4eca2f73-60b1-4e55-aba5-2e0abf687140
+      X-Ms-Correlation-Request-Id:
+      - 4eca2f73-60b1-4e55-aba5-2e0abf687140
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192000Z:4eca2f73-60b1-4e55-aba5-2e0abf687140
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:00 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9a4b4288-20b1-456e-a1f8-8781a3942102
+      - bed3e4af-7953-4d2e-ba7f-d77b286b45de
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - b3eb8714-ae67-4142-ba02-a05dee37ed20
+      X-Ms-Correlation-Request-Id:
+      - b3eb8714-ae67-4142-ba02-a05dee37ed20
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192000Z:b3eb8714-ae67-4142-ba02-a05dee37ed20
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:19:59 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7ac701c3-e6f7-4ca2-9fda-43b177dd6cf6
+      - bce8d30e-ec87-4e4b-9d4b-57d416ce639a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 12394798-e2e5-4f98-8907-bff77e598389
+      X-Ms-Correlation-Request-Id:
+      - 12394798-e2e5-4f98-8907-bff77e598389
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192001Z:12394798-e2e5-4f98-8907-bff77e598389
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:01 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 71127250-5d17-44ff-abfa-f2d30a84a556
+      - d3057bc5-2073-4be1-aab5-ce7cf24df108
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - c08c3204-4d05-4590-8261-ec85438f1443
+      X-Ms-Correlation-Request-Id:
+      - c08c3204-4d05-4590-8261-ec85438f1443
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192001Z:c08c3204-4d05-4590-8261-ec85438f1443
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:01 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 11bd2613-81e8-4ea3-965d-95d6eaafb71b
+      - 2ac27cd1-2c98-4325-af91-008ef31118a7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 8ddbd878-7cae-4673-92d2-ff54ed1ede93
+      X-Ms-Correlation-Request-Id:
+      - 8ddbd878-7cae-4673-92d2-ff54ed1ede93
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192002Z:8ddbd878-7cae-4673-92d2-ff54ed1ede93
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:01 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 136da760-f17a-484b-9093-85d838712c0f
+      - e8864003-39ae-43f6-9130-474ca8e96a5a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 623e4773-36b7-450a-b417-2ce035b902e4
+      X-Ms-Correlation-Request-Id:
+      - 623e4773-36b7-450a-b417-2ce035b902e4
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192002Z:623e4773-36b7-450a-b417-2ce035b902e4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:02 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4ec3b7e3-e1ce-47b3-afdb-40f3a1bd772e
+      - 6f4c8afc-e174-47e4-9548-abad456e592a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 1cac122c-49cd-4925-91a1-72ac3450801f
+      X-Ms-Correlation-Request-Id:
+      - 1cac122c-49cd-4925-91a1-72ac3450801f
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192002Z:1cac122c-49cd-4925-91a1-72ac3450801f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:02 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 7c98d0fe-b4d1-4797-9f50-90ff9ff38d83
+      - c225b406-f9c2-456d-9776-6c4761ad42b6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 8e8adab4-f341-47fa-b84e-6bcaa6cf2637
+      X-Ms-Correlation-Request-Id:
+      - 8e8adab4-f341-47fa-b84e-6bcaa6cf2637
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192003Z:8e8adab4-f341-47fa-b84e-6bcaa6cf2637
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:02 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4a713172-1796-4f70-b5dd-33b423869e6e
+      - d94f1494-ce56-4210-b71f-5574a09d5b12
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 3396015e-26d0-4164-b7e8-5e642df2ed06
+      X-Ms-Correlation-Request-Id:
+      - 3396015e-26d0-4164-b7e8-5e642df2ed06
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192003Z:3396015e-26d0-4164-b7e8-5e642df2ed06
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:03 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1fadb110-86fe-4805-b157-2f20625269c4
+      - d9f692fa-219e-4dd8-b0b6-236e816b23b1
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - b5623b0d-b5f5-45a9-ba29-44b9427978e6
+      X-Ms-Correlation-Request-Id:
+      - b5623b0d-b5f5-45a9-ba29-44b9427978e6
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192004Z:b5623b0d-b5f5-45a9-ba29-44b9427978e6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:04 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4143ab2f-16ef-4340-aa36-57a592ce859e
+      - 5f0fbd94-4ce3-4531-9f33-d5ea82824f9a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 62d3c501-4e5e-4484-a0ef-ea34191d347a
+      X-Ms-Correlation-Request-Id:
+      - 62d3c501-4e5e-4484-a0ef-ea34191d347a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192004Z:62d3c501-4e5e-4484-a0ef-ea34191d347a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:04 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 57c58193-fa77-43c3-817a-5fba2c745684
+      - d5c054c5-e31b-43e6-aff9-4f7e5157521b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 2021988c-46aa-41ef-9e8a-bb761a553b24
+      X-Ms-Correlation-Request-Id:
+      - 2021988c-46aa-41ef-9e8a-bb761a553b24
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192005Z:2021988c-46aa-41ef-9e8a-bb761a553b24
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:05 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 5613cd65-5099-460c-8071-26e1c35559ea
+      X-Ms-Correlation-Request-Id:
+      - 5613cd65-5099-460c-8071-26e1c35559ea
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192005Z:5613cd65-5099-460c-8071-26e1c35559ea
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:05 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - c8a230eb-3f46-4ce7-8d22-f4db24135029
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - a521d825-bd3d-4f99-9d79-e365893cb30a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192006Z:a521d825-bd3d-4f99-9d79-e365893cb30a
+      Date:
+      - Wed, 28 Oct 2015 19:20:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - e1c36571-d4db-48a2-ac34-ec44a5fbddc2
+      X-Ms-Correlation-Request-Id:
+      - e1c36571-d4db-48a2-ac34-ec44a5fbddc2
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192006Z:e1c36571-d4db-48a2-ac34-ec44a5fbddc2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:06 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - c48a3f4f-b58c-4450-bec5-cd1eea43cc12
+      X-Ms-Correlation-Request-Id:
+      - c48a3f4f-b58c-4450-bec5-cd1eea43cc12
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192007Z:c48a3f4f-b58c-4450-bec5-cd1eea43cc12
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:07 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - f3278b22-255e-4813-bcce-0cc44b33360a
+      X-Ms-Correlation-Request-Id:
+      - f3278b22-255e-4813-bcce-0cc44b33360a
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192008Z:f3278b22-255e-4813-bcce-0cc44b33360a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:07 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a5511ff9-2a89-4695-837a-304b58b3c274
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 37407780-d771-4433-bb0f-fa698c0b02cd
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192008Z:37407780-d771-4433-bb0f-fa698c0b02cd
+      Date:
+      - Wed, 28 Oct 2015 19:20:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 93c4084e-5d45-4461-8bbd-9a7b038643cc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 2e1aa28f-5050-4ff0-b2a9-ef5a2f6ede38
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192009Z:2e1aa28f-5050-4ff0-b2a9-ef5a2f6ede38
+      Date:
+      - Wed, 28 Oct 2015 19:20:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 502fd373-c9dc-4000-a82e-523febd8c769
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 4b0af1b8-0542-48ff-a426-1f7d19517c84
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192009Z:4b0af1b8-0542-48ff-a426-1f7d19517c84
+      Date:
+      - Wed, 28 Oct 2015 19:20:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebTz8JMd+nfn
+        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1Nc/8fx1Xl/m9dP80nUbpZ33Op4N
+        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHiHDzaf/Do/qfjnb2dg4cP
+        7nWIRKQxvzKh9O/vM9yPJlXVPi2yi2XVtMUUeOiYabTLpirz19M6z5fNvGqf
+        lNXkq7qgJh/N23bVPLp79ypv2mmVNe1s0tx/+OneeEJtxtOqzsdXxXJWXTXj
+        Zd7eRScz18l284vKhudge+few3w23TvYvp8f7Gzv7+zsbU9m96fb+/cfZvuz
+        7P7u3sH+XX/Kxrd5Y9xYpMeTxYpJofyRv2vpCyIyhqozrSOmbw2TfFFM66qp
+        ztvxGTW+mLfN+Ce/8Mj0Om9bmqWGIRNs/FCC9hnJgX8vBhpinvdnnM1Mc3Bv
+        /8GnBwHTCK2imFdXeY2e87uzPCvLakq/+l3dGmnSBT4EaSiE/I2TX/L/AKOB
+        L+VABQAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1b7149bd-ba96-4d7d-859b-7064afb3abcc"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d2d15845-a4c6-4040-80b7-fbb9079b9f7d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 775cbaae-2b0b-42f8-a7e4-f91bcd9361fc
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192010Z:775cbaae-2b0b-42f8-a7e4-f91bcd9361fc
+      Date:
+      - Wed, 28 Oct 2015 19:20:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7uTB
+        7v7DyWx7kj38dHt/9mC2fXD/4WT7wc6n+9n55F42mU5/34/0xfZ6xQO+Rdf6
+        RllNM4wcb13lTbs2X9A4VnndFtTyUcrklA8vi4aaF8uL123Wcmev19Npns/y
+        mbxJzSx91kLjnUl2P9vZn21PHz68t71/8GC6nU3v7W/f29/Nzx/MDma7D/ft
+        y8XqpFqeFxfrmhFD99+Tr1KDBx47ucVqyu13DQQ8/2+c3LvdkdEHMdS/7uzL
+        gznqTZw8+OoW0ycPNS4uqcnZy+PZjGgCaB/t7ozvjXfGdrLk8ZqWhp++yNt5
+        xXPw9Jpmqph2X1lPymJKb1jgAarU4oc/gx2caAZf/8Tz1zyDT/PLj3z8fkk4
+        GkKSpp/w/bkfxGVRt+us1D87LxIehGdzd5afZ+uyDYfk/rC/6i/f19F+NFs2
+        r/O2JfYJZkw+B53w8fdMc/oiW63KIp89Db+Xrw0NP8qX2aQk7nlW1VdZPSPo
+        1Oo8I+ExLQhpjOZ1Pl3XRXvNNKE2DoEfPp1jKEUZxg5TZ+aLbDovlhC9nw30
+        T1+/Ofny+PWbp09eR9E/qRardZsbNlFk4ojjB/3zS/4fmp61wU0HAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - aaa1e50a-94fc-42aa-9214-1ce7cf2fefdd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - d3dd77df-66ac-443c-9d00-c2102ef4889b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192010Z:d3dd77df-66ac-443c-9d00-c2102ef4889b
+      Date:
+      - Wed, 28 Oct 2015 19:20:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 18fc937d-846f-4357-8f3c-d02d9cd7b2d0
+      X-Ms-Correlation-Request-Id:
+      - 18fc937d-846f-4357-8f3c-d02d9cd7b2d0
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192012Z:18fc937d-846f-4357-8f3c-d02d9cd7b2d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:11 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 4eddf450-f31f-4e3c-b4ad-00538825c958
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 6d72f074-1f14-4868-b492-c1b611196a03
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192012Z:6d72f074-1f14-4868-b492-c1b611196a03
+      Date:
+      - Wed, 28 Oct 2015 19:20:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
+      X-Ms-Correlation-Request-Id:
+      - 9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192013Z:9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:12 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 5e659ca3-957f-42f6-9930-f45c7cc54506
+      X-Ms-Correlation-Request-Id:
+      - 5e659ca3-957f-42f6-9930-f45c7cc54506
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192013Z:5e659ca3-957f-42f6-9930-f45c7cc54506
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:13 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - d0e1f5fe-54df-4f3b-9174-ba732db842b5
+      X-Ms-Correlation-Request-Id:
+      - d0e1f5fe-54df-4f3b-9174-ba732db842b5
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192014Z:d0e1f5fe-54df-4f3b-9174-ba732db842b5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:14 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - d81efe0d-cb24-47b8-b4de-2768074b780b
+      X-Ms-Correlation-Request-Id:
+      - d81efe0d-cb24-47b8-b4de-2768074b780b
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192014Z:d81efe0d-cb24-47b8-b4de-2768074b780b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:14 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
+      X-Ms-Correlation-Request-Id:
+      - 4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192015Z:4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:14 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 10a3e901-bd28-401f-883a-c03ec54edf7e
+      X-Ms-Correlation-Request-Id:
+      - 10a3e901-bd28-401f-883a-c03ec54edf7e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192015Z:10a3e901-bd28-401f-883a-c03ec54edf7e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:14 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
+      X-Ms-Correlation-Request-Id:
+      - 6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192015Z:6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:14 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
+      X-Ms-Correlation-Request-Id:
+      - 4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192016Z:4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:16 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 3d7b58af-f385-4b61-9800-52e40e2a2e07
+      X-Ms-Correlation-Request-Id:
+      - 3d7b58af-f385-4b61-9800-52e40e2a2e07
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192017Z:3d7b58af-f385-4b61-9800-52e40e2a2e07
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:16 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 279eb160-6369-4fbb-8db9-298fff91a944
+      X-Ms-Correlation-Request-Id:
+      - 279eb160-6369-4fbb-8db9-298fff91a944
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192017Z:279eb160-6369-4fbb-8db9-298fff91a944
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:17 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 8db03a4a-c23e-4955-8c05-b787153b1328
+      X-Ms-Correlation-Request-Id:
+      - 8db03a4a-c23e-4955-8c05-b787153b1328
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192018Z:8db03a4a-c23e-4955-8c05-b787153b1328
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:17 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:15 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB2E25:094B:A5CF74F:56311FF2
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 19:20:18 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2148-IAD
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 3dbc8e038a697beb934fb38f368ff32d57face5f
+      Expires:
+      - Wed, 28 Oct 2015 19:25:18 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - a539782d-ba5f-4cbd-af3b-6f074c543739
+      X-Ms-Correlation-Request-Id:
+      - a539782d-ba5f-4cbd-af3b-6f074c543739
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192019Z:a539782d-ba5f-4cbd-af3b-6f074c543739
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:19 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:16 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:0949:62C03EC:56311FF3
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 19:20:19 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1020-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 07ad8b362cf29292e885efe0b1040c05359b139f
+      Expires:
+      - Wed, 28 Oct 2015 19:25:19 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
+      X-Ms-Correlation-Request-Id:
+      - d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192020Z:d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:19 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:17 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C14:094B:A5CFB46:56311FF4
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 28 Oct 2015 19:20:20 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1032-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 8710dff6e0cb9293e9a1106f836d11134ed55c54
+      Expires:
+      - Wed, 28 Oct 2015 19:25:20 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 86c05366-2ab1-478e-a686-8e4c9082f5eb
+      X-Ms-Correlation-Request-Id:
+      - 86c05366-2ab1-478e-a686-8e4c9082f5eb
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192021Z:86c05366-2ab1-478e-a686-8e4c9082f5eb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:20 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 404c3a4e-d867-4c90-8b74-df04ebf31481
+      X-Ms-Correlation-Request-Id:
+      - 404c3a4e-d867-4c90-8b74-df04ebf31481
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192021Z:404c3a4e-d867-4c90-8b74-df04ebf31481
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:20 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 72ffc310-6d16-4d16-93a8-ff0e072688ff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 28c16864-cca0-4f9d-9671-96a26e3dd8aa
+      X-Ms-Routing-Request-Id:
+      - SOUTHCENTRALUS:20151028T192022Z:28c16864-cca0-4f9d-9671-96a26e3dd8aa
+      Date:
+      - Wed, 28 Oct 2015 19:20:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3ddd8696-427a-4c1e-b983-1c4c35b38429
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - b9b8dea5-6267-4785-a6a8-4a1887d2492f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192024Z:b9b8dea5-6267-4785-a6a8-4a1887d2492f
+      Date:
+      - Wed, 28 Oct 2015 19:20:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - d6a3171e-4469-45ff-83a3-46b1470afc74
+      X-Ms-Correlation-Request-Id:
+      - d6a3171e-4469-45ff-83a3-46b1470afc74
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192024Z:d6a3171e-4469-45ff-83a3-46b1470afc74
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:24 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 627de29f-edbb-4ab0-aec5-3d9961ef6a97
+      X-Ms-Correlation-Request-Id:
+      - 627de29f-edbb-4ab0-aec5-3d9961ef6a97
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192024Z:627de29f-edbb-4ab0-aec5-3d9961ef6a97
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:24 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b62b252d-3b0e-4cb7-a0a3-d5f3c41d231c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 5b410708-6933-41f6-969c-838a391831cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192024Z:5b410708-6933-41f6-969c-838a391831cd
+      Date:
+      - Wed, 28 Oct 2015 19:20:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 6819a21e-3101-492c-a58c-ddb6913a4d55
+      X-Ms-Correlation-Request-Id:
+      - 6819a21e-3101-492c-a58c-ddb6913a4d55
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192024Z:6819a21e-3101-492c-a58c-ddb6913a4d55
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:24 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 1c511bab-51ce-479d-a55d-e79e6171e74d
+      X-Ms-Correlation-Request-Id:
+      - 1c511bab-51ce-479d-a55d-e79e6171e74d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192025Z:1c511bab-51ce-479d-a55d-e79e6171e74d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:24 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 259ff1a4-b131-45a8-a320-fd4892dd2703
+      X-Ms-Correlation-Request-Id:
+      - 259ff1a4-b131-45a8-a320-fd4892dd2703
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192025Z:259ff1a4-b131-45a8-a320-fd4892dd2703
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:25 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - a478147a-8802-4dc0-a5a2-379804c8b63f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 9eaaaf16-f0b3-48a0-9990-c757d952cca6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192025Z:9eaaaf16-f0b3-48a0-9990-c757d952cca6
+      Date:
+      - Wed, 28 Oct 2015 19:20:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 74762d52-01f8-420a-9b43-eb84317ae228
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Correlation-Request-Id:
+      - 48dd719f-bc70-4dbc-91fe-65938e5b0083
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192025Z:48dd719f-bc70-4dbc-91fe-65938e5b0083
+      Date:
+      - Wed, 28 Oct 2015 19:20:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
+      X-Ms-Correlation-Request-Id:
+      - 0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:25 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
+      X-Ms-Correlation-Request-Id:
+      - 9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:25 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 82cc8d92-a6a4-4582-9a0d-13cfc9df160e
+      X-Ms-Correlation-Request-Id:
+      - 82cc8d92-a6a4-4582-9a0d-13cfc9df160e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:82cc8d92-a6a4-4582-9a0d-13cfc9df160e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
+      X-Ms-Correlation-Request-Id:
+      - a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 2e722996-ec0b-43ca-81ad-21b13e2ceffa
+      X-Ms-Correlation-Request-Id:
+      - 2e722996-ec0b-43ca-81ad-21b13e2ceffa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:2e722996-ec0b-43ca-81ad-21b13e2ceffa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 05fd7f93-3980-4f2e-b83a-9137ef36ac79
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Correlation-Request-Id:
+      - 0fda8738-bd13-46fb-8006-74186ec9564e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192026Z:0fda8738-bd13-46fb-8006-74186ec9564e
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - d0881d88-5f09-4787-a306-3fe1e0ddf639
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - df8eb603-0d46-4404-abb0-71be1c0e5e27
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192027Z:df8eb603-0d46-4404-abb0-71be1c0e5e27
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
+        3uw+fLS382jvwSc7O492dj4yjX+J/PJ9/PglDAKYvgWGShVLk4+WmUA9mefn
+        20SWmeszSk3vXTwbKNqsp9M8n+UeRDyOomfL86rzHaEZEtQHmw5BjFHm4NH+
+        g0f3H4wfPNzbv/fpbodCRBfzK1NJ//4+w/0of9fmS3QKFHTkdtSWYl8U07pq
+        qvN2fEaNL+ZtM/7JL54W2cWyatpi2rzO25awbrRTv4M+YR349yLoEDHfn5Ab
+        iXhw//7Ozs7DgIjCWFHMq6u8Rs/53VmelWU1pV/9rm6NNEmLD0EaCiF/4+SX
+        /D8Q7/cZYgQAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ca71de79-bd0e-4e90-a9a7-98ee7f9ae837"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2c2c8881-e7ee-4f9f-93f3-5069dc0256ee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 19f26e5e-f249-4f9a-8486-d7bd76fabab2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192027Z:19f26e5e-f249-4f9a-8486-d7bd76fabab2
+      Date:
+      - Wed, 28 Oct 2015 19:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PptmD3Vn+4OH2ZLZD
+        qOQPd7azh9mD7YcHef7g/GGWH9x78Pt+pC+21yse5y361TfKapphzHgrz5p2
+        bb4gjFZ53RbU8lHKVJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8Sc0sZdZC3b2D
+        Tyfn93fubWe7u9Pt/b37NJqd89n2+d6n93anB/m9vZ1d+3KxOqmW58XFumbE
+        0P335KvU4IHHzmmxmnJ7CwHP/7um9W53TPRBDOmvO+/yYHZ6UyYPvrrFxMlD
+        jYtLanL28ng2I2oA2ke7O+O98c54f7BpaTjpi7ydV0z9p9c0R8W0+8p6UhZT
+        esMCD1ClFj/kuesgRHNn3/vIx+yXhOMg9GjWCdOfY/Qvi7pdZ6X+6b9FGBCG
+        zd1Zfp6tyzYcjPvD/qq/fF/H+dFs2bzO25ZYJpgl+by+JHTo4++Z5vRFtlqV
+        RT57Gn4vXxvqfZQvs0lJHPOsqq+yekbQqdV5Vja5aUFIYyiv8+m6Ltprpga1
+        cQj8kCkcw8d7V+lqB6gT8kU2nRdLCNrPBuLfPn22/fLVl0+jiJ9Ui9W6zQ1r
+        KCb0Vhdl/KB/fsn/AyEK1kAmBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7de2ac93-6a64-4d84-9699-3224a9a72317
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 47b1759c-dfca-4a2f-b39c-f2ed936dd17f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192027Z:47b1759c-dfca-4a2f-b39c-f2ed936dd17f
+      Date:
+      - Wed, 28 Oct 2015 19:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - a5a6ae47-2b8d-4687-97cc-98882413f0c2
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - ef0ce38a-160f-4e05-b472-60b110119e12
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192027Z:ef0ce38a-160f-4e05-b472-60b110119e12
+      Date:
+      - Wed, 28 Oct 2015 19:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebR38MnOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBfVk17QV1vP80vXbdR2nmv49lA
+        v2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2CGCPOwaP9B4/uPxg/vHdvd2/v
+        XodIRBrzKxNK//4+w/1oUlXt0yK7WBJZiinw0DHTaJdNVeavp3WeL5t51T4p
+        q8lXdUFNPpq37ap5dPfudJ6fr+pqdn93b2c8oe/H06rOx1fFclZdNeNl3t5F
+        BzPXwfaKfoL+s+3z6fm92TSfbp9PDmbb+w/P728/nB1Mtye79/PZ9Pz8wc7+
+        9K4/XePbvDFuLMLjyWLFZFDeyN+19AURGMPUWdbR0reGQb4opnXVVOft+Iwa
+        X8zbZvyTX3gkep23Lc1Qw5AJNn4oMftM5MC/F/MMMc77M81mhnl4/9O9+w8C
+        hhFaxTD/8jW6ze+SBOd1VhY/CPq5NcakBHwI0nC415fVVV7j7fzuLM/KsprS
+        r1+3Yx+CNJTp+42TX/L/AFTL6L6yBQAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"38d208d0-9d86-4237-bb35-ef4462679cd1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d949fba7-860c-47ef-91a5-723e68614bf4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - ffe96d1c-51e9-42bf-8bc2-26087cb6aab4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192028Z:ffe96d1c-51e9-42bf-8bc2-26087cb6aab4
+      Date:
+      - Wed, 28 Oct 2015 19:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+6dzDb2zmY
+        7Ww/nB18ur2/d+/B9mRy7/52fr5PiH764OF0tvv7fqQvttcrHu0tutY3ymqa
+        Ydh4K8+adm2+oHGs8rotqOWjlGkpH14WDTUvlhev26zlzl6vp9M8n+UzeZOa
+        0YCEOGsh8G6W796b7E62Dw72H2zvP3ywvz15sH9/+34+mZ5Pdu5NJg8P7MvF
+        6qRanhcX65oRQ/ffk69SgwceO7PFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
+        6s2aPPjqFnMnDzUuLqnJ2cvj2YwGAWgf7e6M98Y7Y2VS83hNS8NMX+TtvOIJ
+        eHpN01RMu6+sJ2UxpTcs8ABVavFDnr4OQjR9L830Pc0vP/KR+yXhUAhDmntC
+        9ud4BJdF3a6zUv/03yIMCMPm7iw/z9ZlGw7G/WF/1V++r+P8aLZsXudtS1wT
+        TJR8Xl8SOvTx90xz+iJbrcoinz0Nv5evDfU+ypfZpCSmeVbVV1k9I+jU6jwr
+        m9y0IKQxlNf5dF0X7TVTg9o4BH7IFI7hE+UTO0adky+y6bxYQtx+NnD/9umz
+        7Zevvnwaxf2kWqzWbW64QzGJY40f9M8v+X8A4UjTXDgHAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b2462f03-929c-4c8a-9af2-43f79d17a1ff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 41521af2-cdee-4856-859c-b889cf9ab08d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192028Z:41521af2-cdee-4856-859c-b889cf9ab08d
+      Date:
+      - Wed, 28 Oct 2015 19:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 2a92e365-6a61-43b0-95af-b1a345e9390e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 20befc6c-5661-4522-914d-19cf787f0a5c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192028Z:20befc6c-5661-4522-914d-19cf787f0a5c
+      Date:
+      - Wed, 28 Oct 2015 19:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebT38JOdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBO5/l5k9eXeb3reo2Sznsbzwby
+        NevpNM9n+cxBxOPId7Y8rzrfEaIh9Xyw6RDEGG0OHu3vPbr/YLx77/7Bg4N7
+        HRoRZcyvTCf9+/sM96P8XZvTFNA0EFQduR21pdkXxbSumuq8HZ9R44t524x/
+        8ounRXaxrJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+PNi//2lIRGGt
+        KObVVV6j5/zuLM/KsprSr35Xt0aaRMOHIA2FkL9x8kv+H73RZbdPBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"247ea269-4b41-4c6b-83aa-993ff7d66184"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8a88ea55-878d-4b24-898d-a6d9ff68a4e0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 6e70719b-a8b9-4f3a-ab15-f79701032ecf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192028Z:6e70719b-a8b9-4f3a-ab15-f79701032ecf
+      Date:
+      - Wed, 28 Oct 2015 19:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9aG//QZ7t
+        ffpwe3+yv7u9P/10sn1wL8u2Hz68d37+YPbpp7sH+7/vR/pie73iwd6iZ32j
+        rKYZho238qxp1+YLGsYqr9uCWj5KmZTy4WXRUPNiefG6zVru7PV6Os3zWT6T
+        N6mZJc5aCDzJd2d7s/3JdnZvb0pjONjdnpzvzLZ37z349N7DB9nebJLbl4vV
+        SbU8Ly7WNSOG7r8nX6UGDzx2YovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
+        mzV58NUt5k4ealxcUpOzl8ezGREE0D7a3Rnjv/uDTUvDTF/k7bziCXh6TdNU
+        TDuv0KwQvej7AEP64oc9a5dF3a6zUv8MXiMcCMfm7iw/z9Zl+5GP6S9xf9hf
+        9Zfv60g/mi2b13nbErFBPDtQ+RxcgY+/Z5rTF9lqVRb57Gn4vXz9S7TZR/ky
+        m5RE62dVfZXVM4JOrc6zsslNC0IaY3mdT9d10V4zPaiNQ+CHTeMYQtTu7Cf0
+        /V0lrR2jTsoX2XReLMGlP3zc9WvDH4pKINMGa/ygf37J/wNnM0HUbgYAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - bc0f3de1-7b91-4faa-a7b6-3cf44fcc23e3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 43ee9939-7f7c-4f7e-b9fa-c54003caca11
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192029Z:43ee9939-7f7c-4f7e-b9fa-c54003caca11
+      Date:
+      - Wed, 28 Oct 2015 19:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebT38JOdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKCevnrpeouSzHsLzwayNevpNM9n
+        +cxBxOPIdrY8rzrfEYIh1Xyw6RDEGE0OHu3vPbr/YLx77/7Bg4N7HdoQRcyv
+        TB/9+/sM96P8XZsT6Yn8BFVHbkdtafVFMa2rpjpvx2fU+GLeNuOf/OJpkV0s
+        q6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5mYgPD/bvfxoSUVgqhvmXr9Ft
+        fpeYOa+zsvhB0M+tMSZ58CFIw+FeX1ZXeY2387uzPCvLakq/ft2OfQjSUKbv
+        N05+yf8DyUVI6r0EAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f7ccf557-25a8-4f64-be21-7ac0d5327419"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9ebd16f3-99b9-4b72-be42-253401cbcb2e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - fb100e86-e628-4e71-943e-bf939b9dbb4e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192029Z:fb100e86-e628-4e71-943e-bf939b9dbb4e
+      Date:
+      - Wed, 28 Oct 2015 19:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350/mA6Pb9//8H23v3s
+        YHv//NP97Um+t7v9IJvuzO7f23uwv/vw9/1IX2yvVzy4W/Sob5TVNMNw8Vae
+        Ne3afEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWw
+        n2a7n84ezA627z/Mz4mS57Pth1Mazf2dyaf3Z59OJ3m2Y18uVifV8ry4WNeM
+        GLr/nnyVGjzw2IksVlNuv2sg4Pl/zYze7Q6HPojh+3WnXB5MTG+25MFXt5gz
+        eahxcUlNzl4ez2ZECED7aHdnjP8OBpuWhom+yNt5xYR/ek3TU0y7r6wnZTGl
+        NyzwAFVq8cOetg5GNG2nr15+5CP1S8IhEGY01YTkzzXml0XdrrNS/wxeIxwI
+        x+buLD/P1mUbDsf9YX/VX76vI/1otmxe521L/BJMkXxeXxI+9PH3THP6Ilut
+        yiKfPQ2/l68N/T7Kl9mkJHZ5VtVXWT0j6NTqPCub3LQgpDGW1/l0XRftNdOD
+        2jgEftg0jiHkc4gdm07GF9l0XiwhYD98nPVrwxeKSoAtftA/v+T/ASRleqgJ
+        BwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e5679fcd-fc76-41fe-aff7-9f89e7ee791e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 3c86052a-1058-4b46-99e1-f840fa6e4c52
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192029Z:3c86052a-1058-4b46-99e1-f840fa6e4c52
+      Date:
+      - Wed, 28 Oct 2015 19:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 5731b4db-fb89-4ea0-95e8-e075481a4bd4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - a10ad762-ae99-4470-aa41-6296136a7963
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192029Z:a10ad762-ae99-4470-aa41-6296136a7963
+      Date:
+      - Wed, 28 Oct 2015 19:20:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv55OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
+        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQYwR5eDR/t6j+w/Gu/fuHzw4uNchDpHE
+        /MoE0r+/z3A/yt+1OdGe6E9QdeR21I5YxbSumuq8HZ9R44t524x/8ounRXax
+        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+PNi//2lIROGpKObVVV6j
+        5/zuLM/KsprSr35Xt0aaZMKHIA2FkL9x8kv+H5OriBFIBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"6ef9c26a-a4df-4c03-a614-750d7bc8a473"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ce79fbd7-f427-4364-87ba-a5df86dcab07
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 0a7ba324-bb1b-4399-bc3a-dd297e0f6832
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192029Z:0a7ba324-bb1b-4399-bc3a-dd297e0f6832
+      Date:
+      - Wed, 28 Oct 2015 19:20:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P/o0P3843fs02872
+        Z+fb+9Ode9vZp7v72w/u78weTKYH2f6De7/vR/pie73i4d2iS32jrKYZxou3
+        8qxp1+YLwn+V121BLR+lTDz58LJoqHmxvHjdZi139no9neb5LJ/Jm9TMUmUt
+        lN2f5g/u7e/f357uTO9v7+f5OY3h4Hz7YTb7NM+z6YP9vfv25WJ1Ui3Pi4t1
+        zYih++/JV6nBA4+dymI15fa7BgKe//dM6d3ueOiDGMJfd87lwcz0pksefHWL
+        SZOHGheX1OTs5fFsRpQAtI92d8b47+Fg09Jw0Rd5O6+Y8k+vaX6KafeV9aQs
+        pvSGBR6gSi1+2PPWwYjm7Yuzn9j7yMfql4RjINRosgnLn2vUL4u6XWel/hm8
+        RjgQjs3dWX6ercs2HI77w/6qv3xfR/rRbNm8ztuWGCaYI/m8viR86OPvmeb0
+        RbZalUU+exp+L18b+n2UL7NJSfzyrKqvsnpG0KnVeVY2uWlBSGMsr/Ppui7a
+        a6YHtXEI/LBpHEOI2jkWsYPT2fgim86LJUTsh4+0fm0YQ1GhFh66+EH//JL/
+        B8+evnUPBwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ce1e24b9-5d49-41ed-818f-2138db28cceb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 621b3982-e25c-402c-97b7-fe10304e4be1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192030Z:621b3982-e25c-402c-97b7-fe10304e4be1
+      Date:
+      - Wed, 28 Oct 2015 19:20:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - d16eb53c-76c0-4938-9461-ad545cac6e53
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 6aa61197-5725-4bef-a5d8-1e2792bfaec1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192030Z:6aa61197-5725-4bef-a5d8-1e2792bfaec1
+      Date:
+      - Wed, 28 Oct 2015 19:20:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdh8+2tt5dG/nk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoH5x
+        9hMn1WK1bvNd12uUdN7beDaQr1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcg
+        xmhz8Gh/79H9T8cHe/fuPbj/aYdGRBnzK9OJ/laQdnSWNrOszQivtz+iDP8g
+        qF3K7Llef35RBj++z3A/yt+1OYktiS5B1ZHbUVuKfVFM66qpztvxGTW+mLfN
+        +Ce/eFpkF8uqaYtp8zpvW8K60U79DvqEdeDfi6BDxHx/Qm4m4sH9h7v7+wER
+        +6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTn0I0lAI+Rsnv+T/ASYOzmpIBgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"c51ddd06-f101-4157-b885-7dd2bcf04fe1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 741141e9-1b22-44bc-86c1-378d9c0c9dae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 18cee187-73d3-4453-95ef-6b18259c89d7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192030Z:18cee187-73d3-4453-95ef-6b18259c89d7
+      Date:
+      - Wed, 28 Oct 2015 19:20:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR9P71ONs59Pt
+        892d3e393fsPticHB/e3H8xme5Pp+c7+eb77+36kL7bXKx7sLXrWN8pqmmHY
+        eCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlni
+        rIXAew8ne7N7e9PtBw/y/e3982m+Pdn79NPtB5PsIHtwfvDp3u6OfblYnVTL
+        8+JiXTNi6P578lVq8MBjJ7ZYTbn9roGA5/91M3u3Oyz6IIb31516eTBBvVmT
+        B1/dYu7kocbFJTU5e3k8mxFBAO2j3Z0x/tsfbFoaZvoib+cVT8DTa5qmYtp9
+        ZT0piym9YYEHqFKLH/b0dTCi6fvi7Cf03d2PfOR+STgUwpCmnpD9uR7BZVG3
+        66zUP4PXCAfCsbk7y8+zddmGw3F/2F/1l+/rSD+aLZvXedsS3wRTJZ/Xl4QP
+        ffw905y+yFarsshnT8Pv5WtDv4/yZTYpiW2eVfVVVs8IOrU6z8omNy0IaYzl
+        dT5d10V7zfSgNg6BHzaNYwhRux6n2DHqpHyRTefFEgL3w8ddvzb8oahQiz7W
+        +EH//JL/B69px505BwAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 35e91023-0702-43fb-aec4-749da8a7ba21
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - e6089dad-7d11-480d-9dc0-e3740eaf7186
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192031Z:e6089dad-7d11-480d-9dc0-e3740eaf7186
+      Date:
+      - Wed, 28 Oct 2015 19:20:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - c065ffe4-3d2f-4a70-be73-9c215f697c19
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 4b56ce3e-55be-4418-9e4b-54c13b3f832d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192031Z:4b56ce3e-55be-4418-9e4b-54c13b3f832d
+      Date:
+      - Wed, 28 Oct 2015 19:20:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv95OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
+        PnMQ8TjKnS3Pq853hEBIOB9sOgQxRpaDR/sPHt0/GO8+PPj04NP9DnmIKOZX
+        JpH+/X2G+9GkqtqnRXaxrJq2mAIPHTONdtlUZf56Wuf5splX7ZOymnxVF9Tk
+        o3nbrppHd+82q3y627RVTVO7O55Qg/G0qvPxVbGcVVfNeJm3d9HDzPWwjXcu
+        Fzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94vscdbP/kFzvj
+        27QeNxbX8WSxYgooQ/SnV4dJ373XtA5N6ftP58ap3Pt0d/fg/kEwlTKUKObV
+        VV6j5/zuLM/KsprSr35Xt0aaZNOHIA2FX37j5Jf8P4V9/T3QBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fa097d6d-7d5b-4b92-bc68-57b082cb2ddb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cae137d3-9fb5-4b67-8010-fb61ef519b54
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - ca4b705e-28c0-4286-8b66-aec04876d906
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192031Z:ca4b705e-28c0-4286-8b66-aec04876d906
+      Date:
+      - Wed, 28 Oct 2015 19:20:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9F5tvPwwezT2faD
+        2f3J9v7k4d72ZPrpwfb9B5Odg73pZG82m/y+H+mL7fWKh3iLTvWNsppmGDHe
+        yrOmXZsvaASrvG4LavkoZQLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmli5r
+        oe39g4fT3Z0H+0TH2e72/v3JZPvh3sGD7Un24PzTT6f7D4me9uVidVItz4uL
+        dc2IofvvyVepwQOPnc5iNeX2uwYCnv83Terd7ojogxjKX3fW5cHc9CZMHnx1
+        i2mThxoXl9Tk7OXxbEa0ALSPdnfG+O/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
+        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
+        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
+        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sbORDO4P
+        +7n+Yij00WzZvM7bluQQtLCDl8/rS8KAPv6eaU5fZKtVWeSzp+H38rXhxY/y
+        ZTYpSQyfVfVVVs8IOrU6z8omNy2U27/IpvNiCfF3XX9z9P7yi5dfvTn9yS9e
+        R+mt02EET1FRijvSMsXon1/y/wC5wvXTtQcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 97078b7d-a440-4c4a-805f-a125a1ccec4b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - edece6f3-9e79-4bf7-95db-3866e0de79b0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192032Z:edece6f3-9e79-4bf7-95db-3866e0de79b0
+      Date:
+      - Wed, 28 Oct 2015 19:20:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv75OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
+        PnMQ8TjKnS3Pq853hEBIOB9sOgQxRpaDR/sPHt0/GO9/un/v0wefdshDRDG/
+        Mon07+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAm
+        H83bdtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6Hbbxz
+        udjd3pncz/ay/fPt3dmnD7b3d2f5dra7N92+tzvbebD76cO9T/eIsNR4+ye/
+        2B3fpvW4sbiOJ4sVU0AZoj+9Okz67r2mdWhK3386N07l/b1PD/Y/fRBMpQwl
+        inl1ldfoOb87y7OyrKb0q9/VrZEm2fQhSEPhl984+SX/D9+VFjTQBAAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"be771397-222d-49f3-9642-356d4cf379c4"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 99757a3b-e901-4412-89c0-80b16b0c697f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - e84b0d0c-7b5f-4b5e-8164-8458355d22ce
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192032Z:e84b0d0c-7b5f-4b5e-8164-8458355d22ce
+      Date:
+      - Wed, 28 Oct 2015 19:20:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Ekf/Bg997DB9t7
+        e3uz7f2H5/e2H366v7d97/6ns/3p+b0HD6f7v+9H+mJ7veIh3qJTfaOsphlG
+        jLfyrGnX5gsawSqv24JaPkqZgPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qZml
+        y1po+2Bndn/n/v09GsP57vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8
+        Ly7WNSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTB
+        V7eYNnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/Q
+        hBCp6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMp
+        q2z2JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/V
+        AeGPkAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/
+        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
+        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
+        OkpvnQ4jeIqKUtyRlilG//yS/wcM2vgRtQcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
+      X-Ms-Request-Id:
+      - 555719d7-caa5-4622-be86-668e468b1f78
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 018677d2-c277-40eb-b3b2-f1a12bf1ec6e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192032Z:018677d2-c277-40eb-b3b2-f1a12bf1ec6e
+      Date:
+      - Wed, 28 Oct 2015 19:20:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        ewdvdh8+2tt5dO/eJzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQH2d
+        lXlzXtXT/KvXrtso7bzX8WygX7OeTvN8ls8cRDyOfmfL86rzHWEaks8Hmw5B
+        jBHn4NH+g0f3D8a79z7d293f6xCJSGN+ZULp399nuB9Nqqp9WmQXy6ppiynw
+        0DHTaJdNVeavp3WeL5t51T4pq8lXdUFNPpq37ap5dPfu8rq+eLh7sD+e0Hfj
+        aVXn46tiOauumvEyb+8C+MwB324M7bens/Od7PzBw+17O/uz7f3Zg3vbD6fT
+        +9sH9+/vTnYfzqb5zoO7/lSNb/PGuLHIjieLFZNA+SJ/19IXRFwMUWdYR0rf
+        Gub4opjWVVOdt+Mzanwxb5vxT37hked13rY0Ow1DJtj4oYTsM5AD/16MM8Q0
+        788wm5nl4cGnB5/uB8witIpiXl3lNXrO787yrCyrKf3qd3VrpEkH+BCkoRDy
+        N05+yf8D0SkFR/0EAAA=
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"c180393e-bd19-4c48-9fe2-00f5478c7ceb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4361650a-e4f9-45ec-bcbe-1120102dfc57
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - e0d7f496-2c04-443b-951f-af9bc76bf397
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192033Z:e0d7f496-2c04-443b-951f-af9bc76bf397
+      Date:
+      - Wed, 28 Oct 2015 19:20:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aLp7sHPv4b18ezLb
+        fbi9P90/IDzyve2dnfP7+w8Opg+m+eT3/UhfbK9XPMxb9KxvlNU0w4DxVp41
+        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
+        2V4+vf8w257du3+wvT/bn21nu7u729Pd/N6DezufTh5O9uzLxeqkWp4XF+ua
+        EUP335OvUoMHHjulxWrK7XcNBDz/L5rTu90B0QcxjL/upMuDqenNlzz46haz
+        Jg81Li6pydnL49mMSAFoH+3ujPfGO+NPB5uWho2+yNt5xaR/ek0TVEy7r6wn
+        ZTGlNyzwAFVq8cObuA4uNHGv7cR99frs5Uc+Zr8kHAehR/NOmP6soX8yz8+3
+        X9bVbOMYLou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuW
+        WCaYJfm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSRzzrKqvsnpG0KnV
+        eVY2uWlBSGMor/Ppui7aa6YGtXEIfHMUrhardZv/5BfNRhLHEKJ2Zz+h7+8q
+        ae0YdU6+yKbzYglZ+1nAfZC5FSnDGIpEyNoGYfygf37J/wNfMGMiIwcAAA==
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ff5ef9fb-9254-4c81-90d1-404a715ffe1f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Correlation-Request-Id:
+      - 55278b13-b6e2-4250-9cb0-e246747509e4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151028T192033Z:55278b13-b6e2-4250-9cb0-e246747509e4
+      Date:
+      - Wed, 28 Oct 2015 19:20:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Wed, 28 Oct 2015 19:20:30 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
@@ -1,0 +1,12121 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - 7df5e2d0-4c0c-4d5d-aad1-9ee09794b6d0
+      Client-Request-Id:
+      - 4a6db227-a83d-4889-8ab4-b68f76e3a251
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_174
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 30 Oct 2015 13:50:11 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446216610","not_before":"1446212710","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg"}'
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 766f4380-117b-4eac-a215-f2a2b7013029
+      X-Ms-Correlation-Request-Id:
+      - 766f4380-117b-4eac-a215-f2a2b7013029
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135011Z:766f4380-117b-4eac-a215-f2a2b7013029
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
+      X-Ms-Correlation-Request-Id:
+      - a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135011Z:a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdaXj//od7I9K/h5o1
+        8DZ2wt0MaGAialUXP+Be6G0fGfTRQ6+uyvy4aYqLJQhyWxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyWpLqD0/3Z8p2VG1J0ezxaEMuSh
+        rXp+7BDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUGKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjVzqkVwg9juNgiDdtH/iA0iRus5Gbb
+        BYaxpOCx3ziMu/V6OamqHqv/f3Y8Qfbm/5ujIhwG0O+hccs+uJe4HDzJ2il8
+        LR8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8fykhQUYNGWYOi/BfDpnkMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pI8RDddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lDXLnmdv8yFJfs+ON/bVkCNKec+fg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4zz
+        gT4GANzDaZGtKHOPpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnAgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRZp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b1VnwIk59FtGgW30/hfEO4
+        xHBhhj3hcM0lKr42WoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
+        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
+        TYxE/9tEXXr1Ylk15O++ztuW7GuPvEDEo4oSTohgsOOv5SNLCcbU/tUZPX/J
+        bwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSGipf5gxvqXzeQ
+        lwk8YAFmkAqf+Hi9Nx2UQDsvSvquQ36DIRMDYwl+G5oLQT34iIfGv0l7OzX8
+        hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIYTosqje7my9mq
+        KshlJ8g/otatqXWX1n0uCnr5R1R7H6pNCW61mFGq8ke020g7wlDcE/o8Emz6
+        tPpg2Hd1ovTPH2JXljP075/DrlWg9a+fS0R8GdHPvkl0buOPf1AHdrzfKNr5
+        7CJfVrONVv0GoAx2wLOQhWMK7VfrFrrB7x2QevjI/ICOPYygB4wasSrAfMBf
+        Eq72N9ZrUC30O/0mGssblMIIPwr+kFesWmNY9i9RXejL/oEG9MfX0WMGGfHk
+        HB7mb4C2fwAOYZjupVuvW0oOIkEkuJrX6Evz1cDcSSrLxDc8kfwHOYvBH1jm
+        oSmmCe7ME7P7UztZG5j+ZwsDj1PuNmXVl2amk7IHkxekNh/wlzzN+tuP+IW/
+        +qHN1t26Ih+GXvzRnMnfAG3/ABzC8P+Vc3ZjviOKD3VE//s6HX0w+MuibtdZ
+        +QUlOmnppAtOaK0sxlOE6TIf8JfMKvrbj3iOv4pOwu15jv7n/hhkwCmNn21K
+        0Zu1r9l/rJfoOvXXhG/+GBxShxd/vme3+HfLgaZj8zc6sn8ADqH0AexJ80L/
+        u928iOoZ1nEGHfpYf/vRtCjtzZDNa/Sl+eobmpbeZHQ7pO9lCMFHiqr7jaeM
+        R8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB/dGZbUd7bew+4CbokT7l3y29
+        DZLmb4C2fwAOof+zNBk0vHgEGoV0e2VJ/3N/DGpO/89vCIHbxK4v8vaqqrEG
+        HCIQiV2VWfWNLo4yOcpAPKeYX/MBf+kYj6Yp5M3uLNJHDCP8KPhDXrFsybDs
+        X8KX6Mv+gQb0x/8HmDQ6meaPTQxEa//57Gz1o6n5f9nUvI8LFoIM/hiEf5G1
+        +VV2/Xq9WtFo8tlTWuCekhD/rHVIM/leqjIEG/xB/3N/aIfc5Ua19bqtapol
+        etHHDB32cKW0KJoeT6fVmhYT6BUfYeEJFQVmJbCV+YC/ZJbW3362ZOMm2fj/
+        vGzQ/3a3J3mLrtwn9g+deJr2zuz9bIsOJ/qUm5RF3j/ZF/YV/DHYcYct70J5
+        R4RWJolZ0M0D/SEzG3wkuhTzaP/Ay/QHPjMszS+CPcwHjnPQLPjAtqVP+XfL
+        LaZj8zc6sn8AjqCkv7HUdJnJfmQtAwOxfwUcHyU8kZf+937kVRd7OPL5pnv6
+        xuEL2J/FAUgHHwz2/bMboeTwHzHAs6LpeZ8fBrFY0Pi/WZBVc/azAPTnzuze
+        fokr89QnJX26qBqdQB/rb6wdWPb504iGCD5ihRB+JK2s5mBY9i/uRXUdvwuF
+        Zj4QNYkm9g+8TX84Lajfug8sFPr0Zi3F07B7n9rKH/S/3e1VTS5afkVEJ5J3
+        CKhxlkkK0Is/ot8H0O9u/q7NlwLxR6T8MFKSff9a6VwMhH6n3yLECj5i7MOP
+        pJUlIsOyf3EvSkF+F8QwHwgV0cT+gbfpD0dB/dZ9YKHQpzeTlLQn/Q/a82bq
+        iWEdttwyGB6z/vYj4inxXk+zMiee+3lPMhLZDxFhS8cfaUUZrFDxmyFp+PmP
+        6PpN0XUpGeezZZvX5+SZ/oiy3xRlw89/ROkPp7SjVki5bxj6XSJPPBQUkjFl
+        9bcfTdEQES8Xr4sf/IjJiWJfl4LrJpLkkAHxuPW3HxFwiICr9aQsmjnBo7ft
+        x4ALnGTs+tuPiBgSkdCOq8CvA547iOe+nmZtdlItl/kUA/GRAOweWlNpSl1/
+        kS1JOvozC8phQobwPAhRI8Q6XThoP2uQnYF5lTfrsh94fXBXvPLygii+Yb3l
+        fXvhfoZn8Vk2pVw3OvFxAbgedjPbvJ++tlj1JAoiIF/obyyz0iiQRIZgXwuE
+        oyPZ/GH4ssgferB/AB79gc+MyPKLkD75YICCuztEQWrNf+w89P8Abe0fD+gP
+        S2jzIf2v/yGSyeGH+9u7e7EP0XX3w+GEQDAjXzsTFZkL+chOBkjp/upMDX/J
+        bwUg+OsQqswLurZ/4GX6A5/JnOiLN0wSUYT+dxuifM0EkxAgwF4+slQA5u6v
+        /5fThBWLJ+436JgofOJj+l+HO/kT+p/5cLDz4x+s6/yDMWD5oKb442dBNGPY
+        O3a6fk0jWWA6/t+JKXGimKcuj/9cochIDpue59lbiI4/CiDXGxdmAG3Naiy9
+        449OBIXlNjpQ1aqED2HTAe3ghDC/PiDnJFCLiJNwA2SGvZlkx8usvCYlD8jU
+        h8UCwHp4ZV+PZsoc3lwSWgOg75r5eU0y8nUn6b067KzO/xC7ukuebJtRXqjv
+        wf5wer1LkVH7OmveVG8pVf2zgIODF8L+cIBfSzJu04OF+zUhMszNMsesTdD9
+        ngGwh4uZQmrrY/JNzIwBffe8qPOrrCxfrUtC4pvvyMELYX84wP9PsgC1kayv
+        3ydA9bAg9+Dm8E0niD7uOJT8xbB7R+b1gIJ1D2lCuYPAWdV+ez0Brj9LXXKn
+        g3R6Q47r82xCgH28AK2HKVGnh2bHyVX0GG+4xN5vkQHo78z5xpHGJ/YPvDg4
+        zPvbez470CA7+OZLWheolgty3f8/hTd1916CEUI0fh39D85JH7yD+DWgbwTo
+        VEUXtiEYfay/MelAJ/rd/BYldW+mhMRoYv/A27elN49gQByq6Rrc8vQJQfYH
+        CWi9YcOFmmSNtfj0TjBkICWD60gwf2H/wkCkGf+mg+yN2qUj0Sz4wLalT02c
+        erakzAL9zd/pX0MEogj0gJrSH/Qb/S/ONp3hQmX+/33IhO0AO/N4eAT/Hxwo
+        D3VIAhbks77KL8hjlaHTyz5VALpHpxm/1SPSRVlNsnITai5eRWKNUCPEOrDb
+        avU8v8xLwexnpw/2AaSDTV7AN9IXYgHp6lU+rRakbkiwGNDPRm+XxEQEPzc9
+        unk9W55X9YJ/JTDffM8XOYU+1PPrpnqV/6I1iQW98813Q3JGvfCbHw6eOxgQ
+        jGv6nOL357cL4ctps6qrn6b1EzQP8OpkHSHxRg/w76wuxKzhb/sHNAv9IfrG
+        qAJuLB9ZpcOQwxZ41zXgv/hzbgrtYjAI3kL39Btb6i9eP3vDKNAH5k/9PvhT
+        4fAHHbycUkPL4AOLx+B00f92t7NyNQd0+Qgz2PnoXv8jTC1Z/+KSeNE4AZ3v
+        Ih9O8rYDQqAyhwzPNYJ+LJpV/VTDj6adWwYfWDz+Pz/tZbWezfJVWV2TQv+R
+        zNtu3VyjZfCBxeP/i5NPoxswOz+aam4ZfGDxGJxqJreZlY2G+PSSxkAJE+rA
+        nxPA6s2ShdCbJYfbBmTj9HK/MeUc0YQewSsMK/yI31Uy8tfoynzQYR7hDLxh
+        /0B39If0ZWmPT81fURKT3PBaERO2QyX2fjmcA6k2OMBRyDR5buFpUzeEW1xk
+        3gcsA7bTSlAdYzzLs5aWKwGd/rU9A2APl3PX9kZMqHNg4nEnoUDv+vDIEFwW
+        M3rv6wFkkP6oyNPUUVHIU1zM2aL4fQJWDwsKJ1bVkpgNrX00fD6OokTUpv85
+        agM/+wf9D6QnFDv9XeWTlhjvh9QbxRB1QQP/JjqLwc/KvG7rWHqepYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP5nSNYh2bqtmikRrsnbtlhe3Ew5gimjtLTC2N1fwNwQijEE
+        0uYDIRaa2D/wNv0hMANq8NvhR3iTfvt/A+Uoo7FsW/q9S7LbgN3Fkr35Q76J
+        9eHAhl0YOnzgECxIl/V99T4LRAL5xm4s8K8F9lP/D/pfvA/wMaVC8tnpuxVx
+        0usfcXOUmPS/OP0oAXmxrJq2mP48JJ3pQfKwDqD5G5jpH0NUfjBE2EXe1sX0
+        aX5eLAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+
+        yYwMAcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZh
+        fwyWf5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6T
+        T+v8R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XVbsYeVSPIkf47AA5
+        xqID1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdr
+        ZeyAC4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGw
+        s8/z+r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jq
+        t3m7KunzL2vKkpCDSFB8pNBXD83sos7zaDqdCRPOJCiN34aGwALMOHZ6eW9i
+        KCSGFR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8
+        wfAClsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fH
+        sxl90xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJ
+        lVNf59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/
+        RNtvhLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhH
+        wpCcP4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsf
+        Ci7rJrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT
+        +xc3U71hhdZ8IG8GioLbhB/pH/IHw/v/miLxKfs6ry+Laf6yri4LSmh1Kfyz
+        iMVs2fygWva4+KOLsppk5eD46X/7t4J79/hnDzI9P2vAT14cf3H6swb95ZtX
+        P2uwv/i9f9ZAv/m93/yswX796ie/adgkzefnxXSRLUlP16u6Oi8iYeYNvexv
+        7x1s7GUKi/RGuvpCurrBOL1nl9zpQGa4agvqliF/ez3B2HzsALOHr4WE1gFa
+        TgFu0Ihx1et+YyUMjUu/02+30+b8rup//hpdmQ86elt0Ot6wf6A7+kP6slYG
+        n5q/oqTe3955SPqRSEwEHqTS3WWfyD8i2wDZWBjA/ky7TTLgiKQ4uQ8YZQyF
+        Pu2P1//t/ydUo5fijp1HFMXBfcAoAnX6tD8+/7f/T1KJ6WSlkIjktN6XhlxZ
+        ebZsios5u6Q+TQGuR2VkbRgYWgdUBuYy6hsRJPV8b3tvh5rSH+Rg7dJatP1j
+        h/5HqBPina6btqrJMCi2J9XyvLjoYhHtbhPQsli+fZPVFzkP3wdlBxSF2R3C
+        YAdEBKFzF34ULEFiYmycOoocuQdA9HsDkF7/DSnbaV2spNtboEAj26X/UVP6
+        g1iJ/rfZ+w16uEsewnu53x/Sl6UttXqPWPr9ujR/xhcsbi/u/KVr9jU1irRS
+        4dLX7V+iNQDe/oEG9EdH18QVoPtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJdWQO
+        Sf6z0VebXbCo0fvffFdQMT87kGnWhf/fC/xG3fKanI/Zusxrguj3BiC9/n+6
+        mkyrshzIOQurGkZh7hUeCj6SVpaFmeXsX+BDIz/8LjjVfMBNGQY3498Cppc/
+        8CX90ZGAAAc0od9YIHtC4D7gd4EBfcq/K/c7aOZvIKB/RKeCZvaApuLrTa6S
+        zPTJIxB0go+klSUlo2T/wtgMHfldDMt8wE0ZBjfj34SW+Mb+gS/pj/+XE5ZJ
+        O8DreVZPgbNPeUDqzUXDLTXB1JsPRsofL/22kfo8RozXUJzf09/lTTNwBsbt
+        w49kCgCW/nCUBCD6YGBONhCOlMPB9u5Daix/7FH4LH8QSR9s39vdfmlJSgTt
+        0IeUxpRW9pk8CFw2xCxDvX+NDr9mTzzOGFCanLjEbYTEONMfPIAb+I0J9GQN
+        +H7fANnDxsJAax+b/nS7D3jGwVn0qZl15he0DH5jmQT/0O/02+24jt9VPuWv
+        0ZX5oMN0wqF4w/6B7ugP6ctKAz41f0UpTQyh8QyRtkMlywhMqq/FDQSZ53BT
+        N4Tb+7IGQeqAZcB2Wgmqxxq/qKTWfqeAdXs0hIg8R0z/yLTplAdfyEwEH2lb
+        85vOLQP1JzuYUPkD7ekPganzGc5uj0cc4+rL7gNugh7pU4Og6C+Faf7ghvpX
+        dDZoAuh/ziaYWaH/YVZoTjpUdoT9EZH1D26of33DRL47pYGxyBbE9D+iuP7B
+        DfWvb4biVlVu0JKCA9NJEDA48kcYDf32I4LfjuAN2XsCQQ1/RGL+gxvqX98o
+        ie/OsjabZM3/PxUIkeFnldjvS2z8JD/2y8lPI/K//BHRfxgcns0WxbIAQpQG
+        /xHF7R/cUP/6WaS4XS6h5Hsk1Sw4Md0EIYMzf4TR0W8/moD3mwD6mCifTcr8
+        KaG/ymdPf6Tl6W+Gaf7ghvrXN039aUW/MPl/RHf6m2GaP7ih/vXN0r1YrGgs
+        1P5HlOY/uKH+9bNB6dN3+PdH+p0QFCIrTPMHN9S/vln6E8o/orkQVmGaP7ih
+        /vXN0vy8qPOrrCxrWuP7EcHtH9xQ//pmCW4i09f5dF1TwuVlVRbTH2W6CKb5
+        gxvqXz+7tP8ib+ti+iPS2z+4of71zZI+W88oobu8+BG7098M0/zBDfWvb5bm
+        8NgXi3w5y2enJWFSTF9WVfkj0ts/uKH+9c2S3miaHzE+PlUSK0zzBzfUv362
+        qD+tlkskJavlj+hPfzNM8wc31L9+tujf/MjSKoUVpvmDG+pfP1vEx29fZM3b
+        H2kfUFlhmj+4of71Q5yAuz8KtBim+YMb6l/f7DSYj1c/8nkA0/zBDfWvb5bg
+        ufiYP6I3wzR/cEP965ul97rJLn6kSn4YlIYeF42+YD/maX5OK4FC8v8fkp/G
+        9P9q8v+I6PYPbqh/fbNE97X5j+hOfzNM8wc31L9+1uk++5G64c4ZpvmDG+pf
+        3+wMOHXTVqufWOc1ue309o/ozn9wQ/3rZ5/ud38R/bx+k78DXj+aAf6DG+pf
+        X2cGeA6W2SJvVtkUE/BFMa2rpjpvx6/bqiankt7w5whw+7MmTY+n02q97K/V
+        YngeVXUu7O/p1uuW3r5Dn/HYuCX/ZinHbZX4PGTQxnwQTID8gbfpD5kNQ0CG
+        y2+HHwV/yCu2468zZdF5uL+98+n27n16Rf6g/7lJ4Vno0JT6lwXwLjm/GfDR
+        gOGbAT2d59O3L4inji+zoswmRUlJP3r9m++pw3d3oT2KaW9Ywj48vWAM+U0/
+        67OfnfsOK/ALynJ2ss0HwnZoYv8AMPpDoAQ8xm+HH+FN+o0FI/jCMRiaBB8w
+        GCBBnwZ8GiUuCTz9DzJ/ezqqz7EhxAFSgiiGK7/pZz8PKcu0HdKmdZ4tjpdZ
+        eU0eHejozwFARWYFr1C+8KerCV4ICB8MBQTpkFNHLDSyXwn90ID+4Lf4fR4c
+        xmuIzh9E6KhfCxi8T39IF/22/JujKT4LPuA+0Cl9GhDZzdMGu3Z/e3cHRDe6
+        4qH/x6f+H/Q/9wdPlPnjHv1h9Qt/SF/T/zCVNJGd6XDk70wF6OBIbHDn4WPQ
+        9NuPpkL+oP+5P5jQ5o9gKjZSn7zAqs26k/BzhxjR0EnpXSLSxbJC0PY6b7HU
+        20XUmxD9zWMOQ2z+Wj6y/IIpdn9tnCVtzFDMN/wHNw97Ef4BKvYPvEx/4DPD
+        ZfwiGMR84HgHzYIPbNs4txB16X9xESMQHi3fw/jobz8ipSUljS3uPsqA7Oj5
+        L0Y/GAtQod88gto3ZGRoQH9YDM1o+IOQLmhqvpaX0Sn9IYD7bfk3RwV8FnzA
+        faBT+nTj7EWptlErHNAfVtzNh7dRFfQb/Q9zwbPhOwEL6wQ069WKxkxv+LMF
+        xN5j/iJU49GHHwV/gN5uAgWA/ZO/5GYgdPAbT79MGT6xf+AV+qNDe/6JaTGT
+        jXfM72728GnwgX1vaL52HhBlt192ZgWamchNxO6QTqlMOvht3g9GZfQBeRiB
+        8KPgDwzX0UsA2D/5S26GgQW//X+BfEzAOLdeFs06K5t2PSsqes2nMoD36J5J
+        +EBNvwbBMSz5DdSR34IGAiYku/2L31ZSMXDQw3wgREcT+wfepj86M+Boyo2j
+        5CQhp/91dAR9sre99ymRk4gZp8rdVV39dD5Frz9/qcP08ZnNxUffzSfU2qcd
+        YPao2RQthaWUAsyX0m+HnB2cgakZKP/OxJJR4m/7hw5ZyLiJsgw5bIF3XQP+
+        iz/npj6pg7fQPf3GOuKL18/eMAr0gflTvw/+VDj8QQevzuz4H1g86FN8SVCD
+        2Jw/A2jvM4eq9yFjKJbVtTB/cy/6V5Q3SOfAulJT+QNayf5xGxNLf+zZP/a3
+        d3e9PzwA9Af9r8+D9D8oPOLAKE81ZUWZjx9x1o8465vmrGLZtNmS0mn0wnuz
+        lHIRKEmvyx+gFv0h82SoxRMqH9mpE8oFLfCua8B/8efcFFPJ80Uf6FvyLbqn
+        337EUvyH4wj6g/7n/mBOMH/8LLKUKKsfMdaPGOsbZizLUj+yhPRBBy/HTGgZ
+        fGDxoE/xJUH9EXf1uKujtn7EY/RBBy/HUmgZfGDxoE/xJUH9EY95PLZaT8qi
+        mVP6+CtawPwRS5luHQehZfCBxYM+xZcE9Ucs5bEUsRMt5iBjkV1mRZlNShD0
+        R2yFbh0XoWXwgcWDPsWXBPVHbOWxlfxxUtF4qvJHisp06xgILYMPLB70Kb4k
+        qD/iKDCRcpRVTzTQ6dsfsZTp1nEQWgYfWDzoU3xJUH/EUh5LkS/Vvobbftw0
+        xcUyn72pvk3G8AUZQ3r5R+yFbh03oWXwgcWDPsWXBPX/0+wVYxGJ6uAigSue
+        FITG8uJHysd065gBLYMPLB70Kb4kqP8/5Q6J+X/EI+aDDl6OJdAy+MDiQZ/i
+        S4L6/zseISLUygU/4gjp1jEAWgYfWDzoU3xJUP8/zRH8xzfoskzzui3OC+Ki
+        H62J2G4d+6Bl8IHFgz7FlwT1R/zk8ROlES/z+llWL37ETqZbxz1oGXxg8aBP
+        8SVB/RE7+ewEh4ia/X+JkYT2zB48fTRPP2Ik/OH4gP6g/7k/eP7NHz97jCSe
+        NTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK+XbbHoqab/Nwwiiq+w/yJv62L6
+        /0mkn+bnxbIQlP8/hT6rHB3E/4dR//8i/Z0rqoP4/zDq/1+kPzNRnU+rxSJf
+        zhTh//ch/x5a//9HY7nIqzq/YEz/vzwMYTJqvigoLTabAeVwPD/y7/7/6d/F
+        uAE5c8qVny4vi7pakqT+/8XbdzOHT4MPLBD6FF/yK94M8WeA733m+vE+ZLxk
+        slwL8zf3on9941Np/ngPDXHb6b+7WJdt8aoq85dVVf6IG/gzwPc+c/14HzJe
+        Mt+uhfmbe9G//j/FDVdV/Tavf8QKmGH+DPC9z1w/3oeMl0y2a2H+5l70r/9P
+        sYL41V02+P/gEP4/GBpEBxMoah3b//9G9P+T2fIUqQ7s/2fD+f/JPHV4sFg2
+        bbac/r8ycXn7oO99BqrT+fNuwP/v5t8PG7ovrXbcBOrnwSh1dn9+jfb/L7y8
+        yJbkUs++3R8+vesP60fBCD5z/XgffjenhhJuuBbmb+5F//o5Y42buGCWr8rq
+        GtP+3E55OP3/b0D99lxdNCrPuWPoZbbIs8usKLNJCW76/+7opmXWNMX0i2pS
+        lPlrWpcpSC/Ra//fHRGh+gUrIkzU8XRa0Vp2d0T/H1VAnAV3L/Kf+n3wp8Lh
+        Dzp4OZWFlsEHFg/6FF8S1J8bHcassF1PqbX3t2GAW8/53Wm1XOZTmfMfzb90
+        66YbLYMPLB70Kb4kqP9/mf/j6f9fEqI8p+5F/lO/D/5UOPxBBy8342gZfGDx
+        oE/xJUH9/zYL0Kc+H/i//4gnPLwcC6Bl8IHFgz7FlwT1//M88aO59/ByU42W
+        wQcWD/oUXxLU/8/PPf/zIwbw8HLzjZbBBxYP+hRfEtT/7zMAwfjRxKNbN89o
+        GXxg8aBP8SVB/f/+xHvW/0dMYLp1c46WwQcWD/oUXxLU/3cyAbMBkjLNKpuC
+        B17kV6/yspiOj19+QS/5HAKofZ5RNqG2AVcIrQzGTFRBN/iIh8e/MUX4N3nT
+        Upmb2L8YBgjL1KMP+D3+PUoBSo/s0IipIf9hkh+9Yb/Ol7OLupiNTxeUnKLm
+        /jAB7NYDdwgNYcuj1N+YF3mI/KmMPSARwwg/Cv6QVyyBGJb9SyQNfdk/0ID+
+        6EitY11t7D7gJhhEnMKUjQJPRYm6nlJOrHlCmfq3zfikzLP66ROC7VMSYHq0
+        nWVtNska+rJD3A7WASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovf
+        ixHO/1S75y/9HqPEJXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B8odcxFlVwEA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1d0a4741-af37-4e82-9a1f-ff1b9ac5d990
+      - 87baf32b-2a0e-46d1-b970-f4419d81bfed
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - e9b6fa23-f3d7-416f-b261-41394d8f215a
+      X-Ms-Correlation-Request-Id:
+      - e9b6fa23-f3d7-416f-b261-41394d8f215a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135012Z:e9b6fa23-f3d7-416f-b261-41394d8f215a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:11 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0ea23d81-5a50-48e0-a1b5-1dd330196ab7
+      - 28475699-fe57-4571-bcd9-14c98d26b579
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - a9736a6e-b49c-4473-bc5f-b724a265f200
+      X-Ms-Correlation-Request-Id:
+      - a9736a6e-b49c-4473-bc5f-b724a265f200
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135012Z:a9736a6e-b49c-4473-bc5f-b724a265f200
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:11 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6998a073-a5a6-4cfd-b378-3e2ac5196b2f
+      - eccf7d3d-0a4a-4ae0-b114-42e2b4241ae6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - cb545084-4aa3-49ce-b186-4ffa9433069c
+      X-Ms-Correlation-Request-Id:
+      - cb545084-4aa3-49ce-b186-4ffa9433069c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135013Z:cb545084-4aa3-49ce-b186-4ffa9433069c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:13 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 23ace418-be94-41d2-8284-35507d6a248b
+      - 5d0147b0-9854-4091-b4b9-31ffaa2d1dcf
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 90963331-32b5-46f6-a6d6-02cb7ba1c092
+      X-Ms-Correlation-Request-Id:
+      - 90963331-32b5-46f6-a6d6-02cb7ba1c092
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135013Z:90963331-32b5-46f6-a6d6-02cb7ba1c092
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:13 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - e26ea62f-bdbe-4654-9ae9-fcc124fc87c7
+      - f43e06dd-80c8-454a-a242-adf40b6dc714
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      X-Ms-Correlation-Request-Id:
+      - e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135014Z:e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 00c98da7-71b4-4763-bdfb-cae9e978e7b5
+      - 90cbfc43-cbc1-4113-b501-c39eeceaf370
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      X-Ms-Correlation-Request-Id:
+      - 5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135015Z:5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - aa460d34-332e-4f5c-9cfe-4a9d7e43987b
+      - d8da3728-f7ba-4a0f-882c-dfa9521e8ec4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - a4adabee-c88a-4705-b28e-2a67119dad44
+      X-Ms-Correlation-Request-Id:
+      - a4adabee-c88a-4705-b28e-2a67119dad44
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135015Z:a4adabee-c88a-4705-b28e-2a67119dad44
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:14 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 88df9987-90e3-444c-86c6-f0222d5cfd27
+      - a34235fa-be56-423d-b46d-c223db1444c9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 278753a3-8f94-4ae0-9b82-eb5909914266
+      X-Ms-Correlation-Request-Id:
+      - 278753a3-8f94-4ae0-9b82-eb5909914266
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135016Z:278753a3-8f94-4ae0-9b82-eb5909914266
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:15 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 03d0dbf5-2aa5-41a3-b00c-3e15d005d062
+      - 99184579-24f2-457d-9979-e7a8ceaea6b7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      X-Ms-Correlation-Request-Id:
+      - dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135016Z:dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 437aa9c5-cbec-4fa9-9359-8afbeb9f1749
+      - 90f086bc-6c6e-4fbb-8b17-ee450f4d4817
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      X-Ms-Correlation-Request-Id:
+      - 4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135017Z:4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:16 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b4f8dbd1-81f7-483e-a33a-de86ce0400d9
+      - be0f0c40-dd14-451b-b2d2-cdebd39eaf3e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      X-Ms-Correlation-Request-Id:
+      - ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135018Z:ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:17 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3dac3105-2708-4892-afed-3aa03c12f9e3
+      - fe357ca0-5f78-4dea-9695-616b4fb609e0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 99cc57a1-b092-4d27-9d29-42dc905de53c
+      X-Ms-Correlation-Request-Id:
+      - 99cc57a1-b092-4d27-9d29-42dc905de53c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135018Z:99cc57a1-b092-4d27-9d29-42dc905de53c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:18 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3bf71381-b0e0-48ba-b309-2d5aa670bbd2
+      - a8a4cd8f-d064-4ce4-a853-e20e1d398697
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - eea5294d-3347-4abb-a227-1185d37130cd
+      X-Ms-Correlation-Request-Id:
+      - eea5294d-3347-4abb-a227-1185d37130cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135019Z:eea5294d-3347-4abb-a227-1185d37130cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a4894e74-58f4-4965-a413-9253c0a1ab15
+      - ecd39004-0352-49c2-b11f-2942b03cddfe
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - ef2f97c2-591a-4318-9101-7c2b9d49e707
+      X-Ms-Correlation-Request-Id:
+      - ef2f97c2-591a-4318-9101-7c2b9d49e707
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135020Z:ef2f97c2-591a-4318-9101-7c2b9d49e707
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:19 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2b1e723b-0fc2-47e6-8dcc-4a61cc497977
+      - 76505311-77f6-4368-b77b-b0cfcb82c44c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      X-Ms-Correlation-Request-Id:
+      - ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135020Z:ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:20 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 102182a0-1285-4666-aa24-0e09dcf695eb
+      - f3edb2fd-5273-4bcc-9299-67d70fdb17cc
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 9d29a6a4-6420-4f09-9007-b536d620bd8c
+      X-Ms-Correlation-Request-Id:
+      - 9d29a6a4-6420-4f09-9007-b536d620bd8c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135021Z:9d29a6a4-6420-4f09-9007-b536d620bd8c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8223b929-226e-4cdb-8cfb-603df9bcd5c2
+      - d71eb8a1-ccbc-4289-9614-5c3b16729754
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - eb41f472-5c50-4326-b443-3e19a7061c0a
+      X-Ms-Correlation-Request-Id:
+      - eb41f472-5c50-4326-b443-3e19a7061c0a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135022Z:eb41f472-5c50-4326-b443-3e19a7061c0a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6839b79b-eab5-4e6d-b5d4-7461e88db4fc
+      - 8255009f-180c-4dc9-8137-6d5373a16422
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - eba47ed1-04f7-43c1-b494-cc41825c4311
+      X-Ms-Correlation-Request-Id:
+      - eba47ed1-04f7-43c1-b494-cc41825c4311
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135022Z:eba47ed1-04f7-43c1-b494-cc41825c4311
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:21 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 260f24b1-29a2-4c50-95e8-a3382617d250
+      - a734b6ac-adfa-4f61-a7f3-e2a48ef88c37
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - ad13d1ac-9e52-4253-b328-c96e18a926cb
+      X-Ms-Correlation-Request-Id:
+      - ad13d1ac-9e52-4253-b328-c96e18a926cb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135022Z:ad13d1ac-9e52-4253-b328-c96e18a926cb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 439ef071-c6c8-40fb-aa91-78ca766cb05f
+      - abb0411d-7764-45e3-b12e-9bf4f8930255
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 9f622c66-2391-4fc8-9f75-81deb95e524f
+      X-Ms-Correlation-Request-Id:
+      - 9f622c66-2391-4fc8-9f75-81deb95e524f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135022Z:9f622c66-2391-4fc8-9f75-81deb95e524f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 87700af0-bbf3-4143-9a0d-2ae6fc7eb5f2
+      - b2a2f01d-2a83-4fa3-9173-6d8b8f2b95d9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      X-Ms-Correlation-Request-Id:
+      - 54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135022Z:54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0bdc2daf-3719-49b7-82c6-f4a8a27d04e4
+      - bae1df5f-d4e6-46d0-9b26-9b2080393946
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 46c03546-1bff-4d13-874c-63379281b398
+      X-Ms-Correlation-Request-Id:
+      - 46c03546-1bff-4d13-874c-63379281b398
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135023Z:46c03546-1bff-4d13-874c-63379281b398
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:22 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 95df7a19-77ea-4081-8231-3b4a72781e02
+      - a95f5d86-1d7c-4372-8f90-ad4cee7ef191
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 096d82db-d76c-464f-b8c2-4d5616a2bc41
+      X-Ms-Correlation-Request-Id:
+      - 096d82db-d76c-464f-b8c2-4d5616a2bc41
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135023Z:096d82db-d76c-464f-b8c2-4d5616a2bc41
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - b5d886e7-b939-49b8-8b71-a30c1be7d39a
+      - f77e93d8-2991-4453-aeae-b32a08c3fef6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      X-Ms-Correlation-Request-Id:
+      - 16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135023Z:16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a8b7bdcd-40d0-4bc8-8493-8123139bb2df
+      - b310ade8-0aef-462f-a9da-299f49e5ea80
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      X-Ms-Correlation-Request-Id:
+      - bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135024Z:bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1f8122f8-558c-4ae4-9a2e-25204d18af04
+      - 8494e868-c577-4baf-a9d1-5423268d137a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 6014a524-2663-4794-985a-8551601c720f
+      X-Ms-Correlation-Request-Id:
+      - 6014a524-2663-4794-985a-8551601c720f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135024Z:6014a524-2663-4794-985a-8551601c720f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:23 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 338d1dce-520d-4255-94bd-5b1a50a07690
+      - 6c77558a-6118-4cc2-b51e-dea94bea99da
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      X-Ms-Correlation-Request-Id:
+      - 6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135024Z:6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ce6adbe5-41cb-4b70-9a28-4aea20e3055d
+      - d303e81c-829e-4272-abdf-1cd7f5ca806c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 486e58df-e045-40a8-80b2-37cb57b8c047
+      X-Ms-Correlation-Request-Id:
+      - 486e58df-e045-40a8-80b2-37cb57b8c047
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135025Z:486e58df-e045-40a8-80b2-37cb57b8c047
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:24 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8ec1f6d9-6d7c-4c6e-bdee-7fc75210bd85
+      - a9e5a556-608f-4cb7-8468-795669e4285d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - aef29501-5b22-4d6a-918a-0c6dcb80d1f1
+      X-Ms-Correlation-Request-Id:
+      - aef29501-5b22-4d6a-918a-0c6dcb80d1f1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135025Z:aef29501-5b22-4d6a-918a-0c6dcb80d1f1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5002ceae-860c-4190-b898-31b79e672c52
+      - fe7a41f4-ace2-440e-906b-2f3c291583d5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
+      X-Ms-Correlation-Request-Id:
+      - 1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135025Z:1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6ee70a04-f616-446e-b7cc-a3a44acce863
+      - a8bab030-bde4-4ef8-99dc-84a576b1408a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - c7394779-43b0-461a-968e-6b9059895f62
+      X-Ms-Correlation-Request-Id:
+      - c7394779-43b0-461a-968e-6b9059895f62
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135026Z:c7394779-43b0-461a-968e-6b9059895f62
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:25 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 60fa198b-cde6-4a0f-9203-f4b813352630
+      - ebc8fc79-ce93-4d4e-8ba6-cc682d550cf8
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 8b5c42d1-8038-4637-9dfb-72fd3302e1f1
+      X-Ms-Correlation-Request-Id:
+      - 8b5c42d1-8038-4637-9dfb-72fd3302e1f1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135026Z:8b5c42d1-8038-4637-9dfb-72fd3302e1f1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 448c2aac-246c-4572-bec9-211e8d6d565a
+      - c28a0d1f-ddc4-4e16-b2d1-2805687ff016
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - fd2c1ec9-73c5-40f4-8a85-f264c04e928a
+      X-Ms-Correlation-Request-Id:
+      - fd2c1ec9-73c5-40f4-8a85-f264c04e928a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135026Z:fd2c1ec9-73c5-40f4-8a85-f264c04e928a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8a5dfe00-5236-4f2b-93f6-fc99a6c94a07
+      - 8d49a274-15e7-4e28-8ec4-9f059be6f0de
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - c9aba678-046c-4858-9761-2b01b05a0070
+      X-Ms-Correlation-Request-Id:
+      - c9aba678-046c-4858-9761-2b01b05a0070
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135027Z:c9aba678-046c-4858-9761-2b01b05a0070
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 213f6813-590e-4fe5-b5fb-8b22daed0f78
+      - 3e9f60dd-aa59-482a-8bf1-46f39b0dbead
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 790ea311-d9a4-44c9-8885-7e0de5599ca1
+      X-Ms-Correlation-Request-Id:
+      - 790ea311-d9a4-44c9-8885-7e0de5599ca1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135027Z:790ea311-d9a4-44c9-8885-7e0de5599ca1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3163925d-5f37-40c2-a0dc-75f57a072e9e
+      - 8fbf9dcc-e4b9-431e-9e3e-87393275172a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 5238e877-4c15-493c-8fc1-11a68a1c8e34
+      X-Ms-Correlation-Request-Id:
+      - 5238e877-4c15-493c-8fc1-11a68a1c8e34
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135027Z:5238e877-4c15-493c-8fc1-11a68a1c8e34
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:26 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - be9c1ca8-8f67-4d16-a491-9a77cdb44d4e
+      - e94a6e33-0f5f-4981-9b60-86f90c99db5f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - c8821fa2-2398-4567-a9e3-63c136f08428
+      X-Ms-Correlation-Request-Id:
+      - c8821fa2-2398-4567-a9e3-63c136f08428
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135028Z:c8821fa2-2398-4567-a9e3-63c136f08428
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 54c1f786-ed34-4e13-b718-bdf22ed73206
+      - eb30b569-2d80-4493-9c44-e9e92132684a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 61bf01c4-bc36-4768-bac6-fd36444880be
+      X-Ms-Correlation-Request-Id:
+      - 61bf01c4-bc36-4768-bac6-fd36444880be
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135028Z:61bf01c4-bc36-4768-bac6-fd36444880be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:27 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - afdd4ce2-19be-414e-9a7d-027fb866fb22
+      - b1610139-5359-40b3-bd95-b37b71ef62a2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
+      X-Ms-Correlation-Request-Id:
+      - 10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135028Z:10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:28 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 56ef9880-8c0a-482a-9c13-e6113629a5fe
+      - e4ad4830-8f7a-4f7c-94cf-e09842fdbfc5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 7a3dba2e-49fe-4ce6-8415-21990854f2ca
+      X-Ms-Correlation-Request-Id:
+      - 7a3dba2e-49fe-4ce6-8415-21990854f2ca
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135029Z:7a3dba2e-49fe-4ce6-8415-21990854f2ca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 290ecfec-7e7c-4525-aa53-7f780ad9ad6f
+      - 3b5d50c6-bc7c-4946-a539-478c94efc9d2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 8430505b-2298-4189-9541-60bcafc2ebe9
+      X-Ms-Correlation-Request-Id:
+      - 8430505b-2298-4189-9541-60bcafc2ebe9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135029Z:8430505b-2298-4189-9541-60bcafc2ebe9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a6552e44-5d23-408d-9c8c-0b96d6d1f2d6
+      - f54c203b-3f83-477c-a4ce-555b558080bf
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 19361343-ec89-41a5-952b-5a53ece28c6b
+      X-Ms-Correlation-Request-Id:
+      - 19361343-ec89-41a5-952b-5a53ece28c6b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135029Z:19361343-ec89-41a5-952b-5a53ece28c6b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 325eaabc-597a-4b49-91e2-d307688bd7c2
+      - f7471b65-f111-46e0-a4bd-83effbffb26d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 3ca977af-0226-48dd-8dfd-5695a2957ff0
+      X-Ms-Correlation-Request-Id:
+      - 3ca977af-0226-48dd-8dfd-5695a2957ff0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135030Z:3ca977af-0226-48dd-8dfd-5695a2957ff0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:29 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4ed5e28c-47be-4535-a9ca-e3085bba4686
+      - 75a121db-2ea3-4266-9bfe-c5485c63fb84
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 7e6f063e-7da9-420c-99bd-462c7fd7edfa
+      X-Ms-Correlation-Request-Id:
+      - 7e6f063e-7da9-420c-99bd-462c7fd7edfa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135030Z:7e6f063e-7da9-420c-99bd-462c7fd7edfa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 62531baa-d171-41f3-877e-232b806fecfb
+      - 9e98b1bb-ddaf-434d-a430-10302573c349
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 8ec4bd42-cd78-4479-b119-c7f4c9099b0d
+      X-Ms-Correlation-Request-Id:
+      - 8ec4bd42-cd78-4479-b119-c7f4c9099b0d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135030Z:8ec4bd42-cd78-4479-b119-c7f4c9099b0d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1894e8fe-39f6-4eb8-b099-badfd7e089aa
+      - a4bc56ca-eb5b-49c5-ac03-3a4424e7434f
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 68260ff7-6a05-4f20-be26-c8e1545774e1
+      X-Ms-Correlation-Request-Id:
+      - 68260ff7-6a05-4f20-be26-c8e1545774e1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135031Z:68260ff7-6a05-4f20-be26-c8e1545774e1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 06ffe0d4-0f15-4255-9223-a49397ef6964
+      - 8a957ca3-d599-485c-9256-d8bc57d79026
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 48fd65a2-559e-4f19-947f-5be900fdf538
+      X-Ms-Correlation-Request-Id:
+      - 48fd65a2-559e-4f19-947f-5be900fdf538
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135031Z:48fd65a2-559e-4f19-947f-5be900fdf538
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:30 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2987bc22-86c9-43d3-8843-64060fe9ed06
+      - 486d37db-2ff2-4f88-8b82-36f969fad3d5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - d26b8b47-5292-4cbe-9408-1a265b0ba38d
+      X-Ms-Correlation-Request-Id:
+      - d26b8b47-5292-4cbe-9408-1a265b0ba38d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135031Z:d26b8b47-5292-4cbe-9408-1a265b0ba38d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 032b4904-1902-4216-9d5f-cad1d0b4eda8
+      - 75a36e91-f65b-4675-97ac-8a61ef7d5d47
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - c57450b8-1615-46ec-a41c-e4cfbef8d300
+      X-Ms-Correlation-Request-Id:
+      - c57450b8-1615-46ec-a41c-e4cfbef8d300
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135032Z:c57450b8-1615-46ec-a41c-e4cfbef8d300
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4fd7d051-a779-4050-ae7f-ef9a66d9648b
+      - ad237d25-0ca7-4230-b805-2fe18255e551
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 69b7de07-aaa9-4837-a192-2059357a9c3f
+      X-Ms-Correlation-Request-Id:
+      - 69b7de07-aaa9-4837-a192-2059357a9c3f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135032Z:69b7de07-aaa9-4837-a192-2059357a9c3f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:31 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2c200486-8b0f-460f-953d-4b0b1b86b32a
+      - 6ade8011-fc29-48a9-b091-36ba2ce34f35
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - de65e4f8-e501-46a2-8f28-ea18beea66d0
+      X-Ms-Correlation-Request-Id:
+      - de65e4f8-e501-46a2-8f28-ea18beea66d0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135032Z:de65e4f8-e501-46a2-8f28-ea18beea66d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ac3af394-4e5e-42a5-b0b7-54895ded8059
+      - ca577469-17a0-42a7-b039-0edece6d0b5b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
+      X-Ms-Correlation-Request-Id:
+      - 55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135032Z:55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - aa2bcdd6-ec0d-4587-9857-e16fc2adcc69
+      - df0da330-2d9e-4bbb-9ad8-e0aed03e22df
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 4ba194e1-528c-477f-9668-55f50ea1538e
+      X-Ms-Correlation-Request-Id:
+      - 4ba194e1-528c-477f-9668-55f50ea1538e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135034Z:4ba194e1-528c-477f-9668-55f50ea1538e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - e1a0ef7f-1125-4b73-88e9-774d0b757844
+      - ecb23c75-49d4-49d0-8d1f-9522ea7b25f2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - e081b084-2949-4b76-abb1-8058f1df84ef
+      X-Ms-Correlation-Request-Id:
+      - e081b084-2949-4b76-abb1-8058f1df84ef
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135034Z:e081b084-2949-4b76-abb1-8058f1df84ef
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3ab517fd-fa31-4707-ad1d-71a49708e73f
+      - 652118df-f113-4dc0-9c87-6efdfc8c5a31
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - ab0ab341-6c64-4c80-af85-d5962e62f7ab
+      X-Ms-Correlation-Request-Id:
+      - ab0ab341-6c64-4c80-af85-d5962e62f7ab
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135034Z:ab0ab341-6c64-4c80-af85-d5962e62f7ab
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ec398627-607e-43f9-9fb4-98af0cc9bdf8
+      - f95d2c9b-3915-4bb8-aadc-6b4b1db3c0a2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 7efd3aac-ba0f-4239-a687-5976607f4eec
+      X-Ms-Correlation-Request-Id:
+      - 7efd3aac-ba0f-4239-a687-5976607f4eec
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135034Z:7efd3aac-ba0f-4239-a687-5976607f4eec
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - d24c2533-14d0-43ee-a111-9529b4451a8b
+      X-Ms-Correlation-Request-Id:
+      - d24c2533-14d0-43ee-a111-9529b4451a8b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135035Z:d24c2533-14d0-43ee-a111-9529b4451a8b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:34 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - cea430a8-8ca2-436b-a46d-132b79a2c4c6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 48cb8de6-263e-4aa5-8e80-3c5239606381
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135035Z:48cb8de6-263e-4aa5-8e80-3c5239606381
+      Date:
+      - Fri, 30 Oct 2015 13:50:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 6a5bffcd-5724-4255-9280-9d7225d06684
+      X-Ms-Correlation-Request-Id:
+      - 6a5bffcd-5724-4255-9280-9d7225d06684
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135036Z:6a5bffcd-5724-4255-9280-9d7225d06684
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:36 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 771b475b-9ebf-4c73-be22-1a082adfa2db
+      X-Ms-Correlation-Request-Id:
+      - 771b475b-9ebf-4c73-be22-1a082adfa2db
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135037Z:771b475b-9ebf-4c73-be22-1a082adfa2db
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:37 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 4ac85fb1-2530-435c-980d-ff70ef60bee2
+      X-Ms-Correlation-Request-Id:
+      - 4ac85fb1-2530-435c-980d-ff70ef60bee2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135038Z:4ac85fb1-2530-435c-980d-ff70ef60bee2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:37 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 43729edf-2eea-4fab-8b1e-4142a5591958
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 86779bc2-aa72-45b3-8a68-c414dba1b44c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135039Z:86779bc2-aa72-45b3-8a68-c414dba1b44c
+      Date:
+      - Fri, 30 Oct 2015 13:50:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 671f9ff1-f287-41c8-9f81-e8e558b19fee
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 9c0acff2-189d-48ce-89c6-c9231c70ce7f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135039Z:9c0acff2-189d-48ce-89c6-c9231c70ce7f
+      Date:
+      - Fri, 30 Oct 2015 13:50:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - bf232c4c-bdea-4f34-8253-d183bcaa3511
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 224c4d2f-dca4-4c24-a8bc-46c842137bbf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135039Z:224c4d2f-dca4-4c24-a8bc-46c842137bbf
+      Date:
+      - Fri, 30 Oct 2015 13:50:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59G9h5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19U88f53Xl3n9NL903UZp572O
+        ZwP9mvV0muezfOYg4nH0O1ueV53vCNOQfD7YdAhinDj7Dx7d3x9/evDg4f6n
+        HRoRZcyvTCf9+/sM9qNJVbVPi+xiWTVtMQUaOmQa7LKpyvz1tM7zZTOv2idl
+        NfmqLqjJR/O2XTWP7t69ypt2WmVNO5s09x9+ujeeUJvxtKrz8VWxnFVXzXiZ
+        t3fRycx1st38orLhKdjeufcwn033Drbv5wc72/s7O3vbk9n96fb+/YfZ/iy7
+        v7t3sH/Xn7Hxbd4YNxbp8WSxYlIoe+TvWvqCaIyh6kTriOlbwyNfFNO6aqrz
+        dnxGjS/mbTP+yS88Mr3O25YmqWHIBBs/lKB9PnLg34t/hnjn/flmI888uL9z
+        f/f+QcA0Qqso5tVVXqPn/O4sz8qymtKvfle3RppUgQ9BGgohf+Pkl/w/0KMt
+        +D8FAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1042c595-a74e-44b7-a429-f4bc703db2e3"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 37bb8fa7-d956-41f5-b563-1e7d52e65064
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - f3f9e9b3-ee62-450d-8ad2-3a8463b6e4ed
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135040Z:f3f9e9b3-ee62-450d-8ad2-3a8463b6e4ed
+      Date:
+      - Fri, 30 Oct 2015 13:50:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7s7+
+        3vT+w/vb2YN9Qmh/8mA72997uH2+P5k+2Lk3m+zl937fj/TF9nrFA75F1/pG
+        WU0zjBxvXeVNuzZf0DhWed0W1PJRyuSUDy+LhpoXy4vXbdZyZ6/X02mez/KZ
+        vEnNLH3WQuOdSXY/29mfbU8fPry3vX/wYLqdTe/tb9/b383PH8wOZrsP9+3L
+        xeqkWp4XF+uaEUP335OvUoMHHju5xWrK7XcNBDz/b5zcu92R0Qcx1L/u7MuD
+        OepNnDz46hbTJw81Li6pydnL49mMaAJohM743nhnbCdLHq9pafjpi7ydVzwH
+        T69ppopp95X1pCym9IYFHqBKLX74M9jBiWbw9U88f80z+DS//MjH75eEoyEk
+        afoJ35/7QVwWdbvOSv2z8yLhQXg2d2f5ebYu23BI7g/7q/7yfR3tR7Nl8zpv
+        W2KfYMbkc9AJH3/PNKcvstWqLPLZ0/B7+drQ8KN8mU1K4p5nVX2V1TOCTq3O
+        MxIe04KQxmhe59N1XbTXTBNq4xD44dM5hlKUYewwdWa+yKbzYgnR+9lA//T1
+        m5Mvj1+/efrkdRT9k2qxWre5YRNFJo44ftA/v+T/Adj3QZ5NBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b674e115-ca91-4ee7-bc7f-59cf1bbcc72e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 4c801b82-c133-4b77-a806-42c28b126865
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135040Z:4c801b82-c133-4b77-a806-42c28b126865
+      Date:
+      - Fri, 30 Oct 2015 13:50:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 7ac58a5d-0de8-4326-bfcc-906435adb4a3
+      X-Ms-Correlation-Request-Id:
+      - 7ac58a5d-0de8-4326-bfcc-906435adb4a3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135042Z:7ac58a5d-0de8-4326-bfcc-906435adb4a3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:41 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - fcec968a-8c13-4e74-89eb-d4baf00254d4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - f01b810a-4e98-4b46-93ce-9f2dd15d6a76
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135042Z:f01b810a-4e98-4b46-93ce-9f2dd15d6a76
+      Date:
+      - Fri, 30 Oct 2015 13:50:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - ab4e254b-b5a7-48a3-819f-20167cb477f5
+      X-Ms-Correlation-Request-Id:
+      - ab4e254b-b5a7-48a3-819f-20167cb477f5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135043Z:ab4e254b-b5a7-48a3-819f-20167cb477f5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - c1e7fed6-d66e-4289-b145-66c36a67a80b
+      X-Ms-Correlation-Request-Id:
+      - c1e7fed6-d66e-4289-b145-66c36a67a80b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135043Z:c1e7fed6-d66e-4289-b145-66c36a67a80b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:42 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - e07f481c-2952-4f6e-bf86-20a18c9289fd
+      X-Ms-Correlation-Request-Id:
+      - e07f481c-2952-4f6e-bf86-20a18c9289fd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135043Z:e07f481c-2952-4f6e-bf86-20a18c9289fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
+      X-Ms-Correlation-Request-Id:
+      - 59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135043Z:59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 23204060-f11e-4ec0-a735-0dc7cd1a7da9
+      X-Ms-Correlation-Request-Id:
+      - 23204060-f11e-4ec0-a735-0dc7cd1a7da9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:23204060-f11e-4ec0-a735-0dc7cd1a7da9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 86986549-991d-4da6-8bdc-97e80560bc11
+      X-Ms-Correlation-Request-Id:
+      - 86986549-991d-4da6-8bdc-97e80560bc11
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:86986549-991d-4da6-8bdc-97e80560bc11
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - bbb8a592-6f7d-4d3e-a262-75c72607b5c6
+      X-Ms-Correlation-Request-Id:
+      - bbb8a592-6f7d-4d3e-a262-75c72607b5c6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:bbb8a592-6f7d-4d3e-a262-75c72607b5c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - e0fe3a32-acf7-40fc-aedb-12c8d4978e92
+      X-Ms-Correlation-Request-Id:
+      - e0fe3a32-acf7-40fc-aedb-12c8d4978e92
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:e0fe3a32-acf7-40fc-aedb-12c8d4978e92
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - b88d7f93-4010-4c56-b20f-14d3a7453729
+      X-Ms-Correlation-Request-Id:
+      - b88d7f93-4010-4c56-b20f-14d3a7453729
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:b88d7f93-4010-4c56-b20f-14d3a7453729
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - a041d918-39aa-4de5-92a1-b93bfe80a4ed
+      X-Ms-Correlation-Request-Id:
+      - a041d918-39aa-4de5-92a1-b93bfe80a4ed
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135044Z:a041d918-39aa-4de5-92a1-b93bfe80a4ed
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:43 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - ebaf521c-03a9-4293-ad98-a59a410a4d16
+      X-Ms-Correlation-Request-Id:
+      - ebaf521c-03a9-4293-ad98-a59a410a4d16
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135045Z:ebaf521c-03a9-4293-ad98-a59a410a4d16
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:44 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:47 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB271C:6793:2761259:563375B5
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 13:50:45 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6231-ATL
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 2ad315f718eb548c7b8416390773455fdad2e956
+      Expires:
+      - Fri, 30 Oct 2015 13:55:45 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
+      X-Ms-Correlation-Request-Id:
+      - c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135045Z:c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:45 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C1C:509B:353F7AB:563375B6
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 13:50:46 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1029-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 78b5248bd42f96810fc28f61c49f42476b769f7d
+      Expires:
+      - Fri, 30 Oct 2015 13:55:46 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - a3b44499-d877-404d-8205-bff52d7543f6
+      X-Ms-Correlation-Request-Id:
+      - a3b44499-d877-404d-8205-bff52d7543f6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135046Z:a3b44499-d877-404d-8205-bff52d7543f6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:45 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - C71B4C14:509A:33D9361:563375B6
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 13:50:46 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-jfk1031-JFK
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - bb05726da9e0ae80f4215cc5c22da2da4549e570
+      Expires:
+      - Fri, 30 Oct 2015 13:55:46 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 4da5f25c-91ec-441a-85af-419fdd3e751a
+      X-Ms-Correlation-Request-Id:
+      - 4da5f25c-91ec-441a-85af-419fdd3e751a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135046Z:4da5f25c-91ec-441a-85af-419fdd3e751a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:45 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 081fdc44-6da9-47c0-b164-7995bfcf6683
+      X-Ms-Correlation-Request-Id:
+      - 081fdc44-6da9-47c0-b164-7995bfcf6683
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135046Z:081fdc44-6da9-47c0-b164-7995bfcf6683
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:46 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4c546d80-67e6-4a74-8df0-747a1dcbae7c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - ef1c7afb-7358-4fdb-880c-bc37defe31d3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135047Z:ef1c7afb-7358-4fdb-880c-bc37defe31d3
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 545a181c-8582-458d-bab0-21856cc80dee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - d011ccda-3b6a-46a8-aa90-37d7aa6c9bb5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135047Z:d011ccda-3b6a-46a8-aa90-37d7aa6c9bb5
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 61f54201-55fc-4480-ab0b-94ad758e21f0
+      X-Ms-Correlation-Request-Id:
+      - 61f54201-55fc-4480-ab0b-94ad758e21f0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135047Z:61f54201-55fc-4480-ab0b-94ad758e21f0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:46 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 30431b1f-cefd-4866-ab7d-10a94894a89b
+      X-Ms-Correlation-Request-Id:
+      - 30431b1f-cefd-4866-ab7d-10a94894a89b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135047Z:30431b1f-cefd-4866-ab7d-10a94894a89b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4cd8ccee-fd01-4c65-9ede-3acbd4f3582e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 16c64a28-3242-40c9-b094-e21a33486d76
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:16c64a28-3242-40c9-b094-e21a33486d76
+      Date:
+      - Fri, 30 Oct 2015 13:50:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 803a409c-ddff-4c23-b355-449159c05ab0
+      X-Ms-Correlation-Request-Id:
+      - 803a409c-ddff-4c23-b355-449159c05ab0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:803a409c-ddff-4c23-b355-449159c05ab0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - f972ca26-55f2-4546-9eb6-ae354d05740a
+      X-Ms-Correlation-Request-Id:
+      - f972ca26-55f2-4546-9eb6-ae354d05740a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:f972ca26-55f2-4546-9eb6-ae354d05740a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - d8f7283f-dcf7-4f95-bb55-14730d40ec7c
+      X-Ms-Correlation-Request-Id:
+      - d8f7283f-dcf7-4f95-bb55-14730d40ec7c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:d8f7283f-dcf7-4f95-bb55-14730d40ec7c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:47 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 31ca7296-3253-4dcb-a522-df2c5b79d357
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 065f9f62-9cba-417e-8d95-ec0068789b4f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:065f9f62-9cba-417e-8d95-ec0068789b4f
+      Date:
+      - Fri, 30 Oct 2015 13:50:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 147f9a00-e9e9-43d2-a931-a01efdc50180
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - e4566485-5a88-4467-8e3f-64792d817e00
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135048Z:e4566485-5a88-4467-8e3f-64792d817e00
+      Date:
+      - Fri, 30 Oct 2015 13:50:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 58392b10-2837-4b45-b57d-aa1b6263d5a2
+      X-Ms-Correlation-Request-Id:
+      - 58392b10-2837-4b45-b57d-aa1b6263d5a2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135049Z:58392b10-2837-4b45-b57d-aa1b6263d5a2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:48 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 96ac4cb7-5c00-4349-9602-6647c9e4767a
+      X-Ms-Correlation-Request-Id:
+      - 96ac4cb7-5c00-4349-9602-6647c9e4767a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135049Z:96ac4cb7-5c00-4349-9602-6647c9e4767a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:49 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 7e1107b9-025e-4004-a0c4-44421112ba1e
+      X-Ms-Correlation-Request-Id:
+      - 7e1107b9-025e-4004-a0c4-44421112ba1e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135049Z:7e1107b9-025e-4004-a0c4-44421112ba1e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:49 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 2b83e7a2-b931-4015-b989-80734f48dc44
+      X-Ms-Correlation-Request-Id:
+      - 2b83e7a2-b931-4015-b989-80734f48dc44
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135049Z:2b83e7a2-b931-4015-b989-80734f48dc44
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:49 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 0d7c2f36-a790-472d-b0cb-0a35b495bb9e
+      X-Ms-Correlation-Request-Id:
+      - 0d7c2f36-a790-472d-b0cb-0a35b495bb9e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135050Z:0d7c2f36-a790-472d-b0cb-0a35b495bb9e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 13:50:50 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 1719e474-58f7-4540-b675-ea41229c2f3f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - c9df3236-2e1d-4159-a6f8-df175cca693d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135050Z:c9df3236-2e1d-4159-a6f8-df175cca693d
+      Date:
+      - Fri, 30 Oct 2015 13:50:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 4e0604f2-5448-4803-8a75-55644af297e4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 16bec0a7-7276-4c21-8a06-7ea62b390ad9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135050Z:16bec0a7-7276-4c21-8a06-7ea62b390ad9
+      Date:
+      - Fri, 30 Oct 2015 13:50:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tu/t
+        vNm99+j+Dv3vk52dRzs7H5nGv0R++T5+/BIGAUzfAkOliqXJR8tMoJ7M8/Nt
+        IsvM9Rmlpvcung0UbdbTaZ7Pcg8iHkfRs+V51fmO0AwJ6oNNhyDGKbP/4NH9
+        g/He/Xv37+/tdihEdDG/MpX07+8z3I/yd22+RKdAQUduR20p9kUxraumOm/H
+        Z9T4Yt4245/84mmRXSyrpi2mzeu8bQnrRjv1O+gT1oF/L4IOEfP9CbmRiPd2
+        dvY/PQiJKIwVxby6ymv0nN+d5VlZVlP61e/q1kiTtPgQpKEQ8jdOfsn/A/6g
+        cGNiBAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"043707df-d3a4-491d-974f-6cb82401deac"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b31019d6-6d04-40c9-91c7-36bac4f9e7fb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - d6602cb7-79bb-4f7b-b7c4-70de0756a599
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135051Z:d6602cb7-79bb-4f7b-b7c4-70de0756a599
+      Date:
+      - Fri, 30 Oct 2015 13:50:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PdvbvPdh5MDvfnt3L
+        9rf3H+7Oth8+2D/f/nQ6IVx2dmd5Nv19P9IX2+sVj/MW/eobZTXNMGa8lWdN
+        uzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJroe7e
+        waeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbnxcW6
+        ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++usXE
+        yUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7ynpS
+        FlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7pv0UY
+        EIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm9EW2
+        WpVFPnsafi9fG+p9lC+zSUkc86yqr7J6RtCp1XlWNrlpQUhjKK/z6bou2mum
+        BrVxCPyQKRzDx3tX6WoHqBPyRTadF0sI2s8G4t8+fbb98tWXT6OIn1SL1brN
+        DWsoJvRWF2X8oH9+yf8DYmP4yiYHAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8268c9b5-a9f8-4ed2-95f0-4c87d493bee0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 62f167e9-14ed-4ad0-bc43-9c9843d8a1a8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135051Z:62f167e9-14ed-4ad0-bc43-9c9843d8a1a8
+      Date:
+      - Fri, 30 Oct 2015 13:50:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - ed5091d3-dc80-462f-a4b9-d490790863c9
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 3fec0f0d-f521-40f4-8d0f-4536ca460c4d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135051Z:3fec0f0d-f521-40f4-8d0f-4536ca460c4d
+      Date:
+      - Fri, 30 Oct 2015 13:50:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H93U92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6smraC+p6+2l+6bqN0s57Hc8G
+        +jXr6TTPZ/nMQcTj6He2PK863xGmIfl8sOkQxDhx9h88uv/p+ODe7qc7D+53
+        iESkMb8yofTv7zPcjyZV1T4tsoslkaWYAg8dM4122VRl/npa5/mymVftk7Ka
+        fFUX1OSjeduumkd3707n+fmqrmb3d/d2xhP6fjyt6nx8VSxn1VUzXubtXXQw
+        cx1sr+gn6D/bPp+e35tN8+n2+eRgtr3/8Pz+9sPZwXR7sns/n03Pzx/s7E/v
+        +tM1vs0b48YiPJ4sVkwG5Y38XUtfEIExTJ1lHS19axjki2JaV0113o7PqPHF
+        vG3GP/mFR6LXedvSDDUMmWDjhxKzz0QO/HsxzxDjvD/TbGaYh/t7u/f2AoYR
+        WsUw//I1us3vkgTndVYWPwj6uTXGpAR8CNJwuNeX1VVe4+387izPyrKa0q9f
+        t2MfgjSU6fuNk1/y/wAqG7qdsgUAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0bc0c07c-1d50-43c4-b8bb-cf9238056209"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5720279b-ca8e-4e7c-bdf7-358f68fa9608
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - cba58a7f-e921-4ed3-9de3-415047b16619
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135051Z:cba58a7f-e921-4ed3-9de3-415047b16619
+      Date:
+      - Fri, 30 Oct 2015 13:50:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/amUx3pjsP
+        ptu7s/s72/v3pvvbk4PJZHt6/nDv3sHO/U/3dh7+vh/pi+31ikd7i671jbKa
+        Zhg23sqzpl2bL2gcq7xuC2r5KGVayoeXRUPNi+XF6zZrubPX6+k0z2f5TN6k
+        ZjQgIc5aCLyb5bv3JruT7YOD/Qfb+w8f0Bge7N/fvp9PpueTnXuTycMD+3Kx
+        OqmW58XFumbE0P335KvU4IHHzmyxmnL7XQMBz//rZvZud1j0QQzvrzv18mCC
+        erMmD766xdzJQ42LS2py9vJ4NqNBANpHuzvjvfHOWJnUPF7T0jDTF3k7r3gC
+        nl7TNBXT7ivrSVlM6Q0LPECVWvyQp6+DEE3fSzN9T/PLj3zkfkk4FMKQ5p6Q
+        /TkewWVRt+us1D/9twgDwrC5O8vPs3XZhoNxf9hf9Zfv6zg/mi2b13nbEtcE
+        EyWf15eEDn38PdOcvshWq7LIZ0/D7+VrQ72P8mU2KYlpnlX1VVbPCDq1Os/K
+        JjctCGkM5XU+XddFe83UoDYOgR8yhWP4RPnEjlHn5ItsOi+WELefDdy/ffps
+        ++WrL59GcT+pFqt1mxvuUEziWOMH/fNL/h9LzfwgOAcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 34f95b5e-70c9-484e-b3d2-cdedfcff004a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - b216066c-ff03-4703-bb9b-ce6f2a0c2346
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135052Z:b216066c-ff03-4703-bb9b-ce6f2a0c2346
+      Date:
+      - Fri, 30 Oct 2015 13:50:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - cc425656-96f8-4ee4-ab7c-de47e01db9c5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - bf0c1748-8a0f-4ad4-93e3-c031304e35f9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135052Z:bf0c1748-8a0f-4ad4-93e3-c031304e35f9
+      Date:
+      - Fri, 30 Oct 2015 13:50:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9vU92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4E6nefnTV5f5vWu6zVKOu9tPBvI
+        16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQ47TZ33t0//744cH9h5/uP+zQ
+        iChjfmU66d/fZ7gf5e/anKaApoGg6sjtqC3NviimddVU5+34jBpfzNtm/JNf
+        PC2yi2XVtMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcQ8dPxzv7BfoeGwllR
+        xKurvEbH+d1ZnpVlNaVf/Z5ujTNJhg9BGgodf+Pkl/w/d4Ym904EAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ec36b00e-1d84-4807-8c45-a59d8f936e11"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 027bfafa-474f-49b9-8a26-e74b460ed2a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 3a12f67a-dccd-4cec-9b60-09d6e011a68c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135052Z:3a12f67a-dccd-4cec-9b60-09d6e011a68c
+      Date:
+      - Fri, 30 Oct 2015 13:50:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9KJ/e+3Sy
+        s5Nv784O9rf3D3YebB9M9+9vZ/cfzg7OH977NN/d/X0/0hfb6xUP9hY96xtl
+        Nc0wbLyVZ027Nl/QMFZ53RbU8lHKpJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
+        Sc0scdZC4Em+O9ub7U+2s3t70+396cHu9uR8Z7a9e+/Bp/cePsj2ZpPcvlys
+        TqrleXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig
+        3qzJg69uMXfyUOPikpqcvTyezYgggPbR7s4Y/90fbFoaZvoib+cVT8DTa5qm
+        Ytp5hWaF6EXfBxjSFz/sWbss6nadlfpn8BrhQDg2d2f5ebYu2498TH+J+8P+
+        qr98X0f60WzZvM7blogN4tmByufgCnz8PdOcvshWq7LIZ0/D7+XrX6LNPsqX
+        2aQkWj+r6qusnhF0anWelU1uWhDSGMvrfLqui/aa6UFtHAI/bBrHEKJ2Zz+h
+        7+8qae0YdVK+yKbzYgku/eHjrl8b/lBUApk2WOMH/fNL/h9nVwHSbgYAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 6ec6f168-4364-45ec-b83a-67067ea3ed0d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 409767aa-bd5b-49f3-87f5-1e98430de176
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135052Z:409767aa-bd5b-49f3-87f5-1e98430de176
+      Date:
+      - Fri, 30 Oct 2015 13:50:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9vU92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6+uql6y1KMu8tPBvI1qyn0zyf
+        5TMHEY8j29nyvOp8RwiGVPPBpkMQ4zTZ33t0//744cH9h5/uP+zQhihifmX6
+        6N/fZ7gf5e/anEhP5CeoOnI7akurL4ppXTXVeTs+o8YX87YZ/+QXT4vsYlk1
+        bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyA1E/HS8s3+w36GhcFQM8S9fo9f8
+        LvFyXmdl8YOgm1sjTOLgQ5CGw72+rK7yGm/nd2d5VpbVlH79uh37EKShzN5v
+        nPyS/wf7Gka4vAQAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"26a13215-44d2-4d13-b683-a83fea9e083f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a04951e2-98a6-4634-bb6e-cc1a387a1874
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 0d718901-a6d2-4afe-8b2a-a3e286cfa8f0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135052Z:0d718901-a6d2-4afe-8b2a-a3e286cfa8f0
+      Date:
+      - Fri, 30 Oct 2015 13:50:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+36092m2e29v9/72/v5s
+        b5v6vbc9+fTg3nZ2cO88zx7mO/Tz9/1IX2yvVzy4W/Sob5TVNMNw8VaeNe3a
+        fEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWwNIRP
+        Zw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ/ffk
+        q9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlDjYtL
+        anL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1hgQeo
+        Uosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2d2f5
+        ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW+exp
+        +L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTGIfDD
+        pnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/8lQWOCQcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0b6d824e-58ef-4c18-8de7-299a35e387e1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - bd7030c8-508a-4235-a44a-8ac5f5975454
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135054Z:bd7030c8-508a-4235-a44a-8ac5f5975454
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - cd6ed12a-24b3-4863-aed5-4314790e513f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - e36bfbec-3c2e-440e-81de-fef4fff399e7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135054Z:e36bfbec-3c2e-440e-81de-fef4fff399e7
+      Date:
+      - Fri, 30 Oct 2015 13:50:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9/U92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6xdlP7LnuojTzXsOzgW7NejrN
+        81k+cxDxOLqdLc+rzneEYUg2H2w6BDFOlP29R/fvjx8e3H/46f7DDnGIJOZX
+        JpD+/X2G+1H+rs2J9kR/gqojt6N2xCqmddVU5+34jBpfzNtm/JNfPC2yi2XV
+        tMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcQ8dPxzv7BfoeGwlJRxKurvEbH
+        +d1ZnpVlNaVf/Z5ujTOJhA9BGgodf+Pkl/w/1lFaqkcEAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"86ae9cbe-172e-4618-a950-a33604937de9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3332ad0a-cb09-4d77-b899-702001ffd632
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 8f25e893-de24-4097-af10-3c06dadbe464
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135054Z:8f25e893-de24-4097-af10-3c06dadbe464
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19Pzr4NMsfTif59u6D
+        PULj092D7ezh/Z3t7N69T3f2H957MMsf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        P1R9PzgPBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4b015884-271d-4053-8e06-2e611591de8e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - cc6ca31a-6bf9-49ca-a8f3-da1d6faa4ef8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135054Z:cc6ca31a-6bf9-49ca-a8f3-da1d6faa4ef8
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - ebcdecec-d7b6-4dd4-bbf5-802353a90c0d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 0a77f22d-42bf-4a5a-961e-b7316dc1ce69
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135054Z:0a77f22d-42bf-4a5a-961e-b7316dc1ce69
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        93be7N57dH/n0f39T3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
+        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
+        GKfN/t6j+/fHB3sPP33w8NMOjYgy5lemE/2tIO3oLG1mWZsRXm9/RBn+QVC7
+        lNlzvf78ogx+fJ/hfpS/a3MSWxJdgqojt6O2FPuimNZVU5234zNqfDFvm/FP
+        fvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcTMT9+/d2HoRE7LOS
+        xby6ymv0nN+d5VlZVlP61e/q1kiTOvUhSEMh5G+c/JL/B8HR3/ZIBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"15e05a07-0ca2-435c-8eec-b61e5da24da7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4203e8db-6094-4cc4-a29d-354e1208768b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 49eb0f4d-acc1-46a3-9cb0-852664f1c8f4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135055Z:49eb0f4d-acc1-46a3-9cb0-852664f1c8f4
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR7v385372c6D
+        7Z1ptre9f+/+dPsgz6fbk0938/uzjDDKHvy+H+mL7fWKB3uLnvWNsppmGDbe
+        yrOmXZsvaBirvG4LavkoZVLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljhr
+        IfDew8ne7N7edPvBg3x/e/98mm9P9j79dPvBJDvIHpwffLq3u2NfLlYn1fK8
+        uFjXjBi6/558lRo88NiJLVZTbr9rIOD5f93M3u0Oiz6I4f11p14eTFBv1uTB
+        V7eYO3mocXFJTc5eHs9mRBBA+2h3Z4z/9gebloaZvsjbecUT8PSapqmYdl9Z
+        T8piSm9Y4AGq1OKHPX0djGj6vjj7CX139yMfuV8SDoUwpKknZH+uR3BZ1O06
+        K/XP4DXCgXBs7s7y82xdtuFw3B/2V/3l+zrSj2bL5nXetsQ3wVTJ5/Ul4UMf
+        f880py+y1aos8tnT8Hv52tDvo3yZTUpim2dVfZXVM4JOrc6zsslNC0IaY3md
+        T9d10V4zPaiNQ+CHTeMYQtSuxyl2jDopX2TTebGEwP3wcdevDX8oKtSijzV+
+        0D+/5P8B4BsgKTkHAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b12033a1-9310-4a08-b935-660ecf1b0abf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 2218fb07-7bf0-43d4-ba9e-d7c41e65c4b9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135055Z:2218fb07-7bf0-43d4-ba9e-d7c41e65c4b9
+      Date:
+      - Fri, 30 Oct 2015 13:50:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 64153641-548d-4a83-a077-817cbdc1a892
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 576caf5a-9256-440d-94c5-9b4824f1650e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135055Z:576caf5a-9256-440d-94c5-9b4824f1650e
+      Date:
+      - Fri, 30 Oct 2015 13:50:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9+5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
+        8pmDiMdR7mx5XnW+IwRCwvlg0yGIcbLsP3h0/9Pxwb3dT3cedMlDRDG/Mon0
+        7+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAmH83b
+        dtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6HbbxzudjZ
+        zrPdB3m2t7+dzbLZ9v7+9N52dnDwcHtnZ//e+WRv9/7D8z3uYPsnv9gZ36b1
+        uLG4jieLFVNAGaI/vTpM+u69pnVoSt9/OjdP5cP9vd17e8FUylCimFdXeY2e
+        87uzPCvLakq/+l3dGmmSTR+CNBR++Y2TX/L/ABdFxPzQBAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ac03b5da-e835-4650-87ba-5953e106ba33"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cedd7e86-4a61-47a5-9966-e748981f6d22
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 27efea35-7029-4858-b9cf-a8f55c865a9a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135056Z:27efea35-7029-4858-b9cf-a8f55c865a9a
+      Date:
+      - Fri, 30 Oct 2015 13:50:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1E23bk3uT/LtvOD
+        e/e39z+9v7N98GCSbd9/eP9evrvz6SS7d+/3/UhfbK9XPMRbdKpvlNU0w4jx
+        Vp417dp8QSNY5XVbUMtHKRNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s3RZ
+        C23vHzyc7u482Cc6zna39+9PJtsP9w4ebE+yB+effjrdf0j0tC8Xq5NqeV5c
+        rGtGDN1/T75KDR547HQWqym33zUQ8Py/aVLvdkdEH8RQ/rqzLg/mpjdh8uCr
+        W0ybPNS4uKQmZy+PZzOiBaB9tLszxn/3B5uWho++yNt5xbR/ek0zVEw7r9CE
+        EKno+wBD+uKHPWGXRd2us1L/1On6yRenb+4SCoRic/c1/9ze/cjH9JeEwymr
+        bPYkK7PlNK+fZNO3+XKmZHtZVSVoZ3lXns6wCcQPe+A+yjrs50/uTvrI39UB
+        4Y+QCEQG/8/vD9PkbDmp1svZi6x9tS6ZM/8/Qo8iRPzuq6cvt3/yi52NZHB/
+        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
+        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
+        OkpvnQ4jeIqKUtyRlilG//yS/wduCFLLtQcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 0e787c68-b7e6-4f5a-9887-d9ca4c41b2c2
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 45d2f604-a5d5-44d7-9b2f-487ec5814540
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135056Z:45d2f604-a5d5-44d7-9b2f-487ec5814540
+      Date:
+      - Fri, 30 Oct 2015 13:50:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9Tz/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
+        5TMHEY+j3NnyvOp8RwiEhPPBpkMQ42TZf/Do/oPxg51PPz349KBDHiKK+ZVJ
+        pH9/n+F+NKmq9mmRXSyrpi2mwEPHTKNdNlWZv57Web5s5lX7pKwmX9UFNflo
+        3rar5tHdu80qn+42bVXT1O6OJ9RgPK3qfHxVLGfVVTNe5u1d9DBzPWzjncvF
+        7vbO5H62l+2fb+/OPn2wvb87y7ez3b3p9r3d2c6D3U8f7n26R4Slxts/+cXu
+        +Datx43FdTxZrJgCyhD96dVh0nfvNa1DU/r+07l5Kj99uPvpp/eDqZShRDGv
+        rvIaPed3Z3lWltWUfvW7ujXSJJs+BGko/PIbJ7/k/wHy+oEj0AQAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"79a4e4b1-b793-46f8-a809-201f55afc502"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f4ec7fac-b415-4022-b06d-24c1a1ea3c18
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 23c36bf9-1b7a-429c-88a1-a5073d76ab01
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135056Z:23c36bf9-1b7a-429c-88a1-a5073d76ab01
+      Date:
+      - Fri, 30 Oct 2015 13:50:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9GDh9l+vj/Z3Z48
+        eHhve/9TQik72Hm4vbeze37/fnY+vb+z9/t+pC+21yse4i061TfKapphxHgr
+        z5p2bb6gEazyui2o5aOUCSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZuqyF
+        tg92Zvd37t/f297bO9/d3r//ab49me2dbz+c7J7v5vf2z8/zHftysTqplufF
+        xbpmxND99+Sr1OCBx05nsZpyeyWePP9vmtS73RHRBzGUv+6sy4O56U2YPPjq
+        FtMmDzUuLqnJ2cvj2YxoAWgf7e6M8d/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
+        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
+        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
+        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sZkM7g/7
+        uf5iKPTRbNm8ztuW5BC0sIOXz+tLwoA+/p5pTl9kq1VZ5LOn4ffyteHFj/Jl
+        NilJDJ9V9VVWzwg6tTrPyiY3LZTbv8im82IJ8Xddf3P0/vKLl1+9Of3JL15H
+        6a3TYQRPUVGKO9IyxeifX/L/AKug0K61BwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 61808bd8-2a44-43f8-8ffe-59331ac215d0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - a88dd0f4-4d70-4596-9752-bd33adf25a87
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135056Z:a88dd0f4-4d70-4596-9752-bd33adf25a87
+      Date:
+      - Fri, 30 Oct 2015 13:50:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        93be7N57dH/n0f1PP9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOrr
+        rMyb86qe5l+9dt1Gaee9jmcD/Zr1dJrns3zmIOJx9Dtbnled7wjTkHw+2HQI
+        Ypw4+w+IOOP793fuHewfdIhEpDG/MqH07+8z3I8mVdU+LbKLZdW0xRR46Jhp
+        tMumKvPX0zrPl828ap+U1eSruqAmH83bdtU8unt3eV1fPNw92B9P6LvxtKrz
+        8VWxnFVXzXiZt3cBfOaAbzeG9tvT2flOdv7gIeG/P9venz24t/1wOr2/fXD/
+        /u5k9+Fsmu88uOtP1fg2b4wbi+x4slgxCZQv8nctfUHExRB1hnWk9K1hji+K
+        aV011Xk7PqPGF/O2Gf/kFx55XudtS7PTMGSCjR9KyD4DOfDvxThDTPP+DLOR
+        WT7d3SPShRIltIpiXl3lNXrO787yrCyrKf3qd3VrpEkH+BCkoRDyN05+yf8D
+        JC9LKP0EAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"10151287-e86a-4dca-869a-8ebd68e2834e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b81ab530-bf34-42c4-bcc4-6d45f380b306
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 2c943a95-6076-4e74-8c69-7a18ee3dedef
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135057Z:2c943a95-6076-4e74-8c69-7a18ee3dedef
+      Date:
+      - Fri, 30 Oct 2015 13:50:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHdn9/7u3sGD7fzg
+        02x7fzbNtg8+fUj/5JPZpwf53sG9/fz3/UhfbK9XPMxb9KxvlNU0w4DxVp41
+        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
+        2V4+vU9Iz+7dP6Ax7M+2s93d3e3pbn7vwb2dTycPJ3v25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+d0mI15fa7BgKe/xfN6d3ugOiDGMZfd9LlwdT05ksefHWLWZOH
+        GheX1OTs5fFsRqQANEJnvDfeGX862LQ0bPRF3s4rJv3Ta5qgYtp9ZT0piym9
+        YYEHqFKLH97EdXChiXttJ+6r12cvP/Ix+yXhOAg9mnfC9GcN/ZN5fr79sq5m
+        G8dwWdTtOiv1T/8twoAwbO7O8vNsXbbhYNwf9lf95fs6zo9my+Z13rbEMsEs
+        yef1JaFDH3/PNKcvstWqLPLZ0/B7+dpQ76N8mU1K4phnVX2V1TOCTq3Os7LJ
+        TQtCGkN5nU/XddFeMzWojUPgm6NwtVit2/wnv2g2kjiGELU7+wl9f1dJa8eo
+        c/JFNp0XS8jazwLug8ytSBnGUCRC1jYI4wf980v+H9qMLAEjBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e7a7e3b9-0acf-4c77-bd3e-a5519a899ff8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 3f1ae70c-89aa-46ec-952f-933f29b0f437
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T135057Z:3f1ae70c-89aa-46ec-952f-933f29b0f437
+      Date:
+      - Fri, 30 Oct 2015 13:50:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 13:50:59 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
@@ -1,0 +1,12121 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Ms-Request-Id:
+      - 75395283-d94b-4803-8ba2-81f9e5144e6b
+      Client-Request-Id:
+      - 687bd93f-29a9-4696-9c0b-205f7f4db39d
+      X-Ms-Gateway-Service-Instanceid:
+      - ESTSFE_IN_14
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - flight-uxoptin=true; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 30 Oct 2015 14:10:30 GMT
+      Content-Length:
+      - '1218'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446217832","not_before":"1446213932","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ"}'
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
+      X-Ms-Correlation-Request-Id:
+      - a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141032Z:a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
+        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
+        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
+        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - d7d26ffa-ecae-419c-a5ef-b411b020cc3c
+      X-Ms-Correlation-Request-Id:
+      - d7d26ffa-ecae-419c-a5ef-b411b020cc3c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141032Z:d7d26ffa-ecae-419c-a5ef-b411b020cc3c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
+        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
+        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
+        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
+        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
+        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
+        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
+        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
+        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
+        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
+        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
+        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
+        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdaXj//od7I9K/h5o1
+        8DZ2wt0MaGAialUXP+Be6G0fGfTRQ6+uyvy4aYqLJQhyWxwfEDrUVP741P+D
+        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyWpLqD0/3Z8p2VG1J0ezxaEMuSh
+        rXp+7BDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUGKAP5L0FE7hSU/mD
+        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
+        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjVzqkVwg9juNgiDdtH/iA0iRus5Gbb
+        BYaxpOCx3ziMu/V6OamqHqv/f3Y8Qfbm/5ujIhwG0O+hccs+uJe4HDzJ2il8
+        LR8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8fykhQUYNGWYOi/BfDpnkMFg
+        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
+        35in4pI8RDddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
+        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
+        oJ+7lDXLnmdv8yFJfs+ON/bVkCNKec+fg65gBtqsWBLEn5te75bkib/OmjfV
+        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4zz
+        gT4GANzDaZGtKHOPpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
+        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnAgx4+GgDV
+        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
+        D7L79D/HvxvpcpJRZp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
+        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
+        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b1VnwIk59FtGgW30/hfEO4
+        xHBhhj3hcM0lKr42WoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
+        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
+        TYxE/9tEXXr1Ylk15O++ztuW7GuPvEDEo4oSTohgsOOv5SNLCcbU/tUZPX/J
+        bwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSGipf5gxvqXzeQ
+        lwk8YAFmkAqf+Hi9Nx2UQDsvSvquQ36DIRMDYwl+G5oLQT34iIfGv0l7OzX8
+        hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIYTosqje7my9mq
+        KshlJ8g/otatqXWX1n0uCnr5R1R7H6pNCW61mFGq8ke020g7wlDcE/o8Emz6
+        tPpg2Hd1ovTPH2JXljP075/DrlWg9a+fS0R8GdHPvkl0buOPf1AHdrzfKNr5
+        7CJfVrONVv0GoAx2wLOQhWMK7VfrFrrB7x2QevjI/ICOPYygB4wasSrAfMBf
+        Eq72N9ZrUC30O/0mGssblMIIPwr+kFesWmNY9i9RXejL/oEG9MfX0WMGGfHk
+        HB7mb4C2fwAOYZjupVuvW0oOIkEkuJrX6Evz1cDcSSrLxDc8kfwHOYvBH1jm
+        oSmmCe7ME7P7UztZG5j+ZwsDj1PuNmXVl2amk7IHkxekNh/wlzzN+tuP+IW/
+        +qHN1t26Ih+GXvzRnMnfAG3/ABzC8P+Vc3ZjviOKD3VE//s6HX0w+MuibtdZ
+        +QUlOmnppAtOaK0sxlOE6TIf8JfMKvrbj3iOv4pOwu15jv7n/hhkwCmNn21K
+        0Zu1r9l/rJfoOvXXhG/+GBxShxd/vme3+HfLgaZj8zc6sn8ADqH0AexJ80L/
+        u928iOoZ1nEGHfpYf/vRtCjtzZDNa/Sl+eobmpbeZHQ7pO9lCMFHiqr7jaeM
+        R8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB/dGZbUd7bew+4CbokT7l3y29
+        DZLmb4C2fwAOof+zNBk0vHgEGoV0e2VJ/3N/DGpO/89vCIHbxK4v8vaqqrEG
+        HCIQiV2VWfWNLo4yOcpAPKeYX/MBf+kYj6Yp5M3uLNJHDCP8KPhDXrFsybDs
+        X8KX6Mv+gQb0x/8HmDQ6meaPTQxEa//57Gz1o6n5f9nUvI8LFoIM/hiEf5G1
+        +VV2/Xq9WtFo8tlTWuCekhD/rHVIM/leqjIEG/xB/3N/aIfc5Ua19bqtapol
+        etHHDB32cKW0KJoeT6fVmhYT6BUfYeEJFQVmJbCV+YC/ZJbW3362ZOMm2fj/
+        vGzQ/3a3J3mLrtwn9g+deJr2zuz9bIsOJ/qUm5RF3j/ZF/YV/DHYcYct70J5
+        R4RWJolZ0M0D/SEzG3wkuhTzaP/Ay/QHPjMszS+CPcwHjnPQLPjAtqVP+XfL
+        LaZj8zc6sn8AjqCkv7HUdJnJfmQtAwOxfwUcHyU8kZf+937kVRd7OPL5pnv6
+        xuEL2J/FAUgHHwz2/bMboeTwHzHAs6LpeZ8fBrFY0Pi/WZBVc/azAPTnzuze
+        fokr89QnJX26qBqdQB/rb6wdWPb504iGCD5ihRB+JK2s5mBY9i/uRXUdvwuF
+        Zj4QNYkm9g+8TX84Lajfug8sFPr0Zi3F07B7n9rKH/S/3e1VTS5afkVEJ5J3
+        CKhxlkkK0Is/ot8H0O9u/q7NlwLxR6T8MFKSff9a6VwMhH6n3yLECj5i7MOP
+        pJUlIsOyf3EvSkF+F8QwHwgV0cT+gbfpD0dB/dZ9YKHQpzeTlLQn/Q/a82bq
+        iWEdttwyGB6z/vYj4inxXk+zMiee+3lPMhLZDxFhS8cfaUUZrFDxmyFp+PmP
+        6PpN0XUpGeezZZvX5+SZ/oiy3xRlw89/ROkPp7SjVki5bxj6XSJPPBQUkjFl
+        9bcfTdEQES8Xr4sf/IjJiWJfl4LrJpLkkAHxuPW3HxFwiICr9aQsmjnBo7ft
+        x4ALnGTs+tuPiBgSkdCOq8CvA547iOe+nmZtdlItl/kUA/GRAOweWlNpSl1/
+        kS1JOvozC8phQobwPAhRI8Q6XThoP2uQnYF5lTfrsh94fXBXvPLygii+Yb3l
+        fXvhfoZn8Vk2pVw3OvFxAbgedjPbvJ++tlj1JAoiIF/obyyz0iiQRIZgXwuE
+        oyPZ/GH4ssgferB/AB79gc+MyPKLkD75YICCuztEQWrNf+w89P8Abe0fD+gP
+        S2jzIf2v/yGSyeGH+9u7e7EP0XX3w+GEQDAjXzsTFZkL+chOBkjp/upMDX/J
+        bwUg+OsQqswLurZ/4GX6A5/JnOiLN0wSUYT+dxuifM0EkxAgwF4+slQA5u6v
+        /5fThBWLJ+436JgofOJj+l+HO/kT+p/5cLDz4x+s6/yDMWD5oKb442dBNGPY
+        O3a6fk0jWWA6/t+JKXGimKcuj/9cochIDpue59lbiI4/CiDXGxdmAG3Naiy9
+        449OBIXlNjpQ1aqED2HTAe3ghDC/PiDnJFCLiJNwA2SGvZlkx8usvCYlD8jU
+        h8UCwHp4ZV+PZsoc3lwSWgOg75r5eU0y8nUn6b067KzO/xC7ukuebJtRXqjv
+        wf5wer1LkVH7OmveVG8pVf2zgIODF8L+cIBfSzJu04OF+zUhMszNMsesTdD9
+        ngGwh4uZQmrrY/JNzIwBffe8qPOrrCxfrUtC4pvvyMELYX84wP9PsgC1kayv
+        3ydA9bAg9+Dm8E0niD7uOJT8xbB7R+b1gIJ1D2lCuYPAWdV+ez0Brj9LXXKn
+        g3R6Q47r82xCgH28AK2HKVGnh2bHyVX0GG+4xN5vkQHo78z5xpHGJ/YPvDg4
+        zPvbez470CA7+OZLWheolgty3f8/hTd1916CEUI0fh39D85JH7yD+DWgbwTo
+        VEUXtiEYfay/MelAJ/rd/BYldW+mhMRoYv/A27elN49gQByq6Rrc8vQJQfYH
+        CWi9YcOFmmSNtfj0TjBkICWD60gwf2H/wkCkGf+mg+yN2qUj0Sz4wLalT02c
+        erakzAL9zd/pX0MEogj0gJrSH/Qb/S/ONp3hQmX+/33IhO0AO/N4eAT/Hxwo
+        D3VIAhbks77KL8hjlaHTyz5VALpHpxm/1SPSRVlNsnITai5eRWKNUCPEOrDb
+        avU8v8xLwexnpw/2AaSDTV7AN9IXYgHp6lU+rRakbkiwGNDPRm+XxEQEPzc9
+        unk9W55X9YJ/JTDffM8XOYU+1PPrpnqV/6I1iQW98813Q3JGvfCbHw6eOxgQ
+        jGv6nOL357cL4ctps6qrn6b1EzQP8OpkHSHxRg/w76wuxKzhb/sHNAv9IfrG
+        qAJuLB9ZpcOQwxZ41zXgv/hzbgrtYjAI3kL39Btb6i9eP3vDKNAH5k/9PvhT
+        4fAHHbycUkPL4AOLx+B00f92t7NyNQd0+Qgz2PnoXv8jTC1Z/+KSeNE4AZ3v
+        Ih9O8rYDQqAyhwzPNYJ+LJpV/VTDj6adWwYfWDz+Pz/tZbWezfJVWV2TQv+R
+        zNtu3VyjZfCBxeP/i5NPoxswOz+aam4ZfGDxGJxqJreZlY2G+PSSxkAJE+rA
+        nxPA6s2ShdCbJYfbBmTj9HK/MeUc0YQewSsMK/yI31Uy8tfoynzQYR7hDLxh
+        /0B39If0ZWmPT81fURKT3PBaERO2QyX2fjmcA6k2OMBRyDR5buFpUzeEW1xk
+        3gcsA7bTSlAdYzzLs5aWKwGd/rU9A2APl3PX9kZMqHNg4nEnoUDv+vDIEFwW
+        M3rv6wFkkP6oyNPUUVHIU1zM2aL4fQJWDwsKJ1bVkpgNrX00fD6OokTUpv85
+        agM/+wf9D6QnFDv9XeWTlhjvh9QbxRB1QQP/JjqLwc/KvG7rWHqepYvgq/Dy
+        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
+        p4GOGSIZEcqRjP5nSNYh2bqtmikRrsnbtlhe3Ew5gimjtLTC2N1fwNwQijEE
+        0uYDIRaa2D/wNv0hMANq8NvhR3iTfvt/A+Uoo7FsW/q9S7LbgN3Fkr35Q76J
+        9eHAhl0YOnzgECxIl/V99T4LRAL5xm4s8K8F9lP/D/pfvA/wMaVC8tnpuxVx
+        0usfcXOUmPS/OP0oAXmxrJq2mP48JJ3pQfKwDqD5G5jpH0NUfjBE2EXe1sX0
+        aX5eLAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+
+        yYwMAcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZh
+        fwyWf5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6T
+        T+v8R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XVbsYeVSPIkf47AA5
+        xqID1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdr
+        ZeyAC4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGw
+        s8/z+r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jq
+        t3m7KunzL2vKkpCDSFB8pNBXD83sos7zaDqdCRPOJCiN34aGwALMOHZ6eW9i
+        KCSGFR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8
+        wfAClsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fH
+        sxl90xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJ
+        lVNf59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/
+        RNtvhLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhH
+        wpCcP4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsf
+        Ci7rJrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT
+        +xc3U71hhdZ8IG8GioLbhB/pH/IHw/v/miLxKfs6ry+Laf6yri4LSmh1Kfyz
+        iMVs2fygWva4+KOLsppk5eD46X/7t4J79/hnDzI9P2vAT14cf3H6swb95ZtX
+        P2uwv/i9f9ZAv/m93/yswX796ie/adgkzefnxXSRLUlP16u6Oi8iYeYNvexv
+        7x1s7GUKi/RGuvpCurrBOL1nl9zpQGa4agvqliF/ez3B2HzsALOHr4WE1gFa
+        TgFu0Ihx1et+YyUMjUu/02+30+b8rup//hpdmQ86elt0Ot6wf6A7+kP6slYG
+        n5q/oqTe3955SPqRSEwEHqTS3WWfyD8i2wDZWBjA/ky7TTLgiKQ4uQ8YZQyF
+        Pu2P1//t/ydUo5fijp1HFMXBfcAoAnX6tD8+/7f/T1KJ6WSlkIjktN6XhlxZ
+        ebZsios5u6Q+TQGuR2VkbRgYWgdUBuYy6hsRJPV8b3tvh5rSH+Rg7dJatP1j
+        h/5HqBPina6btqrJMCi2J9XyvLjoYhHtbhPQsli+fZPVFzkP3wdlBxSF2R3C
+        YAdEBKFzF34ULEFiYmycOoocuQdA9HsDkF7/DSnbaV2spNtboEAj26X/UVP6
+        g1iJ/rfZ+w16uEsewnu53x/Sl6UttXqPWPr9ujR/xhcsbi/u/KVr9jU1irRS
+        4dLX7V+iNQDe/oEG9EdH18QVoPtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJdWQO
+        Sf6z0VebXbCo0fvffFdQMT87kGnWhf/fC/xG3fKanI/Zusxrguj3BiC9/n+6
+        mkyrshzIOQurGkZh7hUeCj6SVpaFmeXsX+BDIz/8LjjVfMBNGQY3498Cppc/
+        8CX90ZGAAAc0od9YIHtC4D7gd4EBfcq/K/c7aOZvIKB/RKeCZvaApuLrTa6S
+        zPTJIxB0go+klSUlo2T/wtgMHfldDMt8wE0ZBjfj34SW+Mb+gS/pj/+XE5ZJ
+        O8DreVZPgbNPeUDqzUXDLTXB1JsPRsofL/22kfo8RozXUJzf09/lTTNwBsbt
+        w49kCgCW/nCUBCD6YGBONhCOlMPB9u5Daix/7FH4LH8QSR9s39vdfmlJSgTt
+        0IeUxpRW9pk8CFw2xCxDvX+NDr9mTzzOGFCanLjEbYTEONMfPIAb+I0J9GQN
+        +H7fANnDxsJAax+b/nS7D3jGwVn0qZl15he0DH5jmQT/0O/02+24jt9VPuWv
+        0ZX5oMN0wqF4w/6B7ugP6ctKAz41f0UpTQyh8QyRtkMlywhMqq/FDQSZ53BT
+        N4Tb+7IGQeqAZcB2Wgmqxxq/qKTWfqeAdXs0hIg8R0z/yLTplAdfyEwEH2lb
+        85vOLQP1JzuYUPkD7ekPganzGc5uj0cc4+rL7gNugh7pU4Og6C+Faf7ghvpX
+        dDZoAuh/ziaYWaH/YVZoTjpUdoT9EZH1D26of33DRL47pYGxyBbE9D+iuP7B
+        DfWvb4biVlVu0JKCA9NJEDA48kcYDf32I4LfjuAN2XsCQQ1/RGL+gxvqX98o
+        ie/OsjabZM3/PxUIkeFnldjvS2z8JD/2y8lPI/K//BHRfxgcns0WxbIAQpQG
+        /xHF7R/cUP/6WaS4XS6h5Hsk1Sw4Md0EIYMzf4TR0W8/moD3mwD6mCifTcr8
+        KaG/ymdPf6Tl6W+Gaf7ghvrXN039aUW/MPl/RHf6m2GaP7ih/vXN0r1YrGgs
+        1P5HlOY/uKH+9bNB6dN3+PdH+p0QFCIrTPMHN9S/vln6E8o/orkQVmGaP7ih
+        /vXN0vy8qPOrrCxrWuP7EcHtH9xQ//pmCW4i09f5dF1TwuVlVRbTH2W6CKb5
+        gxvqXz+7tP8ib+ti+iPS2z+4of71zZI+W88oobu8+BG7098M0/zBDfWvb5bm
+        8NgXi3w5y2enJWFSTF9WVfkj0ts/uKH+9c2S3miaHzE+PlUSK0zzBzfUv362
+        qD+tlkskJavlj+hPfzNM8wc31L9+tujf/MjSKoUVpvmDG+pfP1vEx29fZM3b
+        H2kfUFlhmj+4of71Q5yAuz8KtBim+YMb6l/f7DSYj1c/8nkA0/zBDfWvb5bg
+        ufiYP6I3wzR/cEP965ul97rJLn6kSn4YlIYeF42+YD/maX5OK4FC8v8fkp/G
+        9P9q8v+I6PYPbqh/fbNE97X5j+hOfzNM8wc31L9+1uk++5G64c4ZpvmDG+pf
+        3+wMOHXTVqufWOc1ue309o/ozn9wQ/3rZ5/ud38R/bx+k78DXj+aAf6DG+pf
+        X2cGeA6W2SJvVtkUE/BFMa2rpjpvx6/bqiankt7w5whw+7MmTY+n02q97K/V
+        YngeVXUu7O/p1uuW3r5Dn/HYuCX/ZinHbZX4PGTQxnwQTID8gbfpD5kNQ0CG
+        y2+HHwV/yCu2468zZdF5uL+98+n27n16Rf6g/7lJ4Vno0JT6lwXwLjm/GfDR
+        gOGbAT2d59O3L4inji+zoswmRUlJP3r9m++pw3d3oT2KaW9Ywj48vWAM+U0/
+        67OfnfsOK/ALynJ2ss0HwnZoYv8AMPpDoAQ8xm+HH+FN+o0FI/jCMRiaBB8w
+        GCBBnwZ8GiUuCTz9DzJ/ezqqz7EhxAFSgiiGK7/pZz8PKcu0HdKmdZ4tjpdZ
+        eU0eHejozwFARWYFr1C+8KerCV4ICB8MBQTpkFNHLDSyXwn90ID+4Lf4fR4c
+        xmuIzh9E6KhfCxi8T39IF/22/JujKT4LPuA+0Cl9GhDZzdMGu3Z/e3cHRDe6
+        4qH/x6f+H/Q/9wdPlPnjHv1h9Qt/SF/T/zCVNJGd6XDk70wF6OBIbHDn4WPQ
+        9NuPpkL+oP+5P5jQ5o9gKjZSn7zAqs26k/BzhxjR0EnpXSLSxbJC0PY6b7HU
+        20XUmxD9zWMOQ2z+Wj6y/IIpdn9tnCVtzFDMN/wHNw97Ef4BKvYPvEx/4DPD
+        ZfwiGMR84HgHzYIPbNs4txB16X9xESMQHi3fw/jobz8ipSUljS3uPsqA7Oj5
+        L0Y/GAtQod88gto3ZGRoQH9YDM1o+IOQLmhqvpaX0Sn9IYD7bfk3RwV8FnzA
+        faBT+nTj7EWptlErHNAfVtzNh7dRFfQb/Q9zwbPhOwEL6wQ069WKxkxv+LMF
+        xN5j/iJU49GHHwV/gN5uAgWA/ZO/5GYgdPAbT79MGT6xf+AV+qNDe/6JaTGT
+        jXfM72728GnwgX1vaL52HhBlt192ZgWamchNxO6QTqlMOvht3g9GZfQBeRiB
+        8KPgDwzX0UsA2D/5S26GgQW//X+BfEzAOLdeFs06K5t2PSsqes2nMoD36J5J
+        +EBNvwbBMSz5DdSR34IGAiYku/2L31ZSMXDQw3wgREcT+wfepj86M+Boyo2j
+        5CQhp/91dAR9sre99ymRk4gZp8rdVV39dD5Frz9/qcP08ZnNxUffzSfU2qcd
+        YPao2RQthaWUAsyX0m+HnB2cgakZKP/OxJJR4m/7hw5ZyLiJsgw5bIF3XQP+
+        iz/npj6pg7fQPf3GOuKL18/eMAr0gflTvw/+VDj8QQevzuz4H1g86FN8SVCD
+        2Jw/A2jvM4eq9yFjKJbVtTB/cy/6V5Q3SOfAulJT+QNayf5xGxNLf+zZP/a3
+        d3e9PzwA9Af9r8+D9D8oPOLAKE81ZUWZjx9x1o8465vmrGLZtNmS0mn0wnuz
+        lHIRKEmvyx+gFv0h82SoxRMqH9mpE8oFLfCua8B/8efcFFPJ80Uf6FvyLbqn
+        337EUvyH4wj6g/7n/mBOMH/8LLKUKKsfMdaPGOsbZizLUj+yhPRBBy/HTGgZ
+        fGDxoE/xJUH9EXf1uKujtn7EY/RBBy/HUmgZfGDxoE/xJUH9EY95PLZaT8qi
+        mVP6+CtawPwRS5luHQehZfCBxYM+xZcE9Ucs5bEUsRMt5iBjkV1mRZlNShD0
+        R2yFbh0XoWXwgcWDPsWXBPVHbOWxlfxxUtF4qvJHisp06xgILYMPLB70Kb4k
+        qD/iKDCRcpRVTzTQ6dsfsZTp1nEQWgYfWDzoU3xJUH/EUh5LkS/Vvobbftw0
+        xcUyn72pvk3G8AUZQ3r5R+yFbh03oWXwgcWDPsWXBPX/0+wVYxGJ6uAigSue
+        FITG8uJHysd065gBLYMPLB70Kb4kqP8/5Q6J+X/EI+aDDl6OJdAy+MDiQZ/i
+        S4L6/zseISLUygU/4gjp1jEAWgYfWDzoU3xJUP8/zRH8xzfoskzzui3OC+Ki
+        H62J2G4d+6Bl8IHFgz7FlwT1R/zk8ROlES/z+llWL37ETqZbxz1oGXxg8aBP
+        8SVB/RE7+ewEh4ia/X+JkYT2zB48fTRPP2Ik/OH4gP6g/7k/eP7NHz97jCSe
+        NTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK+XbbHoqab/Nwwiiq+w/yJv62L6
+        /0mkn+bnxbIQlP8/hT6rHB3E/4dR//8i/Z0rqoP4/zDq/1+kPzNRnU+rxSJf
+        zhTh//ch/x5a//9HY7nIqzq/YEz/vzwMYTJqvigoLTabAeVwPD/y7/7/6d/F
+        uAE5c8qVny4vi7pakqT+/8XbdzOHT4MPLBD6FF/yK94M8WeA733m+vE+ZLxk
+        slwL8zf3on9941Np/ngPDXHb6b+7WJdt8aoq85dVVf6IG/gzwPc+c/14HzJe
+        Mt+uhfmbe9G//j/FDVdV/Tavf8QKmGH+DPC9z1w/3oeMl0y2a2H+5l70r/9P
+        sYL41V02+P/gEP4/GBpEBxMoah3b//9G9P+T2fIUqQ7s/2fD+f/JPHV4sFg2
+        bbac/r8ycXn7oO99BqrT+fNuwP/v5t8PG7ovrXbcBOrnwSh1dn9+jfb/L7y8
+        yJbkUs++3R8+vesP60fBCD5z/XgffjenhhJuuBbmb+5F//o5Y42buGCWr8rq
+        GtP+3E55OP3/b0D99lxdNCrPuWPoZbbIs8usKLNJCW76/+7opmXWNMX0i2pS
+        lPlrWpcpSC/Ra//fHRGh+gUrIkzU8XRa0Vp2d0T/H1VAnAV3L/Kf+n3wp8Lh
+        Dzp4OZWFlsEHFg/6FF8S1J8bHcassF1PqbX3t2GAW8/53Wm1XOZTmfMfzb90
+        66YbLYMPLB70Kb4kqP9/mf/j6f9fEqI8p+5F/lO/D/5UOPxBBy8342gZfGDx
+        oE/xJUH9/zYL0Kc+H/i//4gnPLwcC6Bl8IHFgz7FlwT1//M88aO59/ByU42W
+        wQcWD/oUXxLU/8/PPf/zIwbw8HLzjZbBBxYP+hRfEtT/7zMAwfjRxKNbN89o
+        GXxg8aBP8SVB/f/+xHvW/0dMYLp1c46WwQcWD/oUXxLU/3cyAbMBkjLNKpuC
+        B17kV6/yspiOj19+QS/5HAKofZ5RNqG2AVcIrQzGTFRBN/iIh8e/MUX4N3nT
+        Upmb2L8YBgjL1KMP+D3+PUoBSo/s0IipIf9hkh+9Yb/Ol7OLupiNTxeUnKLm
+        /jAB7NYDdwgNYcuj1N+YF3mI/KmMPSARwwg/Cv6QVyyBGJb9SyQNfdk/0ID+
+        6EitY11t7D7gJhhEnMKUjQJPRYm6nlJOrHlCmfq3zfikzLP66ROC7VMSYHq0
+        nWVtNska+rJD3A7WASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovf
+        ixHO/1S75y/9HqPEJXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B8odcxFlVwEA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 52e1dcbe-cf8a-4aba-9129-20f040c92660
+      - 616ffc3d-4e84-47bc-b846-4c5e088d59c2
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      X-Ms-Correlation-Request-Id:
+      - 4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141033Z:4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1ceda565-cc8d-4bbb-9bc2-6e1e860bee08
+      - 3c961fe6-a20d-4068-bb4d-7dbdfc2a4bdb
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - d8448c40-63e3-4c90-81df-fc89266f8b39
+      X-Ms-Correlation-Request-Id:
+      - d8448c40-63e3-4c90-81df-fc89266f8b39
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141033Z:d8448c40-63e3-4c90-81df-fc89266f8b39
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:32 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3222289d-9ea8-48c9-bb38-8156d7e0adfa
+      - 52cf3f9c-c6a8-4a50-8e84-99016d8192ce
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 1e390ab7-ea31-489e-82c4-5d425165fe69
+      X-Ms-Correlation-Request-Id:
+      - 1e390ab7-ea31-489e-82c4-5d425165fe69
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141034Z:1e390ab7-ea31-489e-82c4-5d425165fe69
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:33 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0a214414-f6b8-48c7-98e7-5b03724a5480
+      - fa274e59-8fc5-4d96-b7a2-2c47ecdd3729
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - b217c8e0-0e83-4015-85bb-9442b4847047
+      X-Ms-Correlation-Request-Id:
+      - b217c8e0-0e83-4015-85bb-9442b4847047
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141034Z:b217c8e0-0e83-4015-85bb-9442b4847047
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2403ed6d-a124-4e7e-8e98-1b9e1218a251
+      - db5af182-cffe-46f1-bf6c-b3f73e395b97
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      X-Ms-Correlation-Request-Id:
+      - 32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141035Z:32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:34 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 21ddcf78-9d1c-4d15-a770-38d12bc896ad
+      - 30b09d04-a3cd-434f-94b6-9b3cb36f604e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 8ec0ee61-265a-4167-a996-e7659a5f7d73
+      X-Ms-Correlation-Request-Id:
+      - 8ec0ee61-265a-4167-a996-e7659a5f7d73
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141035Z:8ec0ee61-265a-4167-a996-e7659a5f7d73
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:35 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 365d8a8f-1ae8-402d-84ee-720a031fbca2
+      - efd13ec2-9244-4333-8572-536a54ec6676
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - b284adc7-4294-4fd2-b476-de75e74eab36
+      X-Ms-Correlation-Request-Id:
+      - b284adc7-4294-4fd2-b476-de75e74eab36
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141036Z:b284adc7-4294-4fd2-b476-de75e74eab36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 312767f0-f25e-46bd-afce-a931a4b502b8
+      - 9eb79827-98dd-4f45-9daf-5c31e5df381d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      X-Ms-Correlation-Request-Id:
+      - 8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141036Z:8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8bce60d7-b01b-4019-8adb-9e8a891cc70e
+      - b8937aa5-c4bb-49ec-a758-979e0fb2a886
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 5aed2393-f06d-4589-ab43-5bfd048d76bd
+      X-Ms-Correlation-Request-Id:
+      - 5aed2393-f06d-4589-ab43-5bfd048d76bd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141036Z:5aed2393-f06d-4589-ab43-5bfd048d76bd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 5ab3d07e-2099-4ebe-86e2-33edd07ab34f
+      - cadbe5e0-da3c-45ea-b439-c389092f3630
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      X-Ms-Correlation-Request-Id:
+      - d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141037Z:d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:36 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 07107201-3fd3-4d94-8a94-f1da39c1511e
+      - 1bd6afa8-9404-40ec-983f-d938377d10d6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 27d65844-5515-485c-8573-86a8cde826d5
+      X-Ms-Correlation-Request-Id:
+      - 27d65844-5515-485c-8573-86a8cde826d5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141037Z:27d65844-5515-485c-8573-86a8cde826d5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 05b7b68d-d46d-4bd6-8489-0b5256c287de
+      - 5f7d860c-515e-4612-a741-692eeee70811
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      X-Ms-Correlation-Request-Id:
+      - 7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141038Z:7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:37 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 26c3d95d-22e0-4ea5-b24c-b3efa84ad819
+      - d9e48dc2-cb63-499e-b6d2-38f82da4a789
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - f4795dda-c5e1-4541-b353-0f66244d4c7a
+      X-Ms-Correlation-Request-Id:
+      - f4795dda-c5e1-4541-b353-0f66244d4c7a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141038Z:f4795dda-c5e1-4541-b353-0f66244d4c7a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:38 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1c7743c8-b37a-4554-b361-60359b9eb77a
+      - f7b761f9-d079-4f70-a3b1-c5ed6902996b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      X-Ms-Correlation-Request-Id:
+      - 1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141039Z:1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 05f369c2-11ae-4e13-84b9-678955e89d73
+      - 323e481d-0b59-472d-97b9-5b3bfa5f16e6
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      X-Ms-Correlation-Request-Id:
+      - 692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141039Z:692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6ee36960-4ce5-4a43-bae1-3e572b93e115
+      - bbeb6c98-9a87-46f5-b48e-7e1102e1ddaa
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      X-Ms-Correlation-Request-Id:
+      - 35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141039Z:35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 69c23cfa-2996-4381-b0fc-91547b41ed08
+      - 7d13b80c-6f5e-4584-b1a2-f0ced454dde5
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 244c99cf-d479-444f-bf88-5030187ac262
+      X-Ms-Correlation-Request-Id:
+      - 244c99cf-d479-444f-bf88-5030187ac262
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141040Z:244c99cf-d479-444f-bf88-5030187ac262
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 80078e8b-e726-4137-8374-0f1b17b0b2cf
+      - d7c2cc7b-077d-4061-85b7-7667476239fd
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      X-Ms-Correlation-Request-Id:
+      - 70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141040Z:70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:39 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0bd9635c-886d-4c88-97bc-c9c09363abbd
+      - 6c7445c6-daaf-42fc-a714-19a26c75f6cb
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      X-Ms-Correlation-Request-Id:
+      - ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141040Z:ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 042d4e33-5984-4ae5-9fcb-07375b62f9f0
+      - cacc6787-c648-48c3-a3d7-a19d5a49d869
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      X-Ms-Correlation-Request-Id:
+      - dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141041Z:dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:40 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4fe85cab-2c44-4068-93d7-487d47e2f8a4
+      - 840cfa36-f52a-497c-a18b-e08a443a7f22
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      X-Ms-Correlation-Request-Id:
+      - 111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141041Z:111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 51911a30-392e-4e9d-80bb-176ed679a078
+      - af01181b-4147-470e-b4bb-3c755313b1ee
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 1b5688d9-6d22-4a67-be66-eeba650fba58
+      X-Ms-Correlation-Request-Id:
+      - 1b5688d9-6d22-4a67-be66-eeba650fba58
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141042Z:1b5688d9-6d22-4a67-be66-eeba650fba58
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 10db4bf1-982d-4ac6-a9ad-d3a57b38684d
+      - f3f19c75-4aa9-4638-858d-b91c4e736a5b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - eb9894a8-3fdd-4b34-888f-e0df43001b35
+      X-Ms-Correlation-Request-Id:
+      - eb9894a8-3fdd-4b34-888f-e0df43001b35
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141042Z:eb9894a8-3fdd-4b34-888f-e0df43001b35
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:41 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - de810f62-2f7c-47bf-a467-47fe97d800b1
+      - e1cd6f5b-0b70-4e18-bfc0-2b6c12e4d6c9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 1da49536-f400-4140-8577-ed6d928596d7
+      X-Ms-Correlation-Request-Id:
+      - 1da49536-f400-4140-8577-ed6d928596d7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141042Z:1da49536-f400-4140-8577-ed6d928596d7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:42 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2805ffa2-988b-4d46-a99e-9a4272a722fa
+      - 4da9d5e1-7dff-483c-a7fe-0e5fe0959d54
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      X-Ms-Correlation-Request-Id:
+      - 2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141042Z:2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:42 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1a5c4cbd-f6f2-4597-939b-35d6971c8aa7
+      - b91d5730-15e6-4f88-84dc-20ce220e4576
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      X-Ms-Correlation-Request-Id:
+      - 04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141043Z:04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:42 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2b6ddb91-fe4a-4628-a1ac-1c41f2e96d9a
+      - 52c8c39a-4d15-4473-bfe5-f0591d612b66
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      X-Ms-Correlation-Request-Id:
+      - 44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141043Z:44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:43 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 729ba952-3fa4-48c6-b62f-eed6becda240
+      - c66f8630-9080-49d5-b1ec-a0bdbc351963
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      X-Ms-Correlation-Request-Id:
+      - 39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141044Z:39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:43 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 95e6bbac-a1a7-4e37-9dc5-11e52986f2f6
+      - aa8aa458-8f11-4f11-a811-391e4ac2df57
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
+      X-Ms-Correlation-Request-Id:
+      - c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141044Z:c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:43 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - aad2d84c-ef55-4707-8466-e071aa15fde1
+      - aaee80a2-27ce-4c85-9f32-27bf68a13044
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
+      X-Ms-Correlation-Request-Id:
+      - a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141044Z:a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:44 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - ef8f13ba-3fc7-4328-a8a4-042d870f0c00
+      - f98db7b7-366b-4a35-bc82-fab50f520f05
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 8432a1a8-3b65-44b6-b4a0-0fa098dc7608
+      X-Ms-Correlation-Request-Id:
+      - 8432a1a8-3b65-44b6-b4a0-0fa098dc7608
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141044Z:8432a1a8-3b65-44b6-b4a0-0fa098dc7608
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:44 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9b6ac8e9-2dd7-4310-8c90-f419bd490076
+      - afb5ea48-d22c-4b5e-98fb-1f8b53973b32
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - fbea64a9-0c84-4483-a96c-c5df11c9ec71
+      X-Ms-Correlation-Request-Id:
+      - fbea64a9-0c84-4483-a96c-c5df11c9ec71
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141045Z:fbea64a9-0c84-4483-a96c-c5df11c9ec71
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8983e021-5b99-4246-98e6-2241d3732b39
+      - 8c3d48ec-d831-4452-b502-b454a6c0cd7d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 11bec435-ec8a-4d0a-983e-3a2600f11720
+      X-Ms-Correlation-Request-Id:
+      - 11bec435-ec8a-4d0a-983e-3a2600f11720
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141045Z:11bec435-ec8a-4d0a-983e-3a2600f11720
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 3cb47dcc-59eb-4d98-b4e9-a31ab16ee9f4
+      - 66de0fe5-cf49-4d0b-925c-a8fb1dea98f0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - b2496119-b7ea-4789-9e9e-0ee7efc236ab
+      X-Ms-Correlation-Request-Id:
+      - b2496119-b7ea-4789-9e9e-0ee7efc236ab
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141045Z:b2496119-b7ea-4789-9e9e-0ee7efc236ab
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8ce99ea0-a662-42aa-b045-fc8cd20e2bef
+      - e15b4114-0308-4719-9056-e044929c2931
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - e66b01f9-ec5b-49d4-9464-60b72b7c8d14
+      X-Ms-Correlation-Request-Id:
+      - e66b01f9-ec5b-49d4-9464-60b72b7c8d14
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141046Z:e66b01f9-ec5b-49d4-9464-60b72b7c8d14
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:45 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 203bbf29-f286-4bc0-90d3-034a6e1bc514
+      - b725af00-fe4a-4d5b-86d4-04ce0ab7c56c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 9235a5ec-502d-4fbb-b448-19a9f6476d24
+      X-Ms-Correlation-Request-Id:
+      - 9235a5ec-502d-4fbb-b448-19a9f6476d24
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141046Z:9235a5ec-502d-4fbb-b448-19a9f6476d24
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:46 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 07705970-404e-4bc6-b6a6-3a6ed4e16f34
+      - 5d548f74-fe57-4133-807f-644fb8423bb4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 3f81002b-2007-4d66-8ee1-38e77c1bf517
+      X-Ms-Correlation-Request-Id:
+      - 3f81002b-2007-4d66-8ee1-38e77c1bf517
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141046Z:3f81002b-2007-4d66-8ee1-38e77c1bf517
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:46 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2d98266b-7ff9-4ed9-aead-aea7bbd7773a
+      - 93355ce4-4c2e-491b-a371-3f108006a361
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - aa872684-c8a9-43c7-8b7c-5287f19dfd7b
+      X-Ms-Correlation-Request-Id:
+      - aa872684-c8a9-43c7-8b7c-5287f19dfd7b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141047Z:aa872684-c8a9-43c7-8b7c-5287f19dfd7b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:47 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 9e7a2e82-ba83-4d9f-9fc8-c816229ba369
+      - c0c174b5-ebcb-44a7-bff2-d035eb5048d8
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 25e1c66a-5ad7-40e8-88d9-142b8bec3725
+      X-Ms-Correlation-Request-Id:
+      - 25e1c66a-5ad7-40e8-88d9-142b8bec3725
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141047Z:25e1c66a-5ad7-40e8-88d9-142b8bec3725
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:47 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 4a2def83-2501-417e-888b-ccddee2e519a
+      - e0b400b3-3042-41cd-b929-b700a15d3282
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 4d48ab42-c417-4898-b30f-b457efe36fff
+      X-Ms-Correlation-Request-Id:
+      - 4d48ab42-c417-4898-b30f-b457efe36fff
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141047Z:4d48ab42-c417-4898-b30f-b457efe36fff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:47 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 2f15b896-f85a-4686-8d78-eab1113d9c27
+      - dcbaabe1-a771-48ee-81d8-d58ed9659b58
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - ade7663c-c647-43d4-9e54-406a69d064c3
+      X-Ms-Correlation-Request-Id:
+      - ade7663c-c647-43d4-9e54-406a69d064c3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141047Z:ade7663c-c647-43d4-9e54-406a69d064c3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:47 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - baef2c8b-f404-4624-ac7d-ed84cfd910f6
+      - cc5b1715-178b-4f04-8e59-d10e265dd9a4
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - c9beacc5-bc88-48fe-b503-a8db75058732
+      X-Ms-Correlation-Request-Id:
+      - c9beacc5-bc88-48fe-b503-a8db75058732
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141048Z:c9beacc5-bc88-48fe-b503-a8db75058732
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 762af3db-998a-4082-b6b9-cafc6ead770a
+      - 7935ae01-c366-43ae-ae72-b1256774ad6b
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 93b6b471-6b74-46e1-a08d-723533e4fb55
+      X-Ms-Correlation-Request-Id:
+      - 93b6b471-6b74-46e1-a08d-723533e4fb55
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141048Z:93b6b471-6b74-46e1-a08d-723533e4fb55
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6ad28647-2855-428f-bc0b-31aa2d434d2b
+      - edf2acde-9019-4c57-a174-7ca362365f42
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - d4a1590a-13ee-442f-9550-ef84b9c97b5c
+      X-Ms-Correlation-Request-Id:
+      - d4a1590a-13ee-442f-9550-ef84b9c97b5c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141048Z:d4a1590a-13ee-442f-9550-ef84b9c97b5c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a73d495d-6a04-4417-a090-be841acfa04c
+      - f826eed3-fbcf-48c3-b0f6-156bd497a35a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 5e467376-0114-4aee-b4c2-20f10fd540ce
+      X-Ms-Correlation-Request-Id:
+      - 5e467376-0114-4aee-b4c2-20f10fd540ce
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141049Z:5e467376-0114-4aee-b4c2-20f10fd540ce
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - a090cc5d-b2fb-4e4b-8ea1-4673bcc12f8a
+      - bcca837a-83b3-47ab-aab4-48e800665b2c
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - b8742ffe-16d4-46c0-b0bb-228f73ac8189
+      X-Ms-Correlation-Request-Id:
+      - b8742ffe-16d4-46c0-b0bb-228f73ac8189
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141049Z:b8742ffe-16d4-46c0-b0bb-228f73ac8189
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8f8c4487-e6a1-40ff-bb18-444556659453
+      - e4759213-74b8-43fa-90a1-89d177dd7694
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
+      X-Ms-Correlation-Request-Id:
+      - bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141049Z:bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:48 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 152ee9f7-bb01-4e6f-b723-b647208824f3
+      - 90a94a23-4158-4c88-96f8-fd3fae3691af
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 5c1b0976-06b8-4022-bf28-f28a69b6582f
+      X-Ms-Correlation-Request-Id:
+      - 5c1b0976-06b8-4022-bf28-f28a69b6582f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141049Z:5c1b0976-06b8-4022-bf28-f28a69b6582f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 009a8dea-b07c-43d1-9815-634bf75902bd
+      - c563b92b-41b7-4faa-b738-20e376be9343
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
+      X-Ms-Correlation-Request-Id:
+      - 6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141050Z:6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 0b7ed963-e2d6-4d70-8d69-6ff6f1c3ea25
+      - 377b277b-fd4e-409e-abd4-21fcb2f90d34
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
+      X-Ms-Correlation-Request-Id:
+      - 693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141050Z:693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:49 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 1ab5cefb-3061-4f85-9c11-da11ced0453a
+      - fd5ee161-8a62-4b8c-a8b9-eb9ae4c8370a
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 608237d4-c86d-4381-8f48-3703a68ff3e9
+      X-Ms-Correlation-Request-Id:
+      - 608237d4-c86d-4381-8f48-3703a68ff3e9
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141050Z:608237d4-c86d-4381-8f48-3703a68ff3e9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:50 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 09b112fe-8e9f-4716-b164-bd440c21469d
+      - e0995b5d-875a-4072-ba62-7b20c403f43e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - c7389bd6-0490-4155-9ed9-a453c7e7019a
+      X-Ms-Correlation-Request-Id:
+      - c7389bd6-0490-4155-9ed9-a453c7e7019a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141051Z:c7389bd6-0490-4155-9ed9-a453c7e7019a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 8276ba7f-f8f0-4cc9-9fdb-937a360680fa
+      - a16a5aaf-abb5-450f-9c26-216657816eaf
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 8a71dda9-0298-417a-9a53-b31e3ab072b7
+      X-Ms-Correlation-Request-Id:
+      - 8a71dda9-0298-417a-9a53-b31e3ab072b7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141051Z:8a71dda9-0298-417a-9a53-b31e3ab072b7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 46742bff-2d14-4b4d-a053-802f2e661e82
+      - 52f31494-49e7-4116-b16e-98564c4b495d
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - ed786c14-9afe-47b8-9454-744891e02945
+      X-Ms-Correlation-Request-Id:
+      - ed786c14-9afe-47b8-9454-744891e02945
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141051Z:ed786c14-9afe-47b8-9454-744891e02945
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 35986c9d-0bd8-4b44-8bf1-97c70cda7b0a
+      - 75989e36-5390-4fdf-a5c3-f9d9844705f9
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - ef0ec638-9717-4aa2-85e9-04e7011fe632
+      X-Ms-Correlation-Request-Id:
+      - ef0ec638-9717-4aa2-85e9-04e7011fe632
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141052Z:ef0ec638-9717-4aa2-85e9-04e7011fe632
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:51 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Original-Request-Ids:
+      - 6b61db29-bff6-4d39-b19a-07875d1a0360
+      - 8b16f9ae-57b2-45c0-bc0f-800705fa3b7e
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - e2954800-ee51-41cc-9fd1-b31fc065ab93
+      X-Ms-Correlation-Request-Id:
+      - e2954800-ee51-41cc-9fd1-b31fc065ab93
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141052Z:e2954800-ee51-41cc-9fd1-b31fc065ab93
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:52 GMT
+      Content-Length:
+      - '2557'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
+        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
+        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
+        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
+        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
+        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
+        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
+        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
+        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
+        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
+        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
+        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
+        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
+        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
+        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
+        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
+        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
+        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
+        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
+        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
+        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
+        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
+        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
+        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
+        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
+        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
+        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
+        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
+        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
+        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
+        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
+        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
+        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
+        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
+        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
+        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
+        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
+        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
+        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
+        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
+        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
+        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
+        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
+        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
+        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
+        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
+        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
+        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
+        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
+        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
+        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
+        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
+        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
+        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 0fd455e0-191d-49e8-afe7-b35e1bba0a4c
+      X-Ms-Correlation-Request-Id:
+      - 0fd455e0-191d-49e8-afe7-b35e1bba0a4c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141052Z:0fd455e0-191d-49e8-afe7-b35e1bba0a4c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:52 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 767d1e5a-2c62-485e-95b9-0d3b77df2f30
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 94ee99cc-67f0-41df-8c32-faaf84b9e0c2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141053Z:94ee99cc-67f0-41df-8c32-faaf84b9e0c2
+      Date:
+      - Fri, 30 Oct 2015 14:10:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
+        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
+        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
+        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
+        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
+        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
+        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
+        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
+        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
+        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
+        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
+        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
+        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
+        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
+        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
+        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
+        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
+        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
+        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
+        AAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 88770f5c-f234-48d3-a166-c880347e8eec
+      X-Ms-Correlation-Request-Id:
+      - 88770f5c-f234-48d3-a166-c880347e8eec
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141053Z:88770f5c-f234-48d3-a166-c880347e8eec
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:53 GMT
+      Content-Length:
+      - '2015'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
+        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
+        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
+        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
+        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
+        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
+        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
+        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
+        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
+        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
+        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
+        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
+        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
+        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
+        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
+        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
+        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
+        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
+        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
+        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
+        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
+        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
+        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
+        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
+        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
+        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
+        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
+        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
+        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
+        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
+        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
+        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
+        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
+        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
+        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
+        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
+        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
+        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
+        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
+        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 81cc037e-b96d-442a-87ea-ad6e90644676
+      X-Ms-Correlation-Request-Id:
+      - 81cc037e-b96d-442a-87ea-ad6e90644676
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141054Z:81cc037e-b96d-442a-87ea-ad6e90644676
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:53 GMT
+      Content-Length:
+      - '1495'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
+        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
+        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
+        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
+        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
+        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
+        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
+        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
+        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
+        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
+        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
+        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
+        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
+        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
+        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
+        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
+        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
+        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
+        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
+        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
+        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
+        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
+        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
+        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
+        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
+        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
+        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
+        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
+        fwAjSQ3n9RMAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - 69938a43-6ea3-479b-9a71-da8c555770c2
+      X-Ms-Correlation-Request-Id:
+      - 69938a43-6ea3-479b-9a71-da8c555770c2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141055Z:69938a43-6ea3-479b-9a71-da8c555770c2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:54 GMT
+      Content-Length:
+      - '2164'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
+        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
+        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
+        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
+        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
+        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
+        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
+        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
+        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
+        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
+        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
+        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
+        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
+        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
+        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
+        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
+        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
+        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
+        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
+        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
+        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
+        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
+        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
+        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
+        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
+        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
+        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
+        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
+        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
+        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
+        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
+        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
+        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
+        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
+        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
+        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
+        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
+        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
+        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
+        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
+        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
+        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
+        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
+        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
+        ayYAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4e7ecab7-1205-487a-9608-dbfdb0388d5b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - fd75102e-e4e9-49d2-9cf1-dbfec1ee07cb
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141055Z:fd75102e-e4e9-49d2-9cf1-dbfec1ee07cb
+      Date:
+      - Fri, 30 Oct 2015 14:10:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
+        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
+        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
+        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
+        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
+        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
+        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
+        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
+        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
+        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
+        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
+        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
+        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 38809190-9121-4043-9f61-dfd04da7c4cf
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 0ff982ff-431e-4941-9cc1-ab100d4fc93f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141055Z:0ff982ff-431e-4941-9cc1-ab100d4fc93f
+      Date:
+      - Fri, 30 Oct 2015 14:10:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
+        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
+        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
+        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
+        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
+        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
+        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
+        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
+        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
+        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
+        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
+        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
+        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
+        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
+        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
+        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
+        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
+        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
+        Kwa0vggAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
+      X-Ms-Request-Id:
+      - 6584c6ba-eceb-4934-a663-0439122da23a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 1c777228-447e-42b8-a966-ef60f637c4ba
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141056Z:1c777228-447e-42b8-a966-ef60f637c4ba
+      Date:
+      - Fri, 30 Oct 2015 14:10:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdeXT/0092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6+ieev87ry7x+ml+6bqO0817H
+        s4F+zXo6zfNZPnMQ8Tj6nS3Pq853hGlIPh9sOgQxRpx7j/YfPLq/P/704MHD
+        /S6NiDLmV6aT/v19BvvRpKrap0V2sayatpgCDR0yDXbZVGX+elrn+bKZV+2T
+        spp8VRfU5KN5266aR3fvXuVNO62ypp1NmvsPP90bT6jNeFrV+fiqWM6qq2a8
+        zNu76GTmOtluflHZ8BRs79x7mM+mewfb9/ODne39nZ297cns/nR7//7DbH+W
+        3d/dO9i/68/Y+DZvjBuL9HiyWDEplD3ydy19QTTGUHWidcT0reGRL4ppXTXV
+        eTs+o8YX87YZ/+QXHple521Lk9QwZIKNH0rQPh858O/FP0O88/58s5FnHtzf
+        ub97/yBgGqFVFPPqKq/Rc353lmdlWU3pV7+rWyNNqsCHIA2FkL9x8kv+HyB8
+        XwU/BQAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1042c595-a74e-44b7-a429-f4bc703db2e3"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d241bf8c-20fd-4f0f-a842-6623b55d4474
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 0e99d48c-61b7-4c95-986d-3592f8244ec8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141056Z:0e99d48c-61b7-4c95-986d-3592f8244ec8
+      Date:
+      - Fri, 30 Oct 2015 14:10:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
+        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
+        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
+        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7s7+
+        3vT+w/vb2YN9Qmh/8mA72997uH2+P5k+2Lk3m+zl937fj/TF9nrFA75F1/pG
+        WU0zjBxvXeVNuzZf0DhWed0W1PJRyuSUDy+LhpoXy4vXbdZyZ6/X02mez/KZ
+        vEnNLH3WQuOdSXY/29mfbU8fPry3vX/wYLqdTe/tb9/b383PH8wOZrsP9+3L
+        xeqkWp4XF+uaEUP335OvUoMHHju5xWrK7XcNBDz/b5zcu92R0Qcx1L/u7MuD
+        OepNnDz46hbTJw81Li6pydnL49mMaAJohM743nhnbCdLHq9pafjpi7ydVzwH
+        T69ppopp95X1pCym9IYFHqBKLX74M9jBiWbw9U88f80z+DS//MjH75eEoyEk
+        afoJ35/7QVwWdbvOSv2z8yLhQXg2d2f5ebYu23BI7g/7q/7yfR3tR7Nl8zpv
+        W2KfYMbkc9AJH3/PNKcvstWqLPLZ0/B7+drQ8KN8mU1K4p5nVX2V1TOCTq3O
+        MxIe04KQxmhe59N1XbTXTBNq4xD44dM5hlKUYewwdWa+yKbzYgnR+9lA//T1
+        m5Mvj1+/efrkdRT9k2qxWre5YRNFJo44ftA/v+T/Adj3QZ5NBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - da0d8f87-9b9c-459b-b259-b23e2c78e5f2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 82945cfa-2948-4f4a-8d7a-2061a60707dd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141056Z:82945cfa-2948-4f4a-8d7a-2061a60707dd
+      Date:
+      - Fri, 30 Oct 2015 14:10:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
+        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
+        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
+        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
+        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
+        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
+        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
+        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
+        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
+        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:10:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - befe1734-9a5d-4181-84a6-b0fb77e962d3
+      X-Ms-Correlation-Request-Id:
+      - befe1734-9a5d-4181-84a6-b0fb77e962d3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141058Z:befe1734-9a5d-4181-84a6-b0fb77e962d3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:57 GMT
+      Content-Length:
+      - '411'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
+        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
+        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
+        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
+        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
+        dX0nBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - dcff66ba-5c5a-44bc-a274-89484f0f62db
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - d37d5067-cd4d-428e-b28b-9528a812ea7d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141058Z:d37d5067-cd4d-428e-b28b-9528a812ea7d
+      Date:
+      - Fri, 30 Oct 2015 14:10:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
+        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
+        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
+        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
+        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
+        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
+        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
+        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
+        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
+        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
+        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
+        93/j5Jf8PzIr3UrFEwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 9a13e92b-d481-4823-bb24-61ab6e67f5aa
+      X-Ms-Correlation-Request-Id:
+      - 9a13e92b-d481-4823-bb24-61ab6e67f5aa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141058Z:9a13e92b-d481-4823-bb24-61ab6e67f5aa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:58 GMT
+      Content-Length:
+      - '1446'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
+        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
+        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
+        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
+        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
+        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
+        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
+        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
+        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
+        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
+        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
+        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
+        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
+        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
+        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
+        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
+        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
+        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
+        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
+        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
+        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
+        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
+        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
+        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
+        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
+        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
+        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
+        b2cOFgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - b1ff1054-6d7b-4496-a2a8-16db09571159
+      X-Ms-Correlation-Request-Id:
+      - b1ff1054-6d7b-4496-a2a8-16db09571159
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141100Z:b1ff1054-6d7b-4496-a2a8-16db09571159
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:10:59 GMT
+      Content-Length:
+      - '1791'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
+        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
+        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
+        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
+        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
+        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
+        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
+        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
+        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
+        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
+        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
+        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
+        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
+        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
+        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
+        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
+        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
+        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
+        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
+        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
+        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
+        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
+        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
+        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
+        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
+        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
+        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
+        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
+        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
+        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
+        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
+        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
+        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
+        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
+        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - 75f80e07-2c8e-4480-9770-4eb1df45420c
+      X-Ms-Correlation-Request-Id:
+      - 75f80e07-2c8e-4480-9770-4eb1df45420c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141100Z:75f80e07-2c8e-4480-9770-4eb1df45420c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - bf159f8e-9dfc-4db2-bf0a-2b48c488db20
+      X-Ms-Correlation-Request-Id:
+      - bf159f8e-9dfc-4db2-bf0a-2b48c488db20
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141100Z:bf159f8e-9dfc-4db2-bf0a-2b48c488db20
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 2597e597-3ce1-496c-9dfd-0ddb3515de90
+      X-Ms-Correlation-Request-Id:
+      - 2597e597-3ce1-496c-9dfd-0ddb3515de90
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141100Z:2597e597-3ce1-496c-9dfd-0ddb3515de90
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '1160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
+        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
+        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
+        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
+        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
+        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
+        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
+        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
+        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
+        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
+        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
+        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
+        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
+        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
+        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
+        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
+        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
+        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
+        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
+        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
+        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
+      X-Ms-Correlation-Request-Id:
+      - dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141100Z:dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 1982c2b4-6403-4224-95c1-9ba628f8e481
+      X-Ms-Correlation-Request-Id:
+      - 1982c2b4-6403-4224-95c1-9ba628f8e481
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141101Z:1982c2b4-6403-4224-95c1-9ba628f8e481
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Request-Id:
+      - ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
+      X-Ms-Correlation-Request-Id:
+      - ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141101Z:ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '1084'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
+        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
+        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
+        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
+        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
+        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
+        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
+        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
+        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
+        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
+        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
+        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
+        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
+        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
+        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
+        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
+        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
+        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
+        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
+        IA8AAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Request-Id:
+      - 7bf2bf00-f331-4600-8b13-8c878ee69b19
+      X-Ms-Correlation-Request-Id:
+      - 7bf2bf00-f331-4600-8b13-8c878ee69b19
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141101Z:7bf2bf00-f331-4600-8b13-8c878ee69b19
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:00 GMT
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
+        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
+        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
+        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
+        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
+        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
+        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
+        PiqhoAIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
+      X-Ms-Correlation-Request-Id:
+      - b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141101Z:b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:01 GMT
+      Content-Length:
+      - '1685'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
+        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
+        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
+        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
+        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
+        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
+        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
+        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
+        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
+        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
+        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
+        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
+        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
+        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
+        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
+        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
+        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
+        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
+        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
+        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
+        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
+        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
+        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
+        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
+        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
+        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
+        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
+        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
+        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
+        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
+        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
+        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
+        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
+        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Request-Id:
+      - 080fe0a3-6a95-40fd-b124-1cae6f71b6f1
+      X-Ms-Correlation-Request-Id:
+      - 080fe0a3-6a95-40fd-b124-1cae6f71b6f1
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141101Z:080fe0a3-6a95-40fd-b124-1cae6f71b6f1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:01 GMT
+      Content-Length:
+      - '501'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
+        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
+        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
+        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
+        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
+        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
+        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
+        IniEAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB271D:5097:1FE1D13:56337A75
+      Content-Length:
+      - '358'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 14:11:02 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6228-ATL
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 7cb6a11b16faee5457c90ccf5dc434a7a0668e24
+      Expires:
+      - Fri, 30 Oct 2015 14:16:02 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string",
+              "allowedValues": [
+                "East US",
+                "West US",
+                "West Europe",
+                "East Asia",
+                "South East Asia"
+              ],
+              "metadata": {
+                "description": "This is the location where the availability set will be deployed"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "availabilitySet1",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[parameters('location')]",
+              "properties": {}
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - c87e1d57-1318-4901-9cd8-6e1811c59049
+      X-Ms-Correlation-Request-Id:
+      - c87e1d57-1318-4901-9cd8-6e1811c59049
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141102Z:c87e1d57-1318-4901-9cd8-6e1811c59049
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:01 GMT
+      Content-Length:
+      - '493'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
+        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
+        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
+        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
+        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
+- request:
+    method: get
+    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB271C:509A:3468631:56337A76
+      Content-Length:
+      - '1004'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6229-ATL
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - e6b86669e9114825a4d86634441f20e4ac7f8f68
+      Expires:
+      - Fri, 30 Oct 2015 14:16:03 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: |2+
+            {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "childLocationParameter": { "type": "string" },
+                "childDeployName": { "type": "string" }
+              },
+              "resources": [ {
+                "name": "[parameters('childDeployName')]",
+                "type": "Microsoft.Resources/deployments",
+                "apiVersion": "2015-01-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
+                    "contentVersion": "1.0.0.0"
+                  },
+                  "parameters": {
+                    "location": { "value": "[parameters('childLocationParameter')]" }
+                  }
+                }
+              } ],
+              "outputs": {
+                "siteUri" : {
+                  "type" : "string",
+                  "value": "hard-coded output for test"
+                }
+              }
+            }
+
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - d0406c9d-76e0-49fc-aae3-957624a104f2
+      X-Ms-Correlation-Request-Id:
+      - d0406c9d-76e0-49fc-aae3-957624a104f2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141103Z:d0406c9d-76e0-49fc-aae3-957624a104f2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
+        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
+        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
+        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
+        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
+        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
+        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
+        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
+        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
+        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
+        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
+        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
+        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
+        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
+        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
+        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
+        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
+        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
+        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
+        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
+        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
+        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
+        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
+        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
+        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
+        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
+        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
+        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
+        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
+        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Etag:
+      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Github-Request-Id:
+      - 17EB2714:5095:EA5632:56337A77
+      Content-Length:
+      - '1902'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-atl6221-ATL
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d48f36d593112d4b2db8e51ca9c87794c43b09dd
+      Expires:
+      - Fri, 30 Oct 2015 14:16:03 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of storage account"
+              }
+            },
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Admin username"
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Admin password"
+              }
+            },
+            "dnsNameforLBIP": {
+              "type": "string",
+              "metadata": {
+                "description": "DNS for Load Balancer IP"
+              }
+            },
+            "vmNamePrefix": {
+              "type": "string",
+              "defaultValue": "myVM",
+              "metadata": {
+                "description": "Prefix to use for VM names"
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "MicrosoftWindowsServer",
+              "metadata": {
+                "description": "Image Publisher"
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "WindowsServer",
+              "metadata": {
+                "description": "Image Offer"
+              }
+            },
+            "imageSKU": {
+              "type": "string",
+              "defaultValue": "2012-R2-Datacenter",
+              "metadata": {
+                "description": "Image SKU"
+              }
+            },
+            "lbName": {
+              "type": "string",
+              "defaultValue": "myLB",
+              "metadata": {
+                "description": "Load Balancer name"
+              }
+            },
+            "nicNamePrefix": {
+              "type": "string",
+              "defaultValue": "nic",
+              "metadata": {
+                "description": "Network Interface name prefix"
+              }
+            },
+            "publicIPAddressName": {
+              "type": "string",
+              "defaultValue": "myPublicIP",
+              "metadata": {
+                "description": "Public IP Name"
+              }
+            },
+            "vnetName": {
+              "type": "string",
+              "defaultValue": "myVNET",
+              "metadata": {
+                "description": "VNET name"
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D1",
+              "metadata": {
+                "description": "Size of the VM"
+              }
+            }
+          },
+          "variables": {
+            "storageAccountType": "Standard_LRS",
+            "availabilitySetName": "myAvSet",
+            "addressPrefix": "10.0.0.0/16",
+            "subnetName": "Subnet-1",
+            "subnetPrefix": "10.0.0.0/24",
+            "publicIPAddressType": "Dynamic",
+            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+            "numberOfInstances": 2,
+            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
+            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "name": "[parameters('storageAccountName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "accountType": "[variables('storageAccountType')]"
+              }
+            },
+            {
+              "type": "Microsoft.Compute/availabilitySets",
+              "name": "[variables('availabilitySetName')]",
+              "apiVersion": "2015-05-01-preview",
+              "location": "[resourceGroup().location]",
+              "properties": {}
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/publicIPAddresses",
+              "name": "[parameters('publicIPAddressName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/virtualNetworks",
+              "name": "[parameters('vnetName')]",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('subnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('subnetPrefix')]"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "type": "Microsoft.Network/networkInterfaces",
+              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
+              "location": "[resourceGroup().location]",
+              "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+              ],
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[variables('subnetRef')]"
+                      },
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                        }
+                      ],
+                      "loadBalancerInboundNatRules": [
+                        {
+                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-05-01-preview",
+              "name": "[parameters('lbName')]",
+              "type": "Microsoft.Network/loadBalancers",
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+              ],
+              "properties": {
+                "frontendIPConfigurations": [
+                  {
+                    "name": "LoadBalancerFrontEnd",
+                    "properties": {
+                      "publicIPAddress": {
+                        "id": "[variables('publicIPAddressID')]"
+                      }
+                    }
+                  }
+                ],
+                "backendAddressPools": [
+                  {
+                    "name": "BackendPool1"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "name": "RDP-VM0",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50001,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  },
+                  {
+                    "name": "RDP-VM1",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 50002,
+                      "backendPort": 3389,
+                      "enableFloatingIP": false
+                    }
+                  }
+                ],
+                "loadBalancingRules": [
+                  {
+                    "name": "LBRule",
+                    "properties": {
+                      "frontendIPConfiguration": {
+                        "id": "[variables('frontEndIPConfigID')]"
+                      },
+                      "backendAddressPool": {
+                        "id": "[variables('lbPoolID')]"
+                      },
+                      "protocol": "tcp",
+                      "frontendPort": 80,
+                      "backendPort": 80,
+                      "enableFloatingIP": false,
+                      "idleTimeoutInMinutes": 5,
+                      "probe": {
+                        "id": "[variables('lbProbeID')]"
+                      }
+                    }
+                  }
+                ],
+                "probes": [
+                  {
+                    "name": "tcpProbe",
+                    "properties": {
+                      "protocol": "tcp",
+                      "port": 80,
+                      "intervalInSeconds": 5,
+                      "numberOfProbes": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "apiVersion": "2015-06-15",
+              "type": "Microsoft.Compute/virtualMachines",
+              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+              "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+              },
+              "location": "[resourceGroup().location]",
+              "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+              ],
+              "properties": {
+                "availabilitySet": {
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSKU')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "osdisk",
+                    "vhd": {
+                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
+                    },
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage"
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                     "enabled": "true",
+                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 151ed1f2-39d0-49c1-a980-efe6c275f39d
+      X-Ms-Correlation-Request-Id:
+      - 151ed1f2-39d0-49c1-a980-efe6c275f39d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141103Z:151ed1f2-39d0-49c1-a980-efe6c275f39d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Content-Length:
+      - '1307'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
+        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
+        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
+        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
+        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
+        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
+        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
+        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
+        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
+        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
+        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
+        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
+        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
+        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
+        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
+        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
+        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
+        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
+        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
+        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
+        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
+        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
+        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
+        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
+        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
+        AAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 8fe471de-54b4-41f4-94a1-9ba83ac17eb8
+      X-Ms-Correlation-Request-Id:
+      - 8fe471de-54b4-41f4-94a1-9ba83ac17eb8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141103Z:8fe471de-54b4-41f4-94a1-9ba83ac17eb8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Content-Length:
+      - '1090'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
+        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
+        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
+        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
+        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
+        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
+        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
+        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
+        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
+        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
+        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
+        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
+        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
+        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
+        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
+        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
+        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
+        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
+        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
+        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
+        /h+BjiSEdgwAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c683b1e4-999a-47b9-a620-e9bb394dbf38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 809719d8-859f-49a5-b388-fd36e8fb23c7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141104Z:809719d8-859f-49a5-b388-fd36e8fb23c7
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
+        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
+        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
+        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
+        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
+        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
+        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
+        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
+        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
+        /pL/Bx08EGYUBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 448fcf02-88a7-40f4-bbee-3fd4bf8a65e8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Correlation-Request-Id:
+      - dbc90927-5f71-4502-a3dc-51e11e810255
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141104Z:dbc90927-5f71-4502-a3dc-51e11e810255
+      Date:
+      - Fri, 30 Oct 2015 14:11:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
+        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
+        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
+        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
+        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
+        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
+        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
+        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
+        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
+        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
+        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
+        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
+        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
+        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
+        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
+        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
+        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
+        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
+        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
+        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
+        P4bMBwG5FwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - bd649a84-d955-4014-886c-cd571749402f
+      X-Ms-Correlation-Request-Id:
+      - bd649a84-d955-4014-886c-cd571749402f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141104Z:bd649a84-d955-4014-886c-cd571749402f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
+      X-Ms-Correlation-Request-Id:
+      - 052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141104Z:052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:03 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3c75317f-9736-4c88-aa78-34bddd913ff5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14978'
+      X-Ms-Correlation-Request-Id:
+      - 6553f060-4c08-4864-a4b2-88a9fa599b75
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:6553f060-4c08-4864-a4b2-88a9fa599b75
+      Date:
+      - Fri, 30 Oct 2015 14:11:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
+        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
+        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
+        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
+        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
+        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
+        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
+        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
+        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
+        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
+        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 31316f83-9a91-4ea0-be78-42c8d489507c
+      X-Ms-Correlation-Request-Id:
+      - 31316f83-9a91-4ea0-be78-42c8d489507c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:31316f83-9a91-4ea0-be78-42c8d489507c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:04 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14977'
+      X-Ms-Request-Id:
+      - a0698cc7-54f9-43e5-9865-057e1ef2fc61
+      X-Ms-Correlation-Request-Id:
+      - a0698cc7-54f9-43e5-9865-057e1ef2fc61
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:a0698cc7-54f9-43e5-9865-057e1ef2fc61
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:04 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 182b63a6-da2b-4dc1-8441-91ea4efbc100
+      X-Ms-Correlation-Request-Id:
+      - 182b63a6-da2b-4dc1-8441-91ea4efbc100
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:182b63a6-da2b-4dc1-8441-91ea4efbc100
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:04 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 8a223801-30e6-44b8-9e4b-6e789e36c4b1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - a92a8aed-fe78-4015-a6f3-658064962711
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:a92a8aed-fe78-4015-a6f3-658064962711
+      Date:
+      - Fri, 30 Oct 2015 14:11:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
+        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
+        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
+        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
+        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
+        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
+        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
+        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
+        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
+        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
+        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
+        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
+        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
+        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
+        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
+        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
+        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
+        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
+        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
+        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
+        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
+        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
+        H7C8EAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - f038adb2-bd05-41da-a920-0bd4380a68db
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 99d31ecb-5eaf-4fb8-b78e-1139ecb0a5c8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141105Z:99d31ecb-5eaf-4fb8-b78e-1139ecb0a5c8
+      Date:
+      - Fri, 30 Oct 2015 14:11:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
+        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
+        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
+        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
+        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
+        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
+        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
+        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
+        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
+        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
+        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
+        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
+        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
+        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
+        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
+        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
+        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
+        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
+        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
+        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
+        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
+        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
+        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
+        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
+        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
+        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
+        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
+        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
+        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
+        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
+        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 988338cb-11fe-4142-84fd-b4c3c40ea704
+      X-Ms-Correlation-Request-Id:
+      - 988338cb-11fe-4142-84fd-b4c3c40ea704
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:988338cb-11fe-4142-84fd-b4c3c40ea704
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 8eeac86b-4827-4c8d-95c4-0925c865523f
+      X-Ms-Correlation-Request-Id:
+      - 8eeac86b-4827-4c8d-95c4-0925c865523f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:8eeac86b-4827-4c8d-95c4-0925c865523f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:06 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Request-Id:
+      - 7f911484-eba2-4e09-99ec-cc948f1373f2
+      X-Ms-Correlation-Request-Id:
+      - 7f911484-eba2-4e09-99ec-cc948f1373f2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:7f911484-eba2-4e09-99ec-cc948f1373f2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - bd11549c-de21-42e5-bbb2-c443050583bc
+      X-Ms-Correlation-Request-Id:
+      - bd11549c-de21-42e5-bbb2-c443050583bc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:bd11549c-de21-42e5-bbb2-c443050583bc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:05 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - abf9b9a0-35e0-4f90-8c52-d199e4adf662
+      X-Ms-Correlation-Request-Id:
+      - abf9b9a0-35e0-4f90-8c52-d199e4adf662
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:abf9b9a0-35e0-4f90-8c52-d199e4adf662
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 30 Oct 2015 14:11:06 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - c3ae9e0e-0f5b-4fa9-9c62-23e080e353e7
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14979'
+      X-Ms-Correlation-Request-Id:
+      - e0418490-13f1-4af7-9df8-ba85d3b6f24e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141106Z:e0418490-13f1-4af7-9df8-ba85d3b6f24e
+      Date:
+      - Fri, 30 Oct 2015 14:11:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
+        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
+        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
+        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
+        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
+        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
+        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
+        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
+        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
+        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
+        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
+        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
+        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
+        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
+        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
+        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
+        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
+        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - d4f41964-1306-4ab0-8875-07259b9f7c36
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 7d5bf832-e87b-4b6e-ba96-7d00c2c4ebf2
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141107Z:7d5bf832-e87b-4b6e-ba96-7d00c2c4ebf2
+      Date:
+      - Fri, 30 Oct 2015 14:11:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tu/t
+        vNndf7S7+2jn0092dh7t7HxkGv8S+eX7+PFLGAQwfQsMlSqWJh8tM4F6Ms/P
+        t4ksM9dnlJreu3g2ULRZT6d5Pss9iHgcRc+W51XnO0IzJKgPNh2CGKPMvUf7
+        Dx7dPxjv3b93//7ebodCRBfzK1NJ//4+w/0of9fmS3QKFHTkdtSWYl8U07pq
+        qvN2fEaNL+ZtM/7JL54W2cWyatpi2rzO25awbrRTv4M+YR349yLoEDHfn5Ab
+        iXhvZ2f/04OQiMJYUcyrq7xGz/ndWZ6VZTWlX/2ubo00SYsPQRoKIX/j5Jf8
+        PzujnY1iBAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"043707df-d3a4-491d-974f-6cb82401deac"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 90a60cdf-aeec-4c17-8e2f-f2df66c3813b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - bb132c54-ceea-4868-b988-de89d19d5c02
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141107Z:bb132c54-ceea-4868-b988-de89d19d5c02
+      Date:
+      - Fri, 30 Oct 2015 14:11:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PdvbvPdh5MDvfnt3L
+        9rf3H+7Oth8+2D/f/nQ6IVx2dmd5Nv19P9IX2+sVj/MW/eobZTXNMGa8lWdN
+        uzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJroe7e
+        waeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbnxcW6
+        ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++usXE
+        yUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7ynpS
+        FlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7pv0UY
+        EIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm9EW2
+        WpVFPnsafi9fG+p9lC+zSUkc86yqr7J6RtCp1XlWNrlpQUhjKK/z6bou2mum
+        BrVxCPyQKRzDx3tX6WoHqBPyRTadF0sI2s8G4t8+fbb98tWXT6OIn1SL1brN
+        DWsoJvRWF2X8oH9+yf8DYmP4yiYHAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b0e3ba9c-c6cf-4cae-91f0-a1b336b545a4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 6c31bde4-b0c4-4e7e-bd60-8366defef287
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141107Z:6c31bde4-b0c4-4e7e-bd60-8366defef287
+      Date:
+      - Fri, 30 Oct 2015 14:11:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
+        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
+        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
+        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
+        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
+        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
+        /S3MAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 9c95cd00-4512-4c4e-b306-0ac458702e58
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 4da92c20-4425-4565-9474-6eba7c437281
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141108Z:4da92c20-4425-4565-9474-6eba7c437281
+      Date:
+      - Fri, 30 Oct 2015 14:11:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbTz4JOdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+rJr2grrefppfum6jtPNex7OB
+        fs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoEMUace4/2Hzy6/+n44N7upzsP
+        7neIRKQxvzKh9O/vM9yPJlXVPi2yiyWRpZgCDx0zjXbZVGX+elrn+bKZV+2T
+        spp8VRfU5KN5266aR3fvTuf5+aquZvd393bGE/p+PK3qfHxVLGfVVTNe5u1d
+        dDBzHWyv6CfoP9s+n57fm03z6fb55GC2vf/w/P72w9nBdHuyez+fTc/PH+zs
+        T+/60zW+zRvjxiI8nixWTAbljfxdS18QgTFMnWUdLX1rGOSLYlpXTXXejs+o
+        8cW8bcY/+YVHotd529IMNQyZYOOHErPPRA78ezHPEOO8P9NsZpiH+3u79/YC
+        hhFaxTD/8jW6ze+SBOd1VhY/CPq5NcakBHwI0nC415fVVV7j7fzuLM/KsprS
+        r1+3Yx+CNJTp+42TX/L/AEeXYFayBQAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0bc0c07c-1d50-43c4-b8bb-cf9238056209"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 106c0a40-913a-4d6e-8f3c-311278228c13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - dd92b4c7-e9b7-46dc-bb15-8e7ee83a76a4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141108Z:dd92b4c7-e9b7-46dc-bb15-8e7ee83a76a4
+      Date:
+      - Fri, 30 Oct 2015 14:11:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/amUx3pjsP
+        ptu7s/s72/v3pvvbk4PJZHt6/nDv3sHO/U/3dh7+vh/pi+31ikd7i671jbKa
+        Zhg23sqzpl2bL2gcq7xuC2r5KGVayoeXRUPNi+XF6zZrubPX6+k0z2f5TN6k
+        ZjQgIc5aCLyb5bv3JruT7YOD/Qfb+w8f0Bge7N/fvp9PpueTnXuTycMD+3Kx
+        OqmW58XFumbE0P335KvU4IHHzmyxmnL7XQMBz//rZvZud1j0QQzvrzv18mCC
+        erMmD766xdzJQ42LS2py9vJ4NqNBANpHuzvjvfHOWJnUPF7T0jDTF3k7r3gC
+        nl7TNBXT7ivrSVlM6Q0LPECVWvyQp6+DEE3fSzN9T/PLj3zkfkk4FMKQ5p6Q
+        /TkewWVRt+us1D/9twgDwrC5O8vPs3XZhoNxf9hf9Zfv6zg/mi2b13nbEtcE
+        EyWf15eEDn38PdOcvshWq7LIZ0/D7+VrQ72P8mU2KYlpnlX1VVbPCDq1Os/K
+        JjctCGkM5XU+XddFe83UoDYOgR8yhWP4RPnEjlHn5ItsOi+WELefDdy/ffps
+        ++WrL59GcT+pFqt1mxvuUEziWOMH/fNL/h9LzfwgOAcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2c90a9db-ac06-4019-afc3-9f94574e9e33
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - e77e1d12-2b69-498f-b6e7-98e4b1e2b6bd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141108Z:e77e1d12-2b69-498f-b6e7-98e4b1e2b6bd
+      Date:
+      - Fri, 30 Oct 2015 14:11:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 4c234869-d8c6-4cd6-92a5-243ff671f97f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - c498ab07-4546-4583-ab9a-7fba5423dd2c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141108Z:c498ab07-4546-4583-ab9a-7fba5423dd2c
+      Date:
+      - Fri, 30 Oct 2015 14:11:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbRz8MnOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCn8/y8yevLvN51vUZJ572NZwP5
+        mvV0muezfOYg4nHkO1ueV53vCNGQej7YdAhijDb3Hu3vPbp/f/zw4P7DT/cf
+        dmhElDG/Mp307+8z3I/yd21OU0DTQFB15HbUlmZfFNO6aqrzdnxGjS/mbTP+
+        yS+eFtnFsmraYtq8ztuWsG60U7+DPmEd+Pci6BAx35+QG4j46Xhn/2C/Q0Ph
+        rCji1VVeo+P87izPyrKa0q9+T7fGmSTDhyANhY6/cfJL/h/LOmKCTgQAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ec36b00e-1d84-4807-8c45-a59d8f936e11"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5b3ce122-2723-4d92-b80b-9b30a2d2f46c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 51b53fd7-5adb-4c48-a88d-ccaeff3fdc2b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141108Z:51b53fd7-5adb-4c48-a88d-ccaeff3fdc2b
+      Date:
+      - Fri, 30 Oct 2015 14:11:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9KJ/e+3Sy
+        s5Nv784O9rf3D3YebB9M9+9vZ/cfzg7OH977NN/d/X0/0hfb6xUP9hY96xtl
+        Nc0wbLyVZ027Nl/QMFZ53RbU8lHKpJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
+        Sc0scdZC4Em+O9ub7U+2s3t70+396cHu9uR8Z7a9e+/Bp/cePsj2ZpPcvlys
+        TqrleXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig
+        3qzJg69uMXfyUOPikpqcvTyezYgggPbR7s4Y/90fbFoaZvoib+cVT8DTa5qm
+        Ytp5hWaF6EXfBxjSFz/sWbss6nadlfpn8BrhQDg2d2f5ebYu2498TH+J+8P+
+        qr98X0f60WzZvM7blogN4tmByufgCnz8PdOcvshWq7LIZ0/D7+XrX6LNPsqX
+        2aQkWj+r6qusnhF0anWelU1uWhDSGMvrfLqui/aa6UFtHAI/bBrHEKJ2Zz+h
+        7+8qae0YdVK+yKbzYgku/eHjrl8b/lBUApk2WOMH/fNL/h9nVwHSbgYAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 5a0bfe75-da61-47eb-b6b1-942b350f1807
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 0db692d4-5095-43fc-9293-32d1259d577c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141109Z:0db692d4-5095-43fc-9293-32d1259d577c
+      Date:
+      - Fri, 30 Oct 2015 14:11:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbRz8MnOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBPX710vUVJ5r2FZwPZmvV0muez
+        fOYg4nFkO1ueV53vCMGQaj7YdAhijCb3Hu3vPbp/f/zw4P7DT/cfdmhDFDG/
+        Mn307+8z3I/yd21OpCfyE1QduR21pdUXxbSumuq8HZ9R44t524x/8ounRXax
+        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkBiJ+Ot7ZP9jv0FA4Kob4l6/R
+        a36XeDmvs7L4QdDNrREmcfAhSMPhXl9WV3mNt/O7szwry2pKv37djn0I0lBm
+        7zdOfsn/A0h+5h+8BAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"26a13215-44d2-4d13-b683-a83fea9e083f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 945576cc-31e2-46e9-b535-de53eb419d38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 882cf0b9-fd89-4536-9767-3dacbeac06e8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141109Z:882cf0b9-fd89-4536-9767-3dacbeac06e8
+      Date:
+      - Fri, 30 Oct 2015 14:11:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+36092m2e29v9/72/v5s
+        b5v6vbc9+fTg3nZ2cO88zx7mO/Tz9/1IX2yvVzy4W/Sob5TVNMNw8VaeNe3a
+        fEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWwNIRP
+        Zw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ/ffk
+        q9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlDjYtL
+        anL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1hgQeo
+        Uosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2d2f5
+        ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW+exp
+        +L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTGIfDD
+        pnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/8lQWOCQcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2918e677-aea1-4b53-b21d-d9cdee65410f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 78306692-d58f-4924-8009-517feb490caf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141109Z:78306692-d58f-4924-8009-517feb490caf
+      Date:
+      - Fri, 30 Oct 2015 14:11:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - bf9d7311-bdc6-4a27-9b37-c81381e999d0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - d252d076-ae32-49fd-88c9-c5b4385ba00e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141110Z:d252d076-ae32-49fd-88c9-c5b4385ba00e
+      Date:
+      - Fri, 30 Oct 2015 14:11:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbTz8JOdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
+        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQYwR5d6j/b1H9++PHx7cf/jpfpc4RBLz
+        KxNI//4+w/0of9fmRHuiP0HVkdtRO2IV07pqqvN2fEaNL+ZtM/7JL54W2cWy
+        atpi2rzO25awbrRTv4M+YR349yLoEDHfn5AbiPjpeGf/YL9DQ2GpKOLVVV6j
+        4/zuLM/KsprSr35Pt8aZRMKHIA2Fjr9x8kv+HyyRCM5HBAAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"86ae9cbe-172e-4618-a950-a33604937de9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e4431f1a-3b00-4615-bae4-68fe033a6fee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 7785c11c-12b2-4083-baf2-780838116f1f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141110Z:7785c11c-12b2-4083-baf2-780838116f1f
+      Date:
+      - Fri, 30 Oct 2015 14:11:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19Pzr4NMsfTif59u6D
+        PULj092D7ezh/Z3t7N69T3f2H957MMsf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        P1R9PzgPBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8e173e30-9806-45fa-bba0-63db1acc72ad
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - c9e2d1ad-b203-4319-92f0-01b3b5b9387f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141110Z:c9e2d1ad-b203-4319-92f0-01b3b5b9387f
+      Date:
+      - Fri, 30 Oct 2015 14:11:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 5563d63e-47e8-42e7-b437-11d88221a5ff
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 35fbf16c-deef-4f3a-a11a-604b792ebc1f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141110Z:35fbf16c-deef-4f3a-a11a-604b792ebc1f
+      Date:
+      - Fri, 30 Oct 2015 14:11:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        93be7O4/2t19tLvzyc7Oo52dj0zjXyK/fB8/fgmDAFJvgYwSwA7/o2UmUL84
+        +4mTarFat/mu6zVKOu9tPBvI16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQ
+        Y7S592h/79H9++ODvYefPnj4aYdGRBnzK9OJ/laQdnSWNrOszQivtz+iDP8g
+        qF3K7Llef35RBj++z3A/yt+1OYktiS5B1ZHbUVuKfVFM66qpztvxGTW+mLfN
+        +Ce/eFpkF8uqaYtp8zpvW8K60U79DvqEdeDfi6BDxHx/Qm4m4v79ezsPQiL2
+        WcliXl3lNXrO787yrCyrKf3qd3VrpEmd+hCkoRDyN05+yf8DdkdRoEgGAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"15e05a07-0ca2-435c-8eec-b61e5da24da7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 57a94eb0-9449-440a-8678-081cf816b916
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 3152bd0b-b723-45e4-bc6e-4bb322917b7e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141112Z:3152bd0b-b723-45e4-bc6e-4bb322917b7e
+      Date:
+      - Fri, 30 Oct 2015 14:11:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR7v385372c6D
+        7Z1ptre9f+/+dPsgz6fbk0938/uzjDDKHvy+H+mL7fWKB3uLnvWNsppmGDbe
+        yrOmXZsvaBirvG4LavkoZVLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljhr
+        IfDew8ne7N7edPvBg3x/e/98mm9P9j79dPvBJDvIHpwffLq3u2NfLlYn1fK8
+        uFjXjBi6/558lRo88NiJLVZTbr9rIOD5f93M3u0Oiz6I4f11p14eTFBv1uTB
+        V7eYO3mocXFJTc5eHs9mRBBA+2h3Z4z/9gebloaZvsjbecUT8PSapqmYdl9Z
+        T8piSm9Y4AGq1OKHPX0djGj6vjj7CX139yMfuV8SDoUwpKknZH+uR3BZ1O06
+        K/XP4DXCgXBs7s7y82xdtuFw3B/2V/3l+zrSj2bL5nXetsQ3wVTJ5/Ul4UMf
+        f880py+y1aos8tnT8Hv52tDvo3yZTUpim2dVfZXVM4JOrc6zsslNC0IaY3md
+        T9d10V4zPaiNQ+CHTeMYQtSuxyl2jDopX2TTebGEwP3wcdevDX8oKtSijzV+
+        0D+/5P8B4BsgKTkHAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 579381fc-f197-44f0-99c5-ef1ad7894b5a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 59208ef9-7024-4672-bcdb-b14f3570964e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141112Z:59208ef9-7024-4672-bcdb-b14f3570964e
+      Date:
+      - Fri, 30 Oct 2015 14:11:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 0bbc8040-6edf-4bc3-89a0-2e77d889e555
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 1c1f2103-1afb-418b-8cac-ebce78f9bc1f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141112Z:1c1f2103-1afb-418b-8cac-ebce78f9bc1f
+      Date:
+      - Fri, 30 Oct 2015 14:11:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbS798nOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
+        nzmIeBzlzpbnVec7QiAknA82HYIYI8u9R/sPHt3/dHxwb/fTnQf3O+Qhophf
+        mUT69/cZ7keTqmqfFtnFsmraYgo8dMw02mVTlfnraZ3ny2ZetU/KavJVXVCT
+        j+Ztu2oe3b3brPLpbtNWNU3t7nhCDcbTqs7HV8VyVl0142Xe3kUPM9fDNt65
+        XOxs59nugzzb29/OZtlse39/em87Ozh4uL2zs3/vfLK3e//h+R53sP2TX+yM
+        b9N63Fhcx5PFiimgDNGfXh0mffde0zo0pe8/nZun8uH+3u69kNNlKFHMq6u8
+        Rs/53VmelWU1pV/9rm6NNMmmD0EaCr/8xskv+X8AsQnz5tAEAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ac03b5da-e835-4650-87ba-5953e106ba33"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 12f88f6d-0308-442c-9ae3-510657d5459f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 520edc30-c878-428d-bed2-d2ddc7725490
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141112Z:520edc30-c878-428d-bed2-d2ddc7725490
+      Date:
+      - Fri, 30 Oct 2015 14:11:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1E23bk3uT/LtvOD
+        e/e39z+9v7N98GCSbd9/eP9evrvz6SS7d+/3/UhfbK9XPMRbdKpvlNU0w4jx
+        Vp417dp8QSNY5XVbUMtHKRNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s3RZ
+        C23vHzyc7u482Cc6zna39+9PJtsP9w4ebE+yB+effjrdf0j0tC8Xq5NqeV5c
+        rGtGDN1/T75KDR547HQWqym33zUQ8Py/aVLvdkdEH8RQ/rqzLg/mpjdh8uCr
+        W0ybPNS4uKQmZy+PZzOiBaB9tLszxn/3B5uWho++yNt5xbR/ek0zVEw7r9CE
+        EKno+wBD+uKHPWGXRd2us1L/1On6yRenb+4SCoRic/c1/9ze/cjH9JeEwymr
+        bPYkK7PlNK+fZNO3+XKmZHtZVSVoZ3lXns6wCcQPe+A+yjrs50/uTvrI39UB
+        4Y+QCEQG/8/vD9PkbDmp1svZi6x9tS6ZM/8/Qo8iRPzuq6cvt3/yi52NZHB/
+        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
+        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
+        OkpvnQ4jeIqKUtyRlilG//yS/wduCFLLtQcAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 7110017e-7add-4c03-a8ec-da3716a44434
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - ce13a733-5bc9-47e7-a9fc-515647b5e98a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141112Z:ce13a733-5bc9-47e7-a9fc-515647b5e98a
+      Date:
+      - Fri, 30 Oct 2015 14:11:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbS798nOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
+        nzmIeBzlzpbnVec7QiAknA82HYIYI8u9R/sPHt1/MH6w8+mnB58edMhDRDG/
+        Mon07+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAm
+        H83bdtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6Hbbxz
+        udjd3pncz/ay/fPt3dmnD7b3d2f5dra7N92+tzvbebD76cO9T/eIsNR4+ye/
+        2B3fpvW4sbiOJ4sVU0AZoj+9Okz67r2mdWhK3386N0/lpw93P/30fjCVMpQo
+        5tVVXqPn/O4sz8qymtKvfle3Rppk04cgDYVffuPkl/w/IPkF8dAEAAA=
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"79a4e4b1-b793-46f8-a809-201f55afc502"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 241cad7d-b946-4cd0-be22-dbcf8e7c204b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 2ef951e9-c736-4743-ac75-ff0f25ec948c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141113Z:2ef951e9-c736-4743-ac75-ff0f25ec948c
+      Date:
+      - Fri, 30 Oct 2015 14:11:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9GDh9l+vj/Z3Z48
+        eHhve/9TQik72Hm4vbeze37/fnY+vb+z9/t+pC+21yse4i061TfKapphxHgr
+        z5p2bb6gEazyui2o5aOUCSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZuqyF
+        tg92Zvd37t/f297bO9/d3r//ab49me2dbz+c7J7v5vf2z8/zHftysTqplufF
+        xbpmxND99+Sr1OCBx05nsZpyeyWePP9vmtS73RHRBzGUv+6sy4O56U2YPPjq
+        FtMmDzUuLqnJ2cvj2YxoAWgf7e6M8d/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
+        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
+        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
+        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sZkM7g/7
+        uf5iKPTRbNm8ztuW5BC0sIOXz+tLwoA+/p5pTl9kq1VZ5LOn4ffyteHFj/Jl
+        NilJDJ9V9VVWzwg6tTrPyiY3LZTbv8im82IJ8Xddf3P0/vKLl1+9Of3JL15H
+        6a3TYQRPUVGKO9IyxeifX/L/AKug0K61BwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
+      X-Ms-Request-Id:
+      - 79fd8ad7-cc49-4776-8d50-f1156ff34795
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 62e08415-7e64-4380-9a40-c1ce070c5210
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141113Z:62e08415-7e64-4380-9a40-c1ce070c5210
+      Date:
+      - Fri, 30 Oct 2015 14:11:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
+        93be7O4/2t19tHvvk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
+        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
+        xohz79H+g0f3Px3fv79z72D/oEMkIo35lQmlf3+f4X40qar2aZFdLKumLabA
+        Q8dMo102VZm/ntZ5vmzmVfukrCZf1QU1+Wjetqvm0d27y+v64uHuwf54Qt+N
+        p1Wdj6+K5ay6asbLvL0L4DMHfLsxtN+ezs53svMHDwn//dn2/uzBve2H0+n9
+        7YP793cnuw9n03znwV1/qsa3eWPcWGTHk8WKSaB8kb9r6QsiLoaoM6wjpW8N
+        c3xRTOuqqc7b8Rk1vpi3zfgnv/DI8zpvW5qdhiETbPxQQvYZyIF/L8YZYpr3
+        Z5iNzPLp7h6R7tOAWYRWUcyrq7xGz/ndWZ6VZTWlX/2ubo006QAfgjQUQv7G
+        yS/5fwDm8y0Y/QQAAA==
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"10151287-e86a-4dca-869a-8ebd68e2834e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 00c24975-c126-4d08-872a-cacb4716c6fa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 7078ce61-d257-4c8b-b243-1907d204cff4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141113Z:7078ce61-d257-4c8b-b243-1907d204cff4
+      Date:
+      - Fri, 30 Oct 2015 14:11:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHdn9/7u3sGD7fzg
+        02x7fzbNtg8+fUj/5JPZpwf53sG9/fz3/UhfbK9XPMxb9KxvlNU0w4DxVp41
+        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
+        2V4+vU9Iz+7dP6Ax7M+2s93d3e3pbn7vwb2dTycPJ3v25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+d0mI15fa7BgKe/xfN6d3ugOiDGMZfd9LlwdT05ksefHWLWZOH
+        GheX1OTs5fFsRqQANEJnvDfeGX862LQ0bPRF3s4rJv3Ta5qgYtp9ZT0piym9
+        YYEHqFKLH97EdXChiXttJ+6r12cvP/Ix+yXhOAg9mnfC9GcN/ZN5fr79sq5m
+        G8dwWdTtOiv1T/8twoAwbO7O8vNsXbbhYNwf9lf95fs6zo9my+Z13rbEMsEs
+        yef1JaFDH3/PNKcvstWqLPLZ0/B7+dpQ76N8mU1K4phnVX2V1TOCTq3Os7LJ
+        TQtCGkN5nU/XddFeMzWojUPgm6NwtVit2/wnv2g2kjiGELU7+wl9f1dJa8eo
+        c/JFNp0XS8jazwLug8ytSBnGUCRC1jYI4wf980v+H9qMLAEjBwAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - eeb6541c-e67c-4c5a-a91e-1c87bd5765f6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 6eaa8fee-6696-4d04-be0e-892b23d9fcc8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20151030T141113Z:6eaa8fee-6696-4d04-be0e-892b23d9fcc8
+      Date:
+      - Fri, 30 Oct 2015 14:11:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
+        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
+        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
+        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
+        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
+        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
+        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
+        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
+        55f8P07bQ1vOAgAA
+    http_version: 
+  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
In MIQ each Azure Region is now represented as an ExtManagementSystem, just like in Amazon.
This change disrupted the Azure refresh parser to ensure inventory is gathered only for a particular Region (EMS).
The Armrest gem does not support gathering inventory for a particular Region so I had to gather the ResourceGroups in the Region (EMS) and then gather all the inventory in each ResourceGroup.

This PR is organized into the following commits
1) Model code changes - Azure discovery code, parser changes
2) Spec test changes
3) Model changes required to support the UI team.
4) UI team changes for the Add (Azure) Provider screen
5) Last minute changes to address Rubocop complaints.

A separate PR will be filed for the UI changes required to support Azure Discovery.

https://trello.com/c/vXomgclg/67-3-azure-alter-azure-refresh-to-support-private-image-provisioning