### PR TITLE
Avoid useless allocations on MiqQueue.put.

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -60,8 +60,8 @@ class MiqQueue < ActiveRecord::Base
 
   TIMEOUT = 10.minutes
 
-  serialize :args
-  serialize :miq_callback
+  serialize :args, Array
+  serialize :miq_callback, Hash
 
   STATE_READY   = 'ready'.freeze
   STATE_DEQUEUE = 'dequeue'.freeze
@@ -102,8 +102,6 @@ class MiqQueue < ActiveRecord::Base
 
   def self.put(options)
     options = options.reverse_merge(
-      :args         => [],
-      :miq_callback => {},
       :priority     => NORMAL_PRIORITY,
       :queue_name   => "generic",
       :role         => nil,

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -125,7 +125,7 @@ describe MiqQueue do
        :queue_name   => 'ems_metrics_processor',
        :class_name   => 'Metric::Rollup',
        :instance_id  => nil,
-       :args         => '',
+       :args         => [],
        :zone         => 'default',
        :role         => 'ems_metrics_processor',
        :server_guid  => nil,


### PR DESCRIPTION
Saving serialized columns require yaml processing and extra dirty tracking.
An empty hash and array are useless in the queue since we can default
them via the serialize call.

Allocations for a basic MiqQueue.put({}):
Run 1000 times, drops from 1107994 to 777803 (~30%).
Run 10 times, drops from 31903 to 24583 (~23%).