### PR TITLE
Create MiqAeMethodService::Deprecation for automation deprecations

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -1,4 +1,10 @@
 module MiqAeMethodService
+  class Deprecation < Vmdb::Deprecation
+    def self.default_log
+      $miq_ae_logger
+    end
+  end
+
   class MiqAeServiceFront
     include DRbUndumped
     def find(id)


### PR DESCRIPTION
Refactor Vmdb::Deprecation to allow others to inherit from it and easily change the logger

```
irb(main):001:0> MiqAeMethodService::Deprecation.deprecation_warning("aaaaa", "bbbbb")
DEPRECATION WARNING: aaaaa is deprecated and will be removed from ManageIQ D-release (bbbbb). (called from irb_binding at (irb):2)
=> "aaaaa is deprecated and will be removed from ManageIQ D-release (bbbbb)"

-------------------------
==> log/evm.log <==
[----] I, [2015-11-13T16:59:07.204905 #22250:3ff85d399988]  INFO -- : MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2015-11-13T16:59:08.149577 #22250:3ff85d399988]  INFO -- : MIQ(Vmdb::Initializer.init) - Program Name: bin/rails, PID: 22250, ENV['MIQ_GUID']: , ENV['EVMSERVER']: 
[----] W, [2015-11-13T16:59:21.779492 #22250:3ff85d399988]  WARN -- : <AutomationEngine> DEPRECATION WARNING: aaaaa is deprecated and will be removed from ManageIQ D-release (bbbbb). (called from irb_binding at (irb):1)

==> log/automation.log <==
[----] W, [2015-11-13T16:59:21.779689 #22250:3ff85d399988]  WARN -- : DEPRECATION WARNING: aaaaa is deprecated and will be removed from ManageIQ D-release (bbbbb). (called from irb_binding at (irb):1)

```