### PR TITLE
Optimize storages cache pt 2

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -372,7 +372,7 @@ class Storage < ActiveRecord::Base
   # storages to get total_unmanaged_vms in a report or view is optimized
   cache_with_timeout(:total_unmanaged_vms, 15.seconds) do
     StorageFile.all(
-      :select     => "COUNT(id) AS storage_file_count, storage_id",
+      :select     => "COUNT(*) AS storage_file_count, storage_id",
       :conditions => {:ext_name => "vmx", :vm_or_template_id => nil},
       :group      => :storage_id
     ).each_with_object(Hash.new(0)) { |sf, h| h[sf.storage_id] = sf.storage_file_count.to_i }
@@ -388,7 +388,7 @@ class Storage < ActiveRecord::Base
     snap_clause  = "AND #{ActiveRecordQueryParts.not_regexp("base_name", "%\-[0-9][0-9][0-9][0-9][0-9][0-9]\.vmdk")}"
 
     StorageFile.all(
-      :select     => "COUNT(id) AS storage_file_count, storage_id",
+      :select     => "COUNT(*) AS storage_file_count, storage_id",
       :conditions => "ext_name = 'vmdk' AND #{flat_clause} AND #{delta_clause} #{snap_clause}",
       :group      => :storage_id
     ).each_with_object(Hash.new(0)) { |sf, h| h[sf.storage_id] = sf.storage_file_count.to_i }
