### PR TITLE
Fix view toolbar buttons in Cloud provider instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2618,4 +2618,5 @@ class ApplicationController < ActionController::Base
   def restful?
     false
   end
+  public :restful?
 end

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -284,4 +284,5 @@ class EmsCloudController < ApplicationController
   def restful?
     true
   end
+  public :restful?
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1336,6 +1336,19 @@ class ApplicationHelper::ToolbarBuilder
     false
   end
 
+  def url_for_save_button(name, url_tpl)
+    url = safer_eval(url_tpl)
+
+    if %w(view_grid view_tile view_list).include?(name)
+      # blows up in sub screens for CI's, need to get rid of first directory and anything after last slash in @gtl_url, that's being manipulated in JS function
+      url.gsub!(/^\/[a-z|A-Z|0-9|_|-]+/, "")
+      ridx = url.rindex('/')
+      url = url.slice(0..ridx - 1) if ridx
+    end
+
+    url
+  end
+
   def build_toolbar_save_button(item, props, parent = nil)
     button = item.key?(:buttonTwoState) ? item[:buttonTwoState] : (item.key?(:buttonSelect) ? item[:buttonSelect] : item[:button])
     button = parent + "__" + button if parent # Prefix with "parent__" if parent is passed in
@@ -1347,16 +1360,7 @@ class ApplicationHelper::ToolbarBuilder
       :onwhen  => item[:onwhen]
     )
 
-    if item[:url]
-      url = safer_eval(item[:url])
-      if %w(view_grid view_tile view_list).include?(props[:name])
-        # blows up in sub screens for CI's, need to get rid of first directory and anything after last slash in @gtl_url, that's being manipulated in JS function
-        url.gsub!(/^\/[a-z|A-Z|0-9|_|-]+/, "")
-        ridx = url.rindex('/')
-        url = url.slice(0..ridx - 1) if ridx
-      end
-      props[:url] = url
-    end
+    props[:url] = url_for_save_button(button, item[:url]) if item[:url]
 
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
     if item[:popup]

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1336,6 +1336,21 @@ class ApplicationHelper::ToolbarBuilder
     false
   end
 
+  def controller_restful?
+    # want to be able to cache false, so no ||=
+    return @_restful_cache unless @_restful_cache.nil?
+
+    @_restful_cache = (
+      obj = @view_binding.receiver
+
+      if obj.respond_to? :controller
+        obj.controller.try(:restful?)
+      else
+        obj.try(:restful?)
+      end
+    )
+  end
+
   def url_for_save_button(name, url_tpl, controller_restful)
     url = safer_eval(url_tpl)
 
@@ -1363,7 +1378,7 @@ class ApplicationHelper::ToolbarBuilder
       :onwhen  => item[:onwhen]
     )
 
-    props[:url] = url_for_save_button(button, item[:url], @view_binding.eval('controller.try(:restful?)')) if item[:url]
+    props[:url] = url_for_save_button(button, item[:url], controller_restful?) if item[:url]
 
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
     if item[:popup]

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1336,7 +1336,7 @@ class ApplicationHelper::ToolbarBuilder
     false
   end
 
-  def url_for_save_button(name, url_tpl)
+  def url_for_save_button(name, url_tpl, controller_restful)
     url = safer_eval(url_tpl)
 
     if %w(view_grid view_tile view_list).include?(name)
@@ -1344,6 +1344,9 @@ class ApplicationHelper::ToolbarBuilder
       url.gsub!(/^\/[a-z|A-Z|0-9|_|-]+/, "")
       ridx = url.rindex('/')
       url = url.slice(0..ridx - 1) if ridx
+
+      # handle restful routes - we want just / if the url is just an id
+      url = '/' if controller_restful && url =~ %r{^\/(\d+|\d+r\d+)\?$}
     end
 
     url
@@ -1360,7 +1363,7 @@ class ApplicationHelper::ToolbarBuilder
       :onwhen  => item[:onwhen]
     )
 
-    props[:url] = url_for_save_button(button, item[:url]) if item[:url]
+    props[:url] = url_for_save_button(button, item[:url], @view_binding.eval('controller.try(:restful?)')) if item[:url]
 
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
     if item[:popup]

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2798,6 +2798,12 @@ describe ApplicationHelper do
       it "saves the value as it is otherwise" do
         subject.should have_key(:url)
       end
+
+      it "calls url_for_save_button" do
+        b = _toolbar_builder
+        expect(b).to receive(:url_for_save_button).and_call_original
+        b.send(:build_toolbar_save_button, @item, @item_out)
+      end
     end
   end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2807,6 +2807,35 @@ describe ApplicationHelper do
     end
   end
 
+  describe "url_for_save_button" do
+    context "when restful routes" do
+      before do
+        controller.stub(:restful?) { true }
+      end
+
+      it "returns / when button is 'view_grid', 'view_tile' or 'view_list'" do
+        result = url_for_save_button('view_list', '/ems_cloud/1r2?', true)
+        expect(result).to eq('/')
+      end
+
+      it "supports compressed ids" do
+        result = url_for_save_button('view_list', '/ems_cloud/1?', true)
+        expect(result).to eq('/')
+      end
+    end
+
+    context "when restless routes" do
+      before do
+        controller.stub(:restful?) { false }
+      end
+
+      it "gets rid of first directory and anything after last slash when button is 'view_grid', 'view_tile' or 'view_list'" do
+        result = url_for_save_button('view_list', '/some/path/to/the/testing/code', false)
+        expect(result).to eq('/path/to/the/testing')
+      end
+    end
+  end
+
   describe "update_url_parms", :type => :request do
     context "when the given parameter exists in the request query string" do
       before do


### PR DESCRIPTION
In Cloud > Provider > (click on provider) > Instances... when you click on a view_tb button (list view, grid view, ..), it goes back to provider detail..

The button needs to go from `/ems_cloud/1?display=instances` to `/ems_cloud/1?display=instances&type=list`, but omitting `display=instances` works too. Right now, it goes to `/ems_cloud/1?/1?type=list` which is broken.

Previously, the logic was that `@gtl_url` was set to `/ems_cloud/show/1`, and `build_toolbar_save_button` would make that into `:url => '/show'`, which would make `miqToolbarOnClick` go to `/ems_cloud/show/1?type=list`. But since 52458a65 (convert EmsCloudController to use restful routes), `@gtl_url` is just `/ems_cloud/1?` which makes `build_toolbar_save_button` return `:url => '/1?'`.

https://bugzilla.redhat.com/show_bug.cgi?id=1281345