### PR TITLE
Added logging to list the top tables in the replication backlog

### DIFF
--- a/app/models/miq_replication_worker/runner.rb
+++ b/app/models/miq_replication_worker/runner.rb
@@ -48,7 +48,10 @@ class MiqReplicationWorker::Runner < MiqWorker::Runner
     if @last_log_status.nil? || Time.now.utc > (@last_log_status + log_status_interval)
       @last_log_status = Time.now.utc
       count, added, deleted = @worker.class.check_status
-      _log.info("#{log_prefix} Replication Status: Current Backlog=[#{count}], Added=[#{added}], Deleted=[#{deleted}]")
+
+      details = count > 0 ? RrPendingChange.backlog_details : {}
+
+      _log.info("#{log_prefix} Replication Status: Current Backlog=[#{count}], Added=[#{added}], Deleted=[#{deleted}], Tables=[#{details.inspect}]")
     end
   end
 

--- a/app/models/rr_pending_change.rb
+++ b/app/models/rr_pending_change.rb
@@ -14,10 +14,7 @@ class RrPendingChange < ActiveRecord::Base
   class << self; alias_method :backlog, :count; end
 
   def self.backlog_details
-    counts = all(
-      :select => "change_table, COUNT(id) AS count_all",
-      :group  => "change_table"
-    )
+    counts = select("change_table, COUNT(id) AS count_all").group("change_table").order('count_all DESC').limit(20)
     counts.each_with_object({}) { |c, h| h[c.change_table] = c.count_all.to_i }
   end
 end

--- a/spec/factories/rr_pending_changes.rb
+++ b/spec/factories/rr_pending_changes.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :rr_pending_change do
+    change_table "miq_servers"
+    sequence(:change_key) { |n| "id|#{n}" }
+    change_type "U"
+    change_time "2015-11-10 19:19:28"
+  end
+end

--- a/spec/models/rr_pending_change_spec.rb
+++ b/spec/models/rr_pending_change_spec.rb
@@ -32,4 +32,26 @@ describe RrPendingChange do
       end
     end
   end
+
+  describe ".backlog_details" do
+    it "returns the correct counts" do
+      MiqRegion.seed
+      region = MiqRegion.my_region_number
+
+      silence_stream($stdout) do
+        ActiveRecord::Schema.define do
+          create_table "rr#{region}_pending_changes" do |t|
+            t.string    :change_table
+            t.string    :change_key
+            t.string    :change_new_key
+            t.string    :change_type
+            t.timestamp :change_time
+          end
+        end
+      end
+      FactoryGirl.create(:rr_pending_change, :change_table => "users")
+      FactoryGirl.create_list(:rr_pending_change, 2, :change_table => "miq_servers")
+      expect(described_class.backlog_details).to eq("miq_servers" => 2, "users" => 1)
+    end
+  end
 end


### PR DESCRIPTION
This will allow us to debug or improve issues with replication
by determining which tables are contributing most to the
backlog.

@gtanzillo @jrafanie 