### PR TITLE
[WIP] Use a relationship tree to find vms in changed folders

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1157,35 +1157,44 @@ class VmOrTemplate < ActiveRecord::Base
     ems = ExtManagementSystem.find(ems_id)
 
     # Collect the newly added VMs
-    added_vms = ems.vms_and_templates.where("created_on >= ?", update_start_time)
+    added_vm_ids = ems.vms_and_templates.where("created_on >= ?", update_start_time).pluck(:id).to_set
+    updated_folder_ids = ems.ems_folders.where("updated_on >= ?", update_start_time).pluck(:id).to_set
 
     # Create queue items to do additional process like apply tags and link events
-    unless added_vms.empty?
-      added_vm_ids = []
-      added_vms.each do |v|
-        v.post_create_actions_queue
-        added_vm_ids << v.id
-      end
+    unless added_vm_ids.empty?
+      post_create_actions_queue(added_vm_ids)
 
       assign_ems_created_on_queue(added_vm_ids) if VMDB::Config.new("vmdb").config.fetch_path(:ems_refresh, :capture_vm_created_on_date)
     end
 
     # Collect the updated folder relationships to determine which vms need updated path information
-    ems_folders = ems.ems_folders
-    MiqPreloader.preload(ems_folders, :all_relationships)
+    tree = ems.descendant_rels_arranged
+    prune_relationships_for_parent_folder_path!(tree, update_start_time, updated_folder_ids)
 
-    updated_folders = ems_folders.select do |f|
-      f.created_on >= update_start_time || f.updated_on >= update_start_time || # Has the folder itself changed (e.g. renamed)?
-      f.relationships.any? do |r|                                                  # Or has its relationship rows changed?
-        r.created_at >= update_start_time || r.updated_at >= update_start_time || #   Has the direct relationship changed (e.g. this folder moved under another folder)?
-        r.children.any? do |child_r|                                             #   Or have any of the child relationship rows changed (e.g. vm moved under this folder)?
-          child_r.created_at >= update_start_time || child_r.updated_at >= update_start_time
-        end
-      end
+    updated_vm_ids = extract_vm_ids(tree) - added_vm_ids
+    classify_with_parent_folder_path_queue(updated_vm_ids)
+  end
+
+  def self.extract_vm_ids(tree, vm_set = Set.new)
+    tree.each do |rel, children|
+      extract_vm_ids(children, vm_set)
+      vm_set.add?(rel.resource_id) if rel.resource_type == "VmOrTemplate".freeze
     end
-    unless updated_folders.empty?
-      updated_vms = updated_folders.collect(&:all_vms_and_templates).flatten.uniq - added_vms
-      updated_vms.each(&:classify_with_parent_folder_path_queue)
+    vm_set
+  end
+
+  def self.prune_relationships_for_parent_folder_path!(tree, update_start_time, updated_folder_ids)
+    tree.select! do |rel, children|
+      if rel.resource_type == "EmsFolder" &&
+        (rel.updated_at >= update_start_time ||        # folder changed
+         updated_folder_ids.include?(rel.resource_id)) # folder rel changed
+          true
+      elsif rel.resource_type == "VmOrTemplate"
+        rel.updated_at >= update_start_time            # vm rel changed
+      else
+        prune_relationships_for_parent_folder_path!(children, update_start_time, updated_folder_ids)
+        children.any?
+      end
     end
   end
 
@@ -1193,7 +1202,7 @@ class VmOrTemplate < ActiveRecord::Base
     MiqQueue.put(
       :class_name  => name,
       :method_name => 'assign_ems_created_on',
-      :args        => [vm_ids],
+      :args        => Array(vm_ids),
       :priority    => MiqQueue::MIN_PRIORITY
     )
   end
@@ -1228,12 +1237,18 @@ class VmOrTemplate < ActiveRecord::Base
     end
   end
 
+  def self.post_create_actions_queue(ids)
+    Array(ids).each do |id|
+      MiqQueue.put(
+        :class_name  => "VmOrTemplate".freeze,
+        :instance_id => id,
+        :method_name => :post_create_actions
+      )
+    end
+  end
+
   def post_create_actions_queue
-    MiqQueue.put(
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'post_create_actions'
-    )
+    self.class.post_create_actions_queue(id)
   end
 
   def post_create_actions
@@ -1373,14 +1388,20 @@ class VmOrTemplate < ActiveRecord::Base
     !plist.blank?
   end
 
