### PR TITLE
Toolbar: do not add separator to empty drop-down.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -98,9 +98,9 @@ class ApplicationHelper::ToolbarBuilder
           toolbar << props
           current_item = props
           any_visible = false
-          bgi[:items].each_with_index do |bsi, bsi_idx|             # Go thru all of the buttonSelect items
-            if bsi.key?(:separator)                             # If separator found, add it
-              props = {"id" => "sep_#{bg_idx}_#{bsi_idx}", "type" => "separator"}
+          bgi[:items].each_with_index do |bsi, bsi_idx|
+            if bsi.key?(:separator)
+              props = {"id" => "sep_#{bg_idx}_#{bsi_idx}", "type" => "separator", :hidden => !any_visible}
             else
               next if bsi[:image] == 'pdf' && !PdfGenerator.available?
               next if build_toolbar_hide_button(bsi[:pressed] || bsi[:button])  # Use pressed, else button name

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -163,8 +163,9 @@ module ToolbarHelper
 
   # Render separator in the drop down
   #
-  def toolbar_button_separator(_props)
-    content_tag(:div, '', :class => :divider, :role => "presentation")
+  def toolbar_button_separator(props)
+    cls = props[:hidden] ? ' hidden' : ''
+    content_tag(:div, '', :class => "divider #{cls}", :role => "presentation")
   end
 
   # Render normal push child button


### PR DESCRIPTION
address issue reported by @himdel here: https://github.com/ManageIQ/manageiq/issues/5116

@himdel: please, review