### PR TITLE
Fix issue where if MiqSockUtil fails, rake evm:start fails.

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -218,12 +218,12 @@ class MiqServer < ActiveRecord::Base
       update_server_config(cfg, :host, ipaddr)
     end
 
-    unless hostname.empty?
+    unless hostname.blank?
       svr_hash[:hostname] = hostname
       update_server_config(cfg, :hostname, hostname)
     end
 
-    unless mac_address.empty?
+    unless mac_address.blank?
       svr_hash[:mac_address] = mac_address
     end
 


### PR DESCRIPTION
if MiqServer#get_network_information fails, it now returns nil.  In the server startup called from `rake evm:start`, it was then failing with "undefined method \`empty?' for nil:NilClass"

@carbonin Please review.