### PR TITLE
Update vm infra controller spec

### DIFF
--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -59,26 +59,8 @@ describe VmInfraController do
   end
 
   it 'can open the reconfigure tab' do
-    host = FactoryGirl.create(:host,
-                              :vmm_vendor  => 'vmware',
-                              :vmm_product => "ESX",
-                              :hardware    => FactoryGirl.create(:hardware,
-                                                                 :memory_mb            => 1024,
-                                                                 :cpu_total_cores      => 1,
-                                                                 :cpu_cores_per_socket => 1,
-                                                                 :cpu_sockets          => 1
-                                                                )
-                             )
-    vm = FactoryGirl.create(:vm_vmware,
-                            :host     => host,
-                            :hardware => FactoryGirl.create(:hardware,
-                                                            :memory_mb            => 1024,
-                                                            :cpu_total_cores      => 1,
-                                                            :cpu_cores_per_socket => 1,
-                                                            :cpu_sockets          => 1,
-                                                            :virtual_hw_version   => '04'
-                                                           )
-                           )
+    host = FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB))
+    vm   = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -92,26 +74,8 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket <= 1 should not display the cpu_cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host,
-                              :vmm_vendor  => 'vmware',
-                              :vmm_product => "ESX",
-                              :hardware    => FactoryGirl.create(:hardware,
-                                                                 :memory_mb            => 1024,
-                                                                 :cpu_total_cores      => 1,
-                                                                 :cpu_cores_per_socket => 1,
-                                                                 :cpu_sockets          => 1
-                                                                )
-                             )
-    vm = FactoryGirl.create(:vm_vmware,
-                            :host     => host,
-                            :hardware => FactoryGirl.create(:hardware,
-                                                            :memory_mb            => 1024,
-                                                            :cpu_total_cores      => 1,
-                                                            :cpu_cores_per_socket => 1,
-                                                            :cpu_sockets          => 1,
-                                                            :virtual_hw_version   => "04"
-                                                           )
-                           )
+    host = FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB))
+    vm   = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -126,8 +90,8 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4, :cpu_cores_per_socket => 4, :cpu_sockets => 1))
-    vm = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :cpu_sockets => 1))
+    host = FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB))
+    vm   = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -142,8 +106,8 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab displays the submit and cancel buttons' do
-    host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4))
-    vm = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07"))
+    host = FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB))
+    vm   = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -27,7 +27,7 @@ describe VmInfraController do
     seed_session_trees('vm_infra', 'vms_instances_filter_tree')
     xhr :post, :show, :id => vm_vmware.id, :display => 'vmtree_info'
     expect(response.status).to eq(200)
-    response.should render_template('vm_common/_vmtree')
+    expect(response).to render_template('vm_common/_vmtree')
   end
 
   # http://localhost:3000/vm_infra/show/10000000000449
@@ -39,7 +39,7 @@ describe VmInfraController do
     node_id = "v-#{vm_vmware.compressed_id}"
     expect(response.body).to match(/miqDynatreeActivateNodeSilently\('vandt_tree', '#{node_id}'\);/)
 
-    response.should render_template('shared/summary/_textual_tags')
+    expect(response).to render_template('shared/summary/_textual_tags')
     expect(response.body).to match(/VM and Instance &quot;#{vm_vmware.name}&quot;/)
 
     expect(response.status).to eq(200)
@@ -47,7 +47,7 @@ describe VmInfraController do
 
   it 'can open the right size tab' do
     get :show, :id => vm_vmware.id
-    response.should redirect_to(:action => 'explorer')
+    expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)
@@ -61,7 +61,7 @@ describe VmInfraController do
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
-    response.should redirect_to(:action => 'explorer')
+    expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)
@@ -75,7 +75,7 @@ describe VmInfraController do
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
-    response.should redirect_to(:action => 'explorer')
+    expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)
@@ -90,7 +90,7 @@ describe VmInfraController do
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
-    response.should redirect_to(:action => 'explorer')
+    expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)
@@ -105,7 +105,7 @@ describe VmInfraController do
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
-    response.should redirect_to(:action => 'explorer')
+    expect(response).to redirect_to(:action => 'explorer')
 
     post :explorer
     expect(response.status).to eq(200)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -30,7 +30,7 @@ describe VmInfraController do
 
   # http://localhost:3000/vm_infra/show/10000000000449
   it 'can open a VM and select it in the left tree' do
