### PR TITLE
For consistent test timings, compile the STI loader before the tests.

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -36,17 +36,27 @@ namespace :evm do
     EvmApplication.update_stop
   end
 
-  task :compile_assets => :prevent_db_config_load_error do
-    Rake::Task["assets:clobber"].invoke
-    Rake::Task["assets:precompile"].invoke
+  task :compile_assets do
+    with_dummy_database_url_configuration do
+      Rake::Task["assets:clobber"].invoke
+      Rake::Task["assets:precompile"].invoke
+    end
   end
 
-  task :compile_sti_loader => :prevent_db_config_load_error do
-    Rake::Task["environment"].invoke
-    DescendantLoader.instance.class_inheritance_relationships
+  task :compile_sti_loader do
+    with_dummy_database_url_configuration do
+      Rake::Task["environment"].invoke
+      DescendantLoader.instance.class_inheritance_relationships
+    end
   end
 
-  task :prevent_db_config_load_error do
-    ENV["DATABASE_URL"] ||= "postgresql://user:pass@127.0.0.1/dbname"
+  # Loading environment will try to read database.yml unless DATABASE_URL is set.
+  # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
+  # Note: Rails will not actually use the configuration and connect until you issue a query.
+  def with_dummy_database_url_configuration
+    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql://user:pass@127.0.0.1/dbname"
+    yield
+  ensure
+    before.nil? ? ENV.delete("DATABASE_URL") : ENV["DATABASE_URL"] = before
   end
 end

--- a/lib/tasks/test_automation.rake
+++ b/lib/tasks/test_automation.rake
@@ -8,7 +8,7 @@ namespace :test do
   end
 
   desc "Run all automation specs"
-  RSpec::Core::RakeTask.new(:automation => :initialize) do |t|
+  RSpec::Core::RakeTask.new(:automation => [:initialize, "evm:compile_sti_loader"]) do |t|
     EvmTestHelper.init_rspec_task(t)
     t.pattern = EvmTestHelper::AUTOMATION_SPECS
   end

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -8,7 +8,7 @@ namespace :test do
   end
 
   desc "Run all specs except migrations, replication, and automation"
-  RSpec::Core::RakeTask.new(:vmdb => :initialize) do |t|
+  RSpec::Core::RakeTask.new(:vmdb => [:initialize, "evm:compile_sti_loader"]) do |t|
     EvmTestHelper.init_rspec_task(t)
     t.pattern = EvmTestHelper::VMDB_SPECS
   end


### PR DESCRIPTION
Previously, a random test would show up as the slowest test because
it was the first test to hit a missing constant which would cause
autoloading/STI loader to kick in and spend lots of time in this test.

With this change, we should have more constistent test times because
the autoloading magic will be done before any of the tests run.

Replaces #5307