### PR TITLE
Fix cluster level block and object storage views

### DIFF
--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -254,12 +254,12 @@ module EmsClusterHelper::TextualSummary
   end
 
   def textual_block_storage_disk_usage
-    return nil unless @record.respond_to?(:block_storage?) && @record.block_storage?
+    return nil unless @record.respond_to?(:block_storage?) && @record.block_storage? && !@record.cloud.nil?
     {:value => number_to_human_size(@record.cloud_block_storage_disk_usage.bytes, :precision => 2)}
   end
 
   def textual_object_storage_disk_usage
-    return nil unless @record.respond_to?(:object_storage?) && @record.object_storage?
+    return nil unless @record.respond_to?(:object_storage?) && @record.object_storage? && !@record.cloud.nil?
     {:value => number_to_human_size(@record.cloud_object_storage_disk_usage.bytes, :precision => 2)}
   end
 

--- a/app/models/manageiq/providers/openstack/infra_manager/ems_cluster.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/ems_cluster.rb
@@ -67,16 +67,16 @@ class ManageIQ::Providers::Openstack::InfraManager::EmsCluster < ::EmsCluster
 
   # TODO: Assumes there is a single overcloud. Will need
   # to change this once we support multiple overclouds.
-  def overcloud
+  def cloud
     ext_management_system.provider.cloud_ems.first
   end
 
   def cloud_block_storage_disk_usage
-    overcloud.block_storage_disk_usage
+    cloud.block_storage_disk_usage
   end
 
   def cloud_object_storage_disk_usage
-    stack = ext_management_system.orchestration_stacks.find_by(:name => overcloud.name)
+    stack = ext_management_system.orchestration_stacks.find_by(:name => cloud.name)
     replicas = stack.parameters.find_by(:name => 'SwiftReplicas').value.to_i
     object_storage_count = stack.parameters.find_by(:name => 'ObjectStorageCount').value.to_i
     # The number of replicas depends on what was configured in swift as replicas
@@ -84,6 +84,6 @@ class ManageIQ::Providers::Openstack::InfraManager::EmsCluster < ::EmsCluster
     # is the minimum between the configured replicas and object storage nodes.
     # Note the controller node currently also serves as a swift storage node. So
     # this doesn't reflect true disk usage over the entire overcloud.
-    overcloud.object_storage_disk_usage([replicas, object_storage_count].min)
+    cloud.object_storage_disk_usage([replicas, object_storage_count].min)
   end
 end


### PR DESCRIPTION
A undefined method X_disk_usage error occurs when a cloud
provider is not linked to an infrastructure provider.

This patch checks that a cloud provider is present, if it
is not, then disk usage is not displayed for the cluster.

Fixes BZ: 1279435