### PR TITLE
Without this, :silence and :warn go to kernel

### DIFF
--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -17,6 +17,10 @@ module Vmdb
       instance.respond_to?(method)
     end
 
+    class << self
+      delegate :silence, :warn, :to => :instance
+    end
+
     private
 
     def self.evm_log


### PR DESCRIPTION
@gmcculloug tried to use silence in a rspec test to prevent deprecation warnings from being displayed in the test output while testing code that is expected to warn automate users of deprecated accessors.  Unfortunately he found that he was getting the wrong `.silence` method.

Before:
```ruby
irb(main):001:0> Vmdb::Deprecation.silence { Vmdb::Deprecation.deprecation_warning("aaa", "bbb") }; nil
ArgumentError: wrong number of arguments (0 for 1)
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/activesupport/lib/active_support/core_ext/kernel/reporting.rb:89:in `capture'
	from (irb):1
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/railties/lib/rails/commands/console.rb:110:in `start'
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/railties/lib/rails/commands/console.rb:9:in `start'
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/railties/lib/rails/commands/commands_tasks.rb:68:in `console'
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/railties/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /home/bdunne/.gem/ruby/2.2.2/bundler/gems/rails-e2fcb2b4aec6/railties/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

After:
```ruby
irb(main):001:0> Vmdb::Deprecation.silence { Vmdb::Deprecation.deprecation_warning("aaa", "bbb") }; nil
=> nil
```