### PR TITLE
Option to create resource group during provisioning

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers
     def stack_create_options
       {
         :parameters     => stack_parameters,
-        :resource_group => @dialog_options['dialog_resource_group'],
+        :resource_group => @dialog_options['dialog_resource_group'] || @dialog_options['dialog_new_resource_group'],
         :mode           => @dialog_options['dialog_deploy_mode']
       }
     end

--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -36,8 +36,9 @@ class OrchestrationTemplateDialogService
   end
 
   def add_azure_stack_options(dialog_group, position)
-    add_resource_group_field(dialog_group, position)
-    add_mode_field(dialog_group, position + 1)
+    add_resource_group_list(dialog_group, position)
+    add_new_resource_group_field(dialog_group, position + 1)
+    add_mode_field(dialog_group, position + 2)
   end
 
   def add_parameter_group(parameter_group, tab, position)
@@ -135,21 +136,38 @@ class OrchestrationTemplateDialogService
     )
   end
 
-  def add_resource_group_field(group, position)
+  def add_resource_group_list(group, position)
     group.dialog_fields.build(
       :type         => "DialogFieldDropDownList",
       :name         => "resource_group",
-      :description  => "Resource group to which stack is to deploy",
+      :description  => "Select an existing resource group for deployment",
       :data_type    => "string",
       :display      => "edit",
       :dynamic      => true,
       :required     => false,
-      :label        => "Resource Group",
+      :label        => "Existing Resource Group",
       :position     => position,
       :dialog_group => group
     ).tap do |dialog_field|
       dialog_field.resource_action.fqname = "/Cloud/Orchestration/Operations/Methods/Available_Resource_Groups"
     end
+  end
+
+  def add_new_resource_group_field(group, position)
+    group.dialog_fields.build(
+      :type           => "DialogFieldTextBox",
+      :name           => "new_resource_group",
+      :description    => "Create a new resource group upon deployment",
+      :data_type      => "string",
+      :display        => "edit",
+      :required       => false,
+      :options        => {:protected => false},
+      :validator_type => 'regex',
+      :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$',
+      :label          => "(or) New Resource Group",
+      :position       => position,
+      :dialog_group   => group
+    )
   end
 
   def add_parameter_field(parameter, group, position)

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
@@ -1,7 +1,7 @@
 #
 # Description: provide the dynamic list content from available resource groups
 #
-rg_list = {nil => "<default>"}
+rg_list = {nil => "<New resource group>"}
 service_template = $evm.root.attributes["service_template"]
 if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
   service_template.orchestration_manager.resource_groups.each { |t| rg_list[t.name] = t.name }

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe "Available_Resource_Groups Method Validation" do
   let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:default_value) { "<New resource group>" }
   before do
     @ins = "/Cloud/Orchestration/Operations/Methods/Available_Resource_Groups"
   end
@@ -9,7 +10,7 @@ describe "Available_Resource_Groups Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      ws.root["values"].should == {nil => default_value}
     end
   end
 
@@ -18,7 +19,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      ws.root["values"].should == {nil => default_value}
     end
   end
 
@@ -40,15 +41,15 @@ describe "Available_Resource_Groups Method Validation" do
     it "finds all the resource groups and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
       ws.root["values"].should include(
-        nil           => "<default>",
+        nil           => default_value,
         @rgroup1.name => @rgroup1.name,
         @rgroup2.name => @rgroup2.name
       )
     end
 
-    it "provides only default value to the tenant list if orchestration manager does not exist" do
+    it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      ws.root["values"].should == {nil => default_value}
     end
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -20,6 +20,12 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   end
 
   describe 'stack operations' do
+    before do
+      rg = double
+      allow(Azure::Armrest::ResourceGroupService).to receive(:new).and_return(rg)
+      allow(rg).to receive(:create)
+    end
+
     context ".create_stack" do
       it 'creates a stack' do
         expect(orchestration_service).to receive(:create).and_return(the_raw_stack)

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -78,13 +78,14 @@ describe OrchestrationTemplateDialogService do
     )
 
     fields = group.dialog_fields
-    fields.size.should == 4
+    fields.size.should == 5
 
     fields[0].resource_action.fqname.should == "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
-    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",    :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",     :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group", :dynamic => true)
-    assert_field(fields[3], DialogFieldDropDownList, :name => "deploy_mode",    :values => [%w(Complete Complete), %w(Incremental Incremental)])
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",        :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
+    assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
+    assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode",        :values => [%w(Complete Complete), %w(Incremental Incremental)])
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
This is a continuation work of #5272.

Add a text field in the option dialog to receive `New Resource Group`. Its value is only used when the `Existing Resource Group` dropdown list selects `[New resource group]`.

During the provisioning time always try to create the resource group even if it already exists. It does not throw exception. This simplifies the backend process.

Only the last commit is for this PR. The first two are to be merged through #5272 