### PR TITLE
Terminate Cloud-Stacks-instance fix

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1928,6 +1928,7 @@ module ApplicationController::CiProcessing
     when "#{pfx}_clone"                     then prov_redirect("clone")
     when "#{pfx}_migrate"                   then prov_redirect("migrate")
     when "#{pfx}_publish"                   then prov_redirect("publish")
+    when "#{pfx}_terminate"                 then terminatevms
     end
   end
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -485,8 +485,6 @@ module EmsCommon
       tag(Storage) if params[:pressed] == "storage_tag"
       deletestorages if params[:pressed] == "storage_delete"
 
-      terminatevms if params[:pressed] == "instance_terminate"
-
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
       if ["host_shutdown", "host_reboot", "host_standby", "host_enter_maint_mode", "host_exit_maint_mode",

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -63,8 +63,6 @@ class FlavorController < ApplicationController
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)
 
-      terminatevms if params[:pressed] == "instance_terminate"
-
       # Control transferred to another screen, so return
       return if ["#{pfx}_policy_sim", "#{pfx}_compare", "#{pfx}_tag",
                  "#{pfx}_retire", "#{pfx}_protect", "#{pfx}_ownership",

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -60,8 +60,6 @@ class SecurityGroupController < ApplicationController
     if params[:pressed].starts_with?("image_") || # Handle buttons from sub-items screen
        params[:pressed].starts_with?("instance_")
 
-      terminatevms if params[:pressed] == "instance_terminate"
-
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1277018
I found that, flash message was rendered, but with no content. Orchestration Stack instances couldnt be terminated. So I fixed it and move functionality from controllers to ci_processing.

![firefox_screenshot_2015-11-11t13-33-46 089z](https://cloud.githubusercontent.com/assets/9535558/11092138/3f5223c8-8881-11e5-80fe-747a363555e2.png)

@dclarizio @h-kataria please review
