### PR TITLE
Remove monkey patch for webmock v1.11.0, gem is up to v1.22.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ unless ENV['APPLIANCE']
     gem "factory_girl",     "~>4.5.0",  :require => false
     gem "shoulda-matchers", "~>1.0.0",  :require => false
     gem "vcr",              "~>2.6",    :require => false
-    gem "webmock",                      :require => false
+    gem "webmock",          "~>1.12",   :require => false
   end
 
   group :development, :test do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,15 +95,6 @@ RSpec.configure do |config|
   end
 end
 
-# PATCH: Temporary monkey patch until a new version of webmock is released
-#   (newer than 1.11.0).  The aws-sdk gem uses a feature of Net::HTTP that has
-#   not yet been properly exposed.
-#   See: https://github.com/aws/aws-sdk-ruby/issues/232
-#        https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/net_http.rb#L196
-class StubSocket
-  attr_accessor :read_timeout, :continue_timeout
-end
-
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr_cassettes'
   c.hook_into :webmock


### PR DESCRIPTION
Based on the comment we don't need this anymore.