### PR TITLE
accordion and quadicon styling

### DIFF
--- a/app/assets/stylesheets/miq_dynatree.scss
+++ b/app/assets/stylesheets/miq_dynatree.scss
@@ -19,6 +19,8 @@ ul.dynatree-container
 
 #accordion .panel-body {
   background-color: #f9f9f9 !important;
+  border-right: 1px solid #d4d4d4;
+  margin-right: -1px;
   padding-left: 0 !important;  /*needed so that dynatree hover effect goes to edges*/
   padding-right: 0 !important; /*needed so that dynatree hover effect goes to edges*/
 }

--- a/app/assets/stylesheets/schedule_editor.scss
+++ b/app/assets/stylesheets/schedule_editor.scss
@@ -1,6 +1,3 @@
 .button-group {
-  position: fixed;
-  bottom: 30px;
-  right: 5px;
-  z-index: 1;
+  float: right;
 }

--- a/app/assets/stylesheets/template.css.erb
+++ b/app/assets/stylesheets/template.css.erb
@@ -103,7 +103,7 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 div.panecontent .flobj { margin-left: 40px;}
 
 .flobj { position: absolute;z-index: auto;width: 72px;}
-.flobj p { margin: 0 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}
+.flobj p { margin: 5px 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}
 .a72 { padding: 3px  0 0 5px; width: 28px; height: 28px;font-size: 1.3em;line-height: 1.8em;}
 .b72 { padding: 3px 0 0 37px; font-size: 1.3em;line-height: 1.8em;}
 .c72 { padding: 38px 0 0 5px; width: 31px; height: 31px;font-size: 1.3em;line-height: 1.7em;}


### PR DESCRIPTION
* add back in right border to open accordion
* correct position of quad icon text

Old
![screen shot 2015-11-13 at 9 38 46 am](https://cloud.githubusercontent.com/assets/1287144/11148335/38c50574-89ea-11e5-82a6-feba7a9c8fab.png)
New
![screen shot 2015-11-13 at 9 38 14 am](https://cloud.githubusercontent.com/assets/1287144/11148336/38cbbeb4-89ea-11e5-8cbb-e4302499bb2a.png)

Old
![screen shot 2015-11-13 at 9 39 50 am](https://cloud.githubusercontent.com/assets/1287144/11148376/6d2a6f16-89ea-11e5-846a-be6f7a07f84b.png)
New
![screen shot 2015-11-13 at 9 40 21 am](https://cloud.githubusercontent.com/assets/1287144/11148375/6d1f45fa-89ea-11e5-9993-2d1fdf87c796.png)
