### PR TITLE
Give cfme_client a .gitignore

### DIFF
--- a/gems/cfme_client/.gitignore
+++ b/gems/cfme_client/.gitignore
@@ -1,0 +1,10 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+/vendor/bundle


### PR DESCRIPTION
Adds a standard-ish gitignore file as generated by bundler. I also added
the `/vendor/bundle` directory as per the project root.

/cc @matthewd 