### PR TITLE
create tools/ci for travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,23 +23,9 @@ matrix:
 addons:
   postgresql: '9.4'
 before_install:
-- '[[ -z "$SPA_UI" ]] || nvm install 0.12'
-- 'echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc'
-- travis_retry gem install bundler -v ">= 1.8.4"
-- "[[ -f certs/v2_key.dev ]] && cp certs/v2_key.dev certs/v2_key"
-- '[[ -z "$GEM" ]] || cd gems/$GEM'
-- '[[ -n "$GEM" ]] || echo "1" > REGION'
-- '[[ -n "$GEM" ]] || cp config/database.pg.yml config/database.yml'
-- '[[ -n "$GEM" ]] || psql -c "CREATE USER root SUPERUSER PASSWORD ''smartvm'';" -U postgres'
-- '[[ -n "$GEM" ]] || export BUNDLE_WITHOUT=development'
-- export BUNDLE_GEMFILE=$PWD/Gemfile
+- source ${TRAVIS_BUILD_DIR}/tools/ci/before_install.sh
 before_script:
-- '[[ -z "$SPA_UI" ]] || pushd spa_ui/$SPA_UI'
-- '[[ -z "$SPA_UI" ]] || npm install bower gulp -g'
-- '[[ -z "$SPA_UI" ]] || npm install'
-- '[[ -z "$SPA_UI" ]] || npm version'
-- '[[ -z "$SPA_UI" ]] || popd'
-- '[[ -z "$TEST_SUITE" ]] || bundle exec rake test:$TEST_SUITE:setup'
+- source ${TRAVIS_BUILD_DIR}/tools/ci/before_script.sh
 script:
 - bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}
 notifications:

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,0 +1,21 @@
+# source this and dont run it
+# this can change:
+#   BUNDLE_GEMFILE
+#   BUNDLE_WITHOUT
+#   PWD
+
+echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
+travis_retry gem install bundler -v ">= 1.8.4"
+
+if [[ -n "${GEM}" ]] ; then
+  cd gems/${GEM}
+else
+  [[ -z "${SPA_UI}" ]] || nvm install 0.12
+
+  [[ -f certs/v2_key.dev ]] && cp certs/v2_key.dev certs/v2_key
+  echo "1" > REGION
+  cp config/database.pg.yml config/database.yml
+  psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
+  export BUNDLE_WITHOUT=development
+fi
+export BUNDLE_GEMFILE=${PWD}/Gemfile

--- a/tools/ci/before_script.sh
+++ b/tools/ci/before_script.sh
@@ -1,0 +1,11 @@
+
+if [[ -n "$TEST_SUITE" ]] ; then
+  if [[ -n "$SPA_UI" ]] ; then
+    pushd spa_ui/$SPA_UI
+      npm install bower gulp -g
+      npm install
+      npm version
+    popd
+  fi
+  bundle exec rake test:$TEST_SUITE:setup
+fi


### PR DESCRIPTION
move travis build scripts into a script

/cc @matthewd While I'm not ready to go forward with conditional build, I do agree that we need to get this logic out of `.travis.yml` (have been testing with this since Oct 6)

extracted from #4663 

*TANGENT:* I think changing `$BUNDLE_GEMFILE ` may be screwing up our bundle cache, and costing us over a minute per build target, thinking that our gems have always changed.