### PR TITLE
Openstack get reouter external_gateway_info safely

### DIFF
--- a/app/models/manageiq/providers/openstack/refresh_parser_common/networks.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/networks.rb
@@ -167,7 +167,7 @@ module ManageIQ::Providers
 
         def parse_network_router(network_router)
           uid             = network_router.id
-          network_id      = network_router.external_gateway_info.fetch_path("network_id")
+          network_id      = network_router.try(:external_gateway_info).try(:fetch_path, "network_id")
           new_result = {
             :type                  => self.class.network_router_type,
             :name                  => network_router.name,


### PR DESCRIPTION
Doc says the type is xsd:dict but it can be nil

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1278654