### PR TITLE
DialogRunner#dialog_get_form_vars - handle DateTime field input in random order

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -95,15 +95,6 @@ module ApplicationController::DialogRunner
 
     # Use JS to update the display
     render :update do |page|
-      #     page.replace_html("main_div", :partial=>"st_form") if params[:resource_id] || @group_idx || params[:display]
-      #      if changed
-      #       #sample commands to change values of fields when showing hidden tr's
-      #       page << "$('check_box_1').checked = true"
-      #       page << "$('text_area_box_1').value = 'text'"
-      #       page << "$('f2').options[0]= new Option('value 1', 'val1');"
-      #       page << "$('f2').options[1]= new Option('value 2', 'val2');"
-      #       page << "$('f2').value = 'val2'"
-      #       page << javascript_for_miq_button_visibility(changed)
       @edit[:wf].dialog.dialog_tabs.each do |tab|
         tab.dialog_groups.each do |group|
           group.dialog_fields.each_with_index do |field, _i|
@@ -138,7 +129,6 @@ module ApplicationController::DialogRunner
           end
         end
       end
-      #     end
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -229,7 +229,9 @@ module ApplicationController::DialogRunner
 
       elsif %w(start_hour start_min).include?(parameter_key)
         # find any DateTime field and assume it's the only one..
-        field_name = @edit[:wf].dialog.dialog_fields.select { |f| f.type == 'DialogFieldDateTimeControl' }.last.try(:name)
+        field_name = @edit[:wf].dialog.dialog_fields.reverse.find do |f|
+          f.type == 'DialogFieldDateTimeControl'
+        end.try(:name)
         next if field_name.nil?
 
         # if user didn't choose the date and goes with default shown in the textbox,
@@ -250,7 +252,7 @@ module ApplicationController::DialogRunner
         else
           start_min = parameter_value.to_i
         end
-        date_val[1] = sprintf("%02d:%02d", start_hour, start_min)
+        date_val[1] = "%02d:%02d" % [start_hour, start_min]
 
         @edit[:wf].set_value(field_name, date_val.join(' '))
 

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -228,35 +228,41 @@ module ApplicationController::DialogRunner
       parameter_key = parameter_key.split("__protected").first if parameter_key.ends_with?("__protected")
 
       if parameter_key.starts_with?("miq_date__") && @record.field_name_exist?(parameter_key.split("miq_date__").last)
-        @edit[:wf].set_value(parameter_key.split("miq_date__").last, parameter_value)
+        field_name = parameter_key.split("miq_date__").last
+        old = @edit[:wf].value(field_name)
+        new = parameter_value
+
+        # keep the chosen time if DateTime
+        new += old[10..-1] if old && old.length > 10
+
+        @edit[:wf].set_value(field_name, new)
 
       elsif %w(start_hour start_min).include?(parameter_key)
-        field_name = ""
+        # find any DateTime field and assume it's the only one..
+        field_name = @edit[:wf].dialog.dialog_fields.select { |f| f.type == 'DialogFieldDateTimeControl' }.last.try(:name)
+        next if field_name.nil?
 
-        @edit[:wf].dialog.dialog_fields.each_with_index do |field, _|
-          field_name = field.name if %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field.type)
-        end
-
-        # if user didnt choose the date and goes with default shown in the textbox,
+        # if user didn't choose the date and goes with default shown in the textbox,
         # need to set that value in wf before adding hour/min
-        if @edit[:wf].value(field_name).nil?
+        old = @edit[:wf].value(field_name)
+        if old.nil?
           t = Time.zone.now + 1.day
-          date_val = ["#{t.month}/#{t.day}/#{t.year}"]
-          @edit[:wf].set_value(field_name, date_val)
+          date_val = [t.strftime('%m/%d/%Y'), t.strftime('%H:%M')]
         else
-          date_val = @edit[:wf].value(field_name).split(" ")
+          date_val = old.split(" ")
         end
 
-        start_hour = date_val.length >= 2 ? date_val[1].split(":").first : 0
-        start_min = date_val.length >= 3 ? date_val[1].split(":").last : 0
+        start_hour = date_val.length >= 2 ? date_val[1].split(":").first.to_i : 0
+        start_min = date_val.length >= 2 ? date_val[1].split(":").last.to_i : 0
 
         if parameter_key == "start_hour"
