### PR TITLE
Add support for rendering icons instead of images in toolbar items

### DIFF
--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -96,13 +96,17 @@ module ToolbarHelper
     end
   end
 
-  # Render image to go on a toolbar button
+  # Render image/icon to go on a toolbar button
   #
   def toolbar_image(props)
-    tag(:img,
-        :src            => t = "/images/toolbars/#{props['img']}",
-        'data-enabled'  => t,
-        'data-disabled' => "/images/toolbars/#{props['imgdis']}")
+    if props[:icon].present?
+      content_tag(:i, '', :class => props[:icon], :style => "#{props['text'].present? ? 'margin-right: 5px;' : ''}")
+    else
+      tag(:img,
+          :src            => t = "/images/toolbars/#{props['img']}",
+          'data-enabled'  => t,
+          'data-disabled' => "/images/toolbars/#{props['imgdis']}")
+    end
   end
 
   # Render drop-down top button
@@ -174,11 +178,7 @@ module ToolbarHelper
           end
     content_tag(:li, :class => cls + (hidden ? 'hidden' : '')) do
       content_tag(:a, prepare_tag_keys(props).update(:href => '#')) do
-        if props[:icon].present?
-          content_tag(:i,  '', :class => props[:icon]).html_safe
-        else
-          (toolbar_image(props) + props['text'].to_s.html_safe)
-        end
+        (toolbar_image(props) + props['text'].to_s.html_safe)
       end
     end
   end


### PR DESCRIPTION
The toolbar images can be now changed to icons by setting the `:icon` parameter for each toolbar item in the yaml file. The old `:image` parameter is still supported, but it has lower priority when rendering.

**Example:**
![screenshot from 2015-11-03 11-03-32](https://cloud.githubusercontent.com/assets/649130/10905451/9218cbe2-821a-11e5-9be2-544d2c31b70f.png)
```yaml
- :name: vm_lifecycle
  :items:
  - :buttonSelect: vm_lifecycle_choice
    :icon: fa fa-recycle
    :image: lifecycle
    :title: Lifecycle
    :text: Lifecycle
    :items:
    - :button: vm_miq_request_new
      :icon: fa fa-plus
      :image: new
      :url_parms: 'main_div'
      :text: "Provision VMs"
      :title: "Request to Provision VMs"
    - :button: vm_clone
      :icon: fa fa-copy
      :text: "Clone selected item"
      :title: "Clone this item"
      :url_parms: 'main_div'
      :enabled: 'false'
      :onwhen: '1'
    - :button: vm_publish
      :icon: fa fa-level-up
      :text: "Publish selected VM to a Template"
      :title: "Publish selected VM to a Template"
      :url_parms: 'main_div'
      :enabled: 'false'
      :onwhen: '1'
    - :button: vm_migrate
      :image: migrate
      :text: "Migrate selected items"
      :title: "Migrate selected items to another Host/Datastore"
      :url_parms: 'main_div'
      :enabled: 'false'
      :onwhen: '1+'
    - :button: vm_retire
      :image: retire
      :text: "Set Retirement Dates"
      :title: "Set Retirement Dates for the selected items"
      :url_parms: 'main_div'
      :enabled: 'false'
      :onwhen: '1+'
    - :button: vm_retire_now
      :image: retire_now
      :text: "Retire selected items"
      :title: "Retire the selected items"
      :url_parms: 'main_div'
      :confirm: "Retire the selected items?"
      :enabled: 'false'
      :onwhen: '1+'
```