### PR TITLE
Provide an associative array to Arel::InsertManager

### DIFF
--- a/spec/replication/evm_dbsync_spec.rb
+++ b/spec/replication/evm_dbsync_spec.rb
@@ -66,15 +66,18 @@ describe "evm:dbsync" do
 
       arel_table = Arel::Table.new(t)
       2.times do |n|
-        fields = {}
-        fields[arel_table[:name]]        = "#{t}_#{n}"  if @slave_connection.column_exists?(t, "name")
-        fields[arel_table[:description]] = "#{t}_#{n}"  if @slave_connection.column_exists?(t, "description")
-        fields[arel_table[:timestamp]]   = Time.now.utc if @slave_connection.column_exists?(t, "timestamp")
-        fields[arel_table[:created_at]]  = Time.now.utc if @slave_connection.column_exists?(t, "created_at")
-        fields[arel_table[:updated_at]]  = Time.now.utc if @slave_connection.column_exists?(t, "updated_at")
-        next if fields.blank?
+        fields = []
+        fields << [arel_table[:name],        "#{t}_#{n}"]  if @slave_connection.column_exists?(t, "name")
+        fields << [arel_table[:description], "#{t}_#{n}"]  if @slave_connection.column_exists?(t, "description")
+        fields << [arel_table[:timestamp],   Time.now.utc] if @slave_connection.column_exists?(t, "timestamp")
+        fields << [arel_table[:created_at],  Time.now.utc] if @slave_connection.column_exists?(t, "created_at")
+        fields << [arel_table[:updated_at],  Time.now.utc] if @slave_connection.column_exists?(t, "updated_at")
+        next if fields.empty?
 
-        @slave_connection.execute arel_table.insert_manager.insert(fields).to_sql
+        manager = Arel::InsertManager.new(Arel::Table.engine)
+        manager.into(arel_table)
+        manager.insert(fields)
+        @slave_connection.execute(manager.to_sql)
       end
     end
   end


### PR DESCRIPTION
At some point, this test silently broke because nearly all tables have
zero rows to replicate.

According to the arel test suite, there are NO examples where
Arel::InsertManager#insert accepts a hash so let's use the associative
array that is clearly the desired input.

https://github.com/rails/arel/blob/v6.0.3/test/test_insert_manager.rb#L62-L70

Test output before which indicates we're not replicating for most tables:

```
...
                        repositories 100% .........................   0
                  container_projects 100% .........................   0
        ontap_volume_metrics_rollups 100% .........................   0
                    container_quotas 100% .........................   0
                       storage_files 100% .........................   0
                         filesystems 100% .........................   0
               customization_scripts 100% .........................   0
                            pictures 100% .........................   0
                     system_services 100% .........................   0
...
```

Here is the test output after this change which demonstrates that we
are now testing replication of 2 rows for several tables:

```
...
                        repositories 100% .........................   2
                  container_projects 100% .........................   2
        ontap_volume_metrics_rollups 100% .........................   2
                    container_quotas 100% .........................   2
                       storage_files 100% .........................   2
                         filesystems 100% .........................   2
               customization_scripts 100% .........................   2
                            pictures 100% .........................   0
                     system_services 100% .........................   2
...
```