### PR TITLE
Display message when one of the selected instance do not support SSA.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2580,7 +2580,7 @@ class ApplicationController < ActionController::Base
   def render_flash_not_applicable_to_model(type, model_type = "items")
     add_flash(_("%{task} does not apply to at least one of the selected %{model}") %
                 {:model => model_type,
-                 :task  => type.capitalize}, :error)
+                 :task  => type.split.map(&:capitalize).join(' ')}, :error)
     render_flash { |page| page << '$(\'#main_div\').scrollTop();' } if @explorer
   end
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1145,6 +1145,11 @@ module ApplicationController::CiProcessing
         return
       end
 
+      if method == 'scan' && !VmOrTemplate.batch_operation_supported?('smartstate_analysis', vms)
+        render_flash_not_applicable_to_model('Smartstate Analysis', ui_lookup(:tables => "vm_or_template"))
+        return
+      end
+
       if vms.empty?
         add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => request.parameters["controller"]), :task => display_name}, :error)
       else

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -309,4 +309,25 @@ describe HostController do
       expect(flash_messages.first[:message]).to include "Refresh Ems initiated for #{vms.length} VMs"
     end
   end
+
+  context "#vm_button_operation" do
+    it "when the vm_or_template supports scan,  returns true" do
+      vm1 =  FactoryGirl.create(:vm_microsoft)
+      vm2 =  FactoryGirl.create(:vm_vmware)
+      controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm1.id}, #{vm2.id}")
+      controller.send(:vm_button_operation, 'scan', "Smartstate Analysis")
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include "Smartstate Analysis does not apply to at least one of the selected Virtual Machines"
+    end
+
+    it "when the vm_or_template supports scan,  returns true" do
+      vm = FactoryGirl.create(:vm_vmware,
+                              :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
+                              :storage               => FactoryGirl.create(:storage)
+                             )
+      controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm.id}")
+      controller.should_receive(:process_objects)
+      controller.send(:vm_button_operation, 'scan', "Smartstate Analysis")
+    end
+  end
 end


### PR DESCRIPTION
- Display flash message one of the selected Instances do not support Smartstate Analysis Task. Backed support is added in https://github.com/ManageIQ/manageiq/pull/5210
- Updated render_flash_not_applicable_to_model method to capitalize 'type' when there is space in it such as "smartstate analysis"
- Added spec test to verify fix

https://bugzilla.redhat.com/show_bug.cgi?id=1271359

@dclarizio @roliveri  please review

![ssa_for_archived_instances](https://cloud.githubusercontent.com/assets/3450808/11078477/37322e2a-87d4-11e5-8b40-922d619517f3.png)

![ssa_for_non_archived_instance](https://cloud.githubusercontent.com/assets/3450808/11078480/3ccab096-87d4-11e5-8848-ba7e723fe98b.png)
