### PR TITLE
Remove 'manageiq' from provider's summary PDF report

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -869,18 +869,29 @@ en:
       LdapDomain:               LDAP Domain
       LdapRegion:               LDAP Region
       LdapServer:               LDAP Server
-      ManageIQ::Providers::BaseManager:               Provider
+      ManageIQ::Providers::BaseManager:                                     Provider
       #ManageIQ::Providers::BaseManager::VmOrTemplate: VM or Template
       #ManageIQ::Providers::BaseManager::Vm:           VM and Instance
-      ManageIQ::Providers::ConfigurationManager:      Configuration Manager
+      ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Foreman Configured System
-      ManageIQ::Providers::CloudManager:              Cloud Provider
-      ManageIQ::Providers::CloudManager::Vm:          Instance
-      ManageIQ::Providers::CloudManager::Template:    Image
-      ManageIQ::Providers::ContainerManager:          Containers Provider
-      ManageIQ::Providers::InfraManager:              Infrastructure Provider
-      ManageIQ::Providers::InfraManager::Vm:          Virtual Machine
-      ManageIQ::Providers::InfraManager::Template:    Template
+      ManageIQ::Providers::CloudManager:                                    Cloud Provider
+      ManageIQ::Providers::CloudManager::Vm:                                Instance
+      ManageIQ::Providers::CloudManager::Template:                          Image
+      ManageIQ::Providers::ContainerManager:                                Containers Provider
+      ManageIQ::Providers::InfraManager:                                    Infrastructure Provider
+      ManageIQ::Providers::InfraManager::Vm:                                Virtual Machine
+      ManageIQ::Providers::InfraManager::Template:                          Template
+      ManageIQ::Providers::Openstack::InfraManager:                         Infrastructure Provider (Openstack)
+      ManageIQ::Providers::Microsoft::InfraManager:                         Infrastructure Provider (Microsoft)
+      ManageIQ::Providers::Redhat::InfraManager:                            Infrastructure Provider (Redhat)
+      ManageIQ::Providers::Vmware::InfraManager:                            Infrastructure Provider (Vmware)
+      ManageIQ::Providers::Openstack::CloudManager:                         Cloud Provider (Openstack)
+      ManageIQ::Providers::Amazon::CloudManager:                            Cloud Provider (Amazon)
+      ManageIQ::Providers::Azure::CloudManager:                             Cloud Provider (Microsoft Azure)
+      ManageIQ::Providers::Atomic::ContainerManager:                        Container Provider (Atomic)
+      ManageIQ::Providers::Kubernetes::ContainerManager:                    Container Provider (Kubernetes)
+      ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (Openshift)
+      ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (Openshift Enterprise)
       MiqAction:                Action
       MiqAeClass:               Automate Class
       MiqAeDomain:              Automate Domain


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1276785

also changed name of PDF file
also changed for cloud providers summary report and container providers summary report 
 
Infrastructure Provider
before
<img width="1059" alt="before" src="https://cloud.githubusercontent.com/assets/14937244/11002357/9872b360-84ac-11e5-86ed-f0409b8fbf7a.png">

after
<img width="592" alt="screen shot 2015-11-24 at 16 17 57" src="https://cloud.githubusercontent.com/assets/14937244/11371201/a45fc720-92c7-11e5-8f20-9d44e1111bc8.png">

Cloud Provider
before
<img width="1175" alt="screen shot 2015-11-24 at 16 38 32" src="https://cloud.githubusercontent.com/assets/14937244/11371652/da1ddc60-92c9-11e5-94ad-aa401d38f571.png">

after
<img width="647" alt="screen shot 2015-11-24 at 16 24 07" src="https://cloud.githubusercontent.com/assets/14937244/11371251/dcc38dea-92c7-11e5-8486-1a4275280528.png">

Container Provider
before 
<img width="1161" alt="screen shot 2015-11-24 at 16 29 27" src="https://cloud.githubusercontent.com/assets/14937244/11371390/94f24dac-92c8-11e5-98b8-c1dd4a5bd32b.png">

after
<img width="1197" alt="screen shot 2015-11-24 at 16 35 57" src="https://cloud.githubusercontent.com/assets/14937244/11371573/7b9ae28c-92c9-11e5-9ee7-4c5eb47a5f8d.png">


