### PR TITLE
Serialize jqPlot widget chart content to yaml before saving to miq_widget_contents

### DIFF
--- a/app/models/miq_widget/chart_content.rb
+++ b/app/models/miq_widget/chart_content.rb
@@ -6,6 +6,6 @@ class MiqWidget::ChartContent < MiqWidget::ContentGeneration
     theme ||= "MIQ"
 
     report.to_chart(theme, false, MiqReport.graph_options)
-    report.chart
+    Charting.serialized report.chart
   end
 end

--- a/app/views/dashboard/_widget_chart.html.haml
+++ b/app/views/dashboard/_widget_chart.html.haml
@@ -14,8 +14,6 @@
     - if Charting.data_ok?(datum)
       -# we need to count all charts to be able to display multiple
       -# charts on a dashboard screen
-
-      - datum = widget.contents_for_user(current_user).contents
       - WidgetPresenter.chart_data.push(:xml => datum)
       - chart_index = WidgetPresenter.chart_data.length - 1
       - chart_data = YAML.load(datum) if Charting.backend == :jqplot

--- a/lib/charting.rb
+++ b/lib/charting.rb
@@ -10,6 +10,7 @@ class Charting
       :sample_chart,
       :chart_names_for_select,
       :chart_themes_for_select,
+      :serialized,
       :js_load_statement      # javascript statement to reload charts
     ] => :instance
   end

--- a/lib/charting/jqplot_charting.rb
+++ b/lib/charting/jqplot_charting.rb
@@ -52,6 +52,11 @@ class JqplotCharting < Charting
     JqplotThemes::THEMES.collect { |name, _| [name, name] }
   end
 
+  def serialized(data)
+    # ruby hash to yaml
+    data.try(:to_yaml)
+  end
+
   private
 
   def add_sample_chart_data(options, chart)

--- a/lib/charting/ziya_charting.rb
+++ b/lib/charting/ziya_charting.rb
@@ -95,6 +95,11 @@ class ZiyaCharting < Charting
     CHART_NAMES
   end
 
+  def serialized(data)
+    # already xml
+    data
+  end
+
   CHART_NAMES = [
     # ["Area",                 "Area"],
     # ["Area, Stacked",        "StackedArea"],

--- a/spec/lib/charting/jqplot_charting_spec.rb
+++ b/spec/lib/charting/jqplot_charting_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require 'charting'
+
+describe JqplotCharting do
+  subject { described_class.new }
+
+  context '#serialized' do
+    it 'should pass nil' do
+      expect(subject.serialized(nil)).to eq(nil)
+    end
+
+    it 'should yamlify hash' do
+      result = subject.serialized({:data => [], :options => {}})
+      expect(result).to start_with('---')
+      expect(result).to include(':data:')
+    end
+  end
+end

--- a/spec/lib/charting/ziya_charting_spec.rb
+++ b/spec/lib/charting/ziya_charting_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require 'charting'
+
+describe ZiyaCharting do
+  subject { described_class.new }
+
+  context '#serialized' do
+    it 'should pass nil' do
+      expect(subject.serialized(nil)).to eq(nil)
+    end
+
+    it 'should pass xml' do
+      result = subject.serialized('<?xml version="1.0" encoding="UTF-8"?><chart></chart>')
+      expect(result).to include('<chart>')
+    end
+  end
+end

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -60,4 +60,9 @@ describe "Widget Chart Content" do
     content.miq_report_result.html_rows.count { |c| c.match("<td>VMware</td>") }.should eq(3)
     widget.contents_for_user(@user).should eq(content)
   end
+
+  it '#generate returns valid data' do
+    content = widget.generate_one_content_for_user(@group, @user)
+    expect(Charting.data_ok? content.contents).to eq(true)
+  end
 end


### PR DESCRIPTION
Previously, MiqWidgetContents#contents would contain YAML-encoded data in the db

```
---
:data:
- !ruby/array:ReportFormatter::JqplotSeries
  internal:
  - 72
...
```

now it gets saved as `{:data=>[[72, 61, 53, 40, 23, 19, 17, 15, 11, 9, 99]], :options=>...`, which is wrong and leads to "Invalid chart data." message..

This PR restores the previous (YAML) behaviour..