### PR TITLE
Fix 500 when doing template SSA

### DIFF
--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -34,10 +34,4 @@ module Vm::Operations
 
     s
   end
-
-  private
-
-  def validate_unsupported(message_prefix)
-    {:available => false, :message => "#{message_prefix} is not available for #{self.class.model_suffix} VM."}
-  end
 end

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -102,4 +102,8 @@ module VmOrTemplate::Operations
     return {:available => true,   :message => nil}  if current_state.send(check_powered_on ? "==" : "!=", "on")
     {:available => false,  :message => "The VM is#{" not" if check_powered_on} powered on"}
   end
+
+  def validate_unsupported(message_prefix)
+    {:available => false, :message => "#{message_prefix} is not available for #{self.class.model_suffix} VM or Template."}
+  end
 end


### PR DESCRIPTION
The validate_unsupported was defined only on operations, so not
available for template

Fixes issue:
https://github.com/ManageIQ/manageiq/issues/5433