### PR TITLE
Add support for service accounts to Authentication for GCE

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -247,8 +247,8 @@ class EmsCloudController < ApplicationController
       amqp_password = params[:amqp_password] ? params[:amqp_password] : ems.authentication_password(:amqp)
       creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password}
     end
-    if ems.supports_authentication?(:service_account) && params[:service_account]
-      creds[:default] = {:service_account => params[:service_account], :userid => "_"}
+    if ems.supports_authentication?(:auth_key) && params[:service_account]
+      creds[:default] = {:auth_key => params[:service_account], :userid => "_"}
     end
     if ems.supports_authentication?(:oauth) && !session[:oauth_response].blank?
       auth = session[:oauth_response]

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -248,7 +248,7 @@ class EmsCloudController < ApplicationController
       creds[:amqp] = {:userid => params[:amqp_userid], :password => amqp_password}
     end
     if ems.supports_authentication?(:service_account) && params[:service_account]
-      creds[:service_account] = {:service_account => params[:service_account], :userid => "_"}
+      creds[:default] = {:service_account => params[:service_account], :userid => "_"}
     end
     if ems.supports_authentication?(:oauth) && !session[:oauth_response].blank?
       auth = session[:oauth_response]

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -896,8 +896,8 @@ module EmsCommon
     if ems.supports_authentication?(:bearer) && !@edit[:new][:bearer_token].blank?
       creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => "_"} # Must have userid
     end
-    if ems.supports_authentication?(:service_account) && !@edit[:new][:service_account].blank?
-      creds[:default] = {:service_account => @edit[:new][:service_account], :userid => "_"}
+    if ems.supports_authentication?(:auth_key) && !@edit[:new][:service_account].blank?
+      creds[:default] = {:auth_key => @edit[:new][:service_account], :userid => "_"}
     end
     ems.update_authentication(creds, :save => (mode != :validate))
   end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -897,7 +897,7 @@ module EmsCommon
       creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => "_"} # Must have userid
     end
     if ems.supports_authentication?(:service_account) && !@edit[:new][:service_account].blank?
-      creds[:service_account] = {:service_account => @edit[:new][:service_account], :userid => "_"}
+      creds[:default] = {:service_account => @edit[:new][:service_account], :userid => "_"}
     end
     ems.update_authentication(creds, :save => (mode != :validate))
   end

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -95,19 +95,19 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_authentications
-    authentications = @ems.authentications
+    authentications = @ems.authentication_for_summary
     return [{:label => "Default Authentication", :title => "None", :value => "None"}] if authentications.blank?
 
     authentications.collect do |auth|
       label =
-        case auth.authtype
+        case auth[:authtype]
         when "default" then "Default"
         when "metrics" then "C & U Database"
         when "amqp"    then "AMQP"
         else;           "<Unknown>"
         end
 
-      {:label => "#{label} Credentials", :value => auth.status || "None", :title => auth.status_details}
+      {:label => "#{label} Credentials", :value => auth[:status] || "None", :title => auth[:status_details]}
     end
   end
 

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -95,7 +95,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_authentications
-    authentications = @ems.authentication_userid_passwords
+    authentications = @ems.authentications
     return [{:label => "Default Authentication", :title => "None", :value => "None"}] if authentications.blank?
 
     authentications.collect do |auth|

--- a/app/models/auth_service_account.rb
+++ b/app/models/auth_service_account.rb
@@ -1,6 +1,0 @@
-class AuthServiceAccount < Authentication
-  def service_account=(val)
-    @auth_changed = true if val != service_account
-    super val
-  end
-end

--- a/app/models/auth_service_account.rb
+++ b/app/models/auth_service_account.rb
@@ -1,0 +1,6 @@
+class AuthServiceAccount < Authentication
+  def service_account=(val)
+    @auth_changed = true if val != service_account
+    super val
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   def supported_auth_types
     %w(
       oauth
-      service_account
+      auth_key
     )
   end
 
@@ -67,12 +67,12 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
 
     raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(options[:auth_type])
 
-    auth_key = authentication_token(options[:auth_type])
+    auth_token = authentication_token(options[:auth_type])
 
     ::Fog::Compute.new(
       :provider               => "Google",
       :google_project         => project,
-      :google_json_key_string => auth_key,
+      :google_json_key_string => auth_token,
     )
 
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -34,6 +34,10 @@ module AuthenticationMixin
     authentications.select { |a| a.kind_of?(ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair) }
   end
 
+  def authentication_service_accounts
+    authentications.select { |a| a.kind_of?(AuthServiceAccount) }
+  end
+
   def has_authentication_type?(type)
     authentication_types.include?(type)
   end
@@ -153,6 +157,10 @@ module AuthenticationMixin
         elsif self.kind_of?(ManageIQ::Providers::ContainerManager) && value[:auth_key]
           cred = AuthToken.new(:name => "#{self.class.name} #{name}", :authtype => type.to_s,
                                                :resource_id => id, :resource_type => "ExtManagementSystem")
+          authentications << cred
+        elsif self.kind_of?(ManageIQ::Providers::Google::CloudManager) && value[:service_account]
+          cred = AuthServiceAccount.new(:name => "#{self.class.name} #{name}", :authtype => type.to_s,
+                                        :type => "AuthServiceAccount")
           authentications << cred
         else
           cred = authentications.build(:name => "#{self.class.name} #{name}", :authtype => type.to_s,
@@ -295,7 +303,7 @@ module AuthenticationMixin
   end
 
   def available_authentications
-    authentication_userid_passwords + authentication_key_pairs + authentication_tokens
+    authentication_userid_passwords + authentication_key_pairs + authentication_tokens + authentication_service_accounts
   end
 
   def authentication_types

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -34,6 +34,18 @@ module AuthenticationMixin
     authentications.select { |a| a.kind_of?(ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair) }
   end
 
+  def authentication_for_summary
+    summary = []
+    authentications.each do |a|
+      summary << {
+        :authtype       => a.authtype,
+        :status         => a.status,
+        :status_details => a.status_details
+      }
+    end
+    summary
+  end
+
   def has_authentication_type?(type)
     authentication_types.include?(type)
   end
@@ -75,7 +87,7 @@ module AuthenticationMixin
   end
 
   def authentication_status
-    ordered_auths = authentication_userid_passwords.sort_by(&:status_severity)
+    ordered_auths = authentications.sort_by(&:status_severity)
     ordered_auths.last.try(:status) || "None"
   end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -229,7 +229,7 @@ describe EmsCloudController do
                                        :amqp_password    => amqp_creds[:password])
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
-      expect(mocked_ems).to receive(:supports_authentication?).with(:service_account)
+      expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
       expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
     end
 
@@ -241,7 +241,7 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:authentication_password).with(:amqp).and_return(amqp_creds[:password])
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
-      expect(mocked_ems).to receive(:supports_authentication?).with(:service_account)
+      expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
       expect(controller.send(:build_credentials, mocked_ems)).to eq(:default => default_creds, :amqp => amqp_creds)
     end
   end


### PR DESCRIPTION
Add supporting classes for service account authentication used
by Google Compute Engine

@Fryguy can you check that this is correct?  The default credential type for GCE is AuthServiceAccount not AuthUseridPassword which seems to be different than other providers.  With `creds[:service_account]` anyone calling `authentication_best_fit` would return nil.

cc @blomquisg 