### PR TITLE
Log nice message about missing hostname

### DIFF
--- a/gems/pending/util/MiqSockUtil.rb
+++ b/gems/pending/util/MiqSockUtil.rb
@@ -8,6 +8,9 @@ class MiqSockUtil
   # Return the cannonical name for host in DNS
   def self.getFullyQualifiedDomainName
     Socket.gethostbyname(Socket.gethostname).first
+  rescue
+    $log.error "The appliance hostname could not be resolved. Please make sure to set a valid fully qualified hostname."
+    raise
   end
 
   def self.getIpAddr


### PR DESCRIPTION
Log nice message about missing hostname, otherwise, it can be
confusing.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1221707