### PR TITLE
OpenStack set default api version

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -160,7 +160,7 @@ class EmsCloudController < ApplicationController
                      :provider_id                     => @ems.provider_id ? @ems.provider_id : "",
                      :hostname                        => @ems.hostname,
                      :api_port                        => @ems.port,
-                     :api_version                     => @ems.api_version,
+                     :api_version                     => @ems.api_version ? @ems.api_version : "v2",
                      :provider_region                 => @ems.provider_region,
                      :openstack_infra_providers_exist => retrieve_openstack_infra_providers.length > 0 ? true : false,
                      :default_userid                  => @ems.authentication_userid ? @ems.authentication_userid : "",


### PR DESCRIPTION
For providers without api version, we take default v2. Otherwise
UI shows blank field that is not an option

Partial fix BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1278036