### PR TITLE
Add test to detect missing automate service models

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -6,6 +6,8 @@ module MiqAeMethodService
   end
 
   class MiqAeServiceModelBase
+    SERVICE_MODEL_PATH = Rails.root.join("lib/miq_automation_engine/service_models")
+    SERVICE_MODEL_GLOB = SERVICE_MODEL_PATH.join("miq_ae_service_*.rb")
     EXPOSED_ATTR_BLACK_LIST = [/password/, /^auth_key$/]
     class << self
       include DRbUndumped  # Ensure that Automate Method can get at the class itself over DRb
@@ -76,9 +78,30 @@ module MiqAeMethodService
 
     def self.model
       # Set a class-instance variable to get the appropriate model
-      @model ||= Object.const_get(/MiqAeService(.+)$/.match(name)[1].gsub(/_/, '::'))
+      @model ||= /MiqAeService(.+)$/.match(name)[1].gsub(/_/, '::').constantize
     end
     private_class_method :model
+
+    def self.model_name_from_file(filename)
+      File.basename(filename, '.*').split('-').map(&:camelize).join('_')
+    end
+
+    def self.model_name_from_active_record_model(ar_model)
+      "MiqAeMethodService::MiqAeService#{ar_model.name.gsub(/::/, '_')}"
+    end
+
+    def self.service_models
+      Dir.glob(MiqAeMethodService::MiqAeServiceModelBase::SERVICE_MODEL_GLOB).collect do |f|
+        model_name = MiqAeMethodService::MiqAeServiceModelBase.model_name_from_file(f)
+        next if model_name == "MiqAeServiceMethods"
+
+        "MiqAeMethodService::#{model_name}".constantize
+      end.compact!
+    end
+
+    def self.ar_base_model
+      send(:model).base_model
+    end
 
     def self.expose(*args)
       raise ArgumentError, "must pass at least one method name" if args.empty? || args.first.kind_of?(Hash)
@@ -265,9 +288,7 @@ module MiqAeMethodService
   end
 end
 
-# Register all of the service models for autoload on first use
-Dir.glob("#{File.dirname(__FILE__)}/../service_models/miq_ae_service_*.rb").each do |f|
+Dir.glob(MiqAeMethodService::MiqAeServiceModelBase::SERVICE_MODEL_GLOB).each do |f|
   f = File.basename(f, '.*')
-  const = f.split('-').map(&:camelize).join('_')
-  MiqAeMethodService.autoload(const, "service_models/#{f}")
+  MiqAeMethodService.autoload(MiqAeMethodService::MiqAeServiceModelBase.model_name_from_file(f), "service_models/#{f}")
 end

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -14,16 +14,13 @@ describe Job::StateMachine do
       end
     end
 
-    class TestJob < Job
+    @obj = Class.new(Job) do
       include TestStateMachine
-    end
-
-    @obj = TestJob.new
+    end.new
   end
 
   after do
     Object.send(:remove_const, :TestStateMachine)
-    Object.send(:remove_const, :TestJob)
   end
 
   it "should transition from one state to another by a signal" do


### PR DESCRIPTION
Test loads all service models and determines the base_model, then gets the descendants
of all the base models and validates that service models exist, unless specified in the exclude list.

Test validates 
1. Service Model files are named correctly
2. Service Models load correctly
3. Service Models exist for all descendants of sub-classed models (except when explicitly excluded)

Includes some refactoring of MiqAeServiceModelBase to reuse methods in test.