### PR TITLE
Avoid name conflicts between top-level and nested constants

### DIFF
--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -1,11 +1,18 @@
 module RequireNested
   # See also: include_concern
   def require_nested(name)
+    return if const_defined?(name, false)
+
     filename = "#{self}::#{name}".underscore
+    filename = "#{name}".underscore if self == Object
     if Rails.application.config.cache_classes
       autoload name, filename
     else
       require_dependency filename
+    end
+
+    if ActiveSupport::Dependencies.search_for_file("#{name}".underscore) && self != Object
+      Object.require_nested name
     end
   end
 end


### PR DESCRIPTION
If the nested constant is defined, its top level equivalent must be defined too... otherwise the Rails autoloader can get confused.

This should more comprehensively fix issues along the lines of #5126.