### PR TITLE
Change the process title for workers to easily differentiate them.

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -64,6 +64,7 @@ class MiqWorker::Runner
 
   def worker_initialization
     starting_worker_record
+    set_process_title
 
     # Sync the config and roles early since heartbeats and logging require the configuration
     sync_active_roles
@@ -468,5 +469,16 @@ class MiqWorker::Runner
       types = ruby_object_usage
       $log.info("Ruby Object Usage: #{types.sort_by { |_klass, h| h[:count] }.reverse[0, top].inspect}")
     end
+  end
+
+  def set_process_title
+    return unless Process.respond_to?(:setproctitle)
+
+    type   = @worker.type.sub(/^ManageIQ::Providers::/, "")
+    title  = "#{type} id: #{@worker.id}"
+    title << ", queue: #{@worker.queue_name}" if @worker.queue_name
+    title << ", uri: #{@worker.uri}" if @worker.uri
+
+    Process.setproctitle(title)
   end
 end


### PR DESCRIPTION
Example of what `ps` command looks like on my Mac running `rake evm:start` with one provider

```sh
$ ps -ef | grep 1000000000
  501 29796 25394   0  5:16PM ttys006    0:00.00 grep --color=auto 1000000000
  501 28639 28576   0  5:13PM ttys007    0:14.16 MiqEventHandler id: 1000000000011, queue: ems       
  501 28641 28576   0  5:13PM ttys007    2:04.12 MiqGenericWorker id: 1000000000012, queue: generic       
  501 28642 28576   0  5:13PM ttys007    2:04.77 MiqGenericWorker id: 1000000000013, queue: generic       
  501 28645 28576   0  5:13PM ttys007    1:30.94 MiqPriorityWorker id: 1000000000014, queue: generic       
  501 28646 28576   0  5:13PM ttys007    1:32.97 MiqPriorityWorker id: 1000000000015, queue: generic       
  501 28650 28576   0  5:13PM ttys007    0:14.35 MiqReportingWorker id: 1000000000016, queue: reporting       
  501 28651 28576   0  5:13PM ttys007    0:14.32 MiqReportingWorker id: 1000000000017, queue: reporting       
  501 28654 28576   0  5:13PM ttys007    0:17.06 MiqScheduleWorker id: 1000000000018       
  501 28656 28576   0  5:13PM ttys007    0:14.57 MiqUiWorker id: 1000000000019, uri: http://0.0.0.0:3000             
  501 28658 28576   0  5:13PM ttys007    0:14.42 MiqWebServiceWorker id: 1000000000020, uri: http://0.0.0.0:4000             
  501 28803 28576   0  5:14PM ttys007    0:34.92 MiqEmsRefreshCoreWorker id: 1000000000021, queue: ems_1000000000002         
  501 28805 28576   0  5:14PM ttys007    0:32.20 Vmware::InfraManager::RefreshWorker id: 1000000000022, queue: ems_1000000000002         
  501 28807 28576   0  5:14PM ttys007    0:21.13 Vmware::InfraManager::EventCatcher id: 1000000000023, queue: ems_1000000000002         
  501 28812 28576   0  5:14PM ttys007    1:06.90 MiqVimBrokerWorker id: 1000000000024       
```

@matthewd Please review
cc @akrzos 