### PR TITLE
containers: fix openshift enterprise event parser

### DIFF
--- a/app/models/manageiq/providers/openshift_enterprise/container_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openshift_enterprise/container_manager/event_parser.rb
@@ -1,3 +1,3 @@
-module ManageIQ::Providers::Atomic::ContainerManager::EventParser
+module ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::EventParser
   include ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
 end


### PR DESCRIPTION
@blomquisg can you check this? I think it was tiny mistake that slipped through when we added the OpenShift Enterprise provider. Thanks.