### PR TITLE
Do not sent unknown auth_type param to Fog

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -127,6 +127,9 @@ module OpenstackHandle
       # TODO(lsmola) figure out from where to take the project name and domain name
       domain   = opts.delete(:domain_name) || 'admin_domain'
 
+      # Do not send auth_type to fog, it throws warning
+      opts.delete(:auth_type)
+
       unless tenant
         tenant = "any_tenant" if service == "Identity"
         tenant ||= default_tenant_name


### PR DESCRIPTION
Do not sent unknown auth_type param to Fog, it throws fog
warning.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1220457