### PR TITLE
Add a currency column

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -195,8 +195,8 @@ class ChargebackController < ApplicationController
           detail.group = r[:group]
           detail.per_unit = r[:per_unit]
           detail.metric = r[:metric]
-          detail.chargeback_rate_detail_measure_id = r[:chargeback_rate_detail_measure_id]
           detail.chargeback_rate_detail_currency_id = r[:chargeback_rate_detail_currency_id]
+          detail.chargeback_rate_detail_measure_id = r[:chargeback_rate_detail_measure_id]
           @sb[:rate_details].push(detail) unless @sb[:rate_details].include?(detail)
         end
       else
@@ -255,8 +255,19 @@ class ChargebackController < ApplicationController
     cb_rate_get_form_vars
     render :update do |page|                    # Use JS to update the display
       changed = (@edit[:new] != @edit[:current])
+      # Update the new column with the code of the currency selected by the user
+      @edit[:new][:details].each_with_index do |_detail, i|
+        next unless @edit[:new][:details][i][:currency] != @edit[:current][:details][i][:currency]
+        @edit[:current][:details][i][:currency] = @edit[:new][:details][i][:currency]
+        params[:id_column] = i
+        id_currency = @edit[:current][:details][i][:currency]
+        currency = ChargebackRateDetailCurrency.find_by(:id => id_currency)
+        params[:code_currency] = currency.code
+        page.replace("column_currency_#{i}", :partial => "cb_new_currency_column")
+      end
       page << javascript_for_miq_button_visibility(changed)
     end
+    cb_rate_get_form_vars
   end
 
   def cb_rate_show

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -184,7 +184,7 @@ class ChargebackController < ApplicationController
         @sb[:rate] = ChargebackRate.new
         @sb[:rate].description = _("Copy of %{description}") % {:description => rate.description}
         @sb[:rate].rate_type = rate.rate_type
-        rate_details = rate.chargeback_rate_details
+        rate_details = rate.includes(:chargeback_rate_details => :detail_currency)
         # Create new rate detail records for copied rate record
         rate_details.each do |r|
           detail = ChargebackRateDetail.new
@@ -195,8 +195,9 @@ class ChargebackController < ApplicationController
           detail.group = r[:group]
           detail.per_unit = r[:per_unit]
           detail.metric = r[:metric]
-          detail.chargeback_rate_detail_currency_id = r[:chargeback_rate_detail_currency_id]
           detail.chargeback_rate_detail_measure_id = r[:chargeback_rate_detail_measure_id]
+          detail.chargeback_rate_detail_currency_id = r[:chargeback_rate_detail_currency_id]
+          @sb[:rate_details][:currency] = r.detail_currency.code
           @sb[:rate_details].push(detail) unless @sb[:rate_details].include?(detail)
         end
       else
@@ -256,13 +257,16 @@ class ChargebackController < ApplicationController
     render :update do |page|                    # Use JS to update the display
       changed = (@edit[:new] != @edit[:current])
       # Update the new column with the code of the currency selected by the user
+      first_new_detail = @edit[:new][:details].first
+      new_rate_detail_currency = ChargebackRateDetailCurrency.find_by(:id => first_new_detail[:currency])
       @edit[:new][:details].each_with_index do |_detail, i|
-        next unless @edit[:new][:details][i][:currency] != @edit[:current][:details][i][:currency]
-        @edit[:current][:details][i][:currency] = @edit[:new][:details][i][:currency]
+        new_rate_details = @edit[:new][:details][i]
+        current_rate_details = @edit[:current][:details][i]
+        next if new_rate_details[:currency] == current_rate_details[:currency]
+
+        current_rate_details[:currency] = new_rate_details[:currency]
+        params[:code_currency] = new_rate_detail_currency.code
         params[:id_column] = i
-        id_currency = @edit[:current][:details][i][:currency]
-        currency = ChargebackRateDetailCurrency.find_by(:id => id_currency)
-        params[:code_currency] = currency.code
         page.replace("column_currency_#{i}", :partial => "cb_new_currency_column")
       end
       page << javascript_for_miq_button_visibility(changed)

--- a/app/views/chargeback/_cb_new_currency_column.html.haml
+++ b/app/views/chargeback/_cb_new_currency_column.html.haml
@@ -1,0 +1,4 @@
+/In this view, the currency column is updated with the code of the currency selected by the user
+- i = params[:id_column]
+%td{:id => "column_currency_#{i}"}
+ = params[:code_currency]

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -36,6 +36,7 @@
         %th= _('Rate')
         %th= _('Per Time')
         %th= _('Per Unit')
+        %th= _('Currency')
     %tbody
       - @sb[:rate_details].each_with_index do |r, i|
         - @cur_group = r[:group] if @cur_group.nil?
@@ -64,3 +65,6 @@
               /if the rate detail have a metric associated, display an options field with per_unit selected
               %td
                 = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+          /Show the code of the currency selected by the user
+          %td{:id => "column_currency_#{i}"}
+            = r.detail_currency.code

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -67,4 +67,4 @@
                 = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
           /Show the code of the currency selected by the user
           %td{:id => "column_currency_#{i}"}
-            = r.detail_currency.code
+            = r[:currency]

--- a/spec/models/chargeback_rate_detail_currency_spec.rb
+++ b/spec/models/chargeback_rate_detail_currency_spec.rb
@@ -16,7 +16,6 @@ describe ChargebackRateDetailCurrency do
   it "is invalid without a symbol" do
     expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :symbol => nil)).not_to be_valid
   end
-
   it "is invalid without a unicode_hex" do
     expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :unicode_hex => nil)).not_to be_valid
   end


### PR DESCRIPTION
This PR is a continuation of the PR: _https://github.com/ManageIQ/manageiq/pull/4888_

## Description: ##
In the other PR, I added new currencies to the rates. This supported the following features:
* New currencies have been created in a yml file and they will be loaded when we seed the database. 
* The user can select the user currency to be displayed in the rate. 
* The user can edit and save the currency too.

Now, I added a new column in which will be showed the currency selected by the user. This column will be updated with the new currency when the user choose other currency.

## Mockups: ##
- Before:
http://res.cloudinary.com/tledesma/image/upload/v1447197732/Add_new_currency_column_uaeld4.png

- After:
http://res.cloudinary.com/tledesma/image/upload/v1447197731/Add_a_new_currency_column_2_sxbv8i.png

_**Note:**_
_Use Case GR15:_ 
_https://github.com/rhus/charging-docs/wiki/Requirements:-Guiding-and-Rating#gr-15-add-a-new-currency-column_
_Trello Card:_
_https://trello.com/c/P6d5NWTa/23-add-a-new-currency-column_
