### PR TITLE
Speed up chargeback controller spec

### DIFF
--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -81,16 +81,10 @@ describe ChargebackController do
 
   render_views
 
-  context "#explorer" do
-    before(:each) do
-      session[:settings] = {}
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-
-    it 'can render the explorer' do
-      get :explorer
-      expect(response.status).to eq(200)
-      expect(response.body).to_not be_empty
-    end
+  it "#explorer can be rendered" do
+    EvmSpecHelper.create_guid_miq_server_zone
+    get :explorer
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
   end
 end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 
 describe ChargebackController do
-  before(:each) do
-    set_user_privileges
-  end
+  before { set_user_privileges }
 
   context "returns current rate assignments or set them to blank if category/tag is deleted" do
     before(:each) do

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -28,21 +28,17 @@ describe ChargebackController do
       before do
         cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
         ChargebackRate.set_assignments(:Storage, [{:cb_rate => cbr, :tag => [tag, "vm"]}])
+        sandbox = {:active_tree => :cb_assignments_tree, :trees => {:cb_assignments_tree => {:active_node => 'xx-Storage'}}}
+        controller.instance_variable_set(:@sb, sandbox)
       end
 
       it "returns tag for current assignments" do
-        controller.instance_variable_set(:@sb,
-                                         :active_tree => :cb_assignments_tree,
-                                         :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
         controller.send(:cb_assign_set_form_vars)
         expect(assigns(:edit)[:current_assignment][0][:tag][0]['parent_id']).to eq(category.id)
       end
 
       it "returns empty array for current_assignment when tag/category is not found" do
         tag.destroy
-        controller.instance_variable_set(:@sb,
-                                         :active_tree => :cb_assignments_tree,
-                                         :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
         controller.send(:cb_assign_set_form_vars)
         expect(assigns(:edit)[:current_assignment]).to eq([])
       end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -14,13 +14,13 @@ describe ChargebackController do
       it "returns the classification entry record" do
         controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
         controller.send(:get_tags_all, tag.id)
-        assigns(:edit)[:cb_assign][:tags].should eq(entry.id.to_s => entry.description)
+        expect(assigns(:edit)[:cb_assign][:tags]).to eq(entry.id.to_s => entry.description)
       end
 
       it "returns empty hash when classification entry is not found" do
         controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
         controller.send(:get_tags_all, 1)
-        assigns(:edit)[:cb_assign][:tags].should eq({})
+        expect(assigns(:edit)[:cb_assign][:tags]).to eq({})
       end
     end
 
@@ -35,8 +35,7 @@ describe ChargebackController do
                                          :active_tree => :cb_assignments_tree,
                                          :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
         controller.send(:cb_assign_set_form_vars)
-        tag = assigns(:edit)[:current_assignment][0][:tag][0]
-        tag['parent_id'].should eq(category.id)
+        expect(assigns(:edit)[:current_assignment][0][:tag][0]['parent_id']).to eq(category.id)
       end
 
       it "returns empty array for current_assignment when tag/category is not found" do
@@ -45,7 +44,7 @@ describe ChargebackController do
                                          :active_tree => :cb_assignments_tree,
                                          :trees       => {:cb_assignments_tree => {:active_node => 'xx-Storage'}})
         controller.send(:cb_assign_set_form_vars)
-        assigns(:edit)[:current_assignment].should eq([])
+        expect(assigns(:edit)[:current_assignment]).to eq([])
       end
     end
   end
@@ -63,8 +62,8 @@ describe ChargebackController do
       end
       html += '</tbody></table>'
 
-      controller.stub(:cb_rpts_show_saved_report)
-      controller.should_receive(:render)
+      allow(controller).to  receive(:cb_rpts_show_saved_report)
+      expect(controller).to receive(:render)
       controller.instance_variable_set(:@sb,
                                        :active_tree => :cb_reports_tree,
                                        :trees       => {:cb_reports_tree => {:active_node => node}})
@@ -73,9 +72,9 @@ describe ChargebackController do
       controller.instance_variable_set(:@layout, "chargeback")
       controller.instance_variable_set(:@_params, :id => node)
       controller.send(:tree_select)
-      response.should render_template('layouts/_saved_report_paging_bar')
-      controller.send(:flash_errors?).should_not be_true
-      expect(response.status).to eq(200)
+      expect(response).to                        render_template('layouts/_saved_report_paging_bar')
+      expect(controller.send(:flash_errors?)).to be_false
+      expect(response.status).to                 eq(200)
     end
   end
 

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -7,11 +7,6 @@ describe ChargebackController do
     let(:category) { FactoryGirl.create(:classification) }
     let(:tag)      { FactoryGirl.create(:classification, :parent_id => category.id) }
     let(:entry)    { FactoryGirl.create(:classification, :parent_id => tag.id) }
-    before(:each) do
-      cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
-      temp = {:cb_rate => cbr, :tag => [@tag, "vm"]}
-      ChargebackRate.set_assignments(:Storage, [temp])
-    end
 
     context "#get_tags_all" do
       before { entry }
@@ -30,6 +25,11 @@ describe ChargebackController do
     end
 
     context "#cb_assign_set_form_vars" do
+      before do
+        cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
+        ChargebackRate.set_assignments(:Storage, [{:cb_rate => cbr, :tag => [tag, "vm"]}])
+      end
+
       it "returns tag for current assignments" do
         controller.instance_variable_set(:@sb,
                                          :active_tree => :cb_assignments_tree,


### PR DESCRIPTION
- Delay creation of records to prevent creating things that aren't needed for the test
- Don't set attributes on `FactoryGirl.create` when they have defaults and don't matter for the test