### PR TITLE
Recovered code that loads/shows advanced box on initial load.

### DIFF
--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -151,3 +151,6 @@
               .row
                 .col-md-12
                   = yield
+- if show_advanced_search?
+  :javascript
+    #{javascript_show_if_exists("adv_searchbox_div")}


### PR DESCRIPTION
This functionality was lost with removal of app/views/layouts/_dhtmlxlayout_explorer.html.haml in commit 6bc2a622403285e0db04e2afa42922861bea0e11 that used to load advanced search on explorer screens on initial load. Moved showing of advanced search to content.html.haml

Fixes #5117
https://bugzilla.redhat.com/show_bug.cgi?id=1277276

@dclarizio @himdel @epwinchell please review.