### PR TITLE
Fixed condition in show_adv_search? method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1108,7 +1108,7 @@ module ApplicationHelper
                      orchestration_stack repository resource_pool retired security_group service
                      snia_local_file_system storage storage_manager templates vm)
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
-      (@explorer && tree_with_advanced_search? && !@record)
+      (@explorer && x_tree && tree_with_advanced_search? && !@record)
   end
 
   def need_prov_dialogs?(type)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1482,6 +1482,30 @@ describe ApplicationHelper do
     end
   end
 
+  context "#show_adv_search?" do
+    it 'should return false for explorer screen with no trees such as automate/simulation' do
+      controller.instance_variable_set(:@explorer, true)
+      controller.instance_variable_set(:@sb, {})
+      result = helper.show_adv_search?
+      result.should be_false
+    end
+
+    it 'should return true for VM explorer trees' do
+      controller.instance_variable_set(:@explorer, true)
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :vms_instances_filter_tree,
+                                       :trees       => {
+                                         :vms_instances_filter_tree => {
+                                           :tree => :vms_instances_filter_tree,
+                                           :type => :vms_instances_filter
+                                         }
+                                       }
+      )
+      result = helper.show_adv_search?
+      result.should be_true
+    end
+  end
+
   context "#show_advanced_search?" do
     it 'should return true for VM explorer trees' do
       controller.instance_variable_set(:@sb,


### PR DESCRIPTION
- Some explorer screens such as Automate/Simulation do not have tree on the left, there is no need to check whether to display advanced search on those screens.
- Added spec test to verify fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1281860

@dclarizio please review