### PR TITLE
[api] Allow providers#create to accept auth_key for openshift

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -19,4 +19,8 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   def self.event_monitor_class
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
   end
+
+  def supported_auth_attributes
+    %w(userid password auth_key)
+  end
 end


### PR DESCRIPTION
In the UI, adding an openshift provider allows for a token to be added.
The API prevents the token from being added because it only accepts
userid/password in the credentials. This change allows for the
`auth_key` to be specified for openshift providers, bringing it into
parity with the UI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1278041

***

/cc @abellotti @gtanzillo 