### PR TITLE
Defining specific setting for openstack_infra

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -5,6 +5,10 @@ class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCat
     ManageIQ::Providers::Openstack::InfraManager
   end
 
+  def self.settings_name
+    :event_catcher_openstack_infra
+  end
+
   def self.all_valid_ems_in_zone
     require 'openstack/openstack_event_monitor'
     super.select do |ems|

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
@@ -10,4 +10,8 @@ class ManageIQ::Providers::Openstack::InfraManager::MetricsCollectorWorker < ::M
   def self.ems_class
     ManageIQ::Providers::Openstack::InfraManager
   end
+
+  def self.settings_name
+    :ems_metrics_collector_worker_openstack_infra
+  end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
@@ -4,4 +4,8 @@ class ManageIQ::Providers::Openstack::InfraManager::RefreshWorker < ::MiqEmsRefr
   def self.ems_class
     ManageIQ::Providers::Openstack::InfraManager
   end
+
+  def self.settings_name
+    :ems_refresh_worker_openstack_infra
+  end
 end


### PR DESCRIPTION
Due to class renaming and scoping, the settings_name method in
the base worker class MiqWorker, generates a bad settings name
for openstack infra.

Before there was openstack_infra in the class, now it's openstack
for both cloud and infra. So we need to explicitly specify
different settings_name for infra now.

This Bug was visible only for event collecting, since other
workers have the same settings by default.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1278470