@@ -409,7 +409,7 @@ class Storage < ActiveRecord::Base
   cache_with_timeout(:unmanaged_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
       :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(id) AS vm_count, storage_id",
+      :select     => "COUNT(*) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
   end
@@ -425,7 +425,7 @@ class Storage < ActiveRecord::Base
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
       :conditions => ["((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(id) AS vm_count, storage_id",
+      :select     => "COUNT(*) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
   end
@@ -441,7 +441,7 @@ class Storage < ActiveRecord::Base
   cache_with_timeout(:managed_unregistered_vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
       :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(id) AS vm_count, storage_id",
+      :select     => "COUNT(*) AS vm_count, storage_id",
       :group      => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
   end
@@ -609,7 +609,7 @@ class Storage < ActiveRecord::Base
 
   cache_with_timeout(:vm_counts_by_storage_id, 15.seconds) do
     Vm.all(
-      :select => "COUNT(id) AS vm_count, storage_id",
+      :select => "COUNT(*) AS vm_count, storage_id",
       :group  => "storage_id"
     ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -371,11 +371,9 @@ class Storage < ActiveRecord::Base
   # Cache storage file counts for the entire list of storages so that looping over
   # storages to get total_unmanaged_vms in a report or view is optimized
   cache_with_timeout(:total_unmanaged_vms, 15.seconds) do
-    StorageFile.all(
-      :select     => "COUNT(*) AS storage_file_count, storage_id",
-      :conditions => {:ext_name => "vmx", :vm_or_template_id => nil},
-      :group      => :storage_id
-    ).each_with_object(Hash.new(0)) { |sf, h| h[sf.storage_id] = sf.storage_file_count.to_i }
+    StorageFile.where(:ext_name => "vmx", :vm_or_template_id => nil)
+      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def total_unmanaged_vms
@@ -387,11 +385,9 @@ class Storage < ActiveRecord::Base
     delta_clause = "base_name NOT LIKE '%-delta.vmdk'"
     snap_clause  = "AND #{ActiveRecordQueryParts.not_regexp("base_name", "%\-[0-9][0-9][0-9][0-9][0-9][0-9]\.vmdk")}"
 
-    StorageFile.all(
-      :select     => "COUNT(*) AS storage_file_count, storage_id",
-      :conditions => "ext_name = 'vmdk' AND #{flat_clause} AND #{delta_clause} #{snap_clause}",
-      :group      => :storage_id
-    ).each_with_object(Hash.new(0)) { |sf, h| h[sf.storage_id] = sf.storage_file_count.to_i }
+    StorageFile.where("ext_name = 'vmdk' AND #{flat_clause} AND #{delta_clause} #{snap_clause}")
+      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def count_of_vmdk_disk_files
@@ -407,11 +403,9 @@ class Storage < ActiveRecord::Base
   end
 
   cache_with_timeout(:unmanaged_vm_counts_by_storage_id, 15.seconds) do
-    Vm.all(
-      :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(*) AS vm_count, storage_id",
-      :group      => "storage_id"
-    ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
+    Vm.where("((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true)
+      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def total_managed_registered_vms
@@ -423,11 +417,9 @@ class Storage < ActiveRecord::Base
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.all(
-      :conditions => ["((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(*) AS vm_count, storage_id",
-      :group      => "storage_id"
-    ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
+    Vm.where("((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true)
+      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def total_unregistered_vms
@@ -439,11 +431,9 @@ class Storage < ActiveRecord::Base
   end
 
   cache_with_timeout(:managed_unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.all(
-      :conditions => ["((vms.template = ? AND vms.ems_id IS NOT NULL) OR vms.host_id IS NOT NULL)", true],
-      :select     => "COUNT(*) AS vm_count, storage_id",
-      :group      => "storage_id"
-    ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
+    Vm.where("((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true)
+      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def total_managed_unregistered_vms
@@ -608,10 +598,8 @@ class Storage < ActiveRecord::Base
   end
 
   cache_with_timeout(:vm_counts_by_storage_id, 15.seconds) do
-    Vm.all(
-      :select => "COUNT(*) AS vm_count, storage_id",
-      :group  => "storage_id"
-    ).each_with_object(Hash.new(0)) { |v, h| h[v.storage_id] = v.vm_count.to_i }
+    Vm.group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+      .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
   def v_total_vms


### PR DESCRIPTION
- use `count(*)` to half database memory usage
- use pluck to half ruby memory usage.

Just ran to get tangible numbers. the counts are less impressive than when I was running them before. (have run the numbers many times, this is the average of about 40 runs each - ignoring the first run)

---

first: Ruby is the same, but the first line `width` shows the postgres requirements are half.
```sql
explain analyze
SELECT COUNT(id) AS storage_file_count, storage_id -- vs count(*)
FROM "storage_files"
WHERE "storage_files"."ext_name" = 'vmx'
AND "storage_files"."vm_or_template_id" IS NULL
GROUP BY "storage_files"."storage_id";
```
```
-- count(id)
-----------------------
 HashAggregate  (cost=9.61..9.62 rows=1 width=16)
   ->  Bitmap Heap Scan on storage_files  (cost=4.27..9.61 rows=1 width=16)
         Recheck Cond: (vm_or_template_id IS NULL)
         Filter: ((ext_name)::text = 'vmx'::text)
         ->  Bitmap Index Scan on index_storage_files_on_vm_id  (cost=0.00..4.27 rows=2 width=0)
               Index Cond: (vm_or_template_id IS NULL)

-- count(*)
-----------------------
 HashAggregate  (cost=9.61..9.62 rows=1 width=8)
   ->  Bitmap Heap Scan on storage_files  (cost=4.27..9.61 rows=1 width=8)
         Recheck Cond: (vm_or_template_id IS NULL)
         Filter: ((ext_name)::text = 'vmx'::text)
         ->  Bitmap Index Scan on index_storage_files_on_vm_id  (cost=0.00..4.27 rows=2 width=0)
               Index Cond: (vm_or_template_id IS NULL)
```

---

two: reduction

|name|before|after|
---|---|---
count|
memory|45.5kb|30.1kb
objects|565|420

---

/cc @dmetzger57 Darn. I had thought I remembered better results for these.
/cc @akrzos If storages are sufficiently large, we could get a good win for indexes here. I'm assuming it will be small. Let me know if it is over a few thousand.