### PR TITLE
Add .missing methods to the event namespaces

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/AMAZON.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/AMAZON.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/KUBERNETES.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/KUBERNETES.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/OPENSTACK.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VC.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VC.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/RequestEvent/Request.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/RequestEvent/Request.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []


### PR DESCRIPTION
Add .missing methods to the event namespaces to handle the events that we do not expect to handle and are not errors.

https://bugzilla.redhat.com/show_bug.cgi?id=1277220