### PR TITLE
Handle delimiters passed through as text into the web service

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -344,12 +344,19 @@ class MiqRequestWorkflow
     # Rails.logger.warn("#{name} #{start.zero? ? 'start' : 'end'}")
   end
 
+  def self.handle_deprecation(text)
+    deprecated_warn = "method: parse_ws_string, arg Type => String"
+    solution = "arg should be a hash"
+    MiqAeMethodService::Deprecation.deprecation_warning(deprecated_warn, solution) if text.kind_of?(String)
+  end
+
   def parse_ws_string(text_input, options = {})
     self.class.parse_ws_string(text_input, options)
   end
 
   def self.parse_ws_string(text_input, options = {})
     return parse_request_parameter_hash(text_input, options) if text_input.kind_of?(Hash)
+    handle_deprecation(text_input)
     return {} unless text_input.kind_of?(String)
     result = {}
     text_input.split('|').each do |value|

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -23,19 +23,26 @@ describe MiqProvisionWorkflow do
 
       context "With a Valid Template," do
         before(:each) do
-          @ems         = FactoryGirl.create(:ems_vmware,  :name => "Test EMS",  :zone => server.zone)
-          @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on', :ext_management_system => @ems)
-          @vm_template = FactoryGirl.create(:template_vmware, :name => "template", :ext_management_system => @ems, :host => @host)
-          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro", :memory_mb => 512, :cpu_sockets => 2)
+          @ems         = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => server.zone)
+          @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on',
+                                            :ext_management_system => @ems)
+          @vm_template = FactoryGirl.create(:template_vmware, :name => "template", :ext_management_system => @ems,
+                                            :host => @host)
+          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro",
+                                            :memory_mb => 512,
+                                            :cpu_sockets => 2)
           @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
           @lan         = FactoryGirl.create(:lan, :name => "VM Network", :switch => @switch)
-          @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan, :device_type => 'ethernet', :controller_type => 'ethernet', :address => '00:50:56:ba:10:6b', :present => false, :start_connected => true)
+          @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan,
+                                            :device_type => 'ethernet',
+                                            :controller_type => 'ethernet', :address => '00:50:56:ba:10:6b',
+                                            :present => false, :start_connected => true)
         end
 
         it "should create an MiqRequest when calling from_ws" do
           FactoryGirl.create(:classification_cost_center_with_tags)
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.0", admin, "template", "target", false, "cc|001|environment|test","")
+            "1.0", admin, "template", "target", false, "cc|001|environment|test", "")
           request.should be_a_kind_of(MiqRequest)
 
           expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
@@ -60,10 +67,50 @@ describe MiqProvisionWorkflow do
           MiqPassword.decrypt(request.options[:root_password]).should == password_input
         end
 
+        it "should set values when extra '|' are passed in" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, "name=template", "vm_name=spec_test",
+            nil, nil, {'abc' => 'tr|ue', 'blah' => 'nah'}, nil, nil)
+
+          expect(request.options[:ws_values]).to include(:abc => "tr|ue")
+        end
+
+        it "should set values when extra '|' are passed in for multiple values" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, "name=template", "vm_name=spec_test",
+            nil, nil, {'abc' => 'tr|ue', 'blah' => 'na|h'}, nil, nil)
+
+          expect(request.options[:ws_values]).to include(:blah => "na|h")
+        end
+
         it "should set values" do
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
             "1.1", admin, "name=template", "vm_name=spec_test",
+            nil, nil, {'abc' => 'true', 'blah' => 'nah'}, nil, nil)
+
+          expect(request.options[:ws_values]).to include(:abc => "true")
+        end
+
+        it "should set values correctly when a string is passed" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, "name=template", "vm_name=spec_test",
+            nil, nil, "abc=true|blah=nah", nil, nil)
+
+          expect(request.options[:ws_values]).to include(:abc => "true")
+        end
+
+        it "should set values when only a single key value pair is passed in as a string" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, "name=template", "vm_name=spec_test",
             nil, nil, "abc=true", nil, nil)
+
+          expect(request.options[:ws_values]).to include(:abc => "true")
+        end
+
+        it "should set values when only a single key value pair is passed in" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, "name=template", "vm_name=spec_test",
+            nil, nil, {'abc' => 'true'}, nil, nil)
 
           expect(request.options[:ws_values]).to include(:abc => "true")
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1277734

Modified the parse_ws_string method to handle input
that includes delimiters.

A customer can now include a delimiter (namely '|' (pipes))
as text passed into the web service and the string will no
longer be mangled.