### PR TITLE
tune Storage#ext_management_systems

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -72,7 +72,8 @@ class Storage < ActiveRecord::Base
   end
 
   def ext_management_systems
-    @ext_management_systems ||= Host.includes(:storages).select { |h| h.storages.include?(self) }.collect(&:ext_management_system).compact.uniq
+    @ext_management_systems ||= ExtManagementSystem.joins(:hosts => :storages).where(
+      :host_storages => {:storage_id => id}).uniq.to_a
   end
 
   def ext_management_systems_in_zone(zone_name)


### PR DESCRIPTION
Stumbled upon this and it was too low hanging to not do.

```
before: 8 queries, 10,816 objects, 773.5k (34ms)
after:  1 query,      462 objects,  36.5k (22ms)
```

/cc @dmetzger57 