### PR TITLE
find_each with a custom select needs the primary key

### DIFF
--- a/app/models/miq_cim_instance.rb
+++ b/app/models/miq_cim_instance.rb
@@ -224,7 +224,7 @@ class MiqCimInstance < ActiveRecord::Base
   #
   def getAssociators(association)
     results = []
-    query = miq_cim_associations.scoped.includes(:result_instance).select(:result_instance_id)
+    query = miq_cim_associations.scoped.includes(:result_instance).select(:result_instance_id, :id)
     query = query.where_association(association)
     query.find_each { |a| results << a.result_instance }
     results.uniq
@@ -232,7 +232,7 @@ class MiqCimInstance < ActiveRecord::Base
 
   def getAssociatedVmdbObjs(association)
     results = []
-    query = miq_cim_associations.scoped.includes(:result_instance => :vmdb_obj).select(:result_instance_id)
+    query = miq_cim_associations.scoped.includes(:result_instance => :vmdb_obj).select(:result_instance_id, :id)
     query = query.where_association(association)
     query.find_each { |a| results << a.result_instance.vmdb_obj }
     results.uniq

--- a/spec/factories/miq_cim_association.rb
+++ b/spec/factories/miq_cim_association.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_cim_association do
+  end
+end

--- a/spec/factories/miq_cim_instance.rb
+++ b/spec/factories/miq_cim_instance.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_cim_instance do
+  end
+end

--- a/spec/models/miq_cim_instance_spec.rb
+++ b/spec/models/miq_cim_instance_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe MiqCimInstance do
+  before do
+    @instance1 = FactoryGirl.create(:miq_cim_instance)
+    attributes = {
+      :result_instance => @instance1,
+      :assoc_class     => "A",
+      :role            => "B",
+      :result_role     => "C"
+    }
+    @cim_association = FactoryGirl.create(:miq_cim_association, attributes)
+    @instance2       = FactoryGirl.create(:miq_cim_instance, :miq_cim_associations => [@cim_association])
+  end
+
+  it "#getAssociators" do
+    expect(@instance2.getAssociators(:AssocClass => "A", :Role => "B", :ResultRole => "C")
+      .collect(&:id))
+      .to eq [@instance1.id]
+  end
+
+  it "#getAssociatedVmdbObjs" do
+    host = FactoryGirl.create(:host)
+    @instance1.update_attribute(:vmdb_obj, host)
+    expect(@instance2.getAssociatedVmdbObjs(:AssocClass => "A", :Role => "B", :ResultRole => "C"))
+      .to eq [host]
+  end
+end


### PR DESCRIPTION
Fixes: `Primary key not included in the custom select clause`
Add basic test of #getAssociators and #getAssociatedVmdbObjs

https://bugzilla.redhat.com/show_bug.cgi?id=1281890