### PR TITLE
Stopped logging warnings for large queue payload

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -94,7 +94,7 @@ class MiqQueue < ActiveRecord::Base
     args_size = args ? YAML.dump(args).length : 0
     data_size = data ? data.length : 0
 
-    if (args_size + data_size) > 512
+    if (args_size + data_size) > 10240
       culprit = caller.detect { |r| ! (r =~ /miq_queue.rb/) } || ""
       _log.warn("#{culprit.split(":in ").first} called with large payload (args: #{args_size} bytes, data: #{data_size} bytes) #{MiqQueue.format_full_log_msg(self)}")
     end
@@ -121,7 +121,7 @@ class MiqQueue < ActiveRecord::Base
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
 
     msg = MiqQueue.create!(options)
-    msg.warn_if_large_payload
+    msg.warn_if_large_payload unless Rails.env.production?
     _log.info("#{MiqQueue.format_full_log_msg(msg)}")
     msg
   end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -553,7 +553,7 @@ describe MiqQueue do
     EvmSpecHelper.create_guid_miq_server_zone
 
     $log.should_receive(:warn).with(/miq_queue_spec.rb.*large payload/)
-    MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :data => 'a' * 600)
+    MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :data => 'a' * 10600)
   end
 
   it "should not warn if the data size is small" do


### PR DESCRIPTION
These messages were not helpful in production mode
and also were being triggered at too low a level.
The original intent was to find where messages with
MBs of data were being saved to the queue.

https://bugzilla.redhat.com/show_bug.cgi?id=1274336

@jrafanie @kbrock 