### PR TITLE
Hide SSA button for Archived VMs.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -824,6 +824,7 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_refresh"
         return true if @record && !@record.ext_management_system && !(@record.host && @record.host.vmm_product.downcase == "workstation")
       when "vm_scan", "instance_scan"
+        return true unless @record.is_available?(:smartstate_analysis) || @record.is_available_now_error_message(:smartstate_analysis)
         return true unless @record.has_proxy?
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"
         return true unless @perf_options[:typ] == "realtime"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1536,7 +1536,10 @@ describe ApplicationHelper do
       context "and id = vm_scan" do
         before do
           @id = "vm_scan"
+          @record = FactoryGirl.create(:vm_vmware)
           @record.stub(:has_proxy?).and_return(true)
+          @record.stub(:archived? => false)
+          @record.stub(:orphaned? => false)
         end
 
         it "and !@record.has_proxy?" do
@@ -1546,6 +1549,11 @@ describe ApplicationHelper do
 
         it "and @record.has_proxy?" do
           subject.should == false
+        end
+
+        it "and @record.has_proxy? and is archived" do
+          @record.stub(:archived? => true)
+          subject.should == true
         end
       end
 


### PR DESCRIPTION
- Added code to hide SSA button for archived VMs, toolbar button should be hidden when available is false & message is nil.
- Added spec test to verify fix

https://bugzilla.redhat.com/show_bug.cgi?id=1271359

@roliveri please review/test.

This PR fixes an issue where archived VMs still showed SSA button as available.
- Button should be hidden when availability of button is false and there is no message.
- Button should be disabled when availability of button is false and has a message to let user know why the button is not available.
- Button should be enabled when availability is true.