### PR TITLE
Mark translated strings in UI

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -8,6 +8,15 @@ begin
   gettext_options = %w(--sort-by-msgid --location --no-wrap)
   Rails.application.config.gettext_i18n_rails.msgmerge = gettext_options
   Rails.application.config.gettext_i18n_rails.xgettext = gettext_options + ["--add-comments=TRANSLATORS"]
+
+  unless Rails.env.test?
+    db_file  = Rails.root.join("config", "vmdb.yml.db")
+    template = Rails.root.join("config", "vmdb.tmpl.yml")
+    config_file = File.exist?(db_file) ? db_file : template
+    if YAML.load(File.read(config_file)).fetch_path(:ui, :mark_translated_strings)
+      include Vmdb::Gettext::Debug
+    end
+  end
 ensure
   $DEBUG = old_debug
 end

--- a/lib/vmdb/gettext/debug.rb
+++ b/lib/vmdb/gettext/debug.rb
@@ -1,0 +1,31 @@
+require 'fast_gettext'
+
+# include this module to see translations in the UI
+module Vmdb
+  module Gettext
+    module Debug
+      DL = "\u00BB".encode("UTF-8")
+      DR = "\u00AB".encode("UTF-8")
+
+      # modified copy of fast_gettext _ method
+      def _(key)
+        "#{DL}#{FastGettext._(key)}#{DR}"
+      end
+
+      # modified copy of fast_gettext n_ method
+      def n_(*keys)
+        "#{DL}#{FastGettext.n_(*keys)}#{DR}"
+      end
+
+      # modified copy of fast_gettext s_ method
+      def s_(key, separator = nil)
+        "#{DL}#{FastGettext.s_(key, separator)}#{DR}"
+      end
+
+      # modified copy of fast_gettext ns_* method
+      def ns_(*keys)
+        "#{DL}#{FastGettext.ns_(*keys)}#{DR}"
+      end
+    end
+  end
+end

--- a/spec/lib/vmdb/gettext/debug_spec.rb
+++ b/spec/lib/vmdb/gettext/debug_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Vmdb::Gettext::Debug do
+  before { Vmdb::FastGettextHelper.register_locales }
+
+  let(:instance) do
+    Class.new do
+      include Vmdb::Gettext::Debug
+    end.new 
+  end
+
+  let(:dl) { Vmdb::Gettext::Debug::DL }
+  let(:dr) { Vmdb::Gettext::Debug::DR }
+  let(:text) { "Insane text" }
+
+  subject { instance.send(method, *args) }
+
+  shared_examples "debug markers" do
+    it "adds debug markers" do
+      expect(subject).to eq("#{dl}#{text}#{dr}")
+    end
+  end
+
+  describe "#_" do
+    let(:args) { [text] }
+    let(:method) { :_ }
+    include_examples "debug markers"
+  end
+
+  describe "#n_" do
+    let(:args) { [text, text, 1] }
+    let(:method) { :n_ }
+    include_examples "debug markers"
+  end
+
+  describe "#s_" do
+    let(:args) { [text] }
+    let(:method) { :s_ }
+    include_examples "debug markers"
+  end
+
+  describe "#ns_" do
+    let(:args) { [text, text, 1] }
+    let(:method) { :ns_ }
+    include_examples "debug markers"
+  end
+end


### PR DESCRIPTION
This change is to explicitly mark translated strings in UI with »STRING«
when 'ui.mark_translated_strings' is set to true in server's configuration.

This enables us to see strings of UI that did go and parts of UI that
did not go through gettext (i.e. are not translatable yet).

![mark-translated-strings](https://cloud.githubusercontent.com/assets/6648365/10973513/124d82ac-83de-11e5-8e4d-2aab6754e1a3.jpg)
