### PR TITLE
Ensure validate_smartstate_analysis is defined for templates.

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -10,4 +10,8 @@ class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers:
       :message => 'Perform SmartState Analysis on this Image'
     }
   end
+
+  def validate_smartstate_analysis
+    validate_unsupported("Smartstate Analysis")
+  end
 end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -45,8 +45,4 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   def raise_created_event
     MiqEvent.raise_evm_event(self, "vm_create", :vm => self)
   end
-
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
-  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -49,4 +49,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
   def has_proxy?
     true
   end
+
+  def validate_smartstate_analysis
+    validate_supported_check("Smartstate Analysis")
+  end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -44,10 +44,6 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     validate_unsupported("Migrate")
   end
 
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
-  end
-
   # Show Reconfigure VM task
   def reconfigurable?
     true

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb
@@ -28,6 +28,10 @@ module ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared::Scanning
     sync_stashed_metadata(ost)
   end
 
+  def validate_smartstate_analysis
+    validate_supported_check("Smartstate Analysis")
+  end
+
   private
 
   # Moved from MIQExtract.rb

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -31,10 +31,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     validate_supported
   end
 
-  def validate_smartstate_analysis
-    validate_supported_check("Smartstate Analysis")
-  end
-
   #
   # Show Reconfigure VM task
   def reconfigurable?

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -28,6 +28,10 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
     sync_stashed_metadata(ost)
   end
 
+  def validate_smartstate_analysis
+    validate_supported_check("Smartstate Analysis")
+  end
+
   private
 
   # Moved from MIQExtract.rb


### PR DESCRIPTION
By default, validate_smartstate_analysis will return false.
So, we must ensure that the default method is overridden for all
supported types - VMs and Templates.

https://bugzilla.redhat.com/show_bug.cgi?id=1281887