### PR TITLE
Validate Iso and Pxe child dialogs

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -269,6 +269,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     update_field_visibility_linked_clone(options, f)
 
+    update_field_visibility_pxe_iso(f)
+
     # Update field :display value
     f.each { |k, v| show_fields(k, v) }
 
@@ -284,9 +286,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     # Update field :notes_display value
     f.each { |k, v| show_fields(k, v, :notes_display) }
 
-    # need to set required to false for the fields that are not being shown on screen,
-    # based upon ISO/PXE choices in provision tpe pulldown
-    update_field_required
 
     update_field_read_only(options)
   end
@@ -303,11 +302,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 
-  def update_field_required
-    fields(:service) do |fn, f, _dn, _d|
-      f[:required] =  supports_pxe? ? f[:required] : false if [:pxe_image_id, :pxe_server_id].include?(fn)
-      f[:required] =  supports_iso? ? f[:required] : false if [:iso_image_id].include?(fn)
-    end
+  def update_field_visibility_pxe_iso(f)
+    show_flag = self.supports_pxe? ? :edit : :hide
+    f[show_flag] += [:pxe_image_id, :pxe_server_id]
+
+    show_flag = self.supports_iso? ? :edit : :hide
+    f[show_flag] += [:iso_image_id]
   end
 
   def show_customize_fields_pxe(fields)

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -165,6 +165,39 @@ describe MiqProvisionVirtWorkflow do
     end
   end
 
+  context "#update_field_visibility_pxe_iso" do
+    let(:show_hide_iso_pxe) { {:hide => [], :edit => []} }
+    describe "supports iso" do
+      before do
+        workflow.stub(:supports_iso?).and_return(true)
+        workflow.stub(:supports_pxe?).and_return(false)
+      end
+
+      it "sets iso_image_id as a validated key" do
+        workflow.update_field_visibility_pxe_iso(show_hide_iso_pxe)
+        expect(show_hide_iso_pxe[:edit]).to eq [:iso_image_id]
+        expect(show_hide_iso_pxe[:edit]).to_not eq [:pxe_image_id, :pxe_server_id]
+        expect(show_hide_iso_pxe[:hide]).to_not eq [:iso_image_id]
+        expect(show_hide_iso_pxe[:hide]).to eq [:pxe_image_id, :pxe_server_id]
+      end
+    end
+
+    describe "supports pxe" do
+      before do
+        workflow.stub(:supports_iso?).and_return(false)
+        workflow.stub(:supports_pxe?).and_return(true)
+      end
+
+      it "sets pxe_server_id and pxe_image_id as validated keys" do
+        workflow.update_field_visibility_pxe_iso(show_hide_iso_pxe)
+        expect(show_hide_iso_pxe[:edit]).to_not eq [:iso_image_id]
+        expect(show_hide_iso_pxe[:edit]).to eq [:pxe_image_id, :pxe_server_id]
+        expect(show_hide_iso_pxe[:hide]).to eq [:iso_image_id]
+        expect(show_hide_iso_pxe[:hide]).to_not eq [:pxe_image_id, :pxe_server_id]
+      end
+    end
+  end
+
   context "#validate_memory_reservation" do
     let(:values) { {:vm_memory => %w(1024 1024)} }
 


### PR DESCRIPTION
Validate Iso and Pxe child dialogs

https://bugzilla.redhat.com/show_bug.cgi?id=1255190

Refactored how the update_field_required method validates if supports_pxe?
or supports_iso? are required fields.

We now simply apply the :edit, or :hide flags to the MiqProvisionVirtDialog class
which implicitly does not validate on hidden fields