### PR TITLE
Fix nil GCE Product after provider save

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :Refresher
 
-  attr_accessor :project
-
   def self.ems_type
     @ems_type ||= "gce".freeze
   end


### PR DESCRIPTION
The attr_accessor methods clash with the active record methods to retrieve the project from the db.  This causes the project attribute to come back as nil after saving the provider.

cc @lwander @blomquisg 