### PR TITLE
miqSelectPickerEvent - handle urls with non-empty query_string

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1201,7 +1201,9 @@ function miqSelectPickerEvent(element, url, options){
     var selected = $('#' + element).val();
     options =  typeof options !== 'undefined' ? options : {}
     options['no_encoding'] = true;
-    miqJqueryRequest(url + '?' + element + '=' + escape(selected), options);
+
+    var firstarg = ! _.contains(url, '?');
+    miqJqueryRequest(url + (firstarg ? '?' : '&') + element + '=' + escape(selected), options);
     return true;
   });
 }


### PR DESCRIPTION
Pagination is broken if the current url already has a ?query=param, because it would add another ? instead of &.

https://bugzilla.redhat.com/show_bug.cgi?id=1277993