### PR TITLE
kubernetes: move fetch_entities to a new mixin

### DIFF
--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -77,20 +77,15 @@ module EmsRefresh
       end
 
       def fetch_entities(client, entities)
-        h = {}
-        entities.each do |entity|
+        entities.each_with_object({}) do |entity, h|
           begin
-            h[entity[:name].singularize] = client.send("get_" << entity[:name])
+            h[entity[:name].singularize] = client.send("get_#{entity[:name]}")
           rescue KubeException => e
-            if entity[:default].nil?
-              throw e
-            else
-              $log.error("Unexpected Exception during refresh: #{e}")
-              h[entity[:name].singularize] = entity[:default]
-            end
+            raise e if entity[:default].nil?
+            $log.error("Unexpected Exception during refresh: #{e}")
+            h[entity[:name].singularize] = entity[:default]
           end
         end
-        h
       end
     end
   end

--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -75,18 +75,6 @@ module EmsRefresh
           _log.info "#{log_ems_target} Performing post-refresh operations for #{klass} instances...Complete"
         end
       end
-
-      def fetch_entities(client, entities)
-        entities.each_with_object({}) do |entity, h|
-          begin
-            h[entity[:name].singularize] = client.send("get_#{entity[:name]}")
-          rescue KubeException => e
-            raise e if entity[:default].nil?
-            $log.error("Unexpected Exception during refresh: #{e}")
-            h[entity[:name].singularize] = entity[:default]
-          end
-        end
-      end
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher.rb
@@ -1,19 +1,12 @@
 module ManageIQ::Providers::Kubernetes
   class ContainerManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
-
-    def self.entities
-      [{:name => 'pods'}, {:name => 'services'}, {:name => 'replication_controllers'}, {:name => 'nodes'},
-       {:name => 'endpoints'}, {:name => 'namespaces'}, {:name => 'resource_quotas'}, {:name => 'limit_ranges'},
-       {:name => 'persistent_volumes'}, {:name => 'persistent_volume_claims'},
-       # workaround for: https://github.com/openshift/origin/issues/5865
-       {:name => 'component_statuses', :default => []}]
-    end
+    include ManageIQ::Providers::Kubernetes::ContainerManager::RefresherMixin
 
     def parse_inventory(ems, _targets = nil)
-      all_entities = ems.with_provider_connection { |client| fetch_entities(client, self.class.entities) }
-      EmsRefresh.log_inv_debug_trace(all_entities, "inv_hash:")
-      ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser.ems_inv_to_hashes(all_entities)
+      entities = ems.with_provider_connection { |client| fetch_entities(client, KUBERNETES_ENTITIES) }
+      EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
+      ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser.ems_inv_to_hashes(entities)
     end
   end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -1,0 +1,27 @@
+module ManageIQ
+  module Providers
+    module Kubernetes
+      module ContainerManager::RefresherMixin
+        KUBERNETES_ENTITIES = [
+          {:name => 'pods'}, {:name => 'services'}, {:name => 'replication_controllers'}, {:name => 'nodes'},
+          {:name => 'endpoints'}, {:name => 'namespaces'}, {:name => 'resource_quotas'}, {:name => 'limit_ranges'},
+          {:name => 'persistent_volumes'}, {:name => 'persistent_volume_claims'},
+          # workaround for: https://github.com/openshift/origin/issues/5865
+          {:name => 'component_statuses', :default => []}
+        ]
+
+        def fetch_entities(client, entities)
+          entities.each_with_object({}) do |entity, h|
+            begin
+              h[entity[:name].singularize] = client.send("get_#{entity[:name]}")
+            rescue KubeException => e
+              raise e if entity[:default].nil?
+              $log.error("Unexpected Exception during refresh: #{e}")
+              h[entity[:name].singularize] = entity[:default]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -2,21 +2,24 @@ module ManageIQ::Providers
   module Openshift
     class ContainerManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
       include ::EmsRefresh::Refreshers::EmsRefresherMixin
+      include ManageIQ::Providers::Kubernetes::ContainerManager::RefresherMixin
 
       KUBERNETES_EMS_TYPE = ManageIQ::Providers::Kubernetes::ContainerManager.ems_type
 
-      def self.entities
-        [{:name => 'routes'}, {:name => 'projects'}]
-      end
+      OPENSHIFT_ENTITIES = [
+        {:name => 'routes'}, {:name => 'projects'}
+      ]
 
       def parse_inventory(ems, _targets = nil)
-        openshift_entities = ems.with_provider_connection { |client| fetch_entities(client, self.class.entities) }
-        kubernetes_entities = ems.with_provider_connection(:service => KUBERNETES_EMS_TYPE) do |client|
-          fetch_entities(client, ManageIQ::Providers::Kubernetes::ContainerManager::Refresher.entities)
+        kube_entities = ems.with_provider_connection(:service => KUBERNETES_EMS_TYPE) do |kubeclient|
+          fetch_entities(kubeclient, KUBERNETES_ENTITIES)
         end
-        all_entities = openshift_entities.merge(kubernetes_entities)
-        EmsRefresh.log_inv_debug_trace(all_entities, "inv_hash:")
-        ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(all_entities)
+        openshift_entities = ems.with_provider_connection do |openshift_client|
+          fetch_entities(openshift_client, OPENSHIFT_ENTITIES)
+        end
+        entities = openshift_entities.merge(kube_entities)
+        EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
+        ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities)
       end
     end
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_mixin_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_mixin_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'kubeclient'
+
+describe ManageIQ::Providers::Kubernetes::ContainerManager::RefresherMixin do
+  let(:client)  { double("client") }
+  let(:dummy) { (Class.new { include ManageIQ::Providers::Kubernetes::ContainerManager::RefresherMixin }).new }
+
+  context 'when an exception is thrown' do
+    before { allow(client).to receive(:get_pods) { raise KubeException.new(0, 'oh-no', nil) } }
+
+    context 'and there is no default value' do
+      it 'should raise' do
+        expect { dummy.fetch_entities(client, [{:name => 'pods'}]) }.to raise_error(KubeException)
+      end
+    end
+
+    context 'and there is a default value' do
+      it 'should be returned' do
+        expect(dummy.fetch_entities(client, [{:name => 'pods', :default => []}])).to eq('pod' => [])
+      end
+    end
+  end
+end


### PR DESCRIPTION
fetch_entities is relevant only to container providers and does not belong in ems_refresher_mixin.