### PR TITLE
[FIX BUILD] declare net-scp dependency

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -31,6 +31,7 @@ gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
+gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=0.2.0",            :require => false
 gem "ovirt",                   "~>0.7.0",           :require => false


### PR DESCRIPTION
Looks like gem `net-scp` was never declared.

It was used by fog gem. So the issue was never noticed.
Recent version of fog no longer require this library, so the build is now failing.