### PR TITLE
Azure - Create a mapping between the cloud subnet and the default AZ

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -197,9 +197,10 @@ module ManageIQ::Providers
       def parse_cloud_subnet(subnet)
         uid = subnet.id
         new_result = {
-          :ems_ref => uid,
-          :name    => subnet.name,
-          :cidr    => subnet.properties.address_prefix,
+          :ems_ref           => uid,
+          :name              => subnet.name,
+          :cidr              => subnet.properties.address_prefix,
+          :availability_zone => @data_index.fetch_path(:availability_zones, 'default'),
         }
         return uid, new_result
       end

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -117,11 +117,13 @@ describe ManageIQ::Providers::Azure::CloudManager do
     @cn.cloud_subnets.size.should eq(1)
     @subnet = @cn.cloud_subnets.where(:name => "default").first
     @subnet.should have_attributes(
-      :name    => "default",
-      :ems_ref => "/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485"\
-                  "/resourceGroups/Chef-Prod/providers/Microsoft.Network"\
-                  "/virtualNetworks/Chef-Prod/subnets/default",
-      :cidr    => "10.2.0.0/24"
+      :name              => "default",
+      :ems_ref           => "/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485"\
+                             "/resourceGroups/Chef-Prod/providers/Microsoft.Network"\
+                             "/virtualNetworks/Chef-Prod/subnets/default",
+      :cidr              => "10.2.0.0/24",
+      :availability_zone => @az
+
     )
   end
 


### PR DESCRIPTION
Only one availability zone exists in any Azure provider, further support will be added later. This PR creates a mapping between the cloud subnet and the default AZ.