### PR TITLE
Allow automate methods to load service models using old model names

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -1,3 +1,4 @@
+require_relative 'miq_ae_service_model_legacy'
 module MiqAeMethodService
   class Deprecation < Vmdb::Deprecation
     def self.default_log
@@ -15,6 +16,8 @@ module MiqAeMethodService
   class MiqAeService
     include Vmdb::Logging
     include DRbUndumped
+    include MiqAeServiceModelLegacy
+
     @@id_hash = {}
     @@current = []
 
@@ -202,11 +205,15 @@ module MiqAeMethodService
       end
     end
 
-    def vmdb(type, *args)
-      type = type.to_s.underscore
-      type = "ext_management_system" if type == "ems"
-      service = MiqAeMethodService.const_get("MiqAeService#{type.camelize}")
+    def vmdb(model_name, *args)
+      service = service_model(model_name)
       args.empty? ? service : service.find(*args)
+    end
+
+    def service_model(model_name)
+      "MiqAeMethodService::MiqAeService#{model_name}".constantize
+    rescue NameError
+      service_model_lookup(model_name)
     end
 
     def datastore

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_legacy.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_legacy.rb
@@ -1,0 +1,100 @@
+module MiqAeMethodService
+  module MiqAeServiceModelLegacy
+    # Alias model names do not create deprecation warnings
+    ALIAS_MODEL_NAMES = {
+      'ems' => 'ExtManagementSystem'
+    }
+
+    # Legacy model names create deprecation warnings
+    LEGACY_MODEL_NAMES = {
+      # Amazon
+      'auth_key_pair_amazon'                         => 'ManageIQ_Providers_Amazon_CloudManager_AuthKeyPair',
+      'availability_zone_amazon'                     => 'ManageIQ_Providers_Amazon_CloudManager_AvailabilityZone',
+      'cloud_volume_amazon'                          => 'ManageIQ_Providers_Amazon_CloudManager_CloudVolume',
+      'cloud_volume_snapshot_amazon'                 => 'ManageIQ_Providers_Amazon_CloudManager_CloudVolumeSnapshot',
+      'flavor_amazon'                                => 'ManageIQ_Providers_Amazon_CloudManager_Flavor',
+      'floating_ip_amazon'                           => 'ManageIQ_Providers_Amazon_CloudManager_FloatingIp',
+      'orchestration_stack_amazon'                   => 'ManageIQ_Providers_Amazon_CloudManager_OrchestrationStack',
+      'miq_provision_amazon'                         => 'ManageIQ_Providers_Amazon_CloudManager_Provision',
+      'security_group_amazon'                        => 'ManageIQ_Providers_Amazon_CloudManager_SecurityGroup',
+      'template_amazon'                              => 'ManageIQ_Providers_Amazon_CloudManager_Template',
+      'vm_amazon'                                    => 'ManageIQ_Providers_Amazon_CloudManager_Vm',
+      'ems_amazon'                                   => 'ManageIQ_Providers_Amazon_CloudManager',
+      # Cloud
+      'auth_key_pair_cloud'                          => 'ManageIQ_Providers_CloudManager_AuthKeyPair',
+      'miq_provision_cloud'                          => 'ManageIQ_Providers_CloudManager_Provision',
+      'template_cloud'                               => 'ManageIQ_Providers_CloudManager_Template',
+      'vm_cloud'                                     => 'ManageIQ_Providers_CloudManager_Vm',
+      'ems_cloud'                                    => 'ManageIQ_Providers_CloudManager',
+      # Foreman
+      'configuration_profile_foreman'                => 'ManageIQ_Providers_Foreman_ConfigurationManager_ConfigurationProfile',
+      'configured_system_foreman'                    => 'ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem',
+      'miq_provision_task_configured_system_foreman' => 'ManageIQ_Providers_Foreman_ConfigurationManager_ProvisionTask',
+      'configuration_manager_foreman'                => 'ManageIQ_Providers_Foreman_ConfigurationManager',
+      'provider_foreman'                             => 'ManageIQ_Providers_Foreman_Provider',
+      'provisioning_manager_foreman'                 => 'ManageIQ_Providers_Foreman_ProvisioningManager',
+      # Infra
+      'template_infra'                               => 'ManageIQ_Providers_InfraManager_Template',
+      'vm_infra'                                     => 'ManageIQ_Providers_InfraManager_Vm',
+      'ems_infra'                                    => 'ManageIQ_Providers_InfraManager',
+      # Microsoft
+      'host_microsoft'                               => 'ManageIQ_Providers_Microsoft_InfraManager_Host',
+      'miq_provision_microsoft'                      => 'ManageIQ_Providers_Microsoft_InfraManager_Provision',
+      'template_microsoft'                           => 'ManageIQ_Providers_Microsoft_InfraManager_Template',
+      'vm_microsoft'                                 => 'ManageIQ_Providers_Microsoft_InfraManager_Vm',
+      'ems_microsoft'                                => 'ManageIQ_Providers_Microsoft_InfraManager',
+      # Openstack
+      'auth_key_pair_openstack'                      => 'ManageIQ_Providers_Openstack_CloudManager_AuthKeyPair',
+      'availability_zone_openstack'                  => 'ManageIQ_Providers_Openstack_CloudManager_AvailabilityZone',
+      'availability_zone_openstack_null'             => 'ManageIQ_Providers_Openstack_CloudManager_AvailabilityZoneNull',
+      'cloud_resource_quota_openstack'               => 'ManageIQ_Providers_Openstack_CloudManager_CloudResourceQuota',
+      'cloud_volume_openstack'                       => 'ManageIQ_Providers_Openstack_CloudManager_CloudVolume',
+      'cloud_volume_snapshot_openstack'              => 'ManageIQ_Providers_Openstack_CloudManager_CloudVolumeSnapshot',
+      'flavor_openstack'                             => 'ManageIQ_Providers_Openstack_CloudManager_Flavor',
+      'floating_ip_openstack'                        => 'ManageIQ_Providers_Openstack_CloudManager_FloatingIp',
+      'orchestration_stack_openstack'                => 'ManageIQ_Providers_Openstack_CloudManager_OrchestrationStack',
+      'miq_provision_openstack'                      => 'ManageIQ_Providers_Openstack_CloudManager_Provision',
+      'security_group_openstack'                     => 'ManageIQ_Providers_Openstack_CloudManager_SecurityGroup',
+      'template_openstack'                           => 'ManageIQ_Providers_Openstack_CloudManager_Template',
+      'vm_openstack'                                 => 'ManageIQ_Providers_Openstack_CloudManager_Vm',
+      'ems_openstack'                                => 'ManageIQ_Providers_Openstack_CloudManager',
+      # Openstack Infra
+      'ems_cluster_openstack_infra'                  => 'ManageIQ_Providers_Openstack_InfraManager_EmsCluster',
+      'host_openstack_infra'                         => 'ManageIQ_Providers_Openstack_InfraManager_Host',
+      'orchestration_stack_openstack_infra'          => 'ManageIQ_Providers_Openstack_InfraManager_OrchestrationStack',
+      'ems_openstack_infra'                          => 'ManageIQ_Providers_Openstack_InfraManager',
+      # Red Hat
+      'host_redhat'                                  => 'ManageIQ_Providers_Redhat_InfraManager_Host',
+      'miq_provision_redhat'                         => 'ManageIQ_Providers_Redhat_InfraManager_Provision',
+      'miq_provision_redhat_via_iso'                 => 'ManageIQ_Providers_Redhat_InfraManager_ProvisionViaIso',
+      'miq_provision_redhat_via_pxe'                 => 'ManageIQ_Providers_Redhat_InfraManager_ProvisionViaPxe',
+      'template_redhat'                              => 'ManageIQ_Providers_Redhat_InfraManager_Template',
+      'vm_redhat'                                    => 'ManageIQ_Providers_Redhat_InfraManager_Vm',
+      'ems_redhat'                                   => 'ManageIQ_Providers_Redhat_InfraManager',
+      # VMware
+      'host_vmware'                                  => 'ManageIQ_Providers_Vmware_InfraManager_Host',
+      'host_vmware_esx'                              => 'ManageIQ_Providers_Vmware_InfraManager_HostEsx',
+      'miq_provision_vmware'                         => 'ManageIQ_Providers_Vmware_InfraManager_Provision',
+      'miq_provision_vmware_via_pxe'                 => 'ManageIQ_Providers_Vmware_InfraManager_ProvisionViaPxe',
+      'template_vmware'                              => 'ManageIQ_Providers_Vmware_InfraManager_Template',
+      'vm_vmware'                                    => 'ManageIQ_Providers_Vmware_InfraManager_Vm',
+      'ems_vmware'                                   => 'ManageIQ_Providers_Vmware_InfraManager',
+      # Others
+      'configuration_manager'                        => 'ManageIQ_Providers_ConfigurationManager',
+      'provisioning_manager'                         => 'ManageIQ_Providers_ProvisioningManager'
+    }
+
+    def service_model_lookup(model_name)
+      converted_name = model_name.to_s.underscore
+      new_model_name = LEGACY_MODEL_NAMES[converted_name]
+      if new_model_name
+        "MiqAeMethodService::MiqAeService#{new_model_name}".constantize.tap do
+          MiqAeMethodService::Deprecation.deprecation_warning(model_name, new_model_name)
+        end
+      else
+        new_model_name = ALIAS_MODEL_NAMES[converted_name] || converted_name.camelize
+        "MiqAeMethodService::MiqAeService#{new_model_name}".constantize
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceConfigurationManager < MiqAeServiceModelBase
+  class MiqAeServiceManageIQ_Providers_ConfigurationManager < MiqAeServiceExtManagementSystem
     expose :provider,               :association => true
     expose :configuration_profiles, :association => true
     expose :configured_systems,     :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-provisioning_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-provisioning_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceProvisioningManager < MiqAeServiceModelBase
