### PR TITLE
Correctly handled applying Rbac to cloud provisioning security groups

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -21,13 +21,11 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
     return {} if src[:ems].nil?
 
     security_groups = if src[:cloud_network]
-                        load_ar_obj(src[:cloud_network]).security_groups
+                        source = load_ar_obj(src[:cloud_network])
+                        get_targets_for_source(source, :cloud_filter, SecurityGroup, 'security_groups')
                       else
                         source = load_ar_obj(src[:ems])
-
-                        return source.security_groups.non_cloud_network if source.tags.present?
-                        klass = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup
-                        get_targets_for_ems(source, :cloud_filter, klass, 'security_groups.non_cloud_network')
+                        get_targets_for_ems(source, :cloud_filter, SecurityGroup, 'security_groups.non_cloud_network')
                       end
 
     security_groups.each_with_object({}) { |sg, hash| hash[sg.id] = display_name_for_name_description(sg) }

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -41,11 +41,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_security_groups(_options = {})
     return {} unless (src = provider_or_tenant_object)
 
-    if src.tags.present?
-      src_obj = get_targets_for_ems(src, :cloud_filter, SecurityGroup, 'security_groups')
-    else
-      src_obj = src.security_groups
-    end
+    src_obj = get_targets_for_source(src, :cloud_filter, SecurityGroup, 'security_groups')
 
     src_obj.each_with_object({}) do |sg, h|
       h[sg.id] = display_name_for_name_description(sg)
@@ -105,6 +101,10 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
     rails_logger('get_source_and_targets', 1)
     @target_resource = result
+  end
+
+  def get_targets_for_source(src, filter_name, klass, relats)
+    process_filter(filter_name, klass, src.deep_send(relats))
   end
 
   def get_targets_for_ems(src, filter_name, klass, relats)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -208,7 +208,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
       @sg1 = FactoryGirl.create(:security_group_amazon, :name => "sgn_1", :ext_management_system => ems,
                                 :cloud_network => @cn1)
-      @sg2 = FactoryGirl.create(:security_group_amazon, :name => "sgn_1", :ext_management_system => ems)
+      @sg2 = FactoryGirl.create(:security_group_amazon, :name => "sgn_2", :ext_management_system => ems)
     end
 
     it "#allowed_cloud_networks" do


### PR DESCRIPTION
Created a method:  get_targets_for_source which manages
applying Rbac to a passed in source as opposed to finding the
External Management System (ems) on that source.

https://bugzilla.redhat.com/show_bug.cgi?id=1248181