### PR TITLE
[WIP] [RFE] Placement method doesn't take into account read-only datastores

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -111,7 +111,7 @@ module EmsRefresh::SaveInventoryInfra
                     []
                   end
 
-    child_keys = [:operating_system, :switches, :hardware, :system_services]
+    child_keys = [:operating_system, :switches, :hardware, :system_services, :hosts_storages]
     extra_keys = [:ems_cluster, :storages, :vms, :power_state, :ems_children]
     remove_keys = child_keys + extra_keys
 
@@ -215,6 +215,26 @@ module EmsRefresh::SaveInventoryInfra
         disconnects.each(&:disconnect_inv)
       end
     end
+  end
+
+  def save_hosts_storages_inventory(host, hashes, target = nil)
+    target = host if target.nil?
+
+    # Update the associated ids
+    hashes.each do |h|
+      h[:host_id]    = host.id
+      h[:storage_id] = h.fetch_path(:storage, :id)
+    end
+
+    host.hosts_storages(true)
+    deletes =
+      if target == host
+        host.hosts_storages.dup
+      else
+        []
+      end
+
+    save_inventory_multi(:hosts_storages, host, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
   end
 
   def save_folders_inventory(ems, hashes, target = nil)

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -111,7 +111,7 @@ module EmsRefresh::SaveInventoryInfra
                     []
                   end
 
-    child_keys = [:operating_system, :switches, :hardware, :system_services, :hosts_storages]
+    child_keys = [:operating_system, :switches, :hardware, :system_services, :host_storages]
     extra_keys = [:ems_cluster, :storages, :vms, :power_state, :ems_children]
     remove_keys = child_keys + extra_keys
 
@@ -217,7 +217,7 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_hosts_storages_inventory(host, hashes, target = nil)
+  def save_host_storages_inventory(host, hashes, target = nil)
     target = host if target.nil?
 
     # Update the associated ids
@@ -226,15 +226,15 @@ module EmsRefresh::SaveInventoryInfra
       h[:storage_id] = h.fetch_path(:storage, :id)
     end
 
-    host.hosts_storages(true)
+    host.host_storages(true)
     deletes =
       if target == host
-        host.hosts_storages.dup
+        host.host_storages.dup
       else
         []
       end
 
-    save_inventory_multi(:hosts_storages, host, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
+    save_inventory_multi(:host_storages, host, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
   end
 
   def save_folders_inventory(ems, hashes, target = nil)

--- a/app/models/ems_refresh/vc_updates.rb
+++ b/app/models/ems_refresh/vc_updates.rb
@@ -143,6 +143,7 @@ module EmsRefresh::VcUpdates
       "capability.directoryHierarchySupported",
       "capability.perFileThinProvisioningSupported",
       "capability.rawDiskMappingsSupported",
+      "host",
       "summary.capacity",
       "summary.datastore",
       "summary.freeSpace",

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -390,7 +390,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def total_storages
-    HostsStorages.count(:conditions => {:host_id => host_ids}, :select => "DISTINCT storage_id")
+    HostStorage.count(:conditions => {:host_id => host_ids}, :select => "DISTINCT storage_id")
   end
 
   def vm_count_by_state(state)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -47,7 +47,8 @@ class Host < ApplicationRecord
   has_many                  :vms_and_templates, :dependent => :nullify
   has_many                  :vms
   has_many                  :miq_templates
-  has_and_belongs_to_many   :storages, :join_table => :host_storages
+  has_many                  :host_storages
+  has_many                  :storages, :through => :host_storages
   has_many                  :switches, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1720,6 +1720,16 @@ class Host < ApplicationRecord
     nil
   end
 
+  def writable_storages
+    # Check also for nil here in case a refresh has not added
+    # the true/false value to the host_storages records yet
+    storages.where(:host_storages => {:read_only => [false, nil]})
+  end
+
+  def read_only_storages
+    storages.where(:host_storages => {:read_only => true})
+  end
+
   def base_storage_extents
     miq_cim_instance.try(:base_storage_extents) || []
   end

--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -1,0 +1,4 @@
+class HostStorage < ActiveRecord::Base
+  belongs_to :host
+  belongs_to :storage
+end

--- a/app/models/hosts_storage.rb
+++ b/app/models/hosts_storage.rb
@@ -1,3 +1,5 @@
 class HostsStorage < ApplicationRecord
   self.table_name = "host_storages"
+  belongs_to :host
+  belongs_to :storage
 end

--- a/app/models/hosts_storage.rb
+++ b/app/models/hosts_storage.rb
@@ -1,5 +1,0 @@
-class HostsStorage < ApplicationRecord
-  self.table_name = "host_storages"
-  belongs_to :host
-  belongs_to :storage
-end

--- a/app/models/hosts_storages.rb
+++ b/app/models/hosts_storages.rb
@@ -1,3 +1,0 @@
-class HostsStorages < ApplicationRecord
-  self.table_name = "host_storages"
-end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -170,6 +170,19 @@ module ManageIQ::Providers
           # Link up the storages
           storages = get_mors(host_inv, 'datastore').collect { |s| storage_uids[s] }.compact
 
+          # Build list of mount info
+          hosts_storages = []
+          ems_inv[:storage].each do |s_mor, storage_inv|
+            storage_inv["host"].to_miq_a.each do |mount|
+              next if mount["key"] != mor
+              access_mode = mount["mountInfo"]["accessMode"]
+              hosts_storages << {
+                :storage   => storage_uids[s_mor],
+                :read_only => access_mode == "readOnly",
+              }
+            end
+          end
+
           # Store the host 'name' value as uid_ems to use as the lookup value with MiqVim
           uid_ems = summary.nil? ? nil : summary.fetch_path('config', 'name')
 
@@ -210,6 +223,7 @@ module ManageIQ::Providers
             :ems_cluster      => cluster_uids_by_host[mor],
             :operating_system => host_inv_to_os_hash(host_inv, hostname),
             :system_services  => host_inv_to_system_service_hashes(host_inv),
+            :hosts_storages   => hosts_storages,
 
             :hardware         => hardware,
             :switches         => switches,

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -171,12 +171,12 @@ module ManageIQ::Providers
           storages = get_mors(host_inv, 'datastore').collect { |s| storage_uids[s] }.compact
 
           # Build list of mount info
-          hosts_storages = []
+          host_storages = []
           ems_inv[:storage].each do |s_mor, storage_inv|
             storage_inv["host"].to_miq_a.each do |mount|
               next if mount["key"] != mor
               access_mode = mount["mountInfo"]["accessMode"]
-              hosts_storages << {
+              host_storages << {
                 :storage   => storage_uids[s_mor],
                 :read_only => access_mode == "readOnly",
               }
@@ -223,7 +223,7 @@ module ManageIQ::Providers
             :ems_cluster      => cluster_uids_by_host[mor],
             :operating_system => host_inv_to_os_hash(host_inv, hostname),
             :system_services  => host_inv_to_system_service_hashes(host_inv),
-            :hosts_storages   => hosts_storages,
+            :host_storages    => host_storages,
 
             :hardware         => hardware,
             :switches         => switches,

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -4,7 +4,7 @@ class Storage < ApplicationRecord
   has_many :miq_templates,     :foreign_key => :storage_id
   has_many :vms,               :foreign_key => :storage_id
   has_many :host_storages
-  has_many :hosts, :through => :hosts_storages
+  has_many :hosts, :through => :host_storages
   has_and_belongs_to_many :all_vms_and_templates, :class_name => "VmOrTemplate", :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_miq_templates,     :class_name => "MiqTemplate",  :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_vms,               :class_name => "Vm",           :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
@@ -17,7 +17,7 @@ class Storage < ApplicationRecord
   has_many :storage_files,       :dependent => :destroy
   has_many :storage_files_files, -> { where "rsc_type = 'file'" }, :class_name => "StorageFile", :foreign_key => "storage_id"
   has_many :files,               -> { where "rsc_type = 'file'" }, :class_name => "StorageFile", :foreign_key => "storage_id"
-  has_many :hosts_storages
+  has_many :host_storages
 
   has_many :miq_events, :as => :target, :dependent => :destroy
 
@@ -591,7 +591,7 @@ class Storage < ApplicationRecord
     if association_cache.include?(:hosts)
       hosts.size
     else
-      hosts_storages.length
+      host_storages.length
     end
   end
 

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -3,7 +3,8 @@ class Storage < ApplicationRecord
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"
   has_many :miq_templates,     :foreign_key => :storage_id
   has_many :vms,               :foreign_key => :storage_id
-  has_and_belongs_to_many :hosts, :join_table => :host_storages
+  has_many :host_storages
+  has_many :hosts, :through => :hosts_storages
   has_and_belongs_to_many :all_vms_and_templates, :class_name => "VmOrTemplate", :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_miq_templates,     :class_name => "MiqTemplate",  :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_vms,               :class_name => "Vm",           :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id

--- a/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
+++ b/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
@@ -1,5 +1,5 @@
 class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration
-  class HostsStorage < ActiveRecord::Base
+  class HostStorage < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end
 

--- a/gems/pending/VMwareWebService/VimPropMaps.rb
+++ b/gems/pending/VMwareWebService/VimPropMaps.rb
@@ -60,7 +60,7 @@ module VimPropMaps
     :Datastore              => {
       :baseName => "@dataStores",
       :keyPath  => ['summary', 'name'],
-      :props    => ["summary", "info", "capability"]
+      :props    => ["summary", "info", "host", "capability"]
     }
   }
 
@@ -305,6 +305,7 @@ module VimPropMaps
       :keyPath  => ['summary', 'name'],
       :props    => [
         "info",
+        "host",
         "capability.directoryHierarchySupported",
         "capability.perFileThinProvisioningSupported",
         "capability.rawDiskMappingsSupported",

--- a/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
+++ b/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
@@ -1,7 +1,7 @@
 require_migration
 
 describe AddVmwareRoDatastoresToHostsStorages do
-  let(:hosts_storages_stub) { migration_stub(:HostsStorage) }
+  let(:host_storages_stub) { migration_stub(:HostStorage) }
 
   migration_context :up do
     it "Adds ID in correct region" do

--- a/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
+++ b/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
@@ -1,11 +1,38 @@
 require_migration
 
 describe AddVmwareRoDatastoresToHostsStorages do
+  class AddVmwareRoDatastoresToHostsStorages::HostsStorage < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    self.table_name = "hosts_storages"
+  end
+
   let(:host_storages_stub) { migration_stub(:HostStorage) }
+  let(:hosts_storages_stub) { migration_stub(:HostsStorage) }
 
   migration_context :up do
     it "Adds ID in correct region" do
+      seq_start = ActiveRecord::Base.rails_sequence_start
+      seq_start = 1 if seq_start == 0
+
+      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
       migrate
+      h = host_storages_stub.first
+
+      expect(h.id).to eq(seq_start)
+    end
+    it "Maintains host_id after rename" do
+      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
+      migrate
+      h = host_storages_stub.first
+
+      expect(h.host_id).to eq(1)
+    end
+    it "Maintains storage_id after rename" do
+      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
+      migrate
+      h = host_storages_stub.first
+
+      expect(h.storage_id).to eq(2)
     end
   end
 end

--- a/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
+++ b/spec/migrations/20150921204114_add_vmware_ro_datastores_to_hosts_storages_spec.rb
@@ -11,28 +11,45 @@ describe AddVmwareRoDatastoresToHostsStorages do
 
   migration_context :up do
     it "Adds ID in correct region" do
-      seq_start = ActiveRecord::Base.rails_sequence_start
+      seq_start = hosts_storages_stub.rails_sequence_start
       seq_start = 1 if seq_start == 0
 
-      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
+      host_id = seq_start
+      storage_id = seq_start + 1
+
+      hosts_storages_stub.create(:host_id => host_id, :storage_id => storage_id)
       migrate
       h = host_storages_stub.first
 
-      expect(h.id).to eq(seq_start)
+      expect(host_storages_stub.id_to_region h.id).to eq(host_storages_stub.my_region_number)
     end
+
     it "Maintains host_id after rename" do
-      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
+      seq_start = hosts_storages_stub.rails_sequence_start
+      seq_start = 1 if seq_start == 0
+
+      host_id = seq_start
+      storage_id = seq_start + 1
+
+      hosts_storages_stub.create(:host_id => host_id, :storage_id => storage_id)
       migrate
       h = host_storages_stub.first
 
-      expect(h.host_id).to eq(1)
+      expect(h.host_id).to eq(host_id)
     end
+
     it "Maintains storage_id after rename" do
-      h = hosts_storages_stub.create(:host_id => 1, :storage_id => 2)
+      seq_start = hosts_storages_stub.rails_sequence_start
+      seq_start = 1 if seq_start == 0
+
+      host_id = seq_start
+      storage_id = seq_start + 1
+
+      hosts_storages_stub.create(:host_id => host_id, :storage_id => storage_id)
       migrate
       h = host_storages_stub.first
 
-      expect(h.storage_id).to eq(2)
+      expect(h.storage_id).to eq(storage_id)
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -28,6 +28,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     assert_specific_host
     assert_specific_vm
     assert_cpu_layout
+    assert_read_only_datastore
     assert_relationship_tree
   end
 
@@ -463,6 +464,16 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :cpu_total_cores      => 4,
       :cpu_cores_per_socket => 2,
       :cpu_sockets          => 2,
+    )
+  end
+
+  def assert_read_only_datastore
+    ro_datastores = Storage.includes(:hosts).where(:host_storages => {:read_only => true}).to_a
+    expect(ro_datastores.length).to eq(1)
+    ro_datastores[0].should have_attributes(
+      :ems_ref  => "datastore-974",
+      :name     => "NetAppSim2Lun1",
+      :location => "4cfd46de-09fb16d0-d60a-0010187f038c"
     )
   end
 

--- a/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
@@ -4,6 +4,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -66,6 +95,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -128,6 +186,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -190,6 +263,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -248,6 +336,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readOnly
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -310,6 +413,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -368,6 +500,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -426,6 +573,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -484,6 +646,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -546,6 +737,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -608,6 +814,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -666,6 +887,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -724,6 +974,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -782,6 +1047,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -840,6 +1134,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -902,6 +1211,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -960,6 +1284,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1018,6 +1371,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1076,6 +1444,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1134,6 +1531,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1196,6 +1622,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1254,6 +1695,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1312,6 +1768,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1374,6 +1859,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1432,6 +1932,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1490,6 +2005,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1548,6 +2092,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1606,6 +2165,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1668,6 +2256,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1730,6 +2333,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1788,6 +2406,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1850,6 +2497,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1908,6 +2570,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1970,6 +2661,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2032,6 +2752,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2090,6 +2825,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2152,6 +2916,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2210,6 +3003,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2268,6 +3090,7 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2330,6 +3153,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2388,6 +3226,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2446,6 +3313,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2504,6 +3386,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2562,6 +3459,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2620,6 +3546,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2682,6 +3637,7 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2740,6 +3696,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2798,6 +3769,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2856,6 +3856,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-12692
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2914,6 +3929,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"


### PR DESCRIPTION
Capture the read_only property of VMware host datastore mounts so that it can be used for VM provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1187819

DB migration for this change was https://github.com/ManageIQ/manageiq/pull/5113

cc @blomquisg @Fryguy 