### PR TITLE
Fix miq schedule queuing

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -173,7 +173,7 @@ class MiqScheduleWorker::Jobs
   end
 
   def miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
-    MiqSchedule.queue_scheduled_work(schedule_id, rufus_job.job_id, rufus_job.next_time, rufus_job.opts)
+    MiqSchedule.queue_scheduled_work(schedule_id, rufus_job.job_id, rufus_job.next_time.to_i, rufus_job.opts)
   end
 
   def ldap_server_sync_data_from_timer

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -27,14 +27,16 @@ describe MiqScheduleWorker::Jobs do
     require "rufus-scheduler"
 
     it "delegates the queueing to MiqSchedule" do
-      schedule_id = 123
-      scheduler = Rufus::Scheduler.new
-      block = -> { "some work" }
-      rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour, {}, block)
+      Timecop.freeze do
+        schedule_id = 123
+        scheduler = Rufus::Scheduler.new
+        block = -> { "some work" }
+        rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour, {}, block)
 
-      expect(MiqSchedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, rufus_job.next_time, {})
+        expect(MiqSchedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, 1.hour.from_now.to_i, {})
 
-      described_class.new.miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
+        described_class.new.miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
+      end
     end
   end
 end


### PR DESCRIPTION
It looks like a bug was introduced in 58ec7a0 - Rufus' old `Job#at`
doesn't have an exact equivalent in version 3, but was erroneously
replaced with `#next_time`. The former was an integer representation of
time, the latter the equivalent of passing it to `Time.at`. This commit
changes that by calling `#to_i` on the result of `#next_time`.

The impact of this change was not immediately clear, but was showing up
in `MiqQueue#deliver`, where this method guards against non-Integer
values for `at`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1279601