### PR TITLE
Don't remove DATABASE_URL from ENV if it existed previously.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require File.expand_path('../lib/tasks/evm_rake_helper', __FILE__)
 
 include Rake::DSL
 Vmdb::Application.load_tasks

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -37,26 +37,16 @@ namespace :evm do
   end
 
   task :compile_assets do
-    with_dummy_database_url_configuration do
+    EvmRakeHelper.with_dummy_database_url_configuration do
       Rake::Task["assets:clobber"].invoke
       Rake::Task["assets:precompile"].invoke
     end
   end
 
   task :compile_sti_loader do
-    with_dummy_database_url_configuration do
+    EvmRakeHelper.with_dummy_database_url_configuration do
       Rake::Task["environment"].invoke
       DescendantLoader.instance.class_inheritance_relationships
     end
-  end
-
-  # Loading environment will try to read database.yml unless DATABASE_URL is set.
-  # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
-  # Note: Rails will not actually use the configuration and connect until you issue a query.
-  def with_dummy_database_url_configuration
-    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql://user:pass@127.0.0.1/dbname"
-    yield
-  ensure
-    before.nil? ? ENV.delete("DATABASE_URL") : ENV["DATABASE_URL"] = before
   end
 end

--- a/lib/tasks/evm_rake_helper.rb
+++ b/lib/tasks/evm_rake_helper.rb
@@ -1,0 +1,12 @@
+module EvmRakeHelper
+  # Loading environment will try to read database.yml unless DATABASE_URL is set.
+  # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
+  # Note: Rails will not actually use the configuration and connect until you issue a query.
+  def self.with_dummy_database_url_configuration
+    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql://user:pass@127.0.0.1/dbname"
+    yield
+  ensure
+    # ENV['x'] = nil deletes the key because ENV accepts only string values
+    ENV["DATABASE_URL"] = before
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -9,15 +9,14 @@ namespace :test do
   end
 
   task :verify_no_db_access_loading_rails_environment do
-    ENV["DATABASE_URL"] = "postgresql://non_existing_user:pass@127.0.0.1/vmdb_development"
-    begin
-      puts "** Confirming rails environment does not connect to the database"
-      Rake::Task['environment'].invoke
-    rescue ActiveRecord::NoDatabaseError
-      STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
-      raise
-    ensure
-      ENV.delete("DATABASE_URL")
+    EvmRakeHelper.with_dummy_database_url_configuration do
+      begin
+        puts "** Confirming rails environment does not connect to the database"
+        Rake::Task['environment'].invoke
+      rescue ActiveRecord::NoDatabaseError
+        STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
+        raise
+      end
     end
   end
 


### PR DESCRIPTION
verify_no_db_access_loading_rails_environment was blindly removing
it at the end.

Re-use existing with_dummy_database_url_configuration and promote it
to a module in lib/tasks.

Followup to #5340