### PR TITLE
Foreman can now collect inventory from system with no hostgroups

### DIFF
--- a/gems/manageiq_foreman/lib/manageiq_foreman/inventory.rb
+++ b/gems/manageiq_foreman/lib/manageiq_foreman/inventory.rb
@@ -13,8 +13,11 @@ module ManageiqForeman
       # if locations or organizations are enabled (detected by presence in host records)
       #    but it is not present in hostgroups
       #   fetch details for a hostgroups (to get location and organization information)
-      if (hosts.first.key?("location_id") && !hostgroups.first.key?("locations")) ||
-         (hosts.first.key?("organization_id") && !hostgroups.first.key?("organizations"))
+      host = hosts.first
+      hostgroup = hostgroups.first
+      if (host && hostgroup && (
+          (host.key?("location_id") && !hostgroup.key?("locations")) ||
+          (host.key?("organization_id") && !hostgroup.key?("organizations"))))
         hostgroups = connection.load_details(hostgroups, :hostgroups)
       end
       {

--- a/gems/manageiq_foreman/spec/inventory_spec.rb
+++ b/gems/manageiq_foreman/spec/inventory_spec.rb
@@ -1,0 +1,45 @@
+require_relative 'spec_helper'
+
+describe ManageiqForeman::Inventory do
+  describe "#refresh_configuration" do
+    it "fetches location details" do
+      connection = double("connection")
+      expect(connection).to receive(:all).with(:hosts).and_return([{"location_id" => 5}])
+      expect(connection).to receive(:all).with(:hostgroups).and_return([{}])
+      expect(connection).to receive(:load_details).with(Array, :hostgroups)
+      inventory = described_class.new(connection)
+
+      inventory.refresh_configuration
+    end
+
+    it "skips location details if already fetched" do
+      connection = double("connection")
+      expect(connection).to receive(:all).with(:hosts).and_return([{"location_id" => 5}])
+      expect(connection).to receive(:all).with(:hostgroups).and_return([{"locations" => {}}])
+      expect(connection).not_to receive(:load_details)
+      inventory = described_class.new(connection)
+
+      inventory.refresh_configuration
+    end
+
+    it "skips location details if not needed" do
+      connection = double("connection")
+      expect(connection).to receive(:all).with(:hosts).and_return([])
+      expect(connection).to receive(:all).with(:hostgroups).and_return([])
+      expect(connection).not_to receive(:load_details)
+      inventory = described_class.new(connection)
+
+      inventory.refresh_configuration
+    end
+
+    it "fetches organization details" do
+      connection = double("connection")
+      expect(connection).to receive(:all).with(:hosts).and_return([{"organization_id" => 5}])
+      expect(connection).to receive(:all).with(:hostgroups).and_return([{}])
+      expect(connection).to receive(:load_details).with(Array, :hostgroups)
+      inventory = described_class.new(connection)
+
+      inventory.refresh_configuration
+    end
+  end
+end


### PR DESCRIPTION
Update the code to work when hosts or hostgroups is empty

https://bugzilla.redhat.com/show_bug.cgi?id=1277995

/cc @gmcculloug @bdunne please review
/cc @blomquisg  FYI (I did not verify against a live system)