+  def self.classify_with_parent_folder_path_queue(ids, add = true)
+    Array(ids).each do |id|
+      MiqQueue.put(
+        :class_name  => name,
+        :instance_id => id,
+        :method_name => :classify_with_parent_folder_path,
+        :args        => [add],
+        :priority    => MiqQueue::MIN_PRIORITY
+      )
+    end
+  end
+
   def classify_with_parent_folder_path_queue(add = true)
-    MiqQueue.put(
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'classify_with_parent_folder_path',
-      :args        => [add],
-      :priority    => MiqQueue::MIN_PRIORITY
-    )
+    self.class.classify_with_parent_folder_path_queue(id, add)
   end
 
   def classify_with_parent_folder_path(add = true)

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1,6 +1,87 @@
 require "spec_helper"
 
 describe VmOrTemplate do
+  context ".post_refresh_ems" do
+    before do
+      #          fa
+      #       fb
+      #    fc
+      # vc
+      #
+      @before_time = Time.now.utc
+
+      _guid, _server, zone = EvmSpecHelper.local_guid_miq_server_zone
+      @ems      = FactoryGirl.create(:ems_vmware, :zone => zone)
+      @vm       = FactoryGirl.create(:vm_vmware,  :ext_management_system => @ems)
+      @folder_a = FactoryGirl.create(:ems_folder, :ext_management_system => @ems)
+      @folder_b = FactoryGirl.create(:ems_folder, :ext_management_system => @ems)
+      @folder_c = FactoryGirl.create(:ems_folder, :ext_management_system => @ems)
+      @ems.add_child(@folder_a)
+      @folder_a.add_child(@folder_b)
+      @folder_b.add_child(@folder_c)
+      @folder_c.add_child(@vm)
+
+      # post_refresh_ems checks if updated_on >= a provided start time, so jump
+      # forward to avoid subsecond rounding issues.
+      Timecop.travel(1.second)
+      @after_time = Time.now.utc
+    end
+
+    after do
+      Timecop.return
+    end
+
+    def assert_queued_method_for_vm(vm_id, method_name)
+      expected_attributes = {:class_name  => "VmOrTemplate"}
+      if vm_id.kind_of?(Array)
+        expected_attributes[:args] = vm_id
+      else
+        expected_attributes[:instance_id] = vm_id
+      end
+
+      messages = MiqQueue.where(:method_name => method_name).to_a
+      expect(messages.length).to eq 1
+      expect(messages.first).to have_attributes(expected_attributes)
+    end
+
+    it "queues post_create_actions for a new vm" do
+      VmOrTemplate.post_refresh_ems(@ems.id, @before_time)
+      assert_queued_method_for_vm(@vm.id, :post_create_actions)
+    end
+
+    it "queues assign_ems_created_on for a new vm if capture_vm_created_on_date is enabled " do
+      VMDB::Config.stub(:new).and_return(double(:config => {:ems_refresh => {:capture_vm_created_on_date => true}}))
+      VmOrTemplate.post_refresh_ems(@ems.id, @before_time)
+      assert_queued_method_for_vm([@vm.id], :assign_ems_created_on)
+    end
+
+    context "queues classify_with_parent_folder_path for a vm" do
+      it "in an updated folder" do
+        @folder_c.touch
+        VmOrTemplate.post_refresh_ems(@ems.id, @after_time)
+        assert_queued_method_for_vm(@vm.id, :classify_with_parent_folder_path)
+      end
+
+      it "in an updated ancestor folder" do
+        @folder_b.touch
+        VmOrTemplate.post_refresh_ems(@ems.id, @after_time)
+        assert_queued_method_for_vm(@vm.id, :classify_with_parent_folder_path)
+      end
+
+      it "in a folder with an updated relationship" do
+        @folder_c.child_rels.first.touch
+        VmOrTemplate.post_refresh_ems(@ems.id, @after_time)
+        assert_queued_method_for_vm(@vm.id, :classify_with_parent_folder_path)
+      end
+
+      it "with an updated relationship" do
+        @vm.all_relationships.first.touch
+        VmOrTemplate.post_refresh_ems(@ems.id, @after_time)
+        assert_queued_method_for_vm(@vm.id, :classify_with_parent_folder_path)
+      end
+    end
+  end
+
   context ".event_by_property" do
     context "should add an EMS event" do
       before(:each) do


### PR DESCRIPTION
We can use RelationshipMixin#descendants_rels_arranged to build the
folder/vm relationship tree, pruning unchanged folders, and not have
to instantiate any VmOrTemplate objects.

Because we don't need vm instances to queue work on that instance,
create class queuing methods that queue with the ids.