### PR TITLE
trim down ActiveRecordQueryParts part 2

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -381,11 +381,8 @@ class Storage < ActiveRecord::Base
   end
 
   cache_with_timeout(:count_of_vmdk_disk_files, 15.seconds) do
-    flat_clause  = "base_name NOT LIKE '%-flat.vmdk'"
-    delta_clause = "base_name NOT LIKE '%-delta.vmdk'"
-    snap_clause  = "AND #{ActiveRecordQueryParts.not_regexp("base_name", "%\-[0-9][0-9][0-9][0-9][0-9][0-9]\.vmdk")}"
-
-    StorageFile.where("ext_name = 'vmdk' AND #{flat_clause} AND #{delta_clause} #{snap_clause}")
+    # doesnt match *-111111.vmdk, *-flat.vmdk, or *-delta.vmdk
+    StorageFile.where(:ext_name => 'vmdk').where("base_name !~ '-([0-9]{6}|flat|delta)\\.vmdk$'")
       .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end

--- a/lib/active_record_query_parts.rb
+++ b/lib/active_record_query_parts.rb
@@ -18,18 +18,6 @@ module ActiveRecordQueryParts
     " FOR SHARE"
   end
 
-  def self.regexp(field, regex, qualifier = nil)
-    operator = "SIMILAR TO"
-
-    operator = "NOT #{operator}" if qualifier == :negate
-
-    "#{field} #{operator} '#{regex}'"
-  end
-
-  def self.not_regexp(field, regex)
-    regexp(field, regex, :negate)
-  end
-
   def self.glob_to_sql_like(text)
     text.tr!('*?', '%_')
     text

--- a/spec/lib/active_record_query_parts_spec.rb
+++ b/spec/lib/active_record_query_parts_spec.rb
@@ -1,21 +1,6 @@
 require "spec_helper"
 
 describe ActiveRecordQueryParts do
-  context "regexp" do
-    let(:field) { "field" }
-    let(:regex) { "%\-[0-9]\.vmdk" }
-
-    it ".regexp" do
-      result = described_class.regexp(field, regex)
-      expect(result).to eq "#{field} SIMILAR TO '#{regex}'"
-    end
-
-    it ".not_regexp" do
-      result = described_class.not_regexp(field, regex)
-      expect(result).to eq "#{field} NOT SIMILAR TO '#{regex}'"
-    end
-  end
-
   context "glob to sql" do
     it "replaces '*'" do
       expect(described_class.glob_to_sql_like("a*b*c")).to eq("a%b%c")

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -458,4 +458,23 @@ describe Storage do
       expect(metric_rollup.resource_name).to eq("test vm")
     end
   end
+
+  describe "#count_of_vmdk_disk_files" do
+    it "ignores the correct files" do
+      FactoryGirl.create(:storage_file, :storage_id => 1, :ext_name => 'vmdk', :base_name => "good-stuff.vmdk")
+      FactoryGirl.create(:storage_file, :storage_id => 2, :ext_name => 'dat', :base_name => "bad-stuff.dat")
+      FactoryGirl.create(:storage_file, :storage_id => 3, :ext_name => 'vmdk', :base_name => "bad-flat.vmdk")
+      FactoryGirl.create(:storage_file, :storage_id => 4, :ext_name => 'vmdk', :base_name => "bad-delta.vmdk")
+      FactoryGirl.create(:storage_file, :storage_id => 5, :ext_name => 'vmdk', :base_name => "bad-123456.vmdk")
+      FactoryGirl.create(:storage_file, :storage_id => 6, :ext_name => 'vmdk', :base_name => "good-11.vmdk")
+
+      counts = Storage.count_of_vmdk_disk_files
+      expect(counts[1]).to eq(1)
+      expect(counts[2]).to eq(0)
+      expect(counts[3]).to eq(0)
+      expect(counts[4]).to eq(0)
+      expect(counts[5]).to eq(0)
+      expect(counts[6]).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Clean out unneeded methods in `ActiveRecordQueryParts`.

We no longer need to support multiple databases. This redirection did not add much.

/cc @Fryguy good for you?