### PR TITLE
Add autofocus, and current users name to SSUI

### DIFF
--- a/spa_ui/self_service/client/app/components/autofocus/autofocus.directive.js
+++ b/spa_ui/self_service/client/app/components/autofocus/autofocus.directive.js
@@ -19,9 +19,9 @@
     return directive;
 
     function link(scope, element) {
-      $timeout(focus, 1);
+      $timeout(setFocus, 1);
 
-      function focus() {
+      function setFocus() {
         element[0].focus();
       }
     }

--- a/spa_ui/self_service/client/app/components/autofocus/autofocus.directive.js
+++ b/spa_ui/self_service/client/app/components/autofocus/autofocus.directive.js
@@ -1,0 +1,29 @@
+(function() {
+  'use strict';
+
+  /*
+  A few browsers still in use today do not fully support HTML5s 'autofocus'.
+
+  This directive is redundant for browsers that do but has no negative effects.
+   */
+  angular.module('app.components')
+    .directive('autofocus', AutofocusDirective);
+
+  /** @ngInject */
+  function AutofocusDirective($timeout) {
+    var directive = {
+      restrict: 'A',
+      link: link
+    };
+
+    return directive;
+
+    function link(scope, element) {
+      $timeout(focus, 1);
+
+      function focus() {
+        element[0].focus();
+      }
+    }
+  }
+})();

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
@@ -24,10 +24,11 @@
     }
 
     /** @ngInject */
-    function HeaderNavController(Text, Navigation, Messages, API_BASE) {
+    function HeaderNavController(Text, Navigation, Messages, Session, API_BASE) {
       var vm = this;
 
       vm.text = Text.app;
+      vm.user = Session.currentUser;
 
       vm.activate = activate;
       vm.toggleNavigation = toggleNavigation;

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.html
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.html
@@ -15,7 +15,7 @@
   <nav class="collapse navbar-collapse">
     <ul class="nav navbar-nav">
       <li>
-        <a ng-href="{{vm.API_BASE}}" target="_blank" class="nav-item-iconic nav-item-iconic-new-window">          
+        <a ng-href="{{vm.API_BASE}}" target="_blank" class="nav-item-iconic nav-item-iconic-new-window">
           <i class="fa fa-external-link" tooltip="Log into the full administrative UI" tooltip-placement="bottom" tooltip-append-to-body="true"></i>
         </a>
       </li>
@@ -23,7 +23,7 @@
     <ul class="nav navbar-nav navbar-right navbar-iconic">
       <li dropdown>
         <a dropdown-toggle class="nav-item-iconic">
-          <i title="Username" class="fa pficon-user"></i>
+          <i title="{{ ::vm.user().name }}" class="fa pficon-user"></i>
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -8,14 +8,16 @@
   function SessionFactory($http, moment) {
     var model = {
       token: null,
-      expiresOn: moment().subtract(1, 'seconds')
+      expiresOn: moment().subtract(1, 'seconds'),
+      user: {}
     };
 
     var service = {
       current: model,
       create: create,
       destroy: destroy,
-      active: active
+      active: active,
+      currentUser: currentUser
     };
 
     destroy();
@@ -31,7 +33,16 @@
     function destroy() {
       model.token = null;
       model.expiresOn = moment().subtract(1, 'seconds');
+      model.user = {};
       delete $http.defaults.headers.common['X-Auth-Token'];
+    }
+
+    function currentUser(user) {
+      if (angular.isDefined(user)) {
+        model.user = user;
+      }
+
+      return model.user;
     }
 
     // Helpers

--- a/spa_ui/self_service/client/app/states/login/login.html
+++ b/spa_ui/self_service/client/app/states/login/login.html
@@ -12,7 +12,7 @@
             <label for="inputUsername" class="col-sm-2 col-md-2 control-label">Username</label>
 
             <div class="col-sm-10 col-md-10">
-              <input type="text" ng-model="vm.credentials.login" class="form-control" id="inputUsername">
+              <input type="text" ng-model="vm.credentials.login" class="form-control" id="inputUsername" autofocus>
             </div>
           </div>
           <!--/.form-group-*-->

--- a/spa_ui/self_service/client/app/states/login/login.state.js
+++ b/spa_ui/self_service/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session) {
     var vm = this;
 
     vm.title = 'Login';
@@ -43,7 +43,18 @@
       AuthenticationApi.login(vm.credentials.login, vm.credentials.password).then(handleSuccess);
 
       function handleSuccess() {
+        var options = {expand: 'resources', filter: ['userid=' + vm.credentials.login]};
+
+        CollectionsApi.query('users', options).then(handleUserInfo);
         $state.go('dashboard');
+
+        function handleUserInfo(data) {
+          if (!data.resources || 0 == data.resources.length) {
+            return Session.currentUser({name: 'Unknown User', email: ''});
+          }
+
+          Session.currentUser({name: data.resources[0].name, email: data.resources[0].email});
+        }
       }
     }
   }

--- a/spa_ui/self_service/client/app/states/login/login.state.js
+++ b/spa_ui/self_service/client/app/states/login/login.state.js
@@ -49,7 +49,7 @@
         $state.go('dashboard');
 
         function handleUserInfo(data) {
-          if (!data.resources || 0 == data.resources.length) {
+          if (!data.resources || 0 === data.resources.length) {
             return Session.currentUser({name: 'Unknown User', email: ''});
           }
 

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -97,6 +97,7 @@
   <script src="/client/app/blocks/pub-sub/pub-sub.factory.js"></script>
   <script src="/client/app/blocks/recursion/recursion-helper.factory.js"></script>
   <script src="/client/app/blocks/router/router-helper.provider.js"></script>
+  <script src="/client/app/components/autofocus/autofocus.directive.js"></script>
   <script src="/client/app/components/confirmation/confirmation.directive.js"></script>
   <script src="/client/app/components/custom-button/custom-button.directive.js"></script>
   <script src="/client/app/components/dialog-content/dialog-content.directive.js"></script>


### PR DESCRIPTION
- Using the 'autofocus' HTML5 attribute with directive fallback
- After a successful login fire off a filtered users query to fetch the current users info
- Only the current users name and email are being captured.

Closes #5413 
@dclarizio 