### PR TITLE
Fixing bad parsing of class and PID

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -190,7 +190,8 @@ module Metric::CiMixin::Capture
           # Task is done, call the rollup on the parent
           task.state, task.status, task.message = [MiqTask::STATE_FINISHED, MiqTask::STATUS_OK, "Performance collection complete, #{task.context_data[:complete].length} out of #{task.context_data[:targets].length} collections completed"]
 
-          pclass, pid = task.context_data[:parent].split(":")
+          # Splitting e.g. "ManageIQ::Providers::Openstack::InfraManager::EmsCluster:8" to class and id
+          pclass, _, pid = task.context_data[:parent].rpartition(":")
           parent = pclass.constantize.find(pid)
           msg = "Queueing [#{task.context_data[:interval]}] rollup to #{parent.class.name} id: [#{parent.id}] for time range: [#{task.context_data[:start]} - #{task.context_data[:end]}]"
           _log.info "#{msg}..."


### PR DESCRIPTION
Before the classes were in format e.g EmsCluster:8, so split(":")
would work. Now all classes are namespaced, so we can't do that.

Fixing by parsing with lookbehind and lookahead, that checks we
parse by single colon.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1279380