### PR TITLE
Fix getting Azure instance OS type.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -224,9 +224,11 @@ module ManageIQ::Providers
         }
       end
 
+      # find both OS and SKU if possible, otherwise just the OS type.
       def guest_os(instance)
-        image_reference = instance.properties.storage_profile.image_reference
-        image_reference.offer + " " + image_reference.sku.tr('-', ' ')
+        image_reference = instance.properties.storage_profile.try(:image_reference)
+        return instance.properties.storage_profile.os_disk.os_type unless image_reference
+        "#{image_reference.offer} #{image_reference.sku.tr('-', ' ')}"
       end
 
       def populate_hardware_hash_with_disks(hardware_disks_array, instance)


### PR DESCRIPTION
During our test we discovered SKU is only available if the instance was provisioned through a public image. For the one from a private image we can only get the OS type