### PR TITLE
Changed text on link to classic UI

### DIFF
--- a/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
+++ b/spa_ui/self_service/client/app/components/dialog-content/dialog-content.html
@@ -1,7 +1,7 @@
 <div>
   <div ng-if="!vm.supportedDialog">
     <h2>Service Template Contains Unsupported Provision Dialog Types.</h2>
-    <p>To request this service, continue <a ng-href="{{ vm.API_BASE }}/catalog/explorer">to the full administrative UI</a>.</p>
+    <p>To request this service, continue <a ng-href="{{ vm.API_BASE }}/catalog/explorer">to the Operations UI</a>.</p>
   </div>
   <div ng-if=" !vm.dialog.label && vm.supportedDialog ">
     <h2>No Provisioning Dialog Available.</h2>


### PR DESCRIPTION
Changed text on the link back to Classic UI for unsupported dialogs from "full administrative UI" to "Operations UI" on John Hardy's request.

@dclarizio please review.

![screenshot from 2015-11-05 13 11 00](https://cloud.githubusercontent.com/assets/3450808/10977374/ae53beca-83be-11e5-9a9d-43aebaa4ffe2.png)
