### PR TITLE
Change type of flash message after deleting schedules

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -87,7 +87,7 @@ module ReportController::Schedules
     unless flash_errors?
       msg_str = scheds.length > 1 ? _("The selected %s were deleted") : _("The selected %s was deleted")
       add_flash(msg_str % "#{ui_lookup(:model => "MiqReport")} #{ui_lookup(:models => "MiqSchedule")}",
-                :info, true)
+                :success, true)
     end
     self.x_node = "root"
     replace_right_cell(:replace_trees => [:schedules])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1276101

cloud intelligence ==> Reports ==> Schedules ==> Configuration,
delete any schedule/s

before
![before](https://cloud.githubusercontent.com/assets/14937244/10913316/ada24824-824d-11e5-9a16-d4b4b71d5360.png)

after
![after](https://cloud.githubusercontent.com/assets/14937244/10913319/b0f081a8-824d-11e5-97dc-77e5e2686d50.png)