### PR TITLE
Speed up rbac_tree_spec by removing seeding of product features.

### DIFF
--- a/spec/controllers/ops_controller/rbac_tree_spec.rb
+++ b/spec/controllers/ops_controller/rbac_tree_spec.rb
@@ -1,24 +1,16 @@
 require "spec_helper"
-include UiConstants
 
-describe OpsController do
-  render_views
+describe OpsController::RbacTree do
+  let(:role) do
+    # Pick a small subset of the product features tree to allow the spec to
+    #   exercise building more than a single node
+    FactoryGirl.create(:miq_user_role, :features =>
+      %w(all_vm_rules instance instance_view instance_show_list instance_control instance_scan)
+    )
+  end
 
-  context "::RbacTree" do
-    before do
-      [MiqRegion, MiqProductFeature].each(&:seed)
-      feature = MiqProductFeature.find_all_by_identifier("everything")
-      @role   = FactoryGirl.create(:miq_user_role, :name => "Role", :miq_product_features => feature)
-    end
-
-    context "#build" do
-      it "builds features tree" do
-        controller.instance_variable_set(:@role, @role)
-        controller.instance_variable_set(:@role_features, @role.feature_identifiers.sort)
-        features_tree = controller.send(:rbac_build_features_tree)
-        features_tree.should include("Access Rules for all Virtual Machines")
-        expect(response.status).to eq(200)
-      end
-    end
+  it ".build" do
+    features_tree = described_class.build(role, role.feature_identifiers.sort).to_json
+    expect(features_tree).to include("Access Rules for all Virtual Machines")
   end
 end


### PR DESCRIPTION
We still will seed a small subset of the tree, but not the whole thing
as it's overkill.  In addition, remove the unnecessary controller
testing and focus this unit test on the OpsController::RbacTree class
itself.

This spec was a SQL intensive spec with 4360 SQL statements.  This drops
the timing of the spec from 3.44s to 0.64s

@martinpovolny @jrafanie Please review.  I'm not sure if this PR went "too far" as technically I removed a controller spec.  Should I add the controller spec back in, or is it unnecessary with the RbacTree spec being more specific.  I feel like the controller spec would just be checking that we called RbacTree anyway, so it feels like a pointless spec.