### PR TITLE
Fix report result serialization and deserialization

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -73,17 +73,18 @@ class MiqReportResult < ActiveRecord::Base
       serializer_name = binary_blob.data_type
       serializer_name = "Marshal" unless serializer_name == "YAML"  # YAML or Marshal, for now
       serializer = serializer_name.constantize
-      MiqReport.from_hash(serializer.load(binary_blob.binary))
+      loaded = serializer.load(binary_blob.binary)
+      loaded.kind_of?(Hash) ? MiqReport.from_hash(loaded) : loaded
     elsif report.kind_of?(MiqReport)
-      return report
+      report
     else
-      return nil
+      nil
     end
   end
 
   def report_results=(value)
     self.binary_blob = BinaryBlob.new(:name => "report_results", :data_type => "YAML")
-    binary_blob.binary = YAML.dump(value.to_hash)
+    binary_blob.binary = YAML.dump(value.kind_of?(MiqReport) ? value.to_hash : value)
   end
 
   def report_html=(html)

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -1,26 +1,26 @@
 require "spec_helper"
 
 describe MiqReportResult do
-  before(:each) do
-    EvmSpecHelper.local_miq_server
+  context "persisting generated report results" do
+    before(:each) do
+      EvmSpecHelper.local_miq_server
 
-    user = FactoryGirl.create(:user_with_group)
+      user = FactoryGirl.create(:user_with_group)
 
-    5.times do |i|
-      vm = FactoryGirl.build(:vm_vmware)
-      vm.evm_owner_id = user.id               if i > 2
-      vm.miq_group_id = user.current_group.id if vm.evm_owner_id || (i > 1)
-      vm.save
+      5.times do |i|
+        vm = FactoryGirl.build(:vm_vmware)
+        vm.evm_owner_id = user.id               if i > 2
+        vm.miq_group_id = user.current_group.id if vm.evm_owner_id || (i > 1)
+        vm.save
+      end
+
+      @report_theme = 'miq'
+      @show_title   = true
+      @options = MiqReport.graph_options(600, 400)
+
+      Charting.stub(:detect_available_plugin).and_return(JqplotCharting)
     end
 
-    @report_theme = 'miq'
-    @show_title   = true
-    @options = MiqReport.graph_options(600, 400)
-
-    Charting.stub(:detect_available_plugin).and_return(JqplotCharting)
-  end
-
-  context "persisting generated report results" do
     it "should save the original report metadata and the generated table as a binary blob" do
       MiqReport.seed_report(name = "Vendor and Guest OS")
       rpt = MiqReport.where(:name => name).last
@@ -35,6 +35,44 @@ describe MiqReportResult do
       report_result.report_results.kind_of?(MiqReport).should be_true
       report_result.report_results.table.should_not be_nil
       report_result.report_results.table.data.should_not be_nil
+    end
+  end
+
+  describe "serializing and deserializing report results" do
+    it "can serialize and deserialize an MiqReport" do
+      report = FactoryGirl.build(:miq_report)
+      report_result = described_class.new
+
+      report_result.report_results = report
+
+      expect(report_result.report_results.to_hash).to eq(report.to_hash)
+    end
+
+    it "can serialize and deserialize a CSV" do
+      csv = CSV.generate { |c| c << %w(foo bar) << %w(baz qux) }
+      report_result = described_class.new
+
+      report_result.report_results = csv
+
+      expect(report_result.report_results).to eq(csv)
+    end
+
+    it "can serialize and deserialize a plain text report" do
+      txt = <<EOF
++--------------+
+|  Foo Report  |
++--------------+
+| Foo  | Bar   |
++--------------+
+| baz  | qux   |
+| quux | corge |
++--------------+
+EOF
+      report_result = described_class.new
+
+      report_result.report_results = txt
+
+      expect(report_result.report_results).to eq(txt)
     end
   end
 end


### PR DESCRIPTION
It looks like a bug was introduced in fa9984f845b0 where
`MiqReportResult.report_results=` was only expecting a `MiqReport`
object, whereas `#_async_generate_result` will send it a CSV, plain
text, or PDF. It calls `#to_hash` on the object which results in a `NoMethodError`.

As a quick fix, this commit switches on type on both the setter and
getter so that the object passed in can be serialized and deserialized correctly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1273275

***

/cc @gtanzillo 
@miq-bot add-label bug, core, reporting