### PR TITLE
Update cores_per_socket to cpu_cores_per_socket

### DIFF
--- a/product/views/Vm-VmReconfigureRequest.yaml
+++ b/product/views/Vm-VmReconfigureRequest.yaml
@@ -21,7 +21,7 @@ db: Vm
 cols:
 - name
 - num_cpu
-- cores_per_socket
+- cpu_cores_per_socket
 - mem_cpu
 
 # Included tables (joined, has_one, has_many) and columns
@@ -40,7 +40,7 @@ include_for_find:
 col_order: 
 - name
 - num_cpu
-- cores_per_socket
+- cpu_cores_per_socket
 - mem_cpu
 - host.name
 


### PR DESCRIPTION
This is the last deprecation warning in the tests