### PR TITLE
ConfigurationHelper constant was duplicated leading to test failures.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   config.include AuthHelper,  :type => :helper
   config.include AuthRequestHelper, :type => :request
   config.include UiConstants, :type => :view
-  config.include ConfigurationHelper
+  config.include VMDBConfigurationHelper
 
   config.include AutomationSpecHelper, :type => :automation
   config.include PresenterSpecHelper, :type => :presenter, :example_group => {

--- a/spec/support/vmdb_configuration_helper.rb
+++ b/spec/support/vmdb_configuration_helper.rb
@@ -1,4 +1,4 @@
-module ConfigurationHelper
+module VMDBConfigurationHelper
   def stub_server_configuration(config, config_name = "vmdb")
     configuration = double(:config                         => config,
                            :merge_from_template_if_missing => nil,


### PR DESCRIPTION
app/helper/configuration_helper.rb was added in: 6e55c5a85ee
spec/support/configuration_helper.rb was added in: da64b0519ada
(duplicating the constant name)

The changes here fix an error seen when running this spec in isolation or randomly when part of the test suite:

```
1) ConfigurationHelper.render_view_buttons should render HTML tags for compare view button
     Failure/Error: helper.render_view_buttons(resource, view)
     NoMethodError:
       undefined method `render_view_buttons' for #<#<Class:0x007fd662880528>:0x007fd662803230>
     # ./spec/helpers/configuration_helper_spec.rb:9:in `block (4 levels) in <top (required)>'

  2) ConfigurationHelper.render_view_buttons should render HTML tags for compare view button
     Failure/Error: helper.render_view_buttons(resource, view)
     NoMethodError:
       undefined method `render_view_buttons' for #<#<Class:0x007fd662880528>:0x007fd66176b490>
     # ./spec/helpers/configuration_helper_spec.rb:9:in `block (4 levels) in <top (required)>'

  3) ConfigurationHelper.render_view_buttons should render HTML tags for tagging view button
     Failure/Error: helper.render_view_buttons(resource, view)
     NoMethodError:
       undefined method `render_view_buttons' for #<#<Class:0x007fd662880528>:0x007fd661722b78>
     # ./spec/helpers/configuration_helper_spec.rb:9:in `block (4 levels) in <top (required)>'
```