### PR TITLE
Invoke #event_monitor_running once the event catcher has started

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -26,10 +26,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
 
   def monitor_events
     event_monitor_handle.start
+    event_monitor_running
     # TODO: since event_monitor_handle is returning only events that
     # are generated starting from this moment we need to pull the
     # entire # inventory to make sure that it's up-to-date.
-    event_monitor_running
     event_monitor_handle.each do |event|
       # Sleeping here is not necessary because the events are delivered
       # asynchronously when available.

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -29,6 +29,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     # TODO: since event_monitor_handle is returning only events that
     # are generated starting from this moment we need to pull the
     # entire # inventory to make sure that it's up-to-date.
+    event_monitor_running
     event_monitor_handle.each do |event|
       # Sleeping here is not necessary because the events are delivered
       # asynchronously when available.

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -37,6 +37,7 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
   def monitor_events
     event_monitor_handle.start
     event_monitor_handle.each_batch do |events|
+      event_monitor_running
       if events && !events.empty?
         _log.debug("#{log_prefix} Received events #{events.collect { |e| e.payload["event_type"] }}") if _log.debug?
         @queue.enq events

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -31,6 +31,7 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
   def monitor_events
     event_monitor_handle.start
     event_monitor_handle.each_batch do |events|
+      event_monitor_running
       @queue.enq events
       sleep_poll_normal
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -24,6 +24,7 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
   end
 
   def monitor_events
+    event_monitor_running
     event_monitor_handle.monitorEvents do |ea|
       @queue.enq(ea)
       sleep_poll_normal


### PR DESCRIPTION
This change will prevent event catchers from hanging.

Fixes #5347