### PR TITLE
Validate port presence when adding replication worker

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -35,6 +35,7 @@ class MiqRegionRemote < ActiveRecord::Base
 
     log_details = "Host: [#{host}]}, Database: [#{database}], Adapter: [#{adapter}], User: [#{username}]"
 
+    return ["Validation failed due to missing port"] if port.blank?
     begin
       with_remote_connection(host, port, username, password, database, adapter) do |c|
         _log.info("Attempting to connection to: #{log_details}...")

--- a/spec/models/miq_region_remote_spec.rb
+++ b/spec/models/miq_region_remote_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe MiqRegionRemote do
+  describe ".validate_connection_settings" do
+    it "returns a message about indicating the port is missing when blank" do
+      host = "192.0.2.1"
+      port = nil
+      username = "foo"
+      password = "bar"
+
+      actual = described_class.validate_connection_settings(host, port, username, password)
+
+      expect(actual).to include("Validation failed due to missing port")
+    end
+  end
+end


### PR DESCRIPTION
Fixes an issue where replication settings would pass validation in the
UI without a port specified, but the runner would fail because it would
short-circuit replication by guarding against a blank port
setting.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1276375