### PR TITLE
BZ1230655 - Fix for flash message not being displayed at all on invalid import file selection

### DIFF
--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -1,27 +1,6 @@
 //= require import
 
 var Automate = {
-  listenForAutomatePostMessages: function() {
-    window.addEventListener('message', function(event) {
-      miqSparkleOff();
-      clearMessages();
-
-      var importFileUploadId = event.data.import_file_upload_id;
-
-      if (importFileUploadId) {
-        Automate.getAndRenderAutomateJson(importFileUploadId, event.data.message);
-      } else {
-        var messageData = JSON.parse(event.data.message);
-
-        if (messageData.level == 'warning') {
-          showWarningMessage(messageData.message);
-        } else {
-          showErrorMessage(messageData.message);
-        }
-      }
-    });
-  },
-
   getAndRenderAutomateJson: function(importFileUploadId, message) {
     $('.hidden-import-file-upload-id').val(importFileUploadId);
 
@@ -41,7 +20,7 @@ var Automate = {
     })
     .fail(function(failedMessage) {
       var messageData = JSON.parse(failedMessage.responseText);
-      
+
       if (messageData.level == 'warning') {
         showWarningMessage(messageData.message);
       } else {

--- a/app/assets/javascripts/dialog_import_export.js
+++ b/app/assets/javascripts/dialog_import_export.js
@@ -1,26 +1,5 @@
 //= require import
 
-var listenForDialogPostMessages = function() {
-  window.addEventListener('message', function(event) {
-    miqSparkleOff();
-    clearMessages();
-
-    var importFileUploadId = event.data.import_file_upload_id;
-
-    if (importFileUploadId) {
-      getAndRenderServiceDialogJson(importFileUploadId, event.data.message);
-    } else {
-      var messageData = JSON.parse(event.data.message);
-
-      if (messageData.level == 'warning') {
-        showWarningMessage(messageData.message);
-      } else {
-        showErrorMessage(messageData.message);
-      }
-    }
-  });
-};
-
 var renderServiceDialogJson = function(rows_json, importFileUploadId) {
   var statusFormatter = function(row, cell, value, columnDef, dataContext) {
     var status_img = "<img src=/images/icons/16/" + dataContext.status_icon + ".png >";

--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -5,6 +5,34 @@
 //= require slickgrid/plugins/slick.rowselectionmodel
 //= require slickgrid/plugins/slick.checkboxselectcolumn
 
+var ImportSetup = {
+  listenForPostMessages: function(getAndRenderJsonCallback) {
+    window.addEventListener('message', function(event) {
+      ImportSetup.respondToPostMessages(event, getAndRenderJsonCallback);
+    });
+  },
+
+  respondToPostMessages: function(event, getAndRenderJsonCallback) {
+    miqSparkleOff();
+    clearMessages();
+
+    var importFileUploadId = event.data.import_file_upload_id;
+
+    if (importFileUploadId) {
+      getAndRenderJsonCallback(importFileUploadId, event.data.message);
+    } else {
+      var unencodedMessage = event.data.message.replace(/&quot;/g, '"');
+      var messageData = JSON.parse(unencodedMessage);
+
+      if (messageData.level == 'warning') {
+        showWarningMessage(messageData.message);
+      } else {
+        showErrorMessage(messageData.message);
+      }
+    }
+  }
+};
+
 var setUpImportClickHandlers = function(url, grid, importCallback) {
   $('.import-commit').click(function() {
     miqSparkleOn();

--- a/app/assets/javascripts/widget_import_export.js
+++ b/app/assets/javascripts/widget_import_export.js
@@ -1,26 +1,5 @@
 //= require import
 
-var listenForWidgetPostMessages = function() {
-  window.addEventListener('message', function(event) {
-    miqSparkleOff();
-    clearMessages();
-
-    var importFileUploadId = event.data.import_file_upload_id;
-
-    if (importFileUploadId) {
-      getAndRenderWidgetJson(importFileUploadId, event.data.message);
-    } else {
-      var messageData = JSON.parse(event.data.message);
-
-      if (messageData.level == 'warning') {
-        showWarningMessage(messageData.message);
-      } else {
-        showErrorMessage(messageData.message);
-      }
-    }
-  });
-};
-
 var getAndRenderWidgetJson = function(importFileUploadId, message) {
   $('.hidden-import-file-upload-id').val(importFileUploadId);
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -311,7 +311,7 @@ class ReportController < ApplicationController
       end
     end
 
-    redirect_options[:message] = @flash_array.first.to_json
+    redirect_options[:message] = @flash_array.first
 
     redirect_to redirect_options
   end

--- a/app/views/miq_ae_customization/_dialog_import_export.html.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.html.haml
@@ -54,5 +54,5 @@
       miqSparkleOn();
     });
 
-    listenForDialogPostMessages();
+    ImportSetup.listenForPostMessages(getAndRenderServiceDialogJson);
   });

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -83,6 +83,6 @@
       miqSparkleOn();
     });
 
-    Automate.listenForAutomatePostMessages();
+    ImportSetup.listenForPostMessages(Automate.getAndRenderAutomateJson);
     Automate.setUpAutomateImportClickHandlers();
   });

--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -75,7 +75,7 @@
     });
 
     setUpExportWidgetClickHandlers();