-    vm = FactoryGirl.create(:vm_vmware, :name => 'gabelstaplerfahrer')
+    vm = FactoryGirl.create(:vm_vmware)
 
     get :show, :id => vm.id
     response.should redirect_to(:action => 'explorer')
@@ -46,7 +46,7 @@ describe VmInfraController do
   end
 
   it 'can open the right size tab' do
-    vm = FactoryGirl.create(:vm_vmware, :name => 'a_name')
+    vm = FactoryGirl.create(:vm_vmware)
 
     get :show, :id => vm.id
     response.should redirect_to(:action => 'explorer')
@@ -70,7 +70,6 @@ describe VmInfraController do
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
-                            :name     => 'b_name',
                             :host     => host,
                             :hardware => FactoryGirl.create(:hardware,
                                                             :memory_mb            => 1024,
@@ -104,7 +103,6 @@ describe VmInfraController do
                                                                 )
                              )
     vm = FactoryGirl.create(:vm_vmware,
-                            :name     => 'b_name',
                             :host     => host,
                             :hardware => FactoryGirl.create(:hardware,
                                                             :memory_mb            => 1024,
@@ -129,7 +127,7 @@ describe VmInfraController do
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
     host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4, :cpu_cores_per_socket => 4, :cpu_sockets => 1))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :cpu_sockets => 1))
+    vm = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07", :cpu_cores_per_socket => 1, :cpu_sockets => 1))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id
@@ -145,7 +143,7 @@ describe VmInfraController do
 
   it 'the reconfigure tab displays the submit and cancel buttons' do
     host = FactoryGirl.create(:host, :vmm_vendor => 'vmware', :vmm_product => "ESX", :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 4))
-    vm = FactoryGirl.create(:vm_vmware, :name => 'b_name', :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07"))
+    vm = FactoryGirl.create(:vm_vmware, :host => host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 1024, :cpu_total_cores => 1, :virtual_hw_version => "07"))
     controller.stub(:x_node).and_return("v-#{vm.compressed_id}")
 
     get :show, :id => vm.id

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -123,7 +123,6 @@ describe VmInfraController do
       before do
         session[:settings] = {:views => {}, :perpage => {:list => 10}}
         get :explorer
-        request.env['HTTP_REFERER'] = request.fullpath
       end
 
       it 'skips dropping a breadcrumb when a button action is executed' do

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -4,7 +4,7 @@ describe VmInfraController do
   let(:host_1x1)  { FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB)) }
   let(:host_2x2)  { FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB)) }
   let(:vm_vmware) { FactoryGirl.create(:vm_vmware) }
-  before(:each) do
+  before do
     set_user_privileges
 
     session[:settings] = {:quadicons => nil, :views => {:treesize => 20}}

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -161,7 +161,7 @@ describe VmInfraController do
   context "skip or drop breadcrumb" do
     before do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
-      @vm = VmInfra.create(:name => "testvm", :location => "testvm_location", :vendor => "vmware")
+      @vm = FactoryGirl.create(:vm_vmware)
       get :explorer
       request.env['HTTP_REFERER'] = request.fullpath
     end
@@ -184,7 +184,7 @@ describe VmInfraController do
   context "clear or retain existing breadcrumb path" do
     before do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
-      @vm = VmInfra.create(:name => "testvm", :location => "testvm_location", :vendor => "vmware")
+      @vm = FactoryGirl.create(:vm_vmware)
       controller.stub(:render)
       controller.stub(:build_toolbar)
     end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -128,14 +128,12 @@ describe VmInfraController do
 
       it 'skips dropping a breadcrumb when a button action is executed' do
         post :x_button, :id => vm_vmware.id, :pressed => 'vm_ownership'
-        expect(subject.size).to eq(1)
-        expect(subject).to include(:name => "VM or Templates", :url => "/vm_infra/explorer")
+        expect(subject).to eq([{:name => "VM or Templates", :url => "/vm_infra/explorer"}])
       end
 
       it 'drops a breadcrumb when an action allowing breadcrumbs is executed' do
         post :accordion_select, :id => "vms_filter"
-        expect(subject.size).to eq(1)
-        expect(subject).to include(:name => "Virtual Machines", :url => "/vm_infra/explorer")
+        expect(subject).to eq([{:name => "Virtual Machines", :url => "/vm_infra/explorer"}])
       end
     end
 
@@ -150,8 +148,7 @@ describe VmInfraController do
         session[:breadcrumbs] = [{:name => "Instances", :url => "/vm_cloud/explorer"}]
         controller.stub(:x_node).and_return("v-#{vm_vmware.compressed_id}")
         get :explorer
