### PR TITLE
fix appliance_console gemfile path

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -7,11 +7,11 @@ $LOAD_PATH.push(File.dirname(__FILE__))
 
 ROOT = [
   "/var/www/miq",
-  File.expand_path(File.join(File.dirname(__FILE__), ".."))
+  File.expand_path(File.join(File.dirname(__FILE__), "../.."))
 ].detect { |f| File.exist?(f) }
 
 # Set up Environment
-ENV['BUNDLE_GEMFILE'] ||= "#{ROOT}/vmdb/Gemfile"
+ENV['BUNDLE_GEMFILE'] ||= "#{ROOT}/Gemfile"
 require 'bundler'
 Bundler.setup
 


### PR DESCRIPTION
`appliance_console` has the wrong link to the `Gemfile`.

Now that the appliance hardcodes `BUNDLE_GEMFILE`, this does not show up. But it blows up in development (e.g.: on a mac).

/cc @carbonin 
