### PR TITLE
Refactor miq report result

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -93,4 +93,12 @@ class BinaryBlob < ActiveRecord::Base
     part_size = self.part_size || BinaryBlobPart.default_part_size
     (self.size.to_f / part_size).ceil
   end
+
+  def serializer
+    data_type == "YAML" ? YAML : Marshal
+  end
+
+  def data
+    serializer.load(binary)
+  end
 end

--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -101,4 +101,9 @@ class BinaryBlob < ActiveRecord::Base
   def data
     serializer.load(binary)
   end
+
+  def store_data(data_type, the_data)
+    self.data_type = data_type
+    self.binary = serializer.dump(the_data)
+  end
 end

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -78,7 +78,7 @@ class MiqReportResult < ActiveRecord::Base
   end
 
   def report_results=(value)
-    self.binary_blob = BinaryBlob.new(:name => "report_results", :data_type => "YAML")
+    build_binary_blob(:name => "report_results", :data_type => "YAML")
     binary_blob.binary = YAML.dump(value.kind_of?(MiqReport) ? value.to_hash : value)
   end
 

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -114,7 +114,6 @@ class MiqReportResult < ActiveRecord::Base
   def report=(val)
     write_attribute(:report, val.nil? ? nil : val.to_hash)
   end
-  #
 
   def build_html_rows_for_legacy
     return if report && report.respond_to?(:extras) && report.extras.respond_to?(:has_key?) && report.extras.key?(:total_html_rows) && report.extras[:total_html_rows] != 0

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -70,11 +70,8 @@ class MiqReportResult < ActiveRecord::Base
 
   def report_results
     if binary_blob
-      serializer_name = binary_blob.data_type
-      serializer_name = "Marshal" unless serializer_name == "YAML"  # YAML or Marshal, for now
-      serializer = serializer_name.constantize
-      loaded = serializer.load(binary_blob.binary)
-      loaded.kind_of?(Hash) ? MiqReport.from_hash(loaded) : loaded
+      data = binary_blob.data
+      data.kind_of?(Hash) ? MiqReport.from_hash(data) : data
     elsif report.kind_of?(MiqReport)
       report
     else

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -78,8 +78,8 @@ class MiqReportResult < ActiveRecord::Base
   end
 
   def report_results=(value)
-    build_binary_blob(:name => "report_results", :data_type => "YAML")
-    binary_blob.binary = YAML.dump(value.kind_of?(MiqReport) ? value.to_hash : value)
+    build_binary_blob(:name => "report_results")
+    binary_blob.store_data("YAML", value.kind_of?(MiqReport) ? value.to_hash : value)
   end
 
   def report_html=(html)

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -74,8 +74,6 @@ class MiqReportResult < ActiveRecord::Base
       data.kind_of?(Hash) ? MiqReport.from_hash(data) : data
     elsif report.kind_of?(MiqReport)
       report
-    else
-      nil
     end
   end
 

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -76,4 +76,16 @@ describe BinaryBlob do
     @blob.binary = data.dup # binary= destroys the source data, so dup it
     @blob.binary.length.should == data.length
   end
+
+  describe "#serializer" do
+    it "returns YAML if the data_type is YAML" do
+      bb = FactoryGirl.build(:binary_blob, :data_type => "YAML")
+      expect(bb.serializer).to be(YAML)
+    end
+
+    it "returns Marshal if data_type is not YAML" do
+      bb = FactoryGirl.build(:binary_blob, :data_type => "unknown")
+      expect(bb.serializer).to be(Marshal)
+    end
+  end
 end

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -77,6 +77,26 @@ describe BinaryBlob do
     end
   end
 
+  describe "serializing and deserializing data" do
+    it "can store and load data as YAML" do
+      bb = FactoryGirl.build(:binary_blob)
+      data = "foo"
+
+      bb.store_data("YAML", data)
+
+      expect(bb.data).to eq(data)
+    end
+
+    it "can store and load Marshaled data" do
+      bb = FactoryGirl.build(:binary_blob)
+      data = "foo"
+
+      bb.store_data("Marshal", data)
+
+      expect(bb.data).to eq("foo")
+    end
+  end
+
   describe "#serializer" do
     it "returns YAML if the data_type is YAML" do
       bb = FactoryGirl.build(:binary_blob, :data_type => "YAML")

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -3,11 +3,9 @@
 require "spec_helper"
 
 describe BinaryBlob do
-  before(:each) do
-    @blob = FactoryGirl.create(:binary_blob, :name => "test")
-  end
-
   context "#binary= and #binary" do
+    before { @blob = FactoryGirl.build(:binary_blob, :name => "test") }
+
     subject do
       @blob.binary = @data.dup # binary= is descructive (it changes the object passed to it)
       @blob.save
@@ -29,9 +27,30 @@ describe BinaryBlob do
       @data = "--- Quota \xE2\x80\x93 Max CPUs\n...\n"
       subject.bytes.to_a.should == @data.bytes.to_a
     end
+
+    it '#binary= with less data than the max parts size' do
+      data = "test log data"
+      @blob.binary = data.dup # binary= destroys the source data, so dup it
+      @blob.binary.length.should == data.length
+    end
+
+    it '#binary= with more data than the max parts size' do
+      data = "test log data"
+      data *= ((BinaryBlobPart.default_part_size) / data.length * 2)
+      @blob.binary = data.dup # binary= destroys the source data, so dup it
+      @blob.binary.length.should == data.length
+    end
+
+    it '#binary will handle data that is only made up of hex digits' do
+      data = "1234567890abcdef"
+      @blob.binary = data.dup # binary= destroys the source data, so dup it
+      @blob.binary.length.should == data.length
+    end
   end
 
   context "#dump_binary" do
+    before { @blob = FactoryGirl.build(:binary_blob, :name => "test") }
+
     subject do
       @blob.binary = @data.dup
       @string = StringIO.new
@@ -56,25 +75,6 @@ describe BinaryBlob do
       @data = "%PDF-1.4\n%\xE2"
       subject.bytes.to_a.should == @data.bytes.to_a
     end
-  end
-
-  it '#binary= with less data than the max parts size' do
-    data = "test log data"
-    @blob.binary = data.dup # binary= destroys the source data, so dup it
-    @blob.binary.length.should == data.length
-  end
-
-  it '#binary= with more data than the max parts size' do
-    data = "test log data"
-    data *= ((BinaryBlobPart.default_part_size) / data.length * 2)
-    @blob.binary = data.dup # binary= destroys the source data, so dup it
-    @blob.binary.length.should == data.length
-  end
-
-  it '#binary will handle data that is only made up of hex digits' do
-    data = "1234567890abcdef"
-    @blob.binary = data.dup # binary= destroys the source data, so dup it
-    @blob.binary.length.should == data.length
   end
 
   describe "#serializer" do


### PR DESCRIPTION
* Have BinaryBlob work out the appropriate serializer for its data_type
* Add some specs
* Rearrange BinaryBlob specs so they don't all have the same shared
  setup
* Use FactoryGirl.build instead of .create
* Remove a useless else clause
* Remove a useless comment

*** 
I wanted to do some work to clean up a bit after https://github.com/ManageIQ/manageiq/pull/5420. Here's a first step by moving the logic done in `MiqReportResult#report_results` based on `BinaryBlob`'s data into `BinaryBlob`

Tested this in the UI and everything looks good.

cc @gtanzillo 
@miq-bot add-label refactoring, reporting, core