### PR TITLE
Added code to only allow SSA for vmware storage records.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1791,6 +1791,11 @@ module ApplicationController::CiProcessing
     # Either a list or coming from a different controller (eg from host screen, go to its storages)
     if @lastaction == "show_list" || @layout != "storage"
       storages = find_checked_items
+
+      if method == 'scan' && !Storage.batch_operation_supported?('smartstate_analysis', storages)
+        render_flash_not_applicable_to_model('Smartstate Analysis', ui_lookup(:tables => "storage"))
+        return
+      end
       if storages.empty?
         add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "storage"), :task => display_name}, :error)
       else

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -151,7 +151,7 @@ class StorageController < ApplicationController
                                                    "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
       render_or_redirect_partial(pfx)
     else
-      if @refresh_div == "main_div" && @lastaction == "show_list"
+      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
       else
         render_flash

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1130,6 +1130,8 @@ class ApplicationHelper::ToolbarBuilder
         return "No Capacity & Utilization data has been collected for this #{ui_lookup(:table => "storages")}" unless @record.has_perf_data?
       when "storage_delete"
         return "Only #{ui_lookup(:table => "storages")} without VMs and Hosts can be removed" if @record.vms_and_templates.length > 0 || @record.hosts.length > 0
+      when "storage_scan"
+        return @record.is_available_now_error_message(:smartstate_analysis) unless @record.is_available?(:smartstate_analysis)
       end
     when "Tenant"
       return "Default Tenant can not be deleted" if @record.parent.nil? && id == "rbac_tenant_delete"

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -832,4 +832,33 @@ class Storage < ActiveRecord::Base
   def vm_scan_affinity
     with_relationship_type("vm_scan_storage_affinity") { parents }
   end
+
+  # is_available?
+  # Returns:  true or false
+  #
+  # The UI calls this method to determine if a feature is supported for this Storage
+  # and determines if a button should be displayed.  This method should return true
+  # even if a function is not 'currently' available due to some condition that is not
+  # being met.
+  def is_available?(request_type)
+    send("validate_#{request_type}")[:available]
+  end
+
+  # is_available_now_error_message
+  # Returns an error message string if there is an error.
+  # Returns nil to indicate no errors.
+  # This method is used by the UI along with the is_available? methods.
+  def is_available_now_error_message(request_type)
+    send("validate_#{request_type}")[:message]
+  end
+
+  def self.batch_operation_supported?(operation, ids)
+    Storage.where(:id => ids).all? { |s| s.public_send("validate_#{operation}")[:available] }
+  end
+
+  def validate_smartstate_analysis
+    return {:available => false, :message => "Smartstate Analysis cannot be performed on selected Datastore"} if ext_management_systems.blank? ||
+                                                     !ext_management_systems.first.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
+    {:available => true,   :message => nil}
+  end
 end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2398,6 +2398,31 @@ describe ApplicationHelper do
         it_behaves_like 'record with error message', 'smartstate_analysis'
       end
 
+      context "and id = storage_scan" do
+        before do
+          @id = "storage_scan"
+          @record = FactoryGirl.create(:storage)
+          host = FactoryGirl.create(:host_vmware,
+                                    :ext_management_system => FactoryGirl.create(:ems_vmware),
+                                    :storages              => [@record])
+        end
+
+        it "should be available for vmware storages" do
+          subject.should be(false)
+        end
+      end
+
+      context "and id = storage_scan" do
+        before do
+          @id = "storage_scan"
+          @record = FactoryGirl.create(:storage)
+        end
+
+        it "should be not be available for non-vmware storages" do
+          subject.should include('cannot be performed on selected')
+        end
+      end
+
       context "and id = vm_timeline" do
         before do
           @id = "vm_timeline"

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -411,4 +411,38 @@ describe Storage do
       end
     end
   end
+
+  context "#is_available? for Smartstate Analysis" do
+    before do
+      @storage =  FactoryGirl.create(:storage)
+    end
+
+    it "returns true for VMware Storage" do
+      FactoryGirl.create(:host_vmware,
+                         :ext_management_system => FactoryGirl.create(:ems_vmware),
+                         :storages              => [@storage])
+      expect(@storage.is_available?(:smartstate_analysis)).to eq(true)
+    end
+
+    it "returns false for non-vmware Storage" do
+      expect(@storage.is_available?(:smartstate_analysis)).to_not eq(true)
+    end
+  end
+
+  context ".batch_operation_supported?" do
+    before do
+      @storage =  FactoryGirl.create(:storage)
+    end
+
+    it "when the storage supports smarstate analysis,  returns false" do
+      expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(false)
+    end
+
+    it "when the storage perform smartstate analysis, returns true" do
+      FactoryGirl.create(:host_vmware,
+                         :ext_management_system => FactoryGirl.create(:ems_vmware),
+                         :storages              => [@storage])
+      expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
- Added similar approach that is implementd for vm_or_template records to limit smartstate analysis task for vmware storage records only.
- Added spec tests to verify the fix

https://bugzilla.redhat.com/show_bug.cgi?id=1278463

@dclarizio please review.

![vmware_ds_list](https://cloud.githubusercontent.com/assets/3450808/11137717/86ae6df0-8988-11e5-8497-101a74a1283b.png)

![non_vmware_datastore_list](https://cloud.githubusercontent.com/assets/3450808/11137719/8d096466-8988-11e5-9922-e3122eda0f54.png)

![vmware_ds_summary](https://cloud.githubusercontent.com/assets/3450808/11137721/940a43fc-8988-11e5-9145-769c2f9ee8d2.png)
![non_vmware_ds_summary](https://cloud.githubusercontent.com/assets/3450808/11137724/97e5bc22-8988-11e5-99ba-d21bea559576.png)