-          time_value = "#{parameter_value}:#{start_min}"
+          start_hour = parameter_value.to_i
         else
-          time_value = "#{start_hour}:#{parameter_value}"
+          start_min = parameter_value.to_i
         end
+        date_val[1] = sprintf("%02d:%02d", start_hour, start_min)
 
-        @edit[:wf].set_value(field_name, "#{date_val[0]} #{time_value}")
+        @edit[:wf].set_value(field_name, date_val.join(' '))
 
       elsif @edit[:wf].dialog.field(parameter_key).try(:type) == "DialogFieldCheckBox"
         checkbox_value = parameter_value == "1" ? "t" : "f"

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -84,19 +84,19 @@ describe CatalogController do
     end
 
     it "keeps hours and minutes when setting date" do
-      controller.stub(:params).and_return({'miq_date__name'=> "11/13/2015"})
+      controller.stub(:params).and_return({'miq_date__name' => "11/13/2015"})
       controller.send(:dialog_get_form_vars)
       expect(dialog_field.value).to eq('11/13/2015 14:52')
     end
 
     it "keeps date and minutes when setting hours" do
-      controller.stub(:params).and_return({'start_hour'=> "4"})
+      controller.stub(:params).and_return({'start_hour' => "4"})
       controller.send(:dialog_get_form_vars)
       expect(dialog_field.value).to eq('04/05/2015 04:52')
     end
 
     it "keeps date and hourse when setting minutes" do
-      controller.stub(:params).and_return({'start_min'=> "6"})
+      controller.stub(:params).and_return({'start_min' => "6"})
       controller.send(:dialog_get_form_vars)
       expect(dialog_field.value).to eq('04/05/2015 14:06')
     end

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -61,4 +61,44 @@ describe CatalogController do
       expect(response.body).to eq({:values => "01/02/2015"}.to_json)
     end
   end
+
+  describe "#dialog_get_form_vars" do
+    include_context "valid session"
+
+    let(:dialog) { active_record_instance_double("Dialog") }
+    let(:wf) { double(:dialog => dialog) }
+    let(:dialog_field) { DialogFieldDateTimeControl.new }
+
+    let(:session) { {:edit => {:wf => wf}} }
+
+    before do
+      dialog.stub(:field).with("name").and_return(dialog_field)
+      dialog.stub(:field_name_exist?).with("name").and_return(true)
+      dialog.stub(:dialog_fields) { [Struct.new(:name, :type).new("name", "DialogFieldDateTimeControl")] }
+      wf.stub(:value).with("name") { dialog_field.value }
+      wf.stub(:set_value) { |_, val| dialog_field.instance_variable_set(:@value, val) }
+      Dialog.stub(:find_by_id).and_return(dialog)
+
+      dialog_field.instance_variable_set(:@value, "04/05/2015 14:52")
+      controller.instance_variable_set(:@edit, {:rec_id => nil, :wf => wf})
+    end
+
+    it "keeps hours and minutes when setting date" do
+      controller.stub(:params).and_return({'miq_date__name'=> "11/13/2015"})
+      controller.send(:dialog_get_form_vars)
+      expect(dialog_field.value).to eq('11/13/2015 14:52')
+    end
+
+    it "keeps date and minutes when setting hours" do
+      controller.stub(:params).and_return({'start_hour'=> "4"})
+      controller.send(:dialog_get_form_vars)
+      expect(dialog_field.value).to eq('04/05/2015 04:52')
+    end
+
+    it "keeps date and hourse when setting minutes" do
+      controller.stub(:params).and_return({'start_min'=> "6"})
+      controller.send(:dialog_get_form_vars)
+      expect(dialog_field.value).to eq('04/05/2015 14:06')
+    end
+  end
 end


### PR DESCRIPTION
A DateTime dialog has 3 input fields - date, hour and minute

Previously, these needed to be set in that order, otherwise, setting date would reset hours and minutes, setting hours would reset minutes..

Now, a datetime is prefilled with tomorrow at current date and time, and remembers changes in any order.

https://bugzilla.redhat.com/show_bug.cgi?id=1212470