### PR TITLE
Allow non-array MiqQueue args values for now

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -117,6 +117,9 @@ class MiqQueue < ActiveRecord::Base
     options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 
+    # Let's deprecate supplying non-array args soon
+    options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
+
     msg = MiqQueue.create!(options)
     msg.warn_if_large_payload
     _log.info("#{MiqQueue.format_full_log_msg(msg)}")

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -336,6 +336,28 @@ describe MiqQueue do
       expect(MiqQueue.get).to eq(nil)
     end
 
+    it "should accept non-Array args (for now)" do
+      msg = MiqQueue.put(
+        :class_name  => "Class1",
+        :method_name => "Method1",
+        :args        => "not_an_array",
+      )
+
+      msg_from_db = MiqQueue.find(msg.id)
+      expect(msg_from_db.args).to eq(["not_an_array"])
+    end
+
+    it "defaults args / miq_callback to [] / {}" do
+      msg = MiqQueue.put(
+        :class_name  => "Class1",
+        :method_name => "Method1",
+      )
+
+      msg_from_db = MiqQueue.find(msg.id)
+      expect(msg_from_db.args).to eq([])
+      expect(msg_from_db.miq_callback).to eq({})
+    end
+
     it "should put a unique message on the queue if method_name is different" do
       msg1 = MiqQueue.put(
         :class_name  => 'MyClass',

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -337,14 +337,27 @@ describe MiqQueue do
     end
 
     it "should accept non-Array args (for now)" do
-      msg = MiqQueue.put(
-        :class_name  => "Class1",
-        :method_name => "Method1",
-        :args        => "not_an_array",
-      )
+      begin
+        class MiqQueueSpecNonArrayArgs
+          def self.some_method(single_arg)
+            single_arg
+          end
+        end
 
-      msg_from_db = MiqQueue.find(msg.id)
-      expect(msg_from_db.args).to eq(["not_an_array"])
+        msg = MiqQueue.put(
+          :class_name  => "MiqQueueSpecNonArrayArgs",
+          :method_name => "some_method",
+          :args        => "not_an_array",
+        )
+
+        msg_from_db = MiqQueue.find(msg.id)
+        expect(msg_from_db.args).to eq(["not_an_array"])
+
+        _, _, result = msg_from_db.deliver
+        expect(result).to eq "not_an_array"
+      ensure
+        Object.send(:remove_const, :MiqQueueSpecNonArrayArgs)
+      end
     end
 
     it "defaults args / miq_callback to [] / {}" do


### PR DESCRIPTION
Fixes a regression introduced in #5304 where some existing callers
are creating MiqQueue instances with non-array args:
https://github.com/ManageIQ/manageiq/blob/f0c1cb2c07b8ef7e64ad4a19bc845953762d19cf/app/models/miq_server/server_smart_proxy.rb#L97

We'll come back to this and add a deprecation warning so we can clean up
callers to consistently use Arrays in the args attribute.