### PR TITLE
OpenStack catch Neutron events

### DIFF
--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -298,6 +298,7 @@ workers:
           :nova: "notifications.*"
           :cinder: "notifications.*"
           :glance: "notifications.*"
+          :neutron: "notifications.*"
           :quantum: "notifications.*"
         :duration: 10.seconds
         :capacity: 50


### PR DESCRIPTION
OpenStack catch Neutron events

Implements BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1266139