### PR TITLE
Switch back to released Rails versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 #
 
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
-gem "rails", :github => "rails/rails", :branch => "4-2-stable"
+gem "rails",                           "~>4.2.5"
 
 # Local gems
 path "gems/" do

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -7,10 +7,10 @@ gem "bundler",       ">= 1.8.4"
 gem "rake",          "~>10.1"
 gem "iniparse"
 
-gem "activesupport", :github => "rails/rails", :branch => "4-2-stable"
+gem "activesupport",           "~>4.2.5"
 
 # ActiveRecord is used by appliance_console
-gem "activerecord",  :github => "rails/rails", :branch => "4-2-stable"
+gem "activerecord",            "~>4.2.5"
 
 # Not locally modified and not required
 gem "awesome_spawn",           "~> 1.3",            :require => false


### PR DESCRIPTION
Per f8ef3f4c1f74ca799daab8e0808ffe32fbcaee7d, we were on `4-2-stable` for a particular change, which is now released.