-        expect(subject.size).to eq(1)
-        expect(subject).to include(:name => "VM or Templates", :url => "/vm_infra/explorer")
+        expect(subject).to eq([{:name => "VM or Templates", :url => "/vm_infra/explorer"}])
       end
 
       it 'retains the breadcrumb path when cancel is pressed from a VM action' do
@@ -162,8 +159,7 @@ describe VmInfraController do
         controller.instance_variable_set(:@in_a_form, nil)
         post :ownership_update, :button => 'cancel'
 
-        expect(subject.size).to eq(1)
-        expect(subject).to include(:name => "VM or Templates", :url => "/vm_infra/explorer")
+        expect(subject).to eq([{:name => "VM or Templates", :url => "/vm_infra/explorer"}])
       end
     end
   end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -118,12 +118,10 @@ describe VmInfraController do
 
   context "breadcrumbs" do
     subject { controller.instance_variable_get(:@breadcrumbs) }
+    before  { session[:settings] = {:views => {}, :perpage => {:list => 10}} }
 
     context "skip or drop breadcrumb" do
-      before do
-        session[:settings] = {:views => {}, :perpage => {:list => 10}}
-        get :explorer
-      end
+      before { get :explorer }
 
       it 'skips dropping a breadcrumb when a button action is executed' do
         post :x_button, :id => vm_vmware.id, :pressed => 'vm_ownership'
@@ -137,11 +135,7 @@ describe VmInfraController do
     end
 
     context "clear or retain existing breadcrumb path" do
-      before do
-        session[:settings] = {:views => {}, :perpage => {:list => 10}}
-        controller.stub(:render)
-        controller.stub(:build_toolbar)
-      end
+      before { controller.stub(:render => nil, :build_toolbar => nil) }
 
       it 'it clears the existing breadcrumb path and assigns the new explorer path when controllers are switched' do
         session[:breadcrumbs] = [{:name => "Instances", :url => "/vm_cloud/explorer"}]

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -146,9 +146,7 @@ describe VmInfraController do
     end
 
     it 'it clears the existing breadcrumb path and assigns the new explorer path when controllers are switched' do
-      breadcrumbs = []
-      breadcrumbs[0] = {:name => "Instances", :url => "/vm_cloud/explorer"}
-      session[:breadcrumbs] = breadcrumbs
+      session[:breadcrumbs] = [{:name => "Instances", :url => "/vm_cloud/explorer"}]
       controller.stub(:x_node).and_return("v-#{vm_vmware.compressed_id}")
       get :explorer
       breadcrumbs = controller.instance_variable_get(:@breadcrumbs)

--- a/spec/factories/hardware.rb
+++ b/spec/factories/hardware.rb
@@ -1,4 +1,17 @@
 FactoryGirl.define do
   factory :hardware do
+    trait(:cpu1x1) do
+      cpu_sockets          1
+      cpu_cores_per_socket 1
+      cpu_total_cores      1
+    end
+
+    trait(:cpu2x2) do
+      cpu_sockets          2
+      cpu_cores_per_socket 2
+      cpu_total_cores      4
+    end
+
+    trait(:ram1GB) { memory_mb 1024 }
   end
 end

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -50,10 +50,7 @@ FactoryGirl.define do
   end
 
   # Type specific subclasses
-  factory :host_vmware, :parent => :host, :class => "ManageIQ::Providers::Vmware::InfraManager::Host" do
-    vmm_vendor "vmware"
-  end
-
+  factory(:host_vmware,     :parent => :host,        :class => "ManageIQ::Providers::Vmware::InfraManager::Host")
   factory :host_vmware_esx, :parent => :host_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::HostEsx" do
   end
 

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -51,8 +51,7 @@ FactoryGirl.define do
 
   # Type specific subclasses
   factory(:host_vmware,     :parent => :host,        :class => "ManageIQ::Providers::Vmware::InfraManager::Host")
-  factory :host_vmware_esx, :parent => :host_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::HostEsx" do
-  end
+  factory(:host_vmware_esx, :parent => :host_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::HostEsx") { vmm_product "ESX" }
 
   factory :host_redhat, :parent => :host, :class => "ManageIQ::Providers::Redhat::InfraManager::Host" do
     sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }


### PR DESCRIPTION
- Don't `FactoryGirl.create` with `:name`
- Use FactoryGirl rather than models to create in rspec
- Leverage FactoryGirl Traits
- general refactoring