+  class MiqAeServiceManageIQ_Providers_ProvisioningManager < MiqAeServiceExtManagementSystem
     expose :provider,                 :association => true
     expose :operating_system_flavors, :association => true
     expose :customization_scripts,    :association => true

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -40,4 +40,44 @@ module MiqAeServiceSpec
       end
     end
   end
+
+  describe MiqAeService do
+    context "#service_model" do
+      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+
+      it "loads base model" do
+        expect(miq_ae_service.service_model(:VmOrTemplate)).to   be(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+        expect(miq_ae_service.service_model(:vm_or_template)).to be(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+      end
+
+      it "loads sub-classed model" do
+        expect(miq_ae_service.service_model(:Vm)).to be(MiqAeMethodService::MiqAeServiceVm)
+        expect(miq_ae_service.service_model(:vm)).to be(MiqAeMethodService::MiqAeServiceVm)
+      end
+
+      it "loads model with mapped name" do
+        expect(miq_ae_service.service_model(:ems)).to be(MiqAeMethodService::MiqAeServiceExtManagementSystem)
+      end
+
+      it "loads name-spaced model by mapped name" do
+        MiqAeMethodService::Deprecation.silence do
+          expect(miq_ae_service.service_model(:ems_openstack)).to be(
+            MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
+          expect(miq_ae_service.service_model(:vm_openstack)).to  be(
+            MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm)
+        end
+      end
+
+      it "loads name-spaced model by fully-qualified name" do
+        expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager)).to    be(
+          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
+        expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager_Vm)).to be(
+          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm)
+      end
+
+      it "raises error on invalid service_model name" do
+        expect { miq_ae_service.service_model(:invalid_model) }.to raise_error(NameError)
+      end
+    end
+  end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -78,6 +78,12 @@ module MiqAeServiceSpec
       it "raises error on invalid service_model name" do
         expect { miq_ae_service.service_model(:invalid_model) }.to raise_error(NameError)
       end
+
+      it "loads all mapped models" do
+        MiqAeMethodService::MiqAeService::LEGACY_MODEL_NAMES.values.each do |model_name|
+          expect { "MiqAeMethodService::MiqAeService#{model_name}".constantize }.to_not raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is required to support automate methods that access models using
legacy provider model names which are now name-spaced.
For example: $evm.vmdb(:ems_openstack)
is now:      $evm.vmdb(:ManageIQ_Providers_Openstack_CloudManager)

https://bugzilla.redhat.com/show_bug.cgi?id=1280350