### PR TITLE
Azure template vm provisioning from private images

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
@@ -1,0 +1,26 @@
+#
+# Description: provide the dynamic list content from available flavors
+#
+flavor_list = {}
+service_template = $evm.root.attributes["service_template"]
+if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
+  service_template.orchestration_manager.flavors.each { |f| flavor_list[f.name] = f.name }
+end
+flavor_list[nil] = flavor_list.empty? ? "<None>" : "<Choose>"
+
+dialog_field = $evm.object
+
+# sort_by: value / description / none
+dialog_field["sort_by"] = "description"
+
+# sort_order: ascending / descending
+dialog_field["sort_order"] = "ascending"
+
+# data_type: string / integer
+dialog_field["data_type"] = "string"
+
+# required: true / false
+dialog_field["required"] = "true"
+
+dialog_field["values"] = flavor_list
+dialog_field["default_value"] = nil

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Flavors
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
@@ -1,0 +1,35 @@
+#
+# Description: provide the dynamic list content from available images
+#
+image_list = {}
+service_template = $evm.root.attributes["service_template"]
+if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
+  service_template.orchestration_manager.miq_templates.each do |img|
+    os = img.hardware.try(:guest_os) || "unknown"
+    image_list[img.uid_ems] = "#{os} | #{img.name}"
+  end
+end
+if image_list.empty?
+  image_list[nil] = "<None>"
+elsif image_list.size > 1
+  image_list[nil] = "<Choose>"
+else
+  default_value = image_list.first.first
+end
+
+dialog_field = $evm.object
+
+# sort_by: value / description / none
+dialog_field["sort_by"] = "description"
+
+# sort_order: ascending / descending
+dialog_field["sort_order"] = "ascending"
+
+# data_type: string / integer
+dialog_field["data_type"] = "string"
+
+# required: true / false
+dialog_field["required"] = "true"
+
+dialog_field["values"] = image_list
+dialog_field["default_value"] = default_value

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Images
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.rb
@@ -1,0 +1,28 @@
+#
+# Description: provide the dynamic list content from available operating systems
+#
+os_list = {'unknown' => '<Unknown>', 'linux' => 'Linux', 'windows' => 'Windows'}
+selected_os = 'unknown'
+
+image_name = $evm.root["dialog_param_userImageName"]
+if image_name.present?
+  selected_img = $evm.vmdb(:miq_template).find_by_uid_ems(image_name)
+  selected_os = (selected_img.hardware.try(:guest_os) || "unknown").downcase
+end
+
+dialog_field = $evm.object
+
+# sort_by: value / description / none
+dialog_field["sort_by"] = "description"
+
+# sort_order: ascending / descending
+dialog_field["sort_order"] = "ascending"
+
+# data_type: string / integer
+dialog_field["data_type"] = "string"
+
+# required: true / false
+dialog_field["required"] = "true"
+
+dialog_field["values"] = os_list
+dialog_field["default_value"] = selected_os

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Os_Types
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
@@ -13,13 +13,13 @@ dialog_field = $evm.object
 dialog_field["sort_by"] = "description"
 
 # sort_order: ascending / descending
-# dialog_field["sort_order"] = "ascending"
+dialog_field["sort_order"] = "ascending"
 
 # data_type: string / integer
 dialog_field["data_type"] = "string"
 
 # required: true / false
-# dialog_field["required"] = "true"
+dialog_field["required"] = "false"
 
 dialog_field["values"] = rg_list
 dialog_field["default_value"] = nil

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
@@ -13,13 +13,13 @@ dialog_field = $evm.object
 dialog_field["sort_by"] = "description"
 
 # sort_order: ascending / descending
-# dialog_field["sort_order"] = "ascending"
+dialog_field["sort_order"] = "ascending"
 
 # data_type: string / integer
 dialog_field["data_type"] = "string"
 
 # required: true / false
-# dialog_field["required"] = "true"
+dialog_field["required"] = "false"
 
 dialog_field["values"] = tenant_list
 dialog_field["default_value"] = nil

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_flavors.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_flavors.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Flavors
+    name: Available_Flavors
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: Available_Flavors
+

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_images.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_images.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Images
+    name: Available_Images
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: Available_Images
+

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_os_types.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_os_types.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Os_Types
+    name: Available_Os_Types
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: Available_Os_Types
+

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
     expose :ems_folders,    :association => true
     expose :resource_pools, :association => true
     expose :tenant,         :association => true
+    expose :miq_templates,  :association => true
     expose :to_s
     expose :authentication_userid
     expose :authentication_password

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-template.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Azure_CloudManager_Template < MiqAeServiceManageIQ_Providers_CloudManager_Template
+  end
+end

--- a/product/dialogs/service_dialogs/azure-single-vm-from-user-image.yml
+++ b/product/dialogs/service_dialogs/azure-single-vm-from-user-image.yml
@@ -1,0 +1,433 @@
+---
+- description: 
+  buttons: submit,cancel
+  label: azure-single-vm-from-user-image
+  dialog_tabs:
+  - description: 
+    display: edit
+    label: Basic Information
+    display_method: 
+    display_method_options: 
+    position: 0
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Options
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: tenant_name
+        description: Tenant where the stack will be deployed
+        type: DialogFieldDropDownList
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: []
+        values_method: 
+        values_method_options: {}
+        options: {}
+        label: Tenant
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/Orchestration/Operations
+          ae_class: Methods
+          ae_instance: Available_Tenants
+          ae_message: 
+          ae_attributes: {}
+      - name: stack_name
+        description: Name of the stack
+        type: DialogFieldTextBox
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: ''
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Stack Name
+        position: 1
+        validator_type: regex
+        validator_rule: "^[A-Za-z][A-Za-z0-9\\-]*$"
+        reconfigurable: 
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: resource_group
+        description: Select an existing resource group for deployment
+        type: DialogFieldDropDownList
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: []
+        values_method: 
+        values_method_options: {}
+        options: {}
+        label: Existing Resource Group
+        position: 2
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/Orchestration/Operations
+          ae_class: Methods
+          ae_instance: Available_Resource_Groups
+          ae_message: 
+          ae_attributes: {}
+      - name: new_resource_group
+        description: Create a new resource group upon deployment
+        type: DialogFieldTextBox
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: ''
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: "(or) New Resource Group"
+        position: 3
+        validator_type: regex
+        validator_rule: "^[A-Za-z][A-Za-z0-9\\-_]*$"
+        reconfigurable: 
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: deploy_mode
+        description: Select deployment mode
+        type: DialogFieldDropDownList
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: Incremental
+        values:
+        - - Complete
+          - Complete
+        - - Incremental
+          - Incremental
+        values_method: 
+        values_method_options: {}
+        options:
+          :sort_by: :description
+          :sort_order: :ascending
+        label: Mode
+        position: 4
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+    - description: 
+      display: edit
+      label: Parameters
+      display_method: 
+      display_method_options: 
+      position: 1
+      dialog_fields:
+      - name: param_virtualMachineName
+        description: Name of the virtual machine
+        type: DialogFieldTextBox
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: ''
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Virtual Machine Name
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: param_adminUserName
+        description: Administrator user name for the virtual machine
+        type: DialogFieldTextBox
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: ''
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Admin User Name
+        position: 1
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: param_adminPassword
+        description: Password for the administrator
+        type: DialogFieldTextBox
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: ''
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: true
+        label: Admin Password
+        position: 2
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: 
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: param_userImageName
+        description: The image used to provision the virtual machine
+        type: DialogFieldDropDownList
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: []
+        values_method: 
+        values_method_options: {}
+        options: {}
+        label: User Image Name
+        position: 3
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: true
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/Orchestration/Operations
+          ae_class: Methods
+          ae_instance: Available_Images
+          ae_message: 
+          ae_attributes: {}
+      - name: param_operatingSystemType
+        description: Operating system of the virtual machine
+        type: DialogFieldDropDownList
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: []
+        values_method: 
+        values_method_options: {}
+        options: {}
+        label: Operating System Type
+        position: 4
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: 
+        auto_refresh: true
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/Orchestration/Operations
+          ae_class: Methods
+          ae_instance: Available_Os_Types
+          ae_message: 
+          ae_attributes: {}
+      - name: param_virtualMachineSize
+        description: Standard size of the virtual machine
+        type: DialogFieldDropDownList
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: []
+        values_method: 
+        values_method_options: {}
+        options: {}
+        label: Virtual Machine Size
+        position: 5
+        validator_type: 
+        validator_rule: 
+        reconfigurable: true
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/Orchestration/Operations
+          ae_class: Methods
+          ae_instance: Available_Flavors
+          ae_message: 
+          ae_attributes: {}

--- a/product/orchestration_templates/azure-single-vm-from-user-image.yml
+++ b/product/orchestration_templates/azure-single-vm-from-user-image.yml
@@ -1,0 +1,156 @@
+---
+:name: azure-single-vm-from-user-image
+:type: OrchestrationTemplateAzure
+:description: Create a single VM from an user image. No public IP is assigned
+:content: |
+  {
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "virtualMachineName": {
+        "type": "string",
+        "metadata": {
+          "description": "Name of the virtual machine"
+        }
+      },
+      "adminUserName": {
+        "type": "string",
+        "metadata": {
+          "description": "Administrator user name for the virtual machine"
+        }
+      },
+      "adminPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "Password for the administrator"
+        }
+      },
+      "userImageName": {
+        "type": "string",
+        "metadata": {
+          "description": "The image used to provision the virtual machine"
+        }
+      },
+      "operatingSystemType": {
+        "type": "string",
+        "allowedValues": [
+          "windows",
+          "linux"
+        ],
+        "metadata": {
+          "description": "Operating system of the virtual machine"
+        }
+      },
+      "virtualMachineSize": {
+        "type": "string",
+        "metadata": {
+          "description": "Standard size of the virtual machine"
+        }
+      }
+    },
+    "variables": {
+      "location": "[resourceGroup().location]",
+      "virtualNetworkName": "myVNET",
+      "nicName": "[concat(parameters('virtualMachineName'),'-nic')]",
+      "addressPrefix": "10.0.0.0/16",
+      "subnet1Name": "Subnet-1",
+      "subnet1Prefix": "10.0.0.0/24",
+      "publicIPAddressType": "Dynamic",
+      "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+      "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+      "storageAccount": "[split(parameters('userImageName'),'.')[0]]",
+      "osDiskVhdName": "[concat(variables('storageAccount'),'.blob.core.windows.net/vhds/',parameters('virtualMachineName'),'-osDisk.vhd')]"
+    },
+    "resources": [
+      {
+        "apiVersion": "2015-05-01-preview",
+        "type": "Microsoft.Network/virtualNetworks",
+        "name": "[variables('virtualNetworkName')]",
+        "location": "[variables('location')]",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "[variables('addressPrefix')]"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "[variables('subnet1Name')]",
+              "properties": {
+                "addressPrefix": "[variables('subnet1Prefix')]"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2015-05-01-preview",
+        "type": "Microsoft.Network/networkInterfaces",
+        "name": "[variables('nicName')]",
+        "location": "[variables('location')]",
+        "dependsOn": [
+          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        ],
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "[variables('subnet1Ref')]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2015-06-15",
+        "type": "Microsoft.Compute/virtualMachines",
+        "name": "[parameters('virtualMachineName')]",
+        "location": "[variables('location')]",
+        "dependsOn": [
+          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        ],
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[parameters('virtualMachineSize')]"
+          },
+          "osProfile": {
+            "computername": "[parameters('virtualMachineName')]",
+            "adminUsername": "[parameters('adminUserName')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "storageProfile": {
+            "osDisk": {
+              "name": "[concat(parameters('virtualMachineName'),'-osDisk')]",
+              "osType": "[parameters('operatingSystemType')]",
+              "caching": "ReadWrite",
+              "createOption": "FromImage",
+              "image": {
+                "uri": "[parameters('userImageName')]"
+              },
+              "vhd": {
+                "uri": "[variables('osDiskVhdName')]"
+              }
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+              }
+            ]
+          },
+          "diagnosticsProfile": {
+            "bootDiagnostics": {
+               "enabled": "true",
+               "storageUri": "[concat(variables('storageAccount'),'.blob.core.windows.net')]"
+            }
+          }
+        }
+      }
+    ]
+  }
+draft: f

--- a/spec/automation/unit/method_validation/available_flavors_spec.rb
+++ b/spec/automation/unit/method_validation/available_flavors_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe "Available_Flavors Method Validation" do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:default_desc) { "<None>" }
+  before do
+    @ins = "/Cloud/Orchestration/Operations/Methods/Available_Flavors"
+  end
+
+  context "workspace has no service template" do
+    it "provides only default value to the flavor list" do
+      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+
+  context "workspace has service template other than orchestration" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+
+    it "provides only default value to the flavor list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+
+  context "workspace has orchestration service template" do
+    let(:ems) do
+      @flavor1 = FactoryGirl.create(:flavor, :name => 'flavor1')
+      @flavor2 = FactoryGirl.create(:flavor, :name => 'flavor2')
+      FactoryGirl.create(:ems_openstack, :flavors => [@flavor1, @flavor2])
+    end
+
+    let(:service_template) do
+      FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_template_no_ems) do
+      FactoryGirl.create(:service_template_orchestration)
+    end
+
+    it "finds all the flavors and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      ws.root["values"].should include(
+        nil           => "<Choose>",
+        @flavor1.name => @flavor1.name,
+        @flavor2.name => @flavor2.name
+      )
+      ws.root["default_value"].should be_nil
+    end
+
+    it "provides only default value to the flavor list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+end

--- a/spec/automation/unit/method_validation/available_images_spec.rb
+++ b/spec/automation/unit/method_validation/available_images_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe "Available_Images Method Validation" do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:default_desc) { "<None>" }
+  before do
+    @ins = "/Cloud/Orchestration/Operations/Methods/Available_Images"
+  end
+
+  context "workspace has no service template" do
+    it "provides only default value to the image list" do
+      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+
+  context "workspace has service template other than orchestration" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+
+    it "provides only default value to the image list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+
+  context "workspace has orchestration service template" do
+    let(:service_template) do
+      hw1 = FactoryGirl.create(:hardware, :guest_os => 'windows')
+      @img1 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid1', :hardware => hw1)
+
+      hw2 = FactoryGirl.create(:hardware, :guest_os => 'linux')
+      @img2 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid2', :hardware => hw2)
+
+      ems = FactoryGirl.create(:ems_openstack, :miq_templates => [@img1, @img2])
+      FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_template_one_img) do
+      @img1 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid1')
+      ems = FactoryGirl.create(:ems_openstack, :miq_templates => [@img1])
+      FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_template_no_ems) do
+      FactoryGirl.create(:service_template_orchestration)
+    end
+
+    it "finds all the images and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      ws.root["values"].should include(
+        nil           => "<Choose>",
+        @img1.uid_ems => "windows | #{@img1.name}",
+        @img2.uid_ems => "linux | #{@img2.name}"
+      )
+      ws.root["default_value"].should be_nil
+    end
+
+    it "finds the only image and set it as the only item in the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_one_img.id}", user)
+      ws.root["values"].should include(
+        @img1.uid_ems => "unknown | #{@img1.name}"
+      )
+      ws.root["default_value"].should == @img1.uid_ems
+    end
+
+    it "provides only default value to the image list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+end

--- a/spec/automation/unit/method_validation/available_os_types_spec.rb
+++ b/spec/automation/unit/method_validation/available_os_types_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "Available_Os_Types Method Validation" do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  os_list = {'unknown' => '<Unknown>', 'linux' => 'Linux', 'windows' => 'Windows'}
+  before do
+    @ins = "/Cloud/Orchestration/Operations/Methods/Available_Os_Types"
+  end
+
+  let(:service_template) do
+    hw1 = FactoryGirl.create(:hardware, :guest_os => 'windows')
+    @img1 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid1', :hardware => hw1)
+
+    hw2 = FactoryGirl.create(:hardware, :guest_os => 'linux')
+    @img2 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid2', :hardware => hw2)
+
+    ems = FactoryGirl.create(:ems_openstack, :miq_templates => [@img1, @img2])
+    FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
+  end
+
+  it "provides all os types and default to unknown" do
+    ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+    ws.root["values"].should include(os_list)
+    ws.root["default_value"].should == 'unknown'
+  end
+
+  it "provides all os types and auto selects the type based on the user selection of an image" do
+    ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}&dialog_param_userImageName=uid1", user)
+    ws.root["values"].should include(os_list)
+    ws.root["default_value"].should == 'windows'
+  end
+end

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Available_Resource_Groups Method Validation" do
   let(:user) { FactoryGirl.create(:user_with_group) }
-  let(:default_value) { "<New resource group>" }
+  let(:default_desc) { "<New resource group>" }
   before do
     @ins = "/Cloud/Orchestration/Operations/Methods/Available_Resource_Groups"
   end
@@ -10,7 +10,7 @@ describe "Available_Resource_Groups Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => default_value}
+      ws.root["values"].should == {nil => default_desc}
     end
   end
 
@@ -19,7 +19,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => default_value}
+      ws.root["values"].should == {nil => default_desc}
     end
   end
 
@@ -41,7 +41,7 @@ describe "Available_Resource_Groups Method Validation" do
     it "finds all the resource groups and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
       ws.root["values"].should include(
-        nil           => default_value,
+        nil           => default_desc,
         @rgroup1.name => @rgroup1.name,
         @rgroup2.name => @rgroup2.name
       )
@@ -49,7 +49,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_value}
+      ws.root["values"].should == {nil => default_desc}
     end
   end
 end


### PR DESCRIPTION
1. Prepared a sample Azure template for private image provisioning
2. Seed the template through `OrchestrationTemplate.seed`
3. Create a service dialog from the template and modify to use dynamic dropdown list for private images and flavors.
4. Seed the above dialog by exporting the dialog and dropping to the `service_dialog` folder
5. Create automate methods to fill above dynamic dropdown lists.