-    listenForWidgetPostMessages();
+    ImportSetup.listenForPostMessages(getAndRenderWidgetJson);
     setUpImportWidgetClickHandlers();
 
     if ($('#toolbar').length > 0) {

--- a/app/views/report/review_import.html.haml
+++ b/app/views/report/review_import.html.haml
@@ -1,7 +1,7 @@
 :javascript
   var postMessageData = {
     import_file_upload_id: '#{j(@import_file_upload_id)}',
-    message: '#{@message.to_json.html_safe}'
+    message: '#{j(@message.to_json)}'
   };
 
   $(function() {

--- a/app/views/report/review_import.html.haml
+++ b/app/views/report/review_import.html.haml
@@ -1,7 +1,7 @@
 :javascript
   var postMessageData = {
     import_file_upload_id: '#{j(@import_file_upload_id)}',
-    message: '#{j(@message)}'
+    message: '#{@message.to_json.html_safe}'
   };
 
   $(function() {

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -914,7 +914,7 @@ describe ReportController do
         xhr :post, :upload_widget_import_file, params
         response.should redirect_to(
           :action  => :review_import,
-          :message => {:message => "Use the browse button to locate an import file", :level => :warning}.to_json
+          :message => {:message => "Use the browse button to locate an import file", :level => :warning}
         )
       end
     end
@@ -939,7 +939,7 @@ describe ReportController do
           response.should redirect_to(
             :action                => :review_import,
             :import_file_upload_id => 123,
-            :message               => {:message => "Import file was uploaded successfully", :level => :info}.to_json
+            :message               => {:message => "Import file was uploaded successfully", :level => :info}
           )
         end
 
@@ -961,7 +961,7 @@ describe ReportController do
             :message => {
               :message => "Error: the file uploaded is not of the supported format",
               :level   => :error
-            }.to_json
+            }
           )
         end
       end
@@ -978,7 +978,7 @@ describe ReportController do
             :message => {
               :message => "Error: the file uploaded contains no widgets",
               :level   => :error
-            }.to_json
+            }
           )
         end
       end

--- a/spec/javascripts/import_spec.js
+++ b/spec/javascripts/import_spec.js
@@ -1,4 +1,87 @@
 describe('import.js', function() {
+  describe('ImportSetup', function() {
+    describe('#respondToPostMessages', function() {
+      var test = {
+        callback: function(uploadId, message) { }
+      };
+
+      beforeEach(function() {
+        spyOn(test, 'callback');
+        spyOn(window, 'miqSparkleOff');
+        spyOn(window, 'clearMessages');
+        spyOn(window, 'showWarningMessage');
+        spyOn(window, 'showErrorMessage');
+      });
+
+      context('when the import file upload id exists', function() {
+        beforeEach(function() {
+          var event = {
+            data: {
+              import_file_upload_id: 123,
+              message: 'the message'
+            }
+          };
+
+          ImportSetup.respondToPostMessages(event, test.callback);
+        });
+
+        it('turns the sparkle off', function() {
+          expect(window.miqSparkleOff).toHaveBeenCalled();
+        });
+
+        it('clears the messages', function() {
+          expect(window.clearMessages).toHaveBeenCalled();
+        });
+
+        it('triggers the callback', function() {
+          expect(test.callback).toHaveBeenCalledWith(123, 'the message');
+        });
+      });
+
+      context('when the import file upload id does not exist', function() {
+        var event = {data: {import_file_upload_id: ''}};
+
+        context('when the message level is warning', function() {
+          beforeEach(function() {
+            event.data.message = '{&quot;message&quot;:&quot;lol&quot;,&quot;level&quot;:&quot;warning&quot;}';
+            ImportSetup.respondToPostMessages(event, test.callback);
+          });
+
+          it('turns the sparkle off', function() {
+            expect(window.miqSparkleOff).toHaveBeenCalled();
+          });
+
+          it('clears the messages', function() {
+            expect(window.clearMessages).toHaveBeenCalled();
+          });
+
+          it('displays a warning message with the message', function() {
+            expect(window.showWarningMessage).toHaveBeenCalledWith('lol');
+          });
+        });
+
+        context('when the message level is not warning', function() {
+          beforeEach(function() {
+            event.data.message = '{&quot;message&quot;:&quot;lol2&quot;,&quot;level&quot;:&quot;error&quot;}';
+            ImportSetup.respondToPostMessages(event, test.callback);
+          });
+
+          it('turns the sparkle off', function() {
+            expect(window.miqSparkleOff).toHaveBeenCalled();
+          });
+
+          it('clears the messages', function() {
+            expect(window.clearMessages).toHaveBeenCalled();
+          });
+
+          it('displays an error message with the message', function() {
+            expect(window.showErrorMessage).toHaveBeenCalledWith('lol2');
+          });
+        });
+      });
+    });
+  });
+
   describe('#clearMessages', function() {
     beforeEach(function() {
       var html = '';


### PR DESCRIPTION
At first BZ1230655 was the flash message was somehow disappearing which was not reproducible, but with the latest 5.5 build the flash message wasn't appearing at all. The JSON was being html escaped and was giving a JS error.

https://bugzilla.redhat.com/show_bug.cgi?id=1230655

@romanblanco I noticed you were the one who initially changed the haml to encode the ruby being set in the javascript, but I think this change should be fine as we're directly converting the ruby into JSON and then doing html_safe. Thoughts?

@dclarizio Please Review