### PR TITLE
Don't count begin/commit in query counts

### DIFF
--- a/spec/lib/query_counter_spec.rb
+++ b/spec/lib/query_counter_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe QueryCounter do
+  it "counts named queries" do
+    expect(QueryCounter.count { Host.first }).to eq(1)
+  end
+
+  it "counts no named queries" do
+    expect(QueryCounter.count { Host.where(:id => 1).pluck(:id) }).to eq(1)
+  end
+
+  it "doesnt count transactions" do
+    expect(QueryCounter.count { Host.transaction { Host.first ; Host.count }}).to eq(2)
+  end
+end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -6,9 +6,10 @@ class QueryCounter
   end
 
   IGNORED_STATEMENTS = %w(CACHE SCHEMA)
+  IGNORED_QUERIES    = /^(?:ROLLBACK|BEGIN|COMMIT|SAVEPOINT|RELEASE)/
 
   def callback(_name, _start, _finish, _id, payload)
-    @count += 1 unless IGNORED_STATEMENTS.include?(payload[:name])
+    @count += 1 unless IGNORED_STATEMENTS.include?(payload[:name]) || IGNORED_QUERIES.match(payload[:sql])
   end
 
   def callback_proc


### PR DESCRIPTION
Fix the number of queries reported

Before:
The count included `BEGIN` and `END` transactions. So it reported that 5 queries ran.

After:
The count ignores unnamed queries, so it reports that 3 queries ran.

---

```ruby
require "./spec/support/query_counter"
# Zone.where(:name => "zone1").destroy_all
puts QueryCounter.count { Zone.create(:name => "zone1", :description => "throw away") }
```

|name|SQL|
---|---
||`BEGIN`|
|Zone Exists|`SELECT  1 AS one FROM "zones" WHERE`|
|SQL|`INSERT INTO "zones" ("name", "description", "created_on", "updated_on")`|
|MiqServer Load|`SELECT "miq_servers".* FROM "miq_servers" WHERE`|
||`Commit`|

/cc @Fryguy 
