### PR TITLE
Show Tenant column in catalog item's Request info tab only when relevant

### DIFF
--- a/app/views/miq_request/_prov_vm_grid.html.haml
+++ b/app/views/miq_request/_prov_vm_grid.html.haml
@@ -30,6 +30,9 @@
             %td
             %td
             %td
+            - if @edit[:vm_headers].key? 'cloud_tenant'
+              %td
+
         - @vms.each do |row|
           - @id = row.id
           - cls = @edit[:new][:src_vm_id] && @edit[:new][:src_vm_id][0] == @id ? "selected" : ""
@@ -52,6 +55,9 @@
                 = h(row.ext_management_system.name)
             %td
               = h(row.v_total_snapshots)
+            - if @edit[:vm_headers].key? 'cloud_tenant'
+              %td
+                = h(row.cloud_tenant)
   - elsif @vm
     -# grid with only one record for Redhat provisioning
     %table.table.table-striped.table-bordered.table-selectable
@@ -80,3 +86,6 @@
               = h(@vm.ext_management_system.name)
           %td
             = h(@vm.v_total_snapshots)
+          - if @edit[:vm_headers].key? 'cloud_tenant'
+            %td
+              = h(@vm.cloud_tenant)

--- a/gems/pending/spec/util/miq-hash_struct_spec.rb
+++ b/gems/pending/spec/util/miq-hash_struct_spec.rb
@@ -123,6 +123,26 @@ describe MiqHashStruct do
     end
   end
 
+  context '#respond_to?' do
+    let(:hs) { MiqHashStruct.new(:foo => 1) }
+
+    it "getter with existing key" do
+      expect(hs.respond_to?(:foo)).to eq(true)
+    end
+
+    it "setter with existing key" do
+      expect(hs.respond_to?(:foo=)).to eq(true)
+    end
+
+    it "getter with unknown key" do
+      expect(hs.respond_to?(:bar)).to eq(false)
+    end
+
+    it "setter with unknown key" do
+      expect(hs.respond_to?(:bar=)).to eq(true)
+    end
+  end
+
   context "dump and load" do
     let (:orig) { described_class.new("a" => 1, "b" => 2) }
 

--- a/gems/pending/util/miq-hash_struct.rb
+++ b/gems/pending/util/miq-hash_struct.rb
@@ -57,6 +57,14 @@ class MiqHashStruct
 
   def respond_to_missing?(sym, *)
     # Methods for Marshal and YAML dumping and loading shouldn't #respond_to_missing?
-    !sym.in?([:encode_with, :init_with, :yaml_initialize, :marshal_dump, :_dump])
+    return false if sym.in?([:encode_with, :init_with, :yaml_initialize, :marshal_dump, :_dump])
+
+    # Setters are always true
+    return true if sym.to_s.end_with? '='
+
+    # Getters only when the attribute is defined
+    return true if @hash.key?(sym)
+
+    false
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1275514

There was an extra column for Tenant in prov_vm_grid, that was never filled in...

The headers in there come from `build_vm_grid` which uses `.respond_to?` to determine whether there should be a Tenant field for a given set of VMs. Since #3816, MiqHashStruct's `respond_to?` always returns true - this fixes it to only return true if the method is a setter or the field is actually already present in the hash. - ping @bdunne 

Also, this adds the missing fields for the case when the Tenant column *should* be there.