### PR TITLE
Log backtrace of queued job error

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -418,7 +418,7 @@ class MiqQueue < ActiveRecord::Base
         end
       rescue => err
         _log.error("#{MiqQueue.format_short_log_msg(self)}: #{err}")
-        _log.debug("backtrace: #{err.backtrace.join("\n")}")
+        _log.error("backtrace: #{err.backtrace.join("\n")}")
       end
     else
       _log.warn "#{MiqQueue.format_short_log_msg(self)}, Callback is not well-defined, skipping"


### PR DESCRIPTION
Log backtrace of queued job error, otherwise it's almost
impossible to track the error.

In the BZ there is link to another BZ that had very hard
to track exception message.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1279506