### PR TITLE
Add auto width styling for bootstrap-select

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -306,3 +306,14 @@ iframe, .iframe {
 .toolbar-pf#toolbar .toolbar-pf-actions .form-group {
   margin-bottom: 10px !important
 }
+
+/* sets width to auto for bootstrap-select */
+.selectWidth {
+  width: auto !important;
+}
+
+/* compensates for scrollbars in browsers that cover options in very narrow dropdowns */
+
+.selectWidth .dropdown-menu ul li{
+  padding-right: 10px;
+}

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -79,13 +79,13 @@
             - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
               = password_field_tag(field_id, options[field],
                                    :maxlength         => MAX_NAME_LEN,
-                                   :class             => "form-control",
+                                   :class             => "form-control selectWidth",
                                    :disabled          => disabled,
                                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - elsif [:request_notes, :vm_description].include?(field)
               = text_area_tag(field_id, options[field],
                               :maxlength                  => field_hash[:max_length],
-                              :class                      => "form-control",
+                              :class                      => "form-control selectWidth",
                               :size                       => "25x4",
                               :counter                    => "description_count",
                               "data-miq_check_max_length" => true,
@@ -94,7 +94,7 @@
               - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
               = text_field_tag(field_id, options[field],
                                :maxlength         => len,
-                               :class             => "form-control",
+                               :class             => "form-control selectWidth",
                                :disabled          => disabled,
                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -79,13 +79,13 @@
             - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
               = password_field_tag(field_id, options[field],
                                    :maxlength         => MAX_NAME_LEN,
-                                   :class             => "form-control selectWidth",
+                                   :class             => "form-control",
                                    :disabled          => disabled,
                                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - elsif [:request_notes, :vm_description].include?(field)
               = text_area_tag(field_id, options[field],
                               :maxlength                  => field_hash[:max_length],
-                              :class                      => "form-control selectWidth",
+                              :class                      => "form-control",
                               :size                       => "25x4",
                               :counter                    => "description_count",
                               "data-miq_check_max_length" => true,
@@ -94,7 +94,7 @@
               - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
               = text_field_tag(field_id, options[field],
                                :maxlength         => len,
-                               :class             => "form-control selectWidth",
+                               :class             => "form-control",
                                :disabled          => disabled,
                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
@@ -508,15 +508,15 @@
             -# Allow editing of the text field
             = select_tag("start_hour",
                          options_for_select((0..23).to_a, options[:start_hour].to_i),
-                         :class    => "selectpicker")
-            h
+                         :class    => "selectpicker selectWidth")
+            %span h
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent("start_hour", "#{url}")
             = select_tag("start_min",
                          options_for_select((0..55).step(5).to_a, options[:start_min].to_i),
-                         :class    => "selectpicker")
-            m
+                         :class    => "selectpicker selectWidth")
+            %span m
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent("start_min", "#{url}")

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -59,11 +59,13 @@
                        options_for_select(Array.new(24) { |i| i }),
                        "ng-model"    => "scheduleModel.start_hour",
                        "checkchange" => "",
+                       :class        => "selectWidth",
                        "selectpicker-for-select-tag" => "")
           %span h
           = select_tag("start_min",
                        options_for_select(Array.new(12) { |i| i * 5 }),
                        "ng-model"    => "scheduleModel.start_min",
                        "checkchange" => "",
+                       :class        => "selectWidth",
                        "selectpicker-for-select-tag" => "")
           %span m

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -10,19 +10,19 @@
       .col-md-8
         = select_tag('session_timeout_hours',
                       options_for_select(Array.new(25) { |i| i }, @edit[:new][:session][:timeout] / 3600),
-                      :class    => "selectpicker",
+                      :class    => "selectpicker selectWidth",
                       "data-miq_observe" => {:url => url}.to_json)
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('session_timeout_hours', "#{url}")
-        h
+        %span h
         = select_tag('session_timeout_mins', options_for_select(Array.new(12) { |i| i * 5 }, @edit[:new][:session][:timeout] % 3600 / 60),
-                      :class    => "selectpicker",
+                      :class    => "selectpicker selectWidth",
                       "data-miq_observe" => {:url => url}.to_json)
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('session_timeout_mins', "#{url}")
-        m
+        %span m
     .form-group
       %label.col-md-2.control-label
         = _("Mode")

--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -76,7 +76,7 @@
       .col-md-8
         = select_tag("start_hour",
           options_for_select((0..23).to_a, @edit[:new][:start_hour].to_i),
-          :class => "selectpicker")
+          :class => "selectpicker selectWidth")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("start_hour", "#{url}");
@@ -85,7 +85,7 @@
         = _("h")
         = select_tag("start_min",
           options_for_select((0..55).step(5).to_a, @edit[:new][:start_min].to_i),
-          :class => "selectpicker")
+          :class => "selectpicker selectWidth")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent("start_min", "#{url}");


### PR DESCRIPTION
Old
<img width="1252" alt="screen shot 2015-11-09 at 11 36 33 am" src="https://cloud.githubusercontent.com/assets/1287144/11039549/33a146f0-86d6-11e5-8eb6-6f37bc8385bf.png">
New
<img width="1232" alt="screen shot 2015-11-09 at 11 37 00 am" src="https://cloud.githubusercontent.com/assets/1287144/11039551/33a324ac-86d6-11e5-9372-3b4ccb927997.png">

Old
<img width="1173" alt="screen shot 2015-11-09 at 11 35 58 am" src="https://cloud.githubusercontent.com/assets/1287144/11039550/33a2f702-86d6-11e5-8e0e-1b28c12ae8fa.png">
New
<img width="1197" alt="screen shot 2015-11-09 at 11 35 26 am" src="https://cloud.githubusercontent.com/assets/1287144/11039548/339f3e3c-86d6-11e5-9908-765b6b529085.png">
