### PR TITLE
ENV deletes keys on []= with non-string values.

### DIFF
--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -31,7 +31,8 @@ describe "DatabaseConfiguration patch" do
         ENV['DATABASE_URL'] = 'postgres://'
         example.run
       ensure
-        ENV['DATABASE_URL'] = old_env if old_env
+        # ENV['x'] = nil deletes the key because ENV accepts only string values
+        ENV['DATABASE_URL'] = old_env
       end
     end
 
@@ -46,7 +47,8 @@ describe "DatabaseConfiguration patch" do
         old = ENV.delete('DATABASE_URL')
         expect { @app.config.database_configuration }.to raise_error(/Could not load database configuration/)
       ensure
-        ENV['DATABASE_URL'] = old if old
+        # ENV['x'] = nil deletes the key because ENV accepts only string values
+        ENV['DATABASE_URL'] = old
       end
     end
   end


### PR DESCRIPTION
ENV is like a hash but it's not a hash.
`ENV['x'] = nil` will remove the 'x' key.

It's magic: :sparkles:

```ruby
ENV["x"] = "true"
=> "true"

ENV.keys.grep(/x/)
=> ["x"]

ENV["x"] =  nil
=> nil

ENV.keys.grep(/x/)
=> []
```

Cleans up the change in #5266