### PR TITLE
Update compliance spec

### DIFF
--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -2,56 +2,56 @@ require "spec_helper"
 
 describe Compliance do
   context "A small virtual infrastructure" do
-    before(:each) do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems   = FactoryGirl.create(:ems_vmware,    :name => "Test EMS", :zone => @zone)
-      @host1 = FactoryGirl.create(:host,      :name => "Host1", :ext_management_system => @ems)
-      @host2 = FactoryGirl.create(:host,      :name => "Host2")
-      @vm1   = FactoryGirl.create(:vm_vmware, :name => "VM1", :host => @host1, :ext_management_system => @ems)
-    end
+    let(:ems_vmware) { FactoryGirl.create(:ems_vmware,    :name => "Test EMS", :zone => zone) }
+    let(:host1)      { FactoryGirl.create(:host,      :name => "Host1", :ext_management_system => ems_vmware) }
+    let(:host2)      { FactoryGirl.create(:host,      :name => "Host2") }
+    let(:vm1)        { FactoryGirl.create(:vm_vmware, :name => "VM1", :host => host1, :ext_management_system => ems_vmware) }
+    let(:zone)       { FactoryGirl.build(:zone) }
+
+    before { allow(MiqServer).to receive(:my_zone).and_return(zone) }
 
     it "should queue single vm for compliance" do
-      Compliance.check_compliance_queue(@vm1)
+      Compliance.check_compliance_queue(vm1)
 
       MiqQueue.count.should == 1
       msg = MiqQueue.first
-      validate_compliance_message(msg, @vm1)
+      validate_compliance_message(msg, vm1)
     end
 
     it "should queue single vm for compliance via vm method" do
-      @vm1.check_compliance_queue
+      vm1.check_compliance_queue
 
       MiqQueue.count.should == 1
       msg = MiqQueue.first
-      validate_compliance_message(msg, @vm1)
+      validate_compliance_message(msg, vm1)
     end
 
     it "should queue single host for compliance" do
-      Compliance.check_compliance_queue(@host1)
+      Compliance.check_compliance_queue(host1)
 
       MiqQueue.count.should == 1
       msg = MiqQueue.first
-      validate_compliance_message(msg, @host1)
+      validate_compliance_message(msg, host1)
     end
 
     it "should queue single host for compliance via host method" do
-      @host1.check_compliance_queue
+      host1.check_compliance_queue
 
       MiqQueue.count.should == 1
       msg = MiqQueue.first
-      validate_compliance_message(msg, @host1)
+      validate_compliance_message(msg, host1)
     end
 
     it "should queue multiple objects for compliance" do
-      Compliance.check_compliance_queue([@vm1, @host1])
+      Compliance.check_compliance_queue([vm1, host1])
 
       MiqQueue.count.should == 2
       MiqQueue.all.each do |qitem|
         klass, id = qitem.args.first
         target = klass.constantize.find(id)
         case target
-        when Vm then   target.should == @vm1
-        when Host then target.should == @host1
+        when Vm then   target.should == vm1
+        when Host then target.should == host1
         end
         validate_compliance_message(qitem, target)
       end
@@ -59,38 +59,38 @@ describe Compliance do
 
     it "should queue multiple objects for compliance with inputs" do
       inputs = {:foo => 'bar'}
-      Compliance.check_compliance_queue([@vm1, @host1], inputs)
+      Compliance.check_compliance_queue([vm1, host1], inputs)
 
       MiqQueue.count.should == 2
       MiqQueue.all.each do |qitem|
         klass, id = qitem.args.first
         target = klass.constantize.find(id)
         case target
-        when Vm then   target.should == @vm1
-        when Host then target.should == @host1
+        when Vm then   target.should == vm1
+        when Host then target.should == host1
         end
         validate_compliance_message(qitem, target, inputs)
       end
     end
 
     it "should queue single host for scan_and_check_compliance via host method" do
-      @host1.scan_and_check_compliance_queue
+      host1.scan_and_check_compliance_queue
 
       MiqQueue.count.should == 1
       msg = MiqQueue.first
-      validate_scan_and_check_compliance_message(msg, @host1)
+      validate_scan_and_check_compliance_message(msg, host1)
     end
 
     it "should queue multiple objects for scan_and_check_compliance" do
-      Compliance.scan_and_check_compliance_queue([@vm1, @host1, @host2])
+      Compliance.scan_and_check_compliance_queue([vm1, host1, host2])
 
       MiqQueue.count.should == 2
       MiqQueue.all.each do |qitem|
         klass, id = qitem.args.first
         target = klass.constantize.find(id)
         case id
-        when @host1.id then target.should == @host1
-        when @host2.id then target.should == @host2
+        when host1.id then target.should == host1
+        when host2.id then target.should == host2
         end
         validate_scan_and_check_compliance_message(qitem, target)
       end
@@ -98,15 +98,15 @@ describe Compliance do
 
     it "should queue multiple objects for scan_and_check_compliance with inputs" do
       inputs = {:foo => 'bar'}
-      Compliance.scan_and_check_compliance_queue([@vm1, @host1, @host2], inputs)
+      Compliance.scan_and_check_compliance_queue([vm1, host1, host2], inputs)
 
       MiqQueue.count.should == 2
       MiqQueue.all.each do |qitem|
         klass, id = qitem.args.first
         target = klass.constantize.find(id)
         case id
-        when @host1.id then target.should == @host1
-        when @host2.id then target.should == @host2
+        when host1.id then target.should == host1
+        when host2.id then target.should == host2
         end
         validate_scan_and_check_compliance_message(qitem, target, inputs)
       end
@@ -114,8 +114,8 @@ describe Compliance do
 
     context ".scan_and_check_compliance" do
       it "should raise event request_host_scan" do
-        MiqEvent.should_receive(:raise_evm_event).with(@host1, "request_host_scan", {}, {})
-        Compliance.scan_and_check_compliance([@host1.class.name, @host1.id])
+        MiqEvent.should_receive(:raise_evm_event).with(host1, "request_host_scan", {}, {})
+        Compliance.scan_and_check_compliance([host1.class.name, host1.id])
       end
     end
 
@@ -127,25 +127,25 @@ describe Compliance do
         @p.sync_events([event])
         @p.conditions << FactoryGirl.create(:condition, :expression => MiqExpression.new("IS NOT EMPTY" => {"field" => "Vm-id"}))
         ps.add_member(@p)
-        @ems.add_policy(ps)
+        ems_vmware.add_policy(ps)
       end
 
       context "VM" do
         it "compliant" do
-          expect(MiqEvent).to receive(:raise_evm_event_queue).with(@vm1, "vm_compliance_passed")
-          expect(Compliance.check_compliance(@vm1)).to be_true
+          expect(MiqEvent).to receive(:raise_evm_event_queue).with(vm1, "vm_compliance_passed")
+          expect(Compliance.check_compliance(vm1)).to be_true
         end
 
         it "non-compliant" do
           @p.conditions << FactoryGirl.create(:condition, :expression => MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"}))
 
-          expect(MiqEvent).to receive(:raise_evm_event_queue).with(@vm1, "vm_compliance_failed")
-          expect(Compliance.check_compliance(@vm1)).to be_false
+          expect(MiqEvent).to receive(:raise_evm_event_queue).with(vm1, "vm_compliance_failed")
+          expect(Compliance.check_compliance(vm1)).to be_false
         end
       end
 
       context "template" do
-        before { @template = FactoryGirl.create(:template_vmware, :name => "Template 1", :host => @host1, :ext_management_system => @ems) }
+        before { @template = FactoryGirl.create(:template_vmware, :name => "Template 1", :host => host1, :ext_management_system => ems_vmware) }
 
         it "compliant" do
           expect(MiqEvent).to receive(:raise_evm_event_queue).with(@template, "vm_compliance_passed")

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -51,41 +51,43 @@ describe Compliance do
       end
     end
 
-    it "should queue single host for scan_and_check_compliance via host method" do
-      host1.scan_and_check_compliance_queue
+    context ".scan_and_check_compliance_queue" do
+      it "should queue single host for scan_and_check_compliance via host method" do
+        host1.scan_and_check_compliance_queue
 
-      expect(MiqQueue.count).to eq(1)
-      validate_scan_and_check_compliance_message(MiqQueue.first, host1)
-    end
-
-    it "should queue multiple objects for scan_and_check_compliance" do
-      Compliance.scan_and_check_compliance_queue([vm1, host1, host2])
-
-      expect(MiqQueue.count).to eq(2)
-      MiqQueue.all.each do |qitem|
-        klass, id = qitem.args.first
-        target = klass.constantize.find(id)
-        case id
-        when host1.id then target.should == host1
-        when host2.id then target.should == host2
-        end
-        validate_scan_and_check_compliance_message(qitem, target)
+        expect(MiqQueue.count).to eq(1)
+        validate_scan_and_check_compliance_message(MiqQueue.first, host1)
       end
-    end
 
-    it "should queue multiple objects for scan_and_check_compliance with inputs" do
-      inputs = {:foo => 'bar'}
-      Compliance.scan_and_check_compliance_queue([vm1, host1, host2], inputs)
+      it "should queue multiple objects for scan_and_check_compliance" do
+        Compliance.scan_and_check_compliance_queue([vm1, host1, host2])
 
-      expect(MiqQueue.count).to eq(2)
-      MiqQueue.all.each do |qitem|
-        klass, id = qitem.args.first
-        target = klass.constantize.find(id)
-        case id
-        when host1.id then target.should == host1
-        when host2.id then target.should == host2
+        expect(MiqQueue.count).to eq(2)
+        MiqQueue.all.each do |qitem|
+          klass, id = qitem.args.first
+          target = klass.constantize.find(id)
+          case id
+          when host1.id then target.should == host1
+          when host2.id then target.should == host2
+          end
+          validate_scan_and_check_compliance_message(qitem, target)
         end
-        validate_scan_and_check_compliance_message(qitem, target, inputs)
+      end
+
+      it "should queue multiple objects for scan_and_check_compliance with inputs" do
+        inputs = {:foo => 'bar'}
+        Compliance.scan_and_check_compliance_queue([vm1, host1, host2], inputs)
+
+        expect(MiqQueue.count).to eq(2)
+        MiqQueue.all.each do |qitem|
+          klass, id = qitem.args.first
+          target = klass.constantize.find(id)
+          case id
+          when host1.id then target.should == host1
+          when host2.id then target.should == host2
+          end
+          validate_scan_and_check_compliance_message(qitem, target, inputs)
+        end
       end
     end
 

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -14,32 +14,28 @@ describe Compliance do
       Compliance.check_compliance_queue(vm1)
 
       MiqQueue.count.should == 1
-      msg = MiqQueue.first
-      validate_compliance_message(msg, vm1)
+      validate_compliance_message(MiqQueue.first, vm1)
     end
 
     it "should queue single vm for compliance via vm method" do
       vm1.check_compliance_queue
 
       MiqQueue.count.should == 1
-      msg = MiqQueue.first
-      validate_compliance_message(msg, vm1)
+      validate_compliance_message(MiqQueue.first, vm1)
     end
 
     it "should queue single host for compliance" do
       Compliance.check_compliance_queue(host1)
 
       MiqQueue.count.should == 1
-      msg = MiqQueue.first
-      validate_compliance_message(msg, host1)
+      validate_compliance_message(MiqQueue.first, host1)
     end
 
     it "should queue single host for compliance via host method" do
       host1.check_compliance_queue
 
       MiqQueue.count.should == 1
-      msg = MiqQueue.first
-      validate_compliance_message(msg, host1)
+      validate_compliance_message(MiqQueue.first, host1)
     end
 
     it "should queue multiple objects for compliance" do
@@ -77,8 +73,7 @@ describe Compliance do
       host1.scan_and_check_compliance_queue
 
       MiqQueue.count.should == 1
-      msg = MiqQueue.first
-      validate_scan_and_check_compliance_message(msg, host1)
+      validate_scan_and_check_compliance_message(MiqQueue.first, host1)
     end
 
     it "should queue multiple objects for scan_and_check_compliance" do

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe Compliance do
   context "A small virtual infrastructure" do
-    let(:ems_vmware) { FactoryGirl.create(:ems_vmware,    :name => "Test EMS", :zone => zone) }
-    let(:host1)      { FactoryGirl.create(:host,      :name => "Host1", :ext_management_system => ems_vmware) }
-    let(:host2)      { FactoryGirl.create(:host,      :name => "Host2") }
-    let(:vm1)        { FactoryGirl.create(:vm_vmware, :name => "VM1", :host => host1, :ext_management_system => ems_vmware) }
+    let(:ems_vmware) { FactoryGirl.create(:ems_vmware, :zone => zone) }
+    let(:host1)      { FactoryGirl.create(:host, :ext_management_system => ems_vmware) }
+    let(:host2)      { FactoryGirl.create(:host) }
+    let(:vm1)        { FactoryGirl.create(:vm_vmware, :host => host1, :ext_management_system => ems_vmware) }
     let(:zone)       { FactoryGirl.build(:zone) }
 
     before { allow(MiqServer).to receive(:my_zone).and_return(zone) }


### PR DESCRIPTION
- Only FactoryGirl.create when necessary
- Let FactoryGirl handle naming
- Reduce duplication
- Use expectations to reduce database calls
- Correct contexts