### PR TITLE
Allow for automate namespace and domain to have same names

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_domain_search.rb
@@ -29,8 +29,10 @@ module MiqAeEngine
     def search(uri, ns, klass, instance, method)
       unless @partial_ns.include?(ns)
         fqns = MiqAeNamespace.find_by_fqname(ns, false)
-        @fqns_id_cache[ns] = fqns.id if fqns
-        return ns if fqns
+        if fqns && !fqns.domain?
+          @fqns_id_cache[ns] = fqns.id
+          return ns
+        end
       end
       @partial_ns << ns unless @partial_ns.include?(ns)
       find_first_fq_domain(uri, ns, klass, instance, method)

--- a/lib/miq_automation_engine/models/miq_ae_class_copy.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class_copy.rb
@@ -42,7 +42,8 @@ class MiqAeClassCopy
 
   def target_ns(domain, ns)
     return "#{domain}/#{@partial_ns}" if ns.nil?
-    MiqAeNamespace.find_by_fqname(ns, false).nil? ? "#{domain}/#{ns}" : ns
+    ns_obj = MiqAeNamespace.find_by_fqname(ns, false)
+    ns_obj && !ns_obj.domain? ? ns : "#{domain}/#{ns}"
   end
 
   def copy

--- a/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
@@ -4,10 +4,8 @@ include AutomationSpecHelper
 module MiqAeDomainSearchSpec
   include MiqAeEngine
   describe MiqAeDomainSearch do
-    before do
-      MiqAeDatastore.reset
-      @user = FactoryGirl.create(:user_with_group)
-    end
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:search) { MiqAeDomainSearch.new }
 
     def create_ae_instances
       create_ae_model(:name => 'FRED', :ae_namespace => 'FRED', :ae_class => 'WILMA',
@@ -27,16 +25,14 @@ module MiqAeDomainSearchSpec
 
     it "#get_alternate_domain" do
       create_ae_instances
-      search = MiqAeDomainSearch.new
-      search.ae_user = @user
+      search.ae_user = user
       ns = search.get_alternate_domain('miqaedb', '/FRED/WILMA/DOGMATIX', 'FRED', 'WILMA', 'DOGMATIX')
       expect(ns).to eq('BARNEY/FRED')
     end
 
     it "#get_alternate_domain_method" do
       create_ae_methods
-      search = MiqAeDomainSearch.new
-      search.ae_user = @user
+      search.ae_user = user
       ns = search.get_alternate_domain_method('miqaedb', '/FRED/WILMA/OBELIX', 'FRED', 'WILMA', 'OBELIX')
       expect(ns).to eq('BARNEY/FRED')
     end

--- a/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_search_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+include AutomationSpecHelper
+module MiqAeDomainSearchSpec
+  include MiqAeEngine
+  describe MiqAeDomainSearch do
+    before do
+      MiqAeDatastore.reset
+      @user = FactoryGirl.create(:user_with_group)
+    end
+
+    def create_ae_instances
+      create_ae_model(:name => 'FRED', :ae_namespace => 'FRED', :ae_class => 'WILMA',
+                      :instance_name => 'DOGMATIX')
+      create_ae_model(:name => 'BARNEY', :ae_namespace => 'FRED', :ae_class => 'WILMA',
+                      :instance_name => 'DOGMATIX')
+    end
+
+    def create_ae_methods
+      create_ae_model_with_method(:name => 'FRED', :ae_namespace => 'FRED',
+                                  :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_script => 'x=1')
+      create_ae_model_with_method(:name => 'BARNEY', :ae_namespace => 'FRED',
+                                  :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_script => 'x=1')
+    end
+
+    it "#get_alternate_domain" do
+      create_ae_instances
+      search = MiqAeDomainSearch.new
+      search.ae_user = @user
+      ns = search.get_alternate_domain('miqaedb', '/FRED/WILMA/DOGMATIX', 'FRED', 'WILMA', 'DOGMATIX')
+      expect(ns).to eq('BARNEY/FRED')
+    end
+
+    it "#get_alternate_domain_method" do
+      create_ae_methods
+      search = MiqAeDomainSearch.new
+      search.ae_user = @user
+      ns = search.get_alternate_domain_method('miqaedb', '/FRED/WILMA/OBELIX', 'FRED', 'WILMA', 'OBELIX')
+      expect(ns).to eq('BARNEY/FRED')
+    end
+  end
+end

--- a/spec/support/automation_spec_helper.rb
+++ b/spec/support/automation_spec_helper.rb
@@ -69,7 +69,6 @@ module AutomationSpecHelper
     attrs.reverse_merge!(
       :ae_class      => 'CLASS1',
       :ae_namespace  => 'A/B/C',
-      :priority      => 10,
       :enabled       => true,
       :instance_name => 'instance1')
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1281582
    
When doing a domain search for instances, if the automate model contains a namespace which has the same name as one of the domains the search returns incorrect results.