### PR TITLE
Prevent rails from loading database.yml before it is created

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -36,13 +36,17 @@ namespace :evm do
     EvmApplication.update_stop
   end
 
-  task :compile_assets do
-    ENV["DATABASE_URL"] ||= "postgresql://user:pass@127.0.0.1/dbname"
+  task :compile_assets => :prevent_db_config_load_error do
     Rake::Task["assets:clobber"].invoke
     Rake::Task["assets:precompile"].invoke
   end
 
-  task :compile_sti_loader => :environment do
+  task :compile_sti_loader => :prevent_db_config_load_error do
+    Rake::Task["environment"].invoke
     DescendantLoader.instance.class_inheritance_relationships
+  end
+
+  task :prevent_db_config_load_error do
+    ENV["DATABASE_URL"] ||= "postgresql://user:pass@127.0.0.1/dbname"
   end
 end


### PR DESCRIPTION
The compile_sti_loader task was requiring the environment
rake task which caused rails to attempt to parse the
database.yml file.  This file is not present until a database
is created.

If DATABASE_URI is set rails does not look for the config,
assuming that the user will provide the connection parameters.

In this case compile_sti_loader did not need to connect to the
database, so we fake a DATABASE_URI to stop rails from complaining.

https://bugzilla.redhat.com/show_bug.cgi?id=1275676