### PR TITLE
[WIP] Add network security group and firewall parsing support.

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -6,6 +6,10 @@ module ManageIQ::Providers
       VALID_LOCATION = /\w+/
       TYPE_DEPLOYMENT = "microsoft.resources/deployments"
 
+      def self.security_group_type
+        ManageIQ::Providers::Azure::CloudManager::SecurityGroup.name
+      end
+
       def self.ems_inv_to_hashes(ems, options = nil)
         new(ems, options).ems_inv_to_hashes
       end
@@ -19,6 +23,8 @@ module ManageIQ::Providers
         @tds               = ::Azure::Armrest::TemplateDeploymentService.new(@config)
         @vns               = ::Azure::Armrest::Network::VirtualNetworkService.new(@config)
         @ips               = ::Azure::Armrest::Network::IpAddressService.new(@config)
+        @nsg               = ::Azure::Armrest::Network::NetworkSecurityGroupService.new(@config)
+        @nis               = ::Azure::Armrest::Network::NetworkInterfaceService.new(@config)
         @rgs               = ::Azure::Armrest::ResourceGroupService.new(@config)
         @sas               = ::Azure::Armrest::StorageAccountService.new(@config)
         @options           = options || {}
@@ -36,6 +42,7 @@ module ManageIQ::Providers
         get_availability_zones
         get_stacks
         get_cloud_networks
+        get_security_groups
         get_instances
         get_images
         _log.info("#{log_header}...Complete")
@@ -44,6 +51,10 @@ module ManageIQ::Providers
       end
 
       private
+
+      def security_groups
+        @security_groups ||= gather_data_for_this_region(@nsg)
+      end
 
       def get_resource_groups
         resource_groups = @rgs.list.select do |resource_group|
@@ -124,6 +135,32 @@ module ManageIQ::Providers
         process_collection(images, :vms) { |image| parse_image(image) }
       end
 
+      def get_security_groups
+        process_collection(security_groups, :security_groups) do |sg|
+          parse_security_group(sg)
+        end
+      end
+
+      # To get the list of security groups for a VM we need to find any
+      # NIC's associated with the security group, and then get the VM's
+      # associated with the NIC's.
+      #
+      def get_security_groups_for_vm(vm)
+        group_array = []
+
+        security_groups.each do |sg|
+          sg.properties.network_interfaces.each do |nic|
+            resource_group = nic.id[%r{resourceGroups/(.*?)/}, 1]
+            nic = @nis.get(File.basename(nic.id), resource_group)
+            if nic.properties['virtualMachine'] and nic.properties.virtual_machine.id == vm.id
+              group_array << sg
+            end
+          end
+        end
+
+        group_array
+      end
+
       def process_collection(collection, key)
         @data[key] ||= []
 
@@ -142,6 +179,45 @@ module ManageIQ::Providers
           results << arm_service.send(method, resource_group[:name])
         end
         results.flatten
+      end
+
+      def parse_security_group(security_group)
+        uid = security_group.id
+
+        description = [
+          security_group.name,
+          security_group.resource_group,
+          security_group.location
+        ].join(' - ')
+
+        new_result = {
+          :type           => self.class.security_group_type,
+          :ems_ref        => uid,
+          :name           => security_group.name,
+          :description    => description,
+          :firewall_rules => parse_firewall_rules(security_group)
+        }
+
+        return uid, new_result
+      end
+
+      def parse_firewall_rules(sg)
+        rule_array = []
+
+        sg.properties.security_rules.each do |rule|
+          new_result = {
+            :name            => rule.name,
+            :host_protocol   => rule.properties.protocol.upcase,
+            :port            => rule.properties.destination_port_range.split('-').first,
+            :end_port        => rule.properties.destination_port_range.split('-').last,
+            :direction       => rule.properties.direction,
+            :source_ip_range => rule.properties.source_address_prefix
+          }
+
+          rule_array << new_result
+        end
+
+        rule_array
       end
 
       def parse_resource_group(resource_group)
@@ -220,6 +296,10 @@ module ManageIQ::Providers
         series_name = instance.properties.hardware_profile.vm_size
         series      = @data_index.fetch_path(:flavors, series_name)
 
+        security_groups = get_security_groups_for_vm(instance).collect do |sg|
+          @data_index.fetch_path(:security_groups, sg.id)
+        end
+
         new_result = {
           :type                => 'ManageIQ::Providers::Azure::CloudManager::Vm',
           :uid_ems             => uid,
@@ -230,6 +310,7 @@ module ManageIQ::Providers
           :operating_system    => process_os(instance),
           :flavor              => series,
           :location            => uid,
+          :security_groups     => security_groups,
           :orchestration_stack => @data_index.fetch_path(:orchestration_stacks, @resource_to_stack[uid]),
           :availability_zone   => @data_index.fetch_path(:availability_zones, 'default'),
           :hardware            => {
@@ -284,7 +365,7 @@ module ManageIQ::Providers
           _m, sub, group, nic_name = nic.id.match(pattern).to_a
 
           cfg = @config.clone.tap { |c| c.subscription_id = sub }
-          nic_profile = ::Azure::Armrest::Network::NetworkInterfaceService.new(cfg).get(nic_name, group)
+          nic_profile = @nis.get(nic_name, group)
 
           nic_profile.properties.ip_configurations.each do |ipconfig|
             hostname = ipconfig.name
@@ -297,7 +378,7 @@ module ManageIQ::Providers
             next unless public_ip_obj
 
             name = File.basename(public_ip_obj.id)
-            ip_profile = ::Azure::Armrest::Network::IpAddressService.new(cfg).get(name, group)
+            ip_profile = @ips.get(name, group)
             public_ip_addr = ip_profile.properties.try(:ip_address)
             networks_array << {:description => "public", :ipaddress => public_ip_addr, :hostname => hostname}
           end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -361,10 +361,8 @@ module ManageIQ::Providers
 
       def populate_hardware_hash_with_networks(networks_array, instance)
         instance.properties.network_profile.network_interfaces.each do |nic|
-          pattern = %r{/subscriptions/(.+)/resourceGroups/([\w-]+)/.+/networkInterfaces/(.+)}i
-          _m, sub, group, nic_name = nic.id.match(pattern).to_a
-
-          cfg = @config.clone.tap { |c| c.subscription_id = sub }
+          group = nic.id[%r{resourceGroups/(.*?)/}, 1]
+          nic_name = File.basename(nic.id)
           nic_profile = @nis.get(nic_name, group)
 
           nic_profile.properties.ip_configurations.each do |ipconfig|

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -149,6 +149,13 @@ module ManageIQ::Providers
         end
       end
 
+      def get_security_group_for_nic(nic)
+        security_group = nic.properties.network_security_group
+        resource_group = security_group.id[%r{resourceGroups/(.*?)/}, 1]
+        sec_group_name = File.basename(security_group.id)
+        @nsg.get(sec_group_name, resource_group)
+      end
+
       # To get the list of security groups for a VM we need to find any
       # NIC's associated with the security group, and then get the VM's
       # associated with the NIC's.

--- a/app/models/manageiq/providers/azure/cloud_manager/security_group.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/security_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::CloudManager::SecurityGroup < ::SecurityGroup
+end

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://login.windows.net/a50f9983-d1a2-4a8d-be7d-123456789012/oauth2/token
     body:
       encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012&client_secret=5YcZ1lwRmNPWgo82X%2F1l97Fe4VaBGi%2B123456789012%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012&client_secret=5YcZ1lwRmNPWgo82X%2F1l97Fe4VaBGi%2B123456789012&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Length:
       - '188'
       Content-Type:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 1c22f999-fa58-4cc6-a48b-78c90835786d
+      - 5ca12291-4125-4694-8592-3f09de9f645b
       Client-Request-Id:
-      - bac967f7-ef59-4a57-b725-ad37f947ebc4
+      - 5db88b76-e70c-438b-b51f-c5ef1d9c9db7
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_112
+      - ESTSFE_IN_35
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -47,18 +47,18 @@ http_interactions:
       Set-Cookie:
       - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 10 Nov 2015 19:21:05 GMT
+      - Fri, 20 Nov 2015 22:06:44 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1447186865","not_before":"1447182965","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1448060806","not_before":"1448056906","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ"}'
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:05 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -71,11 +71,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -98,15 +98,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - f07bc081-02bb-41af-b868-49fc78d455ff
+      - 768775e7-e29a-4d09-a231-92aca5274748
       X-Ms-Correlation-Request-Id:
-      - f07bc081-02bb-41af-b868-49fc78d455ff
+      - 768775e7-e29a-4d09-a231-92aca5274748
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:f07bc081-02bb-41af-b868-49fc78d455ff
+      - NORTHCENTRALUS:20151120T220647Z:768775e7-e29a-4d09-a231-92aca5274748
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:05 GMT
+      - Fri, 20 Nov 2015 22:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -118,7 +118,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:06 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -131,11 +131,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -158,15 +158,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 169ef359-a005-40be-afcf-caf7a9e16f30
+      - 4caf7741-6d6d-4305-bb6b-05190d086351
       X-Ms-Correlation-Request-Id:
-      - 169ef359-a005-40be-afcf-caf7a9e16f30
+      - 4caf7741-6d6d-4305-bb6b-05190d086351
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:169ef359-a005-40be-afcf-caf7a9e16f30
+      - NORTHCENTRALUS:20151120T220648Z:4caf7741-6d6d-4305-bb6b-05190d086351
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:06 GMT
+      - Fri, 20 Nov 2015 22:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -190,203 +190,211 @@ http_interactions:
         6gJK/2/Hd1pmRN3p8WxBKEMe2qrnxw5h/UNFlNh0URCqwOB26KEfaip//FBx
         Jeze3hZLjQH6QN5bMIErNZU/GCz/MTQ0pkis41VVFtPr92bisJdhwO8tzbcA
         XFeXxSyvv/w6JLOQmTD6IXXDHQ1qsWrBwOklHxeA7mGX2dbH02m17o9b7Zxa
-        Ifwwhost0rB95A9Ck7jBSm62XWAYSwoe+43DuFuvl5Oq6rH6/2fHE6SG/r85
-        KsJhAP0eGrfsg3uJy8GTrJ3C1/JxAKAeVhM0NGSmFwLEQvIpYd1vjsT8aYR0
-        Hc9PWliAQVOGqfMSzKdzBhkM5o8+lSbonP6wXxgA/EGIigOjcKWNTKrDxfwN
-        yPrH0Gw8pNmglvIHqyb+gxQ4/Y15Ki7JQ3TTRZPVIT6RYYAluHtLKGAso9Df
-        fkR52IE+QR0NQ3p+fUB3f9G6arMuPEHSkhPjkrHqbz+aH5CVCTugn4qL42VW
-        XreSQvapDzi9+cgGNBQwplEQvYdwOSBcSBZFCFVA2W8hBAm9gX7uUhoye569
-        zYdU43t2vLGvhjx7SiT/HHQFu9pmxZIg/tz0erek0OZ11ryp3uYE+5vHwcEL
-        Yd8K4I3sYiHeJbkVVU4t1mVvEr+Z7mwn3wR47mBIOpcXX2ScYPUxAOAeTots
-        RUshaOojJFqCpm7rZVa3NNN3qIF+NjiZZENppoFWp4/3HvcgJLDbSbVYrJeF
-        QHlZ5+d5nS+JAh8Ier0inZF/I8AZ/NDU/OBNVpoVDdDDRwOgeojpK9TUR8EI
-        F31s5qVnhvgL+xebBd+WMAT9Xd40toKBBYZI/sAb9AdD8htH6UGOFP3P8e9G
-        upxktNRBoP2xA1CPGq/yWZ9bI9j3cHSWkP/AuBxtBID9k7/kZhhx8Bspsw41
-        5I/v5vxHxy/gn0M07xlu94F9jz41aIvNVuTMH9xQ/4rOAnEltAg1lT+QT5Q/
-        aHLof25+gg8l4+h/RPNHs9eZDZq0r7eERpj8LKJFs/h+CudnERdm2BOOf13m
-        h177emgN9nBXFvRdF92hK48bbmKeFu4JPgIrBr8xwzPP8af9xsrNDAssaz6Q
-        /kKZsn+J0OB9+wca0B8dCYrLhPtUQRi0RBK0N/MHv6l/RUlNk0f/20RdevVi
-        WTXk777O25bsa4+8QMSjihJOiGCw46/lI0sJxtT+1Rk9f8lvBSD46xCq0BBd
-        2z/wMv2Bz8yc8IugofmgR0j3gW1Ln5quhIaKl/mDG+pfN5CXCTxgAWaQCp/4
-        eL03HZSRPC9K+q5DfoMhEwNjCX4bmgtBPfiIh8a/SXs7NfyF/YsBKxEZCihl
-        PhD6o4n9A2/TH535ddTWxu4DbgKgcZqSQhjOMyuN7ubL2aoqyGUnyD+i1q2p
-        dZcW0i4KevlHVHsfqk0JbrWYUe73R7TbSDvCUNwT+jwSbPq0+mDYd3Wi9M8f
-        YleWM/Tvn8OuVaD1r59LRHwZ0c++SXRu449/UAd2vN8o2vnsIl9Ws41W/Qag
-        DHbAs5CVeArtV+sWusHvHZB6+Mj8gI49jKAHjBqxKsB8wF8SrvY31mtQLfQ7
-        /SYayxuUwgg/Cv6QV6xaY1j2L1Fd6Mv+gQb0x9fRYwYZ8eQcHuZvgLZ/AA5h
-        mO6lW69bSg4iQSS4mtfoS/PVwNxJKsvENzyR/Ac5i8EfWDejKaYJ7swTs/tT
-        O1kbmP5nCwOPU+42ZdWXZqaTsgeTF6Q2H/CXPM3624/4hb/6oc3W3boiH4Ze
-        /NGcyd8Abf8AHMLw/5VzdmO+I4oPdUT/+zodfTD4y6Ju11n5BSU6aemkC05o
-        rSzGU4TpMh/wl8wq+tuPeI6/ik7C7XmO/uf+GGTAKY2fbUrRm7Wv2X+sl+g6
-        9deEb/4YHFKHF3++Z7f4d8uBpmPzNzqyfwAOofQB7EnzQv+73byI6hnWcQYd
-        +lh/+9G0KO3NkM1r9KX56hualt5kdDuk72UIwUeKqvuNp4xHw5/2GyvVGBZI
-        Yz6Q/uwsMgj7l8wG3rd/oAH90ZltR3tt7D7gJuiRPuXfLb0NkuZvgLZ/AA6h
-        /7M0GTS8eAQahXR7ZUn/c38Mak7/z28IgdvEri/y9qqqsQYcIhCJXZVZ9Y0u
-        jjI5ykA8p5hf8wF/6RiPpinkze4s0kcMI/wo+ENesWzJsOxfwpfoy/6BBvTH
-        /weYNDqZ5o9NDERr//nsbPWjqfl/2dTc4ILdBP9G+BdZm19l16/XqxWNJp89
-        pUXlKQlxyAbf4IBoJt9LVYZggz/of+4P7ZC73Ki2XrdVTbNEL/qYocMerpQW
-        RdPj6bRa02ICveIjLDyhosCsBLYyH/CXzNL6249kg7/6etO8PclbdOU+sX/o
-        xNO0d2bvZ1t0ONGn3KQs8v7JvrCv4I/BjjtseRfKOyK0MknMOW4e6A+Z2eAj
-        4RfMo/0DL9Mf+MywNL8I9jAfOM5Bs+AD25Y+5d8tt5iOzd/oyP4BOIKS/sZS
-        02Um+5HlfgZi/wo4Pkp4Ii/97/3Iqy72cOTzTff0jcMXsD+LA5AOPhjs+2c3
-        QsnhP2KAZ0XT8z4/DGKxoPF/syCr5uxnAejPndm9/RJX5qlPSvp0UTU6gT7W
-        31g7sOzzpxENEXzECiH8SFpZzcGw7F/ci+o6fhcKzXwgahJN7B94m/5wWlC/
-        dR9YKPTpzVqKp2H3PrWVP+h/u9urmly0/IqITiTvEFDjLJMUoBd/RL8PoN/d
-        /F2bLwXij0j5YaQk+/610rkYCP1Ov0WIFXzE2IcfSStLRIZl/+JelIL8Lohh
-        PhAqoon9A2/TH46C+q37wEKhT28mKWlP+h+0583UE8M6bLllMDxm/e1HxFPi
-        vZ5mZU489/OeZCSyHyLClo4/0ooyWKHiN0PS8PMf0fWboutSMs5nyzavz8kz
-        /RFlvynKhp//iNIfTmlHrZBy3zD0u0SeeCgoJGPK6m8/mqIhIl4uXhc/+BGT
-        E8W+LgXXTSTJIQPicetvPyLgEAFX60lZNHOCR2/bjwEXOMnY9bcfETEkIqEd
-        V4FfBzx3EM99Pc3a7KRaLvMpBuIjAdg9tKbSlLr+IluSdPRnFpTDhAzheRCi
-        Roh1unDQftYgOwPzKm/WZT/w+uCueOXlBVF8w3rL+/bC/QzP4rNsSrludOLj
-        AnA97Ga2eT99bbHqSRREQL7Q31hmpVEgiQzBvhYIR0ey+cPwZZE/9GD/ADz6
-        A58ZkeUXIX3ywQAFd3eIgtSa/9h56P8B2to/HtAfltDmQ/pf/0Mkk8MP97d3
-        92Ifouvuh8MJgWBGvnYmKjIX8pGdDJDS/dWZGv6S3wpA8NchVJkXdG3/wMv0
-        Bz6TOdEXb5ik/VsT5WsmmIQAAfbykaUCMHd//b+cJqxYPHG/QcdE4RMf0/86
-        3Mmf0P/Mh4OdH/9gXecfjAHLBzXlP7550Yxh79jp+jWNZIHp+H8npsSJYp66
-        PP5zhSIjOWx6nmdvITr+KIBcb1yYAbQ1q7H0jj86ERSW2+hAVasSPoRNB7SD
-        E8L8+oCck0AtIk7CDZAZ9maSHS+z8pqUPCBTHxYLAOvhlX09milzeHNJaA2A
-        vmvm5zXJyNedpPfqsLM6/0Ps6i55sm1GeaG+B/vD6fUuRUbt66x5U72lVPXP
-        Ag4OXgj7wwF+Lcm4TQ8W7teEyDA3yxyzNkH3ewbAHi5mCqmtj8k3MTMG9N3z
-        os6vsrJ8tS4JiW++IwcvhP3hAP8/yQLURrK+fp8A1cOC3IObwzedIPq441Dy
-        F8PuHZnXAwrWPaQJ5Q4CZ1X77fUEuP4sdcmdDtLpDTmuz7MJAfbxArQepkSd
-        HpodJ1fRY7zhEnu/RQagvzPnG0can9g/8OLgMO9v7/nsQIPs4JsvaV2gWi7I
-        df//FN7U3XsJRgjR+HX0PzgnffAO4teAvhGgUxVd2IZg9LH+xqQDneh381uU
-        1L2ZEhKjif0Db9+W3jyCAXGopmtwy9MnBNkfJKD1hg0XapI11uLTO8GQgZQM
-        riPB/IX9CwORZvybDrI3apeORLPgA9uWPjVx6tmSMgv0N3/X+cu0oU6HaEZB
-        6QG1pz/oN/pfnJM6FIAW/XlIBRrAANPzEAn+/1/GzqMfEp0FObuv8gtydYUa
-        9LJPKIDukW7Gb/XodlFWk6zchJoLdJGRI9QIsQ7stlo9zy/zUjD72emDnQfp
-        YJP78I30hSBCunqVT6sF6SkSPwb0s9HbJfEVwc9Nj25ez5bnVb3gXwnMN9/z
-        RU4xE/X8uqle5b9oTZJC73zz3ZDoUS/85oeD5w4GBOOaPqfA//ntYv9y2qzq
-        6qdp4QXNA7w66UooAaMa+HcSZmMP8bf9A8qG/hAV5Em++cjqIYYctsC7rgH/
-        xZ9zUygcg0HwFrqn39jEf/H62RtGgT4wf+r3wZ8Khz/o4OX0HFoGH1g8BqeL
-        /re7nZWrOaDLR5jBzkf3+h9hasltKC6JF4330Pku8uEkbzsgBCpzyPBcI1uA
-        1baqn6P40bRzy+ADi8f/56e9rNazWb4qq2tS6D+Sedutm2u0DD6wePx/cfJp
-        dANm50dTzS2DDyweg1PN5DazstEQn17SGCjTQh34cwJYvVmyEHqz5HDbgGyc
-        Xu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfsH+iO/pC+LO3xqfkrSmKS
-        G15kYsJ2qMTeLwd9INUGBzgKmSbPrVht6oZwi4vM+4BlwHZaCapjjGd51tI6
-        J6DTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4ZgstiRu99PYAM0h8VeZo6Kgp5
-        ios5WxS/T8DqYUHhxKpaErOhtY+Gz8ffH0VQImrT/xy1gZ/9g/4H0hOK0p/t
-        7yqftMR4P6TeKIaoCxr4N9FZDH5W5nVbx/L6LF0EX4WXf9sggNpMRZpl2Zdx
-        kWM0sX/gbfpDYHoD0rfDj/Am/cbKJ/jCqTA0CT5gMECCPg10zBDJiFCOZPS/
-        AZKt26qZEuGavG2L5cWPKKfEupFylNFYti393iXZbcDuYq3f/CHfxPpwYMMu
-        DB0+cAgWpEsXv3qflSWBfGM3FvjXAvup/wf9L94H+JhSIfns9N2KOOn1j7g5
-        Skz6X5x+lJO8WFZNW0x/HpLO9GBSswag+RuY6R9DVH4wRNhF3tbF9Gl+XiwL
-        oeWP6Gr+Bmb6x3vTtawufkRUIGcAmr+Bmf5xA1GZrL7P6jzx3yu//smMDAHB
-        8+kOGL2ZuETD3gxEKIMxym/ypSU+o2z/4mZKeR4qqGA+4C9jpOSWYX8Mln+T
-        OcO79g98SX84guu37gOGiL7p02AGhsjqW6rdve3dh158QJSOku1uk0/r/Efk
-        e2/y0WDfz6nYBJ47GJCEagnC+b0DaA+ft9ROV1+7GHlUjyJH+OwAOcaiA9bB
-        CWF+fUDO16MWYMH3g8yw46R6Xl0UU4JGcG3PANDD5aqq356X1VW3a2XsgAuD
-        P5iBwu/lFcv94Ev3FxNeWZ/fBT+aD7gpw+Bm/m80Ux1Glz/wNf0RsLPP8/q9
-        +4CboNP4zBNbIpi1nMjsSR92cmlE8Q4FaXgyhz8i4e1IyESMs+0XWf02b1cl
-        ff5lTRkgcn4Jik9w9NWbguyizvPoUgFjHJIYJMBvQ0Ng5cQ4dnqhSYhP9A2Q
-        GFZ8vC/yFgJI8Py+AKLX+2VRt+us1De6KNhR2Umn374+M8mbAdm4TfhR8AfD
-        C3gNn9g/0Dn98U3y2qfbu/fpFfmD/ud4jD8kPdlhPJqGDlFX60lZTM9eHs9m
-        9E1DlP8RWb8Bsi6FSc+WbV6fE8//iKzfCFnLKps9ycpsOSXo9NqPSPrBJFVO
-        fZ1P1zUt0XxeV+vVj0j7jZCWSNnmb7IJ5bPppR8R9IMJGnoAn1OG9Sq7/hFt
-        vxHagoQ/ouzPBmWn1XKZT4WIPyLoN0DQbLUin5Wp+CNOpcES2YiQ3wBhHQlD
-        cv7sdinduEzQz23v77fm+I3icDLPp2+fLpsXFCkfX2ZFmU2KknwygmUbUdc/
-        FFzWTXbRc1t+Fnu29P8h9pm/o2+b5hWJVn5S1NN10Zt30RK+RNNvog6s6uAm
-        9i9upnrDCq35QN4MFAW3CT8K/mB4/19TJD5lX+f1ZTHNX9bVZUEJrS6Ffxax
-        mC2bH1TLHhd/dFFWk6wcHD/9b/9WcO8e/+xBpudnDfjJi+MvTn/WoL988+pn
-        DfYXv/fPGug3v/ebnzXYr1/95DcNm6T5/LyYLrIl6el6VVfnRSTMvKGX/e29
-        g429TGGR3khXX0hXNxin9+ySOx3IDFdtQd0y5G+vJxibjx1g9vC1kNA6QMsp
-        wA0aMa563W+shKFx6Xf67XbanN9V/c9foyvzQUdvi07HG/YPdEd/SF/WyuBT
-        81eU1PvbOw9JPxKJicCDVLq77BP5R2QbIBsLA9ifabdJBhyRFCf3AaOModCn
-        /fH6v/3/hGpEoZIWsd4UeU2gfkSmATLRS3H/1yOK4uA+YBSBOn3aH5//2/8n
-        qcR0ssqKiOSMw5eGXFl5tmyKizl77j5NAa5HZSS3GBhaB1QG5jLqGxG8v727
-        SwhaK8b+KJm2e9t7O/IHOae727vujx36H42HRtPBp2mrmoyqDuGkWp4XF13U
-        ojhsAkri9vZNVl/kTBMflB1lFGZ3CIMdEGWE+F34UbAEiYmxcT5f5YuqzY9X
-        K4Lo9wYgvf6nVVkOJNScbGCo9K37gDkVHEyfdph3kOv5d/epypGwNz6xf4Bp
-        6A/h9QCcfKT8FJEj/iB8BcDcG/wXfT5AXCMsRNphMt31UmY/otktadboktiq
-        LpbTYpWVP6LcBspl02m1XvZVztcG2OaLVUnp3bMFacivC5YBD6kc6Q6g/a4B
-        pIdMQ77xtC5W0n+ISxQFUqYwEtSU/iB86H/OYjBWm3q4SwHde2VLPqQvmnhR
-        59TqPVKf79el+TO+vhwwJFg94FefgflL10xlxHCDEYAAHsMIP5JWIdPbv0TG
-        AN7+gQb0R0eQ49LuPlUQeDk9W84Yf25p/zJIyd/fDKWbYHIdmUOS/2z01WYX
-        LGr0/jffFbyanx3INOvC/+8FfqNueU2x4mxdcsjj9wYgvf5/upp4Zofe8HFQ
-        VjWMwtwrPBR8JK0sCzPL2b/Ah0Z++F1wqvmAmzIMbsa/BUwvf+BL+qMjAQEO
-        aEK/sUD2hMB9wO8CA/qUf1fud9DM30BA/4hOBc3sAU3F15tcJZnpk0cg6AQf
-        SStLSkbJ/oWxGTryuxiW+YCbMgxuxr8JLfGN/QNf0h//Lycsk3aA1/OsngJn
-        n/KA1JuLhlvqekBvPhgpf7z020bq8xgxXkNxfk9/lzfNwBkYtw8/kikAWPrD
-        URKA6IOBOdlAOFIOB9u7D6mx/LFH2U75g0j6YPve7vZLS1IiaIc+pDSmb5U8
-        yDNtSDEN9f41OvyaPfE4Y0BpcuIStxES40x/8ABu4Dcm0JM14Pt9A2QPGwsD
-        rX1s+tPtPuAZB2fRp2bWmV/QMviNZRL8Q7/Tb7fjOn5X+ZS/Rlfmgw7TCYfi
-        DfsHuqM/pC8rDfjU/BWlNDGEOsVE2g6VLCMwqTrc4FMtCpmmDeqCkKA/NnVD
-        uEVYg6C8D1gGbKeVoHqs8YtKau13Cli3R0OIyHPE9I9Mm0558IXMRPCRtjW/
-        6dwyUH+ygwmVP9Ce/hCYOp/h7PZ4xDGuvuw+4CbokT41CIr+UpjmD26of0Vn
-        gyaA/udsgpkV+h9mheakQ2VH2B8RWf/ghvrXN0zku1MaGCvwgpj+RxTXP7ih
-        /vXNUNyqyg1aUnBgOgkCBkf+CKOh335E8NsRvCF7TyCo4Y9IzH9wQ/3rGyXx
-        3VnWZpOs+ZEC+WEQGz/Jj/1y8tOI/C9/RPQfBtGz2aJYFkCIVt5+RHH7BzfU
-        v34WKW6XbSn5Hkk1C05MN0HI4MwfYXT0248m4P0mgD4mymeTMn9K6K/y2dMf
-        aXn6m2GaP7ih/vVNU39a0S9M/h/Rnf5mmOYPbqh/fbN0LxYrGgu1/xGl+Q9u
-        qH/9bFD69B3+/ZF+JwSFyArT/MEN9a9vlv6E8o9oLoRVmOYPbqh/fbM0Py/q
-        /Cory5rW+H5EcPsHN9S/vlmCm8j0dT5d15RweVmVxfRHmS6Caf7ghvrXzy7t
-        v8jbupj+iPT2D26of32zpM/WM0roLi9+xO70N8M0f3BD/eubpTk89sUiX87y
-        2WlJmBTTl1VV/oj09g9uqH99s6Q3muZHjI9PlcQK0/zBDfWvny3qT6vlEknJ
-        avkj+tPfDNP8wQ31r58t+jc/ryzt/8uIj9++yJq3P9I+oLLCNH9wQ/3rhzgB
-        d38UaDFM8wc31L++2WkwH69+5PMApvmDG+pf3yzBc/Exf0Rvhmn+4Ib61zdL
-        73WTXfxIlfwwKA09Lhp9wRmDp/k5rQQKyX9Efv2DG+pfP7vk/xHR7R/cUP/6
-        Zonua/Mf0Z3+ZpjmD26of/2s0332I3XDnTNM8wc31L++2Rlw6qatVj+xzmty
-        2+ntH9Gd/+CG+tfPPt3v/iL6ef0mfwe8fjQD/Ac31L++zgzwHCyzRd6ssikm
-        4ItiWldNdd6OX7dVTU4lveHPEeD2Z02aHk+n1XrZX6vF8Dyq6lzY39Ot1y29
-        fYc+47FxS/7NUo7bKvF5yKCN+SCYAPkDb9MfMhuGgAyX3w4/Cv6QV2zHX2fK
-        ovNwf3vn0+3d+/SK/EH/c5PCs9ChKfUvC+Bdcn4z4KMBwzcDejrPp29fEE8d
-        X2ZFmU2KkpbX6PVvvqcO392F9iimvWEJ+/D0gjHkN/2sz3527juswC8oy9nJ
-        Nh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM4AvHYGgSfMBggAR9GvBplLgk8PQ/
-        yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2SJvWebY4XmblNXl0oKM/BwAVmRW8
-        QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRDA/qD3+L3eXAYryE6fxCho34tYPA+
-        /SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs2v3t3R0Q3eiKh/4fn/p/0P/cHzxR
-        5o979IfVL/whfU3/w1TSRHamw5G/MxWggyOxwZ2Hj0HTbz+aCvmD/uf+YEKb
-        P4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgXywpB2+u8xVJvF1FvQvQ3jzkMsflr
-        +cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo2D/wMv2BzwyX8YtgEPOB4x00Cz6w
-        bePcQtSl/8VFjEB4tHwP46O//YiUlpQ0trj7KAOyo+e/GP1gLECFfvMIat+Q
-        kaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO635d8cFfBZ8AH3gU7p042zF6XaRq1w
-        QH9YcTcf3kZV0G/0P8wFz4bvBCysE9CsVysaM73hzxYQe4/5i1CNRx9+FPwB
-        ersJFAD2T/6Sm4HQwW88/TJl+MT+gVfojw7t+SemxUw23jG/u9nDp8EH9r2h
-        +dp5QJTdftmZFWhmIjcRu0M6oTJp3+nbvB+MyugD8jAC4UfBHxiuo5cAsH/y
-        l9wMA3O/0W//XyAfEzDOrZdFs87Kpl3Piope86kM4D26ZxI+UNOvQXAMS34D
-        deS3oIGACclu/+K3lVQMHPQwHwjR0cT+gbfpj84MOJpy4yg5Scjpfx0dQZ/s
-        be99SuQkYsapcndVVz+dT9Hrz1/qMH18ZnPx0XfzCbX2aQeYPWo2RUthKaUA
-        86X02yFnB2dgagbKvzOxZJT42/6hQxYybqIsQw5b4F3XgP/iz7mpT+rgLXRP
-        v7GO+OL1szeMAn1g/tTvgz8VDn/QwaszO/4HFg/6FF8S1CA2588A2vvMoep9
-        yBiKZXUtzN/ci/4V5Q3SObCu1FT+gFayf9zGxNIfe/aP/e3dXe8PDwD9Qf/r
-        8yD9DwqPODDKU01ZUebjR5z1I876pjmrWDZttqR0Gr3wI5ZCt46D0DL4wOJB
-        n+JLgvojluqxlCirHzHWjxjrG2Ysy1I/soT0QQcvx0xoGXxg8aBP8SVB/RF3
-        9biro7Z+xGP0QQcvx1JoGXxg8aBP8SVB/RGPeTy2Wk/KoplT+vgrWsD8EUuZ
-        bh0HoWXwgcWDPsWXBPVHLOWxFLETLeYgY5FdZkWZTUoQ9EdshW4dF6Fl8IHF
-        gz7FlwT1R2zlsZX8cVLReKryR4rKdOsYCC2DDywe9Cm+JKg/4igwkXKUVU80
-        0OnbH7GU6dZxEFoGH1g86FN8SVB/xFIeS5Ev1b6G237cNMXFMp+9qb5NxvAF
-        GUN6+UfshW4dN6Fl8IHFgz7FlwT1/9PsFWMRiergIoErnhSExvLiR8rHdOuY
-        AS2DDywe9Cm+JKj/P+UOifl//vGIsoSdSKIXf/AjHvF5hIhQq6b4kdaQbh0D
-        oGXwgcWDPsWXBPX/0xzBf3yDLss0r9vivCAu+tGaiO3WsQ9aBh9YPOhTfElQ
-        f8RPHj9RGvEyr59l9eJH7GS6ddyDlsEHFg/6FF8S1B+xk89OcIio2Y8YCd06
-        vkHL4AOLB32KLwnqjxipy0jiWVPjH7ETunXcg5bBBxYP+hRfEtQfsZPHTvV6
-        2RaLnmr6f8MgovgK+y/yti6m/59E+ml+XiwLQfn/U+izytFB/H8Y9f8v0t+5
-        ojqI/w+j/v9F+jMT1fm0Wizy5UwR/n8f8u+h9f9/NJaLvKrzC8b0/8vDECaj
-        5ouC0mKzGVAOx/Mj/+7/n/5djBuQM6f1lNPlZVFXS5LU/794+27m8GnwgQVC
-        n+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFuO/13F+uyLV5V
-        Zf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m9Y9YATPMnwG+
-        95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GACRa1j+//fiH4O
-        Zwsj+KbG5ilSHdiHT5XDhiaE/uf+YNTMHz8bU9Ufzv9P5qnDg8WyabPl9P+V
-        icvbB33vM1Cdzp93A/5/N/9+2NB9abXjJlA/D0aps/vza7T/f+HlRbYkl3r2
-        7f7w6V1/WD8KRvCZ68f7kPGScMO1MH9zL/rX/xtYI8oFs3xVVteY9ud2ysPp
-        /38D6rfn6qJRec4dQy+zRZ5dZkWZTUpw0/93Rzcts6Yppl9Uk6LMX9O6TEF6
-        iV77/+6ICNUvWBFhoo6n04rWsrsj+v+oAuIsuHuR/9Tvgz8VDn/QwcupLLQM
-        PrB40Kf4kqD+3OgwZoXtekqtvb8NA9x6zu+uqqu8Pl6tmle0EoRRyvT/iBWk
-        WzfzaBl8YPGgT/ElQf25YQXWMXbqlR/kw0neAoj3SVau5gTp1vwxrZbLfCqM
-        8COmkG4dD6Bl8IHFgz7FlwT154YpRB98uH5w8388/f9Lwpzn1L3If+r3wZ8K
-        hz/o4OVmHC2DDywe9Cm+JKj/32YB+tTnA//3H/GEh5djAbQMPrB40Kf4kqD+
-        /4onfsQHHl5u2tEy+MDiQZ/iS4L6/3k++NHce3i5qUbL4AOLB32KLwnq/+fn
-        nv/5EQN4eLn5RsvgA4sHfYovCer/9xmAYPxo4tGtm2e0DD6weNCn+JKg/n9/
-        4j3r/yMmMN26OUfL4AOLB32KLwnq/zuZgNkAydtmlU3BAy/yq1d5WUzHxy+/
-        oJd8DgHUPs8om1DbgCuEVgZjJqqg632kw+MvmSL8m7xpqcxN7F8MA4Rl6tEH
-        /B7/HqUApVF3aMTUkP8wSdLesF/ny9lFXczGpwtKYlNzf5gAduuBO4SGsOVR
-        6m/MizxE/lTGHpCIYYQfBX/IK5ZADMv+JZKGvuwfaEB/dKTWsa42dh9wEwwi
-        TmHKNYGnokRdTyl33jyhFb23zfikzLP66ROC7VMSYHq0nWVtNska+rJD3A7W
-        ASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovfixHO/1S75y/9HqPE
-        JXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B3Ty36hUZAEA
+        Ifwwhost0rB95A9Ck7jBSm60XUTke8owRAJwj6ULE+LGMd2t18tJVfX4/v8f
+        gwuSRv8/GCIhNDCWHk5fp0PuMi47T7J2Cv/MRwhQeyhO0NBMAL0QYBkSVknu
+        fnPE508jRO14i9LCAgyaMkydsWCmnQPJYDCz9Kk0Qef0h/3CAOAPQlQcGIUr
+        bWS6HS7mb0DWPwamZuchzQa1lD9YnfEfpPTpb8xTcUlepZsumqwO8YkMA/zB
+        3VtCAWMZhf72I8rDdvQJ6mgY0vPrA7r7i9ZVm3XhCZKWnBiXjFV/+9H8gKxM
+        2AH9VFwcL7PyupW0s099wOnNRzagoYAxjYLoPYTLAeFCsihCqAJKWpURJPQG
+        +rlLqcvsefY2H1KN79nxxr4aigYo+fxz0BUsbpsVS4L4c9Pr3ZLCoddZ86Z6
+        mxPsbx4HBy+EfSuAN7KLhXiX5FZUObVYl71J/Ga6s518E+C5gyHpXF58kXFS
+        1scAgHs4LbIVLZ+gqY+QaAmauq2XWd3STN+hBvrZ4GSSDaWZBlqdPt573IOQ
+        wG4n1WKxXhYC5WWdn+d1viQKfCDo9Yp0Rv6NAGfwQ1PzgzdZaVZBQA8fDYDq
+        IaavUFMfBSNc9LGZl54Z4i/sX2wWfFvCEPR3edPYCgYWGCL5A2/QHwzJbxyl
+        BzlS9D/HvxvpcpLR8giB9scOQD1qvMpnfW6NYN/D0VlC/gPjcrQRAPbP7+JL
+        boYRB7+RMutQQ/4APPqj4xfwzyGa9wy3+8C+R58atMVmK+bmD26of0VngbgS
+        WoSayh/IQcofNDn0Pzc/wYeSpfQ/ovmj2evMBk3a11t2I0x+FtGiSX0/hfOz
+        iAsz7AlHxi5bRK99PbQGe7i7yNu6mLouukNXHjfcxDwt3BN8BFYMfmOGZ57j
+        T/uNlZsZFljWfCD9hTJl/xKhwfv2DzSgPzoSFJcJ96mCMGiJJGhv5g9+U/+K
+        kpomj/63ibr06sWyasjffZ23LdnXHnmBiEcVJZwQwWDHX8tHlhKMqf2rM3r+
+        kt8KQPDXIVShIbq2f+Bl+gOfmTnhF0FD80GPkO4D25Y+NV0JDRUv8wc31L9u
+        IC8TeMACzCAVPvHxem86KIt5XpT0XYf8BkMmBsYS/DY0F4J68BEPjX+T9nZq
+        +Av7FwNWIjIUUMp8IPRHE/sH3qY/OvPrqK2N3QfcBEDjNCWFMJybVhrdzZez
+        VVWQy06Qf0StW1PrLi2+XRT08o+o9j5UmxLcajGjrPCPaLeRdoShuCf0eSTY
+        9Gn1wbDv6kTpnz/Erixn6N8/h12rQOtfP5eI+DKin32T6NzGH/+gDux4v1G0
+        89lFvqxmG636DUAZ7IBnkddtcY6YPn+VX1AGQUZAffloAGQPsal79cua1k57
+        CF6U1SQrB5FjB55RuwnwXe+Tb6wXYsbLAo0/ZwDHq5UmHl7WxXJarLLybPlV
+        k9dv8mW2hHr7Rnq9JP3IuRQ3Ip/uZ8vzqpaVw6/XI/c5MNVlRgvnU8rirNYt
+        zICPGiD1kBVRhMj0qA6VbyyG1fbmA/6S2NL+xiYMVoR+p9/EOHn8qzDCj4I/
+        5BVrwRiW/UusFPqyf6AB/fF1TJZBRpx2h4f5G6DtH4BDGKZ76dbrlvLAyAUK
+        ruY1+tJ8NTB3krU0oSzLLP9BcUHwB5ZIaYppgjvzxJrtqZ2sDfrtZwsDj1Pu
+        NmXVV9xMJ2UPJi9IbT7gL3ma9bcf8Qt/9UObrbt1Re4qvfijOZO/Adr+ATiE
+        4f8r5+zG1FYUH+qI/vd1Ovpg8JdF3a6z8gvKadMqWRec0FpZjKcI02U+4C+Z
+        VfS3H/EcfxWdhNvzHP3P/THIgFMaP9uUojdrX7P/WC+/aF212TcE3/wxOKQO
+        L/58T2Ty75YDTcfmb3Rk/wAcQukD2JPmhf53u3kR1TOs4ww69LH+9qNpUdqb
+        IZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcbTxmPhj/tN1aqMSyQxnwg/dlZZBD2
+        L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/W3obJM3fAG3/ABxC/2dpMmh4EjJ2
+        6R+FdHtlSf9zfwxqTv/PbwiBWDeL6jJ/vZ4007pYAfwr/fq9uowBttQj8rfr
+        5n0BMsiNUfaLvL2q6rcE1u8ZkHq4qFjpG11MhI2U1Zn7wInmA/7SiQgxVChF
+        XX6jjxhG+FHwxwt+xQoQw7J/QYL+PytOUbYzf2xidcoL5bOz1Y+m5v9lU/M+
+        zmIIMvhjEP4FZeeusuvX69WKRpPPnubID/4sdkgzKWrpw/ug/7k/BjtcitJ5
+        nU/XNWWLPq+r9Y/YnPAwfwO0/QNwCMNvgM1jU9HoHLxaU7RNkP0puAEYg9to
+        jl63VU1oEVi/V0Dq4yFNj6fTak0rl/SKj4kQQeeeaQc6mg/4S55D/e1HzMBf
+        bZw/I6TBH/S/3e1J3qIr94n9Y1Cgf7ZVIqealZuURd4/3Rz2Ffwx2HGHLe/C
+        KEeUsUwSc46bB/pDZjb4SPgF82j/wMv0Bz4zLM0vgj3MB45z0Cz4wLalT/l3
+        yy2mY/M3OrJ/AI6gpL+x1HSZyX5kuZ+B2L8Cjo8SnshL/3s/8mqQNxx7f9M9
+        fePwBezP4gCkgw8G+/75tVBy+I8Y4FnR9KKKD4NYLGj83yzIqjn7WQD6s+tO
+        cZcDZvf2i6yZpz4p7dhF1egE+lh/Y+3Ass+fRjRE8BErhPAjaWU1B8Oyf3Ev
+        quv4XSg084GoSTSxf+Bt+sNpQf3WfWCh0Kc3aymeht371Fb+oP/tbq9qcr3z
+        KyI6kbxDQI2fTVqKXvwR/T6Afnfzd22+FIg/IuWHkZLs+9daUMBA6Hf6LUKs
+        4CPGPvxIWlkiMiz7F/eiFOR3QQzzgVARTewfeJv+cBTUb90HFgp9ejNJSXvS
+        /6A9b6aeGNZhyy2D4THrbz8inhLv9TQrc+K5n/ckI5H9EBG2dPyRVpTBChW/
+        GZKGn/+Irt8UXTWpd7Zs8/qcPNMfUfabomz4+Y8o/eGUdtQKKfcNQ79L5ImH
+        gkIypqz+9qMpGiLi5eJ18YMfMTlR7OtScN1EkhwyIB63/vYjAg4RcLWelEUz
+        J3j0tv0YcIGTjF1/+xERQyIS2t+ICmSiBHRiLMOP/r9MOiZePK/3NGuzk2q5
+        zKfoyScwYPdIPpWm1PUX2ZIkv8+1GBooNoTnQYgaIdbpwkH7WYPsjOervFmX
+        /aDyg7viVaUXRPENa0nv2wv3MzyLz7Ip5fHRiY8LwPWwm9nm/dS8xarH8uBR
+        +UJ/Y30kjQJRYQj2tYB7O1qLPwxfFgFBD/YPwKM/8JmRKX4R4iEfDFBwd4co
+        SK35j52H/h+grf3jAf1hCW0+pP/1P0SiPPxwf3t3L/Yhuu5+OJzsCGbka2fZ
+        InMhH9nJACndX52p4S/5rQAEfx1ClXlB1/YPvEx/4DOZE33xhkkiitD/bkOU
+        r5k8EwIE2MtHlgrA3P31/3KasGLxxP0GHROFT3xM/+twJ39C/zMfDnZ+/IN1
+        nX8wBiwf1JT/+OZFM4a9Y6fr1zSSBabj/52YEieKeery+M8ViozksOl5nr2F
+        6PijAHK9cWEG0NasNNM7/uhEUFhuowNVrUr4EDYd0A5OCPPrA3JOArWIOAk3
+        QGbYm0l2vMzKa1LygEx9WCwArIdX9vVopszhzSWhNQD6rpmf1yQjX3eS3qvD
+        hjoiL/LnoKu75Mm2GeW8+h7sD6fXuxT1ta+z5k31ltLwPws4OHgh7A8H+LUk
+        4zY9WLhfEyLD3CxzzNoE3e8ZAHu4mCmktj4m38TMGNB3z4s6v8rK8tW6JCS+
+        +Y4cvBD2hwP8/yQLUBvJaPt9AlQPC3IPbg7fdILo445DyV8Mu3dkXg8oWPeQ
+        JpQ7CJxV7bfXE+D6s9QldzpIpzfkuD7PJgTYxwvQepgSdXpodpxcRY/xhkvs
+        /RYZgP7OnG8caXxi/8CLg8O8v73nswMNsoNvvqQ1j2q5INf9/1N4U3fvJRgh
+        ROPX0f/gnPTBO4hfA/pGgE5VdGEbgtHH+huTDnSi381vUVL3ZkpIjCb2D7x9
+        W3rzCAbEoZquwS1PnxBkf5CA1hs2XKhJ1liLT+8EQwZSMriOBPMX9i8MRJrx
+        bzrI3qhdvhDNgg9sW/rUxKlnS8os0N/8Xecv04Y6HaIZBaUH1J7+oN/of3FO
+        6lAAWvTnIRVoAANMz0Mk+P9/GTuPfkh0FuTsvsovyNUVatDLPqEAuke6Gb/V
+        o9tFWU2ychNqLtBFRo5QI8Q6sNtq9Ty/zEvB7GenD3YepINN7sM30heCCOnq
+        VT6tFqSnSPwY0M9Gb5fEVwQ/Nz26eT1bnlf1gn8lMN98zxc5xUzU8+umepX/
+        ojVJCr3zzXdDoke98JsfDp47GBCMa/qcAv/nt4v9y2mzqqufpoUXNA/w6qQr
+        oQSMauDfSZiNPcTf9g8oG/pDVJAn+eYjq4cYctgC77oG/Bd/zk2hcAwGwVvo
+        nn5jE//F62dvGAX6wPyp3wd/Khz+oIOX03NoGXxg8RicLvrf7nZWruaALh9h
+        Bjsf3et/hKklt6G4JF403kPnu8iHk7ztgBCozCHDc41sAVbbqn6O4kfTzi2D
+        Dywe/5+f9rJaz2b5qqyuSaH/SOZtt26u0dJ+gA8sHl9j8jEnZpp+TiafRjdg
+        dn401dwy+MDiMTjVTG4zKxsN8ekljYEyLdSBPyeA1ZslC6E3Sw63DcjG6eV+
+        Y8o5ogk9glcYVvgRv6tk5K/RlfmgwzzCGXjD/oHu6A/py9Ien5q/oiQmpcmL
+        TEzYDpXY++WgD6Ta4ABHIdPkuRWrTd0QbnGReR+wDNhOK0F1jPEsz1pa5wR0
+        +tf2DIA9XM5d2xsxoc6BicedhAK968MjQ3BZzOi9rweQQfqjIk9TR0UhT3Ex
+        Z4vi9wlYPSwonFhVS2I2tPbR8Pk4ihJRm/7nqA387B/0P5CeUOz0d5VPWmK8
+        H1JvFEPUBQ38m+gsBj8r87qtY3l9li6Cr8LLv20QQG2mIs2y7Mu4yDGa2D/w
+        Nv0hML0B6dvhR3iTfmPlE3zhVBiaBB8wGCBBnwY6ZohkRChHMvrfAMnWbdVM
+        iXBN3rbF8uJHlFNi3Ug5ymgs25Z+75LsNmB3sdZv/pBvYn04sGEXhg4fOAQL
+        0qWLX73PypJAvrEbC/xrgf3U/4P+F+8DfEypkHx2+m5FnPT6R9wcJSb9L04/
+        ykleLKumLaY/D0lnejCpWQPQ/A3M9I8hKj8YIuwib+ti+jQ/L5aF0PJHdDV/
+        AzP9473pWlYXPyIqkDMAzd/ATP+4gahMVt9ndZ7475Vf/2RGhoDg+XQHjN5M
+        XKJhbwYilMEY5Tf50hKfUbZ/cTOlPA8VVDAf8JcxUnLLsD8Gy7/JnOFd+we+
+        pD8cwfVb9wFDRN/0aTADQ2T1LdXu3vbuQy8+IEpHyXa3yad1/iPyvTf5aLDv
+        51RsAs8dDEhCtQTh/N4BtIfPW2qnq69djDyqR5EjfHaAHGPRAevghDC/PiDn
+        61ELsOD7QWbYcVI9ry6KKUEjuLZnAOjhclXVb8/L6qrbtTJ2wIXBH8xA4ffy
+        iuV+8KX7iwmvrM/vgh/NB9yUYXAz/zeaqQ6jyx/4mv4I2Nnnef3efcBN0Gl8
+        5oktEcxaTmT2pA87uTSieIeCNDyZwx+R8HYkZCLG2faLrH6bt6uSPv+ypgwQ
+        Ob8ExSc4+upNQXZR53l0qYAxDkkMEuC3oSGwcmIcO73QJMQn+gZIDCs+3hd5
+        CwEkeH5fANHr/bKo23VW6htdFOyo7KTTb1+fmeTNgGzcJvwo+IPhBbyGT+wf
+        6Jz++CZ57dPt3fv0ivxB/3M8xh+SnuwwHk1Dh6ir9aQspmcvj2cz+qYhyv+I
+        rN8AWZfCpGfLNq/Pied/RNZvhKxllc2eZGW2nBJ0eu1HJP1gkiqnvs6n65qW
+        aD6vq/XqR6T9RkhLpGzzN9mE8tn00o8I+sEEDT2AzynDepVdfxO0JVooKe04
+        zAc/X2gL9vwRZX82KDutlst8KkT8EUG/AYJmqxX5rEzFH3EqDZbIRoT8Bgjr
+        SBiS84fRpcsE/dz2/n5rjt8oDifzfPr26bJ5QZHy8WVWlNmkKMknI1i2EXX9
+        Q8Fl3WQXPbflZ7FnS/8fYp/5O/q2aV6RaOUnRT1dF715Fy3hSzT9JurAqg5u
+        Yv/iZqo3rNCaD+TNQFFwm/Cj4A+G9/81ReJT9nVeXxbT/GVdXRaU0OpS+GcR
+        i9my+UG17HHxRxdlNcnKwfHT//ZvBffu8c8eZHp+1oCfvDj+4vRnDfrLN69+
+        1mB/8Xv/rIF+83u/+VmD/frVT37TsEmaz8+L6SJbkp6uV3V1XkTCzBt62d/e
+        O9jYyxQW6Y109YV0dYNxes8uudOBzHDVFtQtQ/72eoKx+dgBZg9fCwmtA7Sc
+        AtygEeOq1/3GShgal36n326nzfld1f/8NboyH3T0tuh0vGH/QHf0h/RlrQw+
+        NX9FSb2/vfOQ9CORmAg8SKW7yz6Rf0S2AbKxMID9mXabZMARSXFyHzDKGAp9
+        2h+v/9v/T6hGFCppEetNkdcE6kdkGiATvRT3fz2iKA7uA0YRqNOn/fH5v/1/
+        kkpMJ6usiEjOOHxpyJWVZ8umuJiz5+7TFOB6VEZyi4GhdUBlYC6jvhHB+9u7
+        u4SgtWLsj5Jpu7e9tyN/kHO6u73r/tih/9F4aDQdfJq2qsmo6hBOquV5cdFF
+        LYrDJqAkbm/fZPVFzjTxQdlRRmF2hzDYAVFGiN+FHwVLkJgYG+fzVb6o2vx4
+        tSKIfm8A0ut/WpXlQELNyQaGSt+6D5hTwcH0aYd5B7mef3efqhwJe+MT+weY
+        hv4QXg/AyUfKTxE54g/CVwDMvcF/0ecDxDXCQqQdJtNdL2X2I5rdkmaNLomt
+        6mI5LVZZ+SPKbaBcNp1W62Vf5XxtgG2+WJWU3j1bkIb8umAZ8JDKke4A2u8a
+        QHrINOQbT+tiJf2HuERRIGUKI0FN6Q/Ch/7nLAZjtamHuxTQvVe25EP6ookX
+        dU6t3iP1+X5dmj/j68sBQ4LVA371GZi/dM1URgw3GAEI4DGM8CNpFTK9/Utk
+        DODtH2hAf3QEOS7t7lMFgZfTs+WM8eeW9i+DlPz9zVC6CSbXkTkk+c9GX212
+        waJG73/zXcGr+dmBTLMu/P9e4DfqltcUK87WJYc8fm8A0uv/p6uJZ3boDR8H
+        ZVXDKMy9wkPBR9LKsjCznP0LfGjkh98Fp5oPuCnD4Gb8W8D08ge+pD86EhDg
+        gCb0GwtkTwjcB/wuMKBP+XflfgfN/A0E5I+4aNDMHtBUfL3JVZJJnzoCQSf4
+        SFpZUjJK9i+MzdCR38WwzAfclGFwM/5NaIlv7B/4kv74fzlhmbQDvJ5n9RQ4
+        +5QHpN5cNNxS1wN688FI+eOl3zZSn8eI8RqK83v6u7xpBs7AuH34kUwBwNIf
+        jpIARB8MzMkGwpFyONjefUiN5Y89ynbKH0TSB9v3drdfWpISQTv0IaUxfavk
+        QZ5pQ4ppqPev0eHX7InHGQNKkxOXuI2QGGf6gwdwA78xgZ6sAd/vGyB72FgY
+        aO1j059u9wHPODiLPjWzzvyClsFvLJPgH/qdfrsd1/G7yqf8NboyH3SYTjgU
+        b9g/0B39IX1ZacCn5q8opYkh1Ckm0naoZBmBSfW1uIEg8xxu6oZwe1/WIEgd
+        sAzYTitB7bHGs2xSF1N6z+8eUHsITUuac+qV2vroCDHdXPFv/JkSWOfNn9ah
+        IcBZ2M7K1ZxUxkbcf1FJYH38AKSHMfUeJ6HgR4hEcLPDYHYNvhAuCj7StuY3
+        5UsG6jNqwIzyB9rTHwLTkgpN3F8d/nZCpy+7D7gJeqRPDYKiexWm+YMb6l/R
+        aSDmof85e2Y4iv4HjqI56VDZEfZHRNY/uKH+9Q0T+e6UBsbqpiCm/xHF9Q9u
+        qH99MxS3an6DhhccmE6CgMGRP8Jo6LcfEfx2BG/IIBEIavgjEvMf3FD/+kZJ
+        fHeWtdkka36kQH4YxMZPcrS+nPw0shaXPyL6D4Po2WxRLAsgRKuGP6K4/YMb
+        6l8/ixS3S860cBBJkwtOTDdByODMH2F09NuPJuD9JoA+JspnkzJ/Suiv8tnT
+        H2l5+pthmj+4of71TVN/WtEvTP4f0Z3+ZpjmD26of32zdC8WKxoLtf8RpfkP
+        bqh//WxQ+vQd/v2RficEhcgK0/zBDfWvb5b+hPKPaC6EVZjmD26of32zND8v
+        6vwqK8ua1id/RHD7BzfUv75ZgpvI9HU+XdeUcHlZlcX0R5kugmn+4Ib6188u
+        7b/IW1oa+BHp7R/cUP/6ZkmfrWeU0F1e/H+B3f//QnN47ItFvpzls9OSMCmm
+        L6uq/BG72z+4of71zZLeaJofMT4+VRIrTPMHN9S/fraoP62WSyQlq+WP6E9/
+        M0zzBzfUv3626N/8yNIqhRWm+YMb6l8/W8THb19kzdsfaR9QWWGaP7ih/vVD
+        nIC7Pwq0GKb5gxvqX9/sNJiPVz/yeQDT/MEN9a9vluC5+Jg/ojfDNH9wQ/3r
+        m6X3uskufqRKfhiUhh4Xjb5gP+Zpfk4rgULyH5Ff/+CG+tfPLvl/RHT7BzfU
+        v75Zovva/Ed0p78ZpvmDG+pfP+t0n/1I3XDnDNP8wQ31r292Bpy6aavVT6zz
+        mtx2evtHdOc/uKH+9bNP97u/iH5ev8nfAa8fzQD/wQ31r68zAzwHy2yRN6ts
+        ign4opjWVVOdt+PXbVWTU0lv+HMEuP1Zk6bH02m1XvbXajE8j6o6F/b3dOt1
+        S2/foc94bNySf7OU47ZKfB4yaGM+CCZA/sDb9IfMhiEgw+W3w4+CP+QV2/HX
+        mbLoPNzf3vl0e/c+vSJ/0P/cpPAsdGhK/csCeJec3wz4aMDwzYCezvPp2xfE
+        U8eXWVFmk6KkpB+9/s331OG7u9AexbQ3LGEfnl4whvymn/XZz859hxX4BWU5
+        O9nmA2E7NLF/ABj9IVACHuO3w4/wJv3GghF84RgMTYIPGAyQoE8DPo0SlwSe
+        /geZvz0d1efYEOIAKUEUw5Xf9LOfh5Rl2g5p0zrPFsfLrLwmjw509OcAoCKz
+        glcoX/jT1QQvBIQPhgKCdMipIxYa2a+EfmhAf/Bb/D4PDuM1ROcPInTUrwUM
+        3qc/pIt+W/7N0RSfBR9wH+iUPg2I7OZpg127v727A6IbXfHQ/+NT/w/6n/uD
+        J8r8cY/+sPqFP6Sv6X+YSprIznQ48nemAnRwJDa48/AxaPrtR1Mhf9D/3B9M
+        aPNHMBU+9XvUJy+warPuJPysIXYjYkRDJ6V3iUgXywpB2+u8xVJvF1FvQvQ3
+        jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo2D/wMv2BzwyX8YtgEPOB
+        4x00Cz6wbePcQtNO/4uLGIHwaPkexkd/+xEpLSlpbHH3UQZkR89/MfrBWIAK
+        /eYR1L4hI0MD+sNiaEbDH4R0QVPztbyMTukPAdxvy785KuCz4APuA53Spxtn
+        L0q1jerqgP6w4m4+vI0Oo9/of5gLng3fCVhYJ6BZr1Y0ZnrDny0g9h7zF6Ea
+        jz78KPgD9HYTKADsn/wlNwOhg994+mXK8In9A6/QHx3a809Mi5lsvGN+d7OH
+        T4MP7HtD87XzgCi7/bIzK9DMRG4idod0SmXSwW/zfjAqow/IwwiEHwV/YLiO
+        XgLA/slfcjMMLPjt/wvkYwLGufWyaNZZ2bTrWVHRaz6VAbxH90zCB2r6NQiO
+        YclvoI78FjQQMCHZ7V/8tpKKgYMe5gMhOprYP/A2/dGZAUdTbhwlJwk5/a+j
+        I+iTve29T4mcRMw4Ve6u6uqn8yl6/flLHaaPz2wuPvpuPqHWPu0As0fNpmgp
+        LKUUYL6Ufjvk7OAMTM1A+XcmlowSf9s/dMhCxk2UZchhC7zrGvBf/Dk39Ukd
+        vIXu6TfWEV+8fvaGUaAPzJ/6ffCnwuEPOnh1Zsf/wOJBn+JLghrE5vwZQHuf
+        OVS9DxlDsayuhfmbe9G/orxBOgfWlZrKH9BK9o/bmFj6Y8/+sb+9u+v94QGg
+        P+h/fR6k/0HhEQdGeaopK8p8/IizfsRZ3zRnFcumzZaUTqMXfsRS6NZxEFoG
+        H1g86FN8SVB/xFI9lhJl9SPG+hFjfcOMZVnqR5aQPujg5ZgJLYMPLB70Kb4k
+        qD/irh53ddTWj3iMPujg5VgKLYMPLB70Kb4kqD/iMY/HVutJWTRzSh9/RQuY
+        P2Ip063jILQMPrB40Kf4kqD+iKU8liJ2osUcZCyyy6wos0kJgv6IrdCt4yK0
+        DD6weNCn+JKg/oitPLaSP04qGk9V/khRmW4dA6Fl8IHFgz7FlwT1RxwFJlKO
+        suqJBjp9+yOWMt06DkLL4AOLB32KLwlqhKUItMc9DlXvQ8ZQmMa1MH9zL/rX
+        /7dYinyp9jXc9uOmKS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/
+        n2avGItIVAcXCVzxpCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXfMqkVWLL+8
+        WlLP82J1NiMci/OC/iIIP+ITdOvYAi2DDywe9Cm+JKj/P+UTyQ39SJeYDzp4
+        OZZAy+ADiwd9ii8J6v/veISIUCsX/IgjpFvHAGgZfGDxoE/xJUH9/zRH8B/f
+        oGs7zWvYIOKiH62d2W4d+6Bl8IHFgz7FlwT1R/zk8ROlmy/z+llWL37ETqZb
+        xz1oGXxg8aBP8SVB/RE7+ewEh4ia/YiR0K3jG7QMPrB40Kf4kqD+iJG6jCSe
+        NTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK8pdF/0VNP/GwYRxVfYf5G3dTH9
+        /yTST/PzYlkIyv+fQp9Vjg7i/8Oo/3+R/s4V1UH8fxj1/y/Sn5mozqfVYpEv
+        Z4rw//uQfw+t//+jsVzkVZ1fMKb/Xx6GMBk1X1AePZvNgHI4nh/5d///9O9i
+        3ICcOeXKT5eXRV0tSVL/v+Tt0/AMAXmOeQ6I2OAGN3P4NPiAifzDmMqfvak0
+        f7yHhrjt9N9drMu2eFWV+cuqKv9/ohvc5OPT4AMLhD7Fl/yKJ6/8GeB7n7l+
+        vA8ZL5lv18L8zb3oX/+f4oarqn6b1z9iBcwwfwb43meuH+9Dxksm27Uwf3Mv
+        +tf/p1hB/OouG/x/cAj/HwwNooMJFLWO7f9/I/r/yWx5ilQH9v+z4fz/ZJ46
+        PFgsmzZbTv9fmbi8fdD3PgPV6fx5N+D/d/Pvhw3dl1Y7bgL182CUOrs/v0b7
+        /xdeXmRLcqln3+4Pn971h/WjYASfuX68DxkvCTdcC/M396J//b+BNaJcMMtX
+        ZXWNaX9upzyc/v83oH57rl7V1WUBTD8vq0lWHq9Wr2n5opjmL+tiOS1WWXm2
+        /IpWNN7ky2yJ+f//7lCLRlVX7mR3mS3y7DIrymxSQnD+vzu6aZk1TTH9opoU
+        Za5z+P9t1iRUv8igczFRx9NpRcv23RH9f1TXcsLfvch/6vfBnwqHP+jg5bQz
+        WgYfWDzoU3xJUH9u1DWzwnY9pdbe34YBbj3nd1fVVV6Tampe0aIXRinT/yNW
+        kG7dzKNl8IHFgz7FlwT154YVWMfYqVd+kA8neQsg3idZuZoTpFvzx7RaLvOp
+        MMKPmEK6dTyAlsEHFg/6FF8S1J8bphB98OH6wc3/8fT/L2sDPKfuRf5Tvw/+
+        VDj8QQcvN+NoGXxg8aBP8SVB/f82C9CnPh/4v/+IJzy8HAugZfCBxYM+xZcE
+        9f9XPPHzmg9+nvPBj+bew8tNNVoGH1g86FN8SVD/Pz/3/M+PGMDDy803WgYf
+        WDzoU3xJUP+/zwAE40cTj27dPKNl8IHFgz7FlwT1//sT71n/HzGB6dbNOVoG
+        H1g86FN8SVD/38kEzAZI3jarbAoeeJFfvcrLYjo+fvkFveRzCKD2eUbZhNoG
+        XCG0MhgzUQXd4CMeHv/GFOHf5E1LZW5i/2IYICxTjz7g9/j3KAUojbpDI6aG
+        /IdJkvaG/Tpfzi7qYjY+XVASm5r7wwSwWw/cITSELY9Sf2Ne5CHypzL2gEQM
+        I/wo+ENesQRiWPYvkTT0Zf9AA/qjI7WOdbWx+4CbYBBxClOuCTwVJep6Srnz
+        5gktXr5txidlntVPnxBsn5IA06PtLGuzSdbQlx3idrAOCAHEN9NZCIBP7B9K
+        DSFiAE4+spTkLkEF0wXedF/zX/xejHD+p9o9f+n3GCUusSv9D8Ql0naINC0J
+        JjUnYD+iEdMI//0/PFGYsaBtAQA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:06 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
@@ -399,11 +407,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -422,17 +430,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14999'
       X-Ms-Request-Id:
-      - 9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - feed9a87-92a6-44ad-8aa4-0fd042c4ddb0
       X-Ms-Correlation-Request-Id:
-      - 9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - feed9a87-92a6-44ad-8aa4-0fd042c4ddb0
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - NORTHCENTRALUS:20151120T220649Z:feed9a87-92a6-44ad-8aa4-0fd042c4ddb0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:06 GMT
+      - Fri, 20 Nov 2015 22:06:48 GMT
       Content-Length:
       - '411'
     body:
@@ -449,7 +457,7 @@ http_interactions:
         5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
         dX0nBgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
@@ -462,11 +470,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -489,20 +497,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
       X-Ms-Request-Id:
-      - 0e486cc4-6169-4179-a940-8cdba8f86316
+      - 4f9aee84-6dd3-422b-a04d-0489b4788df9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14893'
+      - '14999'
       X-Ms-Correlation-Request-Id:
-      - 22a7d03c-cdc2-42f0-8c0a-6a312d43b4e2
+      - e62de18d-e446-446e-b8a7-10eb3efbe34d
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:22a7d03c-cdc2-42f0-8c0a-6a312d43b4e2
+      - NORTHCENTRALUS:20151120T220649Z:e62de18d-e446-446e-b8a7-10eb3efbe34d
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Fri, 20 Nov 2015 22:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -526,7 +534,7 @@ http_interactions:
         72FXjg82DMbr5WuP5d7D3VDp+mP5Rmfm+OGGoXwj87JxLLeYl/cZzO6mJKTX
         zc/OYL7ZidmolP/fNTP48f3fOPkl/w/0zz7qHRoAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -539,11 +547,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -562,17 +570,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
+      - '14999'
       X-Ms-Request-Id:
-      - 2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - 08fe6f26-044b-40ce-ba81-da327e7cafe4
       X-Ms-Correlation-Request-Id:
-      - 2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - 08fe6f26-044b-40ce-ba81-da327e7cafe4
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - NORTHCENTRALUS:20151120T220650Z:08fe6f26-044b-40ce-ba81-da327e7cafe4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Fri, 20 Nov 2015 22:06:49 GMT
       Content-Length:
       - '1446'
     body:
@@ -612,7 +620,7 @@ http_interactions:
         ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
         b2cOFgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -625,11 +633,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -648,17 +656,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14999'
       X-Ms-Request-Id:
-      - 6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - 2045c16a-8a8e-4bf5-b538-22eded016eb0
       X-Ms-Correlation-Request-Id:
-      - 6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - 2045c16a-8a8e-4bf5-b538-22eded016eb0
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - NORTHCENTRALUS:20151120T220651Z:2045c16a-8a8e-4bf5-b538-22eded016eb0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Fri, 20 Nov 2015 22:06:50 GMT
       Content-Length:
       - '1791'
     body:
@@ -705,7 +713,7 @@ http_interactions:
         fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
         lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -718,11 +726,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -741,17 +749,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
+      - '14999'
       X-Ms-Request-Id:
-      - f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - e61cb676-4557-45db-ba9e-207eff8b462a
       X-Ms-Correlation-Request-Id:
-      - f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - e61cb676-4557-45db-ba9e-207eff8b462a
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - NORTHCENTRALUS:20151120T220651Z:e61cb676-4557-45db-ba9e-207eff8b462a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Fri, 20 Nov 2015 22:06:51 GMT
       Content-Length:
       - '133'
     body:
@@ -761,7 +769,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -774,11 +782,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -797,17 +805,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14894'
+      - '14999'
       X-Ms-Request-Id:
-      - a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - 8029b8a2-2b0c-421b-b3be-d2cf96256093
       X-Ms-Correlation-Request-Id:
-      - a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - 8029b8a2-2b0c-421b-b3be-d2cf96256093
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - NORTHCENTRALUS:20151120T220654Z:8029b8a2-2b0c-421b-b3be-d2cf96256093
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Fri, 20 Nov 2015 22:06:54 GMT
       Content-Length:
       - '133'
     body:
@@ -817,7 +825,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -830,11 +838,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -853,17 +861,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14999'
       X-Ms-Request-Id:
-      - 97facd28-d917-4249-ba90-29f63dd710e2
+      - 3e86ab58-249c-47a2-85ca-16cea2f45170
       X-Ms-Correlation-Request-Id:
-      - 97facd28-d917-4249-ba90-29f63dd710e2
+      - 3e86ab58-249c-47a2-85ca-16cea2f45170
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:97facd28-d917-4249-ba90-29f63dd710e2
+      - NORTHCENTRALUS:20151120T220655Z:3e86ab58-249c-47a2-85ca-16cea2f45170
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Fri, 20 Nov 2015 22:06:55 GMT
       Content-Length:
       - '1160'
     body:
@@ -896,7 +904,7 @@ http_interactions:
         a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
         dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -909,11 +917,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -932,17 +940,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14902'
+      - '14999'
       X-Ms-Request-Id:
-      - ad3c6072-1be1-4f37-8491-226045e517a1
+      - 0c0a3bb9-7da5-4baa-a9ee-2941e42c68ef
       X-Ms-Correlation-Request-Id:
-      - ad3c6072-1be1-4f37-8491-226045e517a1
+      - 0c0a3bb9-7da5-4baa-a9ee-2941e42c68ef
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:ad3c6072-1be1-4f37-8491-226045e517a1
+      - NORTHCENTRALUS:20151120T220656Z:0c0a3bb9-7da5-4baa-a9ee-2941e42c68ef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Fri, 20 Nov 2015 22:06:55 GMT
       Content-Length:
       - '133'
     body:
@@ -952,7 +960,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -965,11 +973,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -988,17 +996,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14878'
+      - '14999'
       X-Ms-Request-Id:
-      - 8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - 0ed662a8-96aa-49b3-b781-15f0f2535269
       X-Ms-Correlation-Request-Id:
-      - 8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - 0ed662a8-96aa-49b3-b781-15f0f2535269
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - NORTHCENTRALUS:20151120T220657Z:0ed662a8-96aa-49b3-b781-15f0f2535269
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Fri, 20 Nov 2015 22:06:57 GMT
       Content-Length:
       - '133'
     body:
@@ -1008,7 +1016,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -1021,11 +1029,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1044,17 +1052,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14884'
+      - '14999'
       X-Ms-Request-Id:
-      - 59c09c74-6334-42fa-96c0-59ab658a203f
+      - 60698eb8-9238-4776-932b-002f84239444
       X-Ms-Correlation-Request-Id:
-      - 59c09c74-6334-42fa-96c0-59ab658a203f
+      - 60698eb8-9238-4776-932b-002f84239444
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:59c09c74-6334-42fa-96c0-59ab658a203f
+      - NORTHCENTRALUS:20151120T220658Z:60698eb8-9238-4776-932b-002f84239444
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:09 GMT
+      - Fri, 20 Nov 2015 22:06:57 GMT
       Content-Length:
       - '1084'
     body:
@@ -1086,7 +1094,7 @@ http_interactions:
         vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
         IA8AAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
@@ -1099,11 +1107,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1122,17 +1130,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14901'
+      - '14999'
       X-Ms-Request-Id:
-      - de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - 742e93df-afd0-4265-8a93-893fac0e94de
       X-Ms-Correlation-Request-Id:
-      - de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - 742e93df-afd0-4265-8a93-893fac0e94de
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - NORTHCENTRALUS:20151120T220659Z:742e93df-afd0-4265-8a93-893fac0e94de
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:09 GMT
+      - Fri, 20 Nov 2015 22:06:58 GMT
       Content-Length:
       - '502'
     body:
@@ -1151,7 +1159,7 @@ http_interactions:
         Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
         PiqhoAIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Fri, 20 Nov 2015 22:06:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
@@ -1164,11 +1172,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1187,17 +1195,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
+      - '14999'
       X-Ms-Request-Id:
-      - 017c7249-0be2-45fc-a90f-587062e54fc2
+      - e90baeb2-90a0-44d9-a006-387c6ee9f096
       X-Ms-Correlation-Request-Id:
-      - 017c7249-0be2-45fc-a90f-587062e54fc2
+      - e90baeb2-90a0-44d9-a006-387c6ee9f096
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:017c7249-0be2-45fc-a90f-587062e54fc2
+      - NORTHCENTRALUS:20151120T220659Z:e90baeb2-90a0-44d9-a006-387c6ee9f096
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:10 GMT
+      - Fri, 20 Nov 2015 22:06:58 GMT
       Content-Length:
       - '1685'
     body:
@@ -1242,7 +1250,7 @@ http_interactions:
         Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
         jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
@@ -1255,11 +1263,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1278,17 +1286,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14904'
+      - '14999'
       X-Ms-Request-Id:
-      - c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - a749b05e-5e42-4c33-aeac-5d85d6a416cf
       X-Ms-Correlation-Request-Id:
-      - c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - a749b05e-5e42-4c33-aeac-5d85d6a416cf
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - NORTHCENTRALUS:20151120T220700Z:a749b05e-5e42-4c33-aeac-5d85d6a416cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:10 GMT
+      - Fri, 20 Nov 2015 22:07:00 GMT
       Content-Length:
       - '501'
     body:
@@ -1307,7 +1315,7 @@ http_interactions:
         WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
         IniEAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:00 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
@@ -1323,8 +1331,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Content-Security-Policy:
       - default-src 'none'
@@ -1336,26 +1344,20 @@ http_interactions:
       - nosniff
       Strict-Transport-Security:
       - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
       X-Github-Request-Id:
-      - 17EB2E25:509B:1F8178E3:564243A7
+      - C71B4F1C:19D9:1D56A8:564F9989
       Content-Length:
-      - '358'
+      - '9'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Fri, 20 Nov 2015 22:07:06 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2142-IAD
+      - cache-lax1421-LAX
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1365,44 +1367,16 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 386abbf7e84f32a23643408a11eae895fe4a9d4a
+      - fc3637493669cf3bf3757968d1f7036d812307a1
       Expires:
-      - Tue, 10 Nov 2015 19:26:11 GMT
+      - Fri, 20 Nov 2015 22:12:06 GMT
       Source-Age:
       - '0'
     body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
+      encoding: UTF-8
+      string: Not Found
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:11 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
@@ -1415,11 +1389,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1438,17 +1412,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
+      - '14999'
       X-Ms-Request-Id:
-      - 83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - e95f093d-f18c-467d-a7fc-3f77538ff1be
       X-Ms-Correlation-Request-Id:
-      - 83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - e95f093d-f18c-467d-a7fc-3f77538ff1be
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192111Z:83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - NORTHCENTRALUS:20151120T220706Z:e95f093d-f18c-467d-a7fc-3f77538ff1be
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Fri, 20 Nov 2015 22:07:06 GMT
       Content-Length:
       - '493'
     body:
@@ -1466,7 +1440,7 @@ http_interactions:
         AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
         +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:11 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:06 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
@@ -1502,19 +1476,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2E24:5099:1AD71016:564243A3
+      - C71B4F1C:19DF:5179C1:564F998A
       Content-Length:
       - '1004'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Fri, 20 Nov 2015 22:07:07 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2148-IAD
+      - cache-lax1429-LAX
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1524,9 +1498,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - cd710ad53de5c1b4c2f21cb41043abba08aac970
+      - 7a4d6ba4e223972293b0e2390a1ce31be59a8031
       Expires:
-      - Tue, 10 Nov 2015 19:26:11 GMT
+      - Fri, 20 Nov 2015 22:12:07 GMT
       Source-Age:
       - '0'
     body:
@@ -1563,7 +1537,7 @@ http_interactions:
             }
 
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
@@ -1576,11 +1550,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -1599,17 +1573,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
+      - '14998'
       X-Ms-Request-Id:
-      - 2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - 32028382-ea7f-4a4d-9984-90c201a37c69
       X-Ms-Correlation-Request-Id:
-      - 2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - 32028382-ea7f-4a4d-9984-90c201a37c69
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192112Z:2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - NORTHCENTRALUS:20151120T220707Z:32028382-ea7f-4a4d-9984-90c201a37c69
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Fri, 20 Nov 2015 22:07:07 GMT
       Content-Length:
       - '1505'
     body:
@@ -1650,7 +1624,7 @@ http_interactions:
         DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
         VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:07 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -1686,19 +1660,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2E15:5099:1AD71810:564243A7
+      - 17EB2F14:19DA:2A273F:564F998C
       Content-Length:
       - '1902'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Fri, 20 Nov 2015 22:07:08 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2126-IAD
+      - cache-sjc3123-SJC
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1708,9 +1682,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - f7fe52e11eea87a782ee5cf9fe3882a83801caa7
+      - 43675440ab89ecc792bda3b7044021e68fa61a02
       Expires:
-      - Tue, 10 Nov 2015 19:26:12 GMT
+      - Fri, 20 Nov 2015 22:12:08 GMT
       Source-Age:
       - '0'
     body:
@@ -2055,7 +2029,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
@@ -2068,11 +2042,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2091,17 +2065,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14882'
+      - '14998'
       X-Ms-Request-Id:
-      - ffa518dd-d755-478a-8177-721f2badd825
+      - f7ed371f-3273-4a86-8d34-9f7758fbc665
       X-Ms-Correlation-Request-Id:
-      - ffa518dd-d755-478a-8177-721f2badd825
+      - f7ed371f-3273-4a86-8d34-9f7758fbc665
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192112Z:ffa518dd-d755-478a-8177-721f2badd825
+      - NORTHCENTRALUS:20151120T220708Z:f7ed371f-3273-4a86-8d34-9f7758fbc665
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Fri, 20 Nov 2015 22:07:08 GMT
       Content-Length:
       - '1307'
     body:
@@ -2138,7 +2112,7 @@ http_interactions:
         miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
         AAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
@@ -2151,11 +2125,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2174,17 +2148,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
+      - '14998'
       X-Ms-Request-Id:
-      - a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - c8c35064-ba98-49ba-8a4e-b740378258dc
       X-Ms-Correlation-Request-Id:
-      - a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - c8c35064-ba98-49ba-8a4e-b740378258dc
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192113Z:a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - NORTHCENTRALUS:20151120T220709Z:c8c35064-ba98-49ba-8a4e-b740378258dc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Fri, 20 Nov 2015 22:07:08 GMT
       Content-Length:
       - '1090'
     body:
@@ -2216,7 +2190,7 @@ http_interactions:
         557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
         /h+BjiSEdgwAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2229,11 +2203,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2254,20 +2228,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6e2845f4-4dfa-493f-b6a4-9b6b10b3dc2a
+      - afbf7acf-53e3-47d0-9508-54f0bec01309
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - cc893dd2-1bff-4a38-a44a-5b9ff2a66e7c
+      - bb53dbea-1945-4056-b473-28b1b2a74971
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192113Z:cc893dd2-1bff-4a38-a44a-5b9ff2a66e7c
+      - NORTHCENTRALUS:20151120T220710Z:bb53dbea-1945-4056-b473-28b1b2a74971
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Fri, 20 Nov 2015 22:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2287,7 +2261,7 @@ http_interactions:
         /3eP88Xv8+rz9xxik5V5c14RjHVzcEADep8Rdj/ydBOe4HvvD9tMP+Mf9OEv
         +X8AsdVUNRQHAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2300,11 +2274,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2325,20 +2299,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7494af24-9d2a-46e9-b825-90010373baf5
+      - 976917ac-f935-41b3-8ecf-374c3e32837a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 75d44c8c-3d8e-406e-ace3-c9f7f6f7c061
+      - b50fa387-c7c7-4845-ad40-239505deac55
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:75d44c8c-3d8e-406e-ace3-c9f7f6f7c061
+      - NORTHCENTRALUS:20151120T220711Z:b50fa387-c7c7-4845-ad40-239505deac55
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Fri, 20 Nov 2015 22:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2368,7 +2342,7 @@ http_interactions:
         izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
         P4bMBwG5FwAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2381,11 +2355,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2404,17 +2378,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14877'
+      - '14998'
       X-Ms-Request-Id:
-      - 3979703f-07d5-44db-95e5-77e9a27cb752
+      - 113a9e4f-e6f6-4484-828e-65ed124e34f0
       X-Ms-Correlation-Request-Id:
-      - 3979703f-07d5-44db-95e5-77e9a27cb752
+      - 113a9e4f-e6f6-4484-828e-65ed124e34f0
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:3979703f-07d5-44db-95e5-77e9a27cb752
+      - NORTHCENTRALUS:20151120T220711Z:113a9e4f-e6f6-4484-828e-65ed124e34f0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Fri, 20 Nov 2015 22:07:11 GMT
       Content-Length:
       - '133'
     body:
@@ -2424,7 +2398,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2437,11 +2411,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2460,17 +2434,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14899'
+      - '14998'
       X-Ms-Request-Id:
-      - 4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - c98d2ec2-749f-43f8-acc9-26b3c2a8d0ed
       X-Ms-Correlation-Request-Id:
-      - 4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - c98d2ec2-749f-43f8-acc9-26b3c2a8d0ed
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - NORTHCENTRALUS:20151120T220712Z:c98d2ec2-749f-43f8-acc9-26b3c2a8d0ed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Fri, 20 Nov 2015 22:07:12 GMT
       Content-Length:
       - '133'
     body:
@@ -2480,7 +2454,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2493,11 +2467,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2518,20 +2492,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f9c136df-73d2-4256-939f-9bef42c2aa95
+      - 7b34e8b0-59ec-4031-a797-143cece458bd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - d0b670e1-902a-4162-b4c1-7737e43b92ec
+      - b9733df1-a86a-473c-b19a-fbfd3d0e9f5e
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:d0b670e1-902a-4162-b4c1-7737e43b92ec
+      - NORTHCENTRALUS:20151120T220712Z:b9733df1-a86a-473c-b19a-fbfd3d0e9f5e
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Fri, 20 Nov 2015 22:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2550,7 +2524,7 @@ http_interactions:
         c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
         9/6wzfQz/kEf/pL/B5s5aaAjBgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2563,11 +2537,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2586,17 +2560,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
+      - '14998'
       X-Ms-Request-Id:
-      - aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - 70f7de23-1813-4e6e-8338-e811a1e2d70c
       X-Ms-Correlation-Request-Id:
-      - aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - 70f7de23-1813-4e6e-8338-e811a1e2d70c
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - NORTHCENTRALUS:20151120T220713Z:70f7de23-1813-4e6e-8338-e811a1e2d70c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Fri, 20 Nov 2015 22:07:13 GMT
       Content-Length:
       - '133'
     body:
@@ -2606,7 +2580,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:15 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2619,11 +2593,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2642,17 +2616,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14998'
       X-Ms-Request-Id:
-      - d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - 61d79f03-0b2f-4784-8f46-db8515d5d194
       X-Ms-Correlation-Request-Id:
-      - d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - 61d79f03-0b2f-4784-8f46-db8515d5d194
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - NORTHCENTRALUS:20151120T220713Z:61d79f03-0b2f-4784-8f46-db8515d5d194
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Fri, 20 Nov 2015 22:07:13 GMT
       Content-Length:
       - '133'
     body:
@@ -2662,7 +2636,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:15 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2675,11 +2649,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2698,17 +2672,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
+      - '14998'
       X-Ms-Request-Id:
-      - 44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - f72db6d4-e3d8-42c5-b268-a4e8f3b62f06
       X-Ms-Correlation-Request-Id:
-      - 44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - f72db6d4-e3d8-42c5-b268-a4e8f3b62f06
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - NORTHCENTRALUS:20151120T220714Z:f72db6d4-e3d8-42c5-b268-a4e8f3b62f06
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Fri, 20 Nov 2015 22:07:14 GMT
       Content-Length:
       - '133'
     body:
@@ -2718,7 +2692,1187 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b1bb9ffa-f892-4355-b2da-182e125bf973
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - bbee1eec-e1ec-4caf-85c0-90a985882984
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220715Z:bbee1eec-e1ec-4caf-85c0-90a985882984
+      Date:
+      - Fri, 20 Nov 2015 22:07:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d2l/HydT9d10V533/UQy9vsAqh99+7v+9H9LLt/
+        8OnD+9sPqP/t/Tzf2Z483L23fXD+4ODBfn7/3vlk9/f9yHu5vV7xiG+JgPdm
+        WU0zEAFv51nTrv0vaWSrvG6LvKGvLX3li8uiodeK5cXrNmu589fr6TTPZ7k3
+        KmpqybYW0p/ns1k++XR/+9NPP324vT99kG0/fLiTbU/2Du4/ON/fmTy4/zAA
+        0Cjqr9Yl46HTLY+HFB479fO29Ycpz0eCwd3/l0z+3WBkd+MofwhbyIPJis6i
+        PPj6lnMpD15oq2lVot2b6SrSQmj1sqrbV9nyggF+K9JsljdtsWT2C9ru79+L
+        tBagx7MZzUXzss7Pi3dofAPgW7XPaLANqPPRcVlWV5EWq7qoMFXUZnd3Z6ff
+        YFbU+RQdUouPzpaTar2cfRS2+iX+n78kANGZlYCNu9h89P96Lu5h/PORiQ92
+        Io0F5q140oN7q/bvx8N7Pzwebpp5F5n/d7NwDOGfjxy8txdpLDBvxZEe3Fu1
+        fz8OvveNcLD74/seNEL9PFuXrWEY5gsCeSvXg5H/SWK5s+UT7t8DjOf/bcwf
+        G+vdGwfx/0KBIH4z9ERTHkJaCBOkbZ2dnxfT9LyuFmlWlulPftHQl+lPvjh9
+        E4FFnVvhivGqzEMgLrFmhJIRgRvbCsiepPxkUbfrrNTZjLzn9fH+L7+XzH16
+        f+cbEboARGfiQzE6/sG6zp9X2exJVmbLaV4PseP/Z2Tq1iP6/7aAYZRpScNM
+        JzrOCDxC4P8lQtablcirXje992Ndvbdo7fZb/OyI1tN8eU04DXHe/xdk6YYh
+        /L9feDAAtkOFzKqRn8ib1NX/S8Qk1tQDe6v2TixAgkiDQCpILPotfnakgthJ
+        XJ4v122cq/6/IBg3j+L//bLBY0irdcszayRDLQuJDFy3trK//siLczLFpIu0
+        CITqZi+OmIdp/w1J1dmyzetNPPn/Gcm6cST/v5EuM9IIQMLg/yViFWvqge21
+        3zCo95ahm9w1YhGm8IfLEAwlIUUA4zz3/wXpuWkM/++XG4yABaQrOpFXqa//
+        j0pIrL0TDdAg0iCQDBKNfov3lwz3R5CZU+ZjQT7PCC8CuDEt93MjHA6/u1O8
+        R6/M7u/tBCP2h2h+1c+MXrCDsbrgZdW0F4TZ9tP80s3Ez9EojYjruwO4+aK9
+        f3Awm0z3drZ3s/zB9n6W7W8fTA/ube/v7z68P83y/Ye7gWjHV7bRdxwH780f
+        +sr27mx/9vDB3mz7/nlGIzp/uLt9sLf3cPv83v1PZ9PJw717WbAm9PVWtlW7
+        bpMmqq6261kv8f//Pl7orK/cPIIP4Rh5MI/RCZYHX99ymuXBC1aj/6ystty7
+        d/Aw0lyg3kpNe5Bv1d6pdTLMN3k8tOh9k1q/TSTu/gi0urKE4SHmEwJ5K4Fg
+        5BHxDiWD/t8nD7HhSnyxaRz/L5QKYjlDUjTlIVA8znxg3KMwsvhRsP5eYodA
+        45uQuwBEZ+JDSeqlwofY8f9LYnXrQf1/W8Ywyh+tulAbfMuEirToSNdNYfw3
+        Jl2InQinIc77/4g43TCK//fLDwbA1qiQiTUiFHmTuvp/iaTEmnpgb9XeSQZI
+        EGkQCAZJRr/Fz45gEDuJ40N5gThX/X9ENm4eyP/7xYPH0EtxqX0hqYEPR9lh
+        8+uP3DknVky6SItArm5254h5mPbfkGBxJmoTT/5/SbhuHMz/bwTMjDQCkDD4
+        f4lkxZp6YHvtNwzqvcXoJr+NWIQp/OFiBHNJSBHAOM/9f0SAbhrG//tFByNg
+        GelKT+RV6uv/o0ISa++kAzSINAiEg6Sj3+L9hcP9EeTqlP9YlnmFgwBuTNT9
+        3MiHw+/uysjGLL/cv3c/GLQ/SvOrfsY/6MNf8v8AuqGrsW84AAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 37594aab-7f74-4bdf-9f4d-772534b560a1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 625f8d70-4029-445b-93cc-983d03f0b5fc
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220715Z:625f8d70-4029-445b-93cc-983d03f0b5fc
+      Date:
+      - Fri, 20 Nov 2015 22:07:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dvnr50ch+Wszw2d1mPWmmdbFqi2rZ3N3/dO98Lzs/2M4/fZBv7+9MP91+
+        eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2tV83dk2qxWrf5T37R3F3V1WUx
+        y+vm7hfFtK6a6rwdv8jbq6p+e3cpP1/n03VdtNf6cohT3mYXwOq7d3/fj+6d
+        n+/t7k+m2we7B+fb+/n0/vbk3oPpdj7NPt1/mO9kD+/f/30/8l5ur1c8zFt2
+        7b1ZVtMM48fbeda0a/9LGtMqr9sib+hrS1T54rJo6LViefG6zVru/PV6Os3z
+        WT5zEKippdhaqH7/4NPdew8fEJmzvWx7/+A8387uTybbe5Pdyf696YN8J88C
+        AI2i/mpdMh46x/J4SOGx8z3Lz7N12W5nZVldbTfN3AeJ5/89PHA3GODdmzH/
+        EE6RB/MXnVh58PUtp1cevNBW06pEuzfTVaSFkOxlVbevsuUFA/xWpNksb9pi
+        yRwZtN3bizQWmMezGc1I87LOz4t3aHsD3Fu1z2isDYjz0THmIdJiVRcVZo3a
+        7O7s7PQbzIo6n6JDavHR2XJSrZezj8JWv8T/0/vj+x40Qp0ZwjAOcwmBvJUY
+        MPI/Sax3tnzC/XuA8fy/SApiw7x7I/7/L5QFYjVDSjTlIaSFzH/a1tn5eTFN
+        z+tqkZKIp0Qw+jL9yRenbyKwqHMrVzE2lSkIJCXWjFAy3H9jWwHZE5KfLOp2
+        nZU6j5H3vD7e/+X3ErdP738z8haA6Ex8KEHHP1jX+fMqmz3Jymw5zeshdvz/
+        gjjdejD/35YtjDItaZjpRMcZgUcI/L9EvnqzEnnV66b3fqyr95aq3X6Lnx2p
+        epovrwmnIc77f7kY3YD9//vlBgNg61PIhBrRibxJXf2/REJiTT2wt2rvJAIk
+        iDQIBIIkot/iZ0cgiJ3E0fly3ca56v/lMnHzAP7fLxY8hrRatzypRijUnpC0
+        EMnStrK//shtc+LEpIu0COTpZreNmIdp/w0J1NmyzetNPPn/BaG6cRD/vxEs
+        M9IIQMLg/yUSFWvqge213zCo9xafm/wzYhGm8IeLD8wjIUUA4zz3/3LBuQn9
+        //eLDEbAstGVmsir1Nf/R4Uj1t5JBWgQaRAIBUlFv8X7C4X7I8i9KduxDJ9n
+        hBcB3Jh4+zmSC4fg3bxe3d+5HwzWH535VT8z2sCOw2qAL85+wsu5/lwNzIi1
+        vtxByhfjB7MHO/cffnqw/fDBvU+393enO9vZ7qf3trPp7oOD3fzhpw+zmS/G
+        /19aM5nMiKL3Ht7f3r+/e4/ovH9Ayor+2T3PJ7PJ/b1Pp5/uBACCJQWCsJFn
+        zYyrJt2w8iDY3P1/ARN80KLJ+7KKPJjA6MzKg69vOb/y4AWrtn+0aMJPqLlv
+        E127PwLFrQxhOIe5hEDeSg4YeYSyQwme/xeJQWycEjZsGsD/C4WBeM3QEk15
+        CBRhMwMY1ycMGCT8/lH4jaZMrkgLT94QP3wTAheA6Ex8KEK9lPYQO/5/Qp5u
+        PZr/bwsXRvmjZRNqg2+ZUJEWHbG6KSz/xsQKARHhNMR5/2+XoxvQ/3+/4GAA
+        bH8KmVEjO5E3qav/l4hIrKkH9lbtnUiABJEGgUSQSPRb/OxIBLGTuDoU5ce5
+        6v/tQnHzCP7fLxc8hl6mSi0KiQvRDPld8+uPPDcnT0y6SItAoG723Ih5mPbf
+        kERxPmkTT/5/QqpuHMX/byTLjDQCkDD4f4lIxZp6YHvtNwzqveXnJheNWIQp
+        /OHyAwNJSBHAOM/9v11ybsL///0ygxGwcHTFJvIq9fX/UemItXdiARpEGgRS
+        QWLRb/H+UuH+CDJwyncsxLwyQQA3pt9+jgTDIXh3UfyivQd7D4LR+sMzv+pn
+        Rh/YgVgdQNKlSOy6Sfi5GqARb305jpsv1ZPdg92dbO9ge+deltGCKK07HJzf
+        z7bv7U3y3Uk+2X/w4J4v1f9fWkl5mE8enk9pRJ8efDoljbV3j8hNayq0pHJw
+        /8H5g917DzyyEIBgnYEgbGRhM/+qWHU5op71cvv/7+OFjQsqsRF8CMfIg3mM
+        TrA8+PqW0ywPXrDK/M3Jy0gLId2NKtrTu0Hbe/cOHkaaC9RbaWgP8q3aO41O
+        NvkmR+dHSyrfoDzEhithxaZx/L9QKojlDEnRlIdAITjzgfGMwoDiR/H5e4kd
+        4otvQu4CEJ2JDyWpl/UeYsf/L4nVrQf1/20Zwyh/tMBCbfAtEyrSoiNdN0Xv
+        35h0IWwinIY47/8j4nTDKP7fLz8YAFujYskTa0Qo8iZ19f8SSYk19cDeqr2T
+        DJAg0iAQDJKMfoufHcEgdhLHh1ICca76/4hs3DyQ//eLB4+hl91S+0JSQ6RD
+        Utj8+iN3zokVky7SIpCrm905Yh6m/TckWJyD2sST/18SrhsH8/8bATMjjQAk
+        DP5fIlmxph7YXvsNg3pvMbrJbyMWYQp/uBjBXBJSBDDOc/8fEaCbhvH/ftHB
+        CFhGutITeZX6+v+okMTaO+kADSINAuEg6ei3eH/hcH8EuTplP5ZlXtsggBsT
+        dT9H8uEQxOLLVN7d3d/7NBj0ZhXwc4/6dJ6fN3l9mde7B5/e+7lA/cXv8+rz
+        90S6yUjhnFcEY90cHIRIuz8CriI8Cc7/63jpMnD/gtcIB2BslO3gKM2v+pmZ
+        NTsya2ecBt9zEv5DHzGNCT+N7dCX47j5JmM339nbnd7Pt6fn2e42LXntYuU+
+        374/meUP8nsPpvnsgW8y/r+0svfp/fP9vXt7n27vTCdE7tmn97YPdvbz7U8/
+        JU9k78G9ew/vfxoACBa8CMJGnjbzr4y0YV1MsLn7/x5e+KCVvfflGHkwj9EJ
+        lgdf33Ka5cEL1lP40cqePqG7cJtUj/sj0OvKEoaFmE8I5K0EgpFHPmUo2/j/
+        PnmIDVdC103joD6/UZYmfjH0QFPun1I1PInGZw4jzh/lcd5LZkjtfyNCE4Do
+        THwoBr21kiFe+v+STNx6UITAz5WAAMUfralRG3zLhIq06IjGTbmZb0w0EA0T
+        TkNs8/8RWbhhFNTjzybzo3e2A4XMiuH/yJvU1f9L2DzW1AN7q/aOrUGCSIOA
+        q4mt+y1+driaeEH8BUrTxFni/yOMffNAqNOfTd5mBHrpQtXsxPI0biTbza8/
+        8oKcTDDpIi0CobjZC6KZZ9p/Q1LBSaZNDPVNSgY4m9jiZ00ybhwMdfz/Aukw
+        aEYAEgb/LxGLWFMPbK/9hkG9twzc5O7Q/DKFP1wGYKgIKQIYZ5j/j3D/TcOg
+        Ln82+R7dM4N3WT/yKvX1/1EOj7V3rA0aRBoEnE2s3W/x/pzt/ggyQ8o7LIi8
+        bEAAN6aFfo6Y2yHorSPtHdzvLMa4P26f8V+tJy3NoJuHn6sxGvHUl/t4+Xnb
+        /GH+6f3pOWVr811C52CPfts5v7f9YOc8m+1/ep/StjM/b/v/pUz/zvlsln06
+        nW1Ps4d72/v75w+2Hx5k+fa9yfmn093zh/cOzoNc7v+/M/3KBx+U5X9fbpEH
+        cxidXHnw9S2nWB68YPX4j7L8+oTK/Dbxq/sj0OXKEoZ9mE8I5K2EgZFHkDiU
+        //h/lyzEhiru/KYxUH/fKDsTrxhaoCn3T+ErT6DxZkJH/kex7XvJC/z6b0Jg
+        AhCdiQ9FoJe5HeKl/6/Iw60HRJ3/XAkHUPxRdp/a4FsmVKRFRyxuCne/MbFA
+        jEI4DbHN/wfk4IYRUG8/m4yP3ln/FzIjhvcjb1JX/y9h8VhTD+yt2juWBgki
+        DQKOJpbut/jZ4WjiBfETKHCOs8T/B5j65kFQhz+bfM0I9JI3qtGJ3WnMyFua
+        X3/k+Th5YNJFWgQCcbPnQzPPtP+GJIJTLJsY6v8rUnHjQKjT/xdIhkEzApAw
+        +H+JSMSaemB77TcM6r35/yYXh+aXKfzh/A8DRUgRwDjD/H+A828aAnX3s8nz
+        6J6Zu8v2kVepr/+PcnesvWNr0CDSIOBqYut+i/fnavdHkAFSvmEh5GQ5AdyY
+        /vk5YmyHoGHq/fs7wYD9EZpf9TP+QR/+kv8HrHpFqRp+AAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 0b3adf24-f028-42d7-9413-032f3374d00c
+      X-Ms-Correlation-Request-Id:
+      - 0b3adf24-f028-42d7-9413-032f3374d00c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220716Z:0b3adf24-f028-42d7-9413-032f3374d00c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:15 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - be8ad80e-4f23-4e4c-bb24-9b07c79eaf4f
+      X-Ms-Correlation-Request-Id:
+      - be8ad80e-4f23-4e4c-bb24-9b07c79eaf4f
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220717Z:be8ad80e-4f23-4e4c-bb24-9b07c79eaf4f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:17 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 386a3c3f-f171-440c-85d7-634698125a76
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 7893cbb8-3580-4903-a3d6-43ea813acffb
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220717Z:7893cbb8-3580-4903-a3d6-43ea813acffb
+      Date:
+      - Fri, 20 Nov 2015 22:07:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dvnr50ch+Wszw2d1mPWmmdbFqi2rZ3N3/dO98Lzs/2M4/fZBv7+9MP91+
+        eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2tV83dRfGLsh+s63z37qquLotZ
+        Xjd3vyimddVU5+34Rd5eVfXbu0v5+TqfruuivdZ3Q5TyNrsAUt+9+/t+dC/7
+        dDKbPHiwfS/fn2zv359Oth8+mO5s55NP7z2YTGfn+XT39/3Ie7m9XvEob9m1
+        92ZZTTMMH2/nWdOu/S9pTKu8bou8oa8tTeWLy6Kh14rlxes2a7nz1+vpNM9n
+        +cxBoKaWYGsh+v6nD/cezLIH27P7s9n2/uzebPvhbGdv+2H+YLK/ez6Z3ct2
+        AgCNov5qXTIeOsXyeEjhsdM9y8+zddluZ2VZXW3Xs5UPEs//a1jgbjC+uzcj
+        /iGMIg+mLzqv8uDrW86uPHihraZViXZvpj2UqYVQ7GVVt6+y5QUD/Fak2Sxv
+        2mLJDBm0vXfv4GGkuUA9ns1oSpqXdX5evEPrGyDfqn1Go21Ano+OMRORFqu6
+        qDBv1GZ3Z2en32BW1PkUHVKLj86Wk2q9nH0Utvol/p/eH9/3oBHqzBKGdZhP
+        COSt5ICR/0livrPlE+7fA4zn/z1iEBvl3RvR/3+hMBCnGUqiKQ8hLWT607bO
+        zs+LaXpeV4uUZDz9yS8a+jL9yRenbyKwqHMrWDEulRkIRCXWjFAyzH9jWwHZ
+        k5GfLOp2nZU6j5H3vD7e/+X3krZP738z4haA6Ex8KEDHYOznVTZ7kpXZcprX
+        Q+z4/wFpuvVY/r8tWhhlWtIw04mOMwKPEPh/iXj1ZiXyqtdN7/1YV+8tVLv9
+        Fj87QvU0X14TTkOc9/9uKboB+f/3iw0GwLankPk0khN5k7r6f4mAxJp6YG/V
+        3gkESBBpEMgDCUS/xc+OPBA7iZvz5bqNc9X/u0XiZvz/3y8VPIa0Wrc8p0Ym
+        1JqQsMBRayv76498NidNTLpIi0CcbvbZiHmY9t+QPJ0t27zexJP/H5CpG8fw
+        /xu5MiONACQM/l8iULGmHthe+w2Dem/puck5IxZhCn+49MA4ElIEMM5z/++W
+        m5uw/3+/xGAELBpdoYm8Sn39f1Q2Yu2dUIAGkQaBTJBQ9Fu8v0y4P4Ksm7Id
+        i/B5RngRwI0pt58bsXD43c3r1YP7B8FY/cGZX/UzowvsMKz8f3H2E470P0fD
+        MjKt74Yo+SI8vX++O7uXz7bv7We72/sP7k+3Hx482Nne2Znu3d+5f2+yv7Pn
+        i/D/p5ZKJnvTvU8P7m3v7+6Qeto539+eEGm3H+7vTe9nkwezh+d7AYBgKYEg
+        bORXM92qRTesOAg2d3/OWeCDlkrel1HkwfRF51UefH3L2ZUHL1iF/aOlEn1C
+        rX2bsNr9EShtZQnDOswnBPJWcsDII4gdyuz8v0YMYqOUeGET+v8vFAbiNENJ
+        NOUhUGTN02+cnjBS6IfdBAcPOreCFeNSmYFAVGLNCCXD/De2FZA9Gbkxcvb6
+        eP+X30vaEDh8E+IWgOhMfChAvUT2EDv+f0Cabj2W/2+LFkb5o6USaoNvmVCR
+        Fh2huika/8aECoEQ4TTEef/vlqIbkP9/v9hgAGx7CplPIzmRN6mr/5cISKyp
+        B/ZW7Z1AgASRBoE8kED0W/zsyAOxk7g5FNvHuer/3SJxM/7/75cKHkMvO6XW
+        hIQFjhqldM2vP/LZnDQx6SItAnG62Wcj5mHaf0PyxEmkTTz5/wGZunEM/7+R
+        KzPSCEDC4P8lAhVr6oHttd8wqPeWnpucM2IRpvCHSw+MIyFFAOM89/9uubkJ
+        +//3SwxGwKLRFZrIq9TX/0dlI9beCQVoEGkQyAQJRb/F+8uE+yPIuinbsQjz
+        UgQB3Jhy+7kRC4cf3jv49NNgrP7gzK/6Gf+gD3/J/wN/+xj0bDIAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 33b6643e-7f68-4f78-ba42-766752b8bda8
+      X-Ms-Correlation-Request-Id:
+      - 33b6643e-7f68-4f78-ba42-766752b8bda8
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220718Z:33b6643e-7f68-4f78-ba42-766752b8bda8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:18 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - bf1ab172-338c-4cd7-abe6-3ba6ea8107ee
+      X-Ms-Correlation-Request-Id:
+      - bf1ab172-338c-4cd7-abe6-3ba6ea8107ee
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220719Z:bf1ab172-338c-4cd7-abe6-3ba6ea8107ee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:18 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 407465c6-fcac-4750-a3e9-720b3af231ea
+      X-Ms-Correlation-Request-Id:
+      - 407465c6-fcac-4750-a3e9-720b3af231ea
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220719Z:407465c6-fcac-4750-a3e9-720b3af231ea
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:18 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 189f6bf7-65c2-4ec5-895d-b942fc1268ff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 49c99f4d-48ea-41bc-a38a-e2629029209d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220720Z:49c99f4d-48ea-41bc-a38a-e2629029209d
+      Date:
+      - Fri, 20 Nov 2015 22:07:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
+        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
+        u18U07pqqvN2/CJvr6r67d2l/HydT9d10V533/UQy9vsAqh99+7v+9H9LLt/
+        8OnD+9sPqP/t/Tzf2Z483L23fXD+4ODBfn7/3vlk9/f9yHu5vV7xiG+JgPdm
+        WU0zEAFv51nTrv0vaWSrvG6LvKGvLX3li8uiodeK5cXrNmu589fr6TTPZ7k3
+        KmpqybYW0p/ns1k++XR/+9NPP324vT99kG0/fLiTbU/2Du4/ON/fmTy4/zAA
+        0Cjqr9Yl46HTLY+HFB479fO29Ycpz0eCwd3/l0z+3WBkd+MofwhbyIPJis6i
+        PPj6lnMpD15oq2lVot2b6SrSQmj1sqrbV9nyggF+K9JsljdtsWT2C9ru79+L
+        tBagx7MZzUXzss7Pi3dofAPgW7XPaLANqPPRcVlWV5EWq7qoMFXUZnd3Z6ff
+        YFbU+RQdUouPzpaTar2cfRS2+iX+n78kANGZlYCNu9h89P96Lu5h/PORiQ92
+        Io0F5q140oN7q/bvx8N7Pzwebpp5F5n/d7NwDOGfjxy8txdpLDBvxZEe3Fu1
+        fz8OvveNcLD74/seNEL9PFuXrWEY5gsCeSvXg5H/SWK5s+UT7t8DjOf/bcwf
+        G+vdGwfx/0KBIH4z9ERTHkJaCBOkbZ2dnxfT9LyuFmlWlulPftHQl+lPvjh9
+        E4FFnVvhivGqzEMgLrFmhJIRgRvbCsiepPxkUbfrrNTZjLzn9fH+L7+XzH16
+        f+cbEboARGfiQzE6/sG6zp9X2exJVmbLaV4PseP/Z2Tq1iP6/7aAYZRpScNM
+        JzrOCDxC4P8lQtablcirXje992Ndvbdo7fZb/OyI1tN8eU04DXHe/xdk6YYh
+        /L9feDAAtkOFzKqRn8ib1NX/S8Qk1tQDe6v2TixAgkiDQCpILPotfnakgthJ
+        XJ4v122cq/6/IBg3j+L//bLBY0irdcszayRDLQuJDFy3trK//siLczLFpIu0
+        CITqZi+OmIdp/w1J1dmyzetNPPn/Gcm6cST/v5EuM9IIQMLg/yViFWvqge21
+        3zCo95ahm9w1YhGm8IfLEAwlIUUA4zz3/wXpuWkM/++XG4yABaQrOpFXqa//
+        j0pIrL0TDdAg0iCQDBKNfov3lwz3R5CZU+ZjQT7PCC8CuDEt93MjHA6/u1O8
+        R6/M7u/tBCP2h2h+1c+MXrCDsbrgZdW0F4TZ9tP80s3Ez9EojYjruwO4+aK9
+        f3Awm0z3drZ3s/zB9n6W7W8fTA/ube/v7z68P83y/Ye7gWjHV7bRdxwH780f
+        +sr27mx/9vDB3mz7/nlGIzp/uLt9sLf3cPv83v1PZ9PJw717WbAm9PVWtlW7
+        bpMmqq6261kv8f//Pl7orK/cPIIP4Rh5MI/RCZYHX99ymuXBC1aj/6ystty7
+        d/Aw0lyg3kpNe5Bv1d6pdTLMN3k8tOh9k1q/TSTu/gi0urKE4SHmEwJ5K4Fg
+        5BHxDiWD/t8nD7HhSnyxaRz/L5QKYjlDUjTlIVA8znxg3KMwsvhRsP5eYodA
+        45uQuwBEZ+JDSeqlwofY8f9LYnXrQf1/W8Ywyh+tulAbfMuEirToSNdNYfw3
+        Jl2InQinIc77/4g43TCK//fLDwbA1qiQiTUiFHmTuvp/iaTEmnpgb9XeSQZI
+        EGkQCAZJRr/Fz45gEDuJ40N5gThX/X9ENm4eyP/7xYPH0EtxqX0hqYEPR9lh
+        8+uP3DknVky6SItArm5254h5mPbfkGBxJmoTT/5/SbhuHMz/bwTMjDQCkDD4
+        f4lkxZp6YHvtNwzqvcXoJr+NWIQp/OFiBHNJSBHAOM/9f0SAbhrG//tFByNg
+        GelKT+RV6uv/o0ISa++kAzSINAiEg6Sj3+L9hcP9EeTqlP9YlnmFgwBuTNT9
+        3MiHw+/uysjGLL/cv3c/GLQ/SvOrfsY/6MNf8v8AuqGrsW84AAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dcf2db4e-8e47-4e22-888d-264d0da1ecce
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - b949627f-24f5-4474-a833-0d0a14f18caa
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220721Z:b949627f-24f5-4474-a833-0d0a14f18caa
+      Date:
+      - Fri, 20 Nov 2015 22:07:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dvnr50ch+Wszw2d1mPWmmdbFqi2rZ3N3/dO98Lzs/2M4/fZBv7+9MP91+
+        eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2tV83dk2qxWrf5T37R3F3V1WUx
+        y+vm7hfFtK6a6rwdv8jbq6p+e3cpP1/n03VdtNf6cohT3mYXwOq7d3/fj+6d
+        n+/t7k+m2we7B+fb+/n0/vbk3oPpdj7NPt1/mO9kD+/f/30/8l5ur1c8zFt2
+        7b1ZVtMM48fbeda0a/9LGtMqr9sib+hrS1T54rJo6LViefG6zVru/PV6Os3z
+        WT5zEKippdhaqH7/4NPdew8fEJmzvWx7/+A8387uTybbe5Pdyf696YN8J88C
+        AI2i/mpdMh46x/J4SOGx8z3Lz7N12W5nZVldbTfN3AeJ5/89PHA3GODdmzH/
+        EE6RB/MXnVh58PUtp1cevNBW06pEuzfTVaSFkOxlVbevsuUFA/xWpNksb9pi
+        yRwZtN3bizQWmMezGc1I87LOz4t3aHsD3Fu1z2isDYjz0THmIdJiVRcVZo3a
+        7O7s7PQbzIo6n6JDavHR2XJSrZezj8JWv8T/0/vj+x40Qp0ZwjAOcwmBvJUY
+        MPI/Sax3tnzC/XuA8fy/SApiw7x7I/7/L5QFYjVDSjTlIaSFzH/a1tn5eTFN
+        z+tqkZKIp0Qw+jL9yRenbyKwqHMrVzE2lSkIJCXWjFAy3H9jWwHZE5KfLOp2
+        nZU6j5H3vD7e/+X3ErdP738z8haA6Ex8KEHHP1jX+fMqmz3Jymw5zeshdvz/
+        gjjdejD/35YtjDItaZjpRMcZgUcI/L9EvnqzEnnV66b3fqyr95aq3X6Lnx2p
+        epovrwmnIc77f7kY3YD9//vlBgNg61PIhBrRibxJXf2/REJiTT2wt2rvJAIk
+        iDQIBIIkot/iZ0cgiJ3E0fly3ca56v/lMnHzAP7fLxY8hrRatzypRijUnpC0
+        EMnStrK//shtc+LEpIu0COTpZreNmIdp/w0J1NmyzetNPPn/BaG6cRD/vxEs
+        M9IIQMLg/yUSFWvqge213zCo9xafm/wzYhGm8IeLD8wjIUUA4zz3/3LBuQn9
+        //eLDEbAstGVmsir1Nf/R4Uj1t5JBWgQaRAIBUlFv8X7C4X7I8i9KduxDJ9n
+        hBcB3Jh4+zmSC4fg3bxe3d+5HwzWH535VT8z2sCOw2qAL85+wsu5/lwNzIi1
+        vtxByhfjB7MHO/cffnqw/fDBvU+393enO9vZ7qf3trPp7oOD3fzhpw+zmS/G
+        /19aM5nMiKL3Ht7f3r+/e4/ovH9Ayor+2T3PJ7PJ/b1Pp5/uBACCJQWCsJFn
+        zYyrJt2w8iDY3P1/ARN80KLJ+7KKPJjA6MzKg69vOb/y4AWrtn+0aMJPqLlv
+        E127PwLFrQxhOIe5hEDeSg4YeYSyQwme/xeJQWycEjZsGsD/C4WBeM3QEk15
+        CBRhMwMY1ycMGCT8/lH4jaZMrkgLT94QP3wTAheA6Ex8KEK9lPYQO/5/Qp5u
+        PZr/bwsXRvmjZRNqg2+ZUJEWHbG6KSz/xsQKARHhNMR5/2+XoxvQ/3+/4GAA
+        bH8KmVEjO5E3qav/l4hIrKkH9lbtnUiABJEGgUSQSPRb/OxIBLGTuDoU5ce5
+        6v/tQnHzCP7fLxc8hl6mSi0KiQvRDPld8+uPPDcnT0y6SItAoG723Ih5mPbf
+        kERxPmkTT/5/QqpuHMX/byTLjDQCkDD4f4lIxZp6YHvtNwzqveXnJheNWIQp
+        /OHyAwNJSBHAOM/9v11ybsL///0ygxGwcHTFJvIq9fX/UemItXdiARpEGgRS
+        QWLRb/H+UuH+CDJwyncsxLwyQQA3pt9+jgTDIXh3UfyivQd7D4LR+sMzv+pn
+        Rh/YgVgdQNKlSOy6Sfi5GqARb305jpsv1ZPdg92dbO9ge+deltGCKK07HJzf
+        z7bv7U3y3Uk+2X/w4J4v1f9fWkl5mE8enk9pRJ8efDoljbV3j8hNayq0pHJw
+        /8H5g917DzyyEIBgnYEgbGRhM/+qWHU5op71cvv/7+OFjQsqsRF8CMfIg3mM
+        TrA8+PqW0ywPXrDK/M3Jy0gLId2NKtrTu0Hbe/cOHkaaC9RbaWgP8q3aO41O
+        NvkmR+dHSyrfoDzEhithxaZx/L9QKojlDEnRlIdAITjzgfGMwoDiR/H5e4kd
+        4otvQu4CEJ2JDyWpl/UeYsf/L4nVrQf1/20Zwyh/tMBCbfAtEyrSoiNdN0Xv
+        35h0IWwinIY47/8j4nTDKP7fLz8YAFujYskTa0Qo8iZ19f8SSYk19cDeqr2T
+        DJAg0iAQDJKMfoufHcEgdhLHh1ICca76/4hs3DyQ//eLB4+hl91S+0JSQ6RD
+        Utj8+iN3zokVky7SIpCrm905Yh6m/TckWJyD2sST/18SrhsH8/8bATMjjQAk
+        DP5fIlmxph7YXvsNg3pvMbrJbyMWYQp/uBjBXBJSBDDOc/8fEaCbhvH/ftHB
+        CFhGutITeZX6+v+okMTaO+kADSINAuEg6ei3eH/hcH8EuTplP5ZlXtsggBsT
+        dT9H8uEQxOLLVN7d3d/7NBj0ZhXwc4/6dJ6fN3l9mde7B5/e+7lA/cXv8+rz
+        90S6yUjhnFcEY90cHIRIuz8CriI8Cc7/63jpMnD/gtcIB2BslO3gKM2v+pmZ
+        NTsya2ecBt9zEv5DHzGNCT+N7dCX47j5JmM339nbnd7Pt6fn2e42LXntYuU+
+        374/meUP8nsPpvnsgW8y/r+0svfp/fP9vXt7n27vTCdE7tmn97YPdvbz7U8/
+        JU9k78G9ew/vfxoACBa8CMJGnjbzr4y0YV1MsLn7/x5e+KCVvfflGHkwj9EJ
+        lgdf33Ka5cEL1lP40cqePqG7cJtUj/sj0OvKEoaFmE8I5K0EgpFHPmUo2/j/
+        PnmIDVdC103joD6/UZYmfjH0QFPun1I1PInGZw4jzh/lcd5LZkjtfyNCE4Do
+        THwoBr21kiFe+v+STNx6UITAz5WAAMUfralRG3zLhIq06IjGTbmZb0w0EA0T
+        TkNs8/8RWbhhFNTjzybzo3e2A4XMiuH/yJvU1f9L2DzW1AN7q/aOrUGCSIOA
+        q4mt+y1+driaeEH8BUrTxFni/yOMffNAqNOfTd5mBHrpQtXsxPI0biTbza8/
+        8oKcTDDpIi0CobjZC6KZZ9p/Q1LBSaZNDPVNSgY4m9jiZ00ybhwMdfz/Aukw
+        aEYAEgb/LxGLWFMPbK/9hkG9twzc5O7Q/DKFP1wGYKgIKQIYZ5j/j3D/TcOg
+        Ln82+R7dM4N3WT/yKvX1/1EOj7V3rA0aRBoEnE2s3W/x/pzt/ggyQ8o7LIi8
+        bEAAN6aFfo6Y2yHorSPtHdzvLMa4P26f8V+tJy3NoJuHn6sxGvHUl/t4+Xnb
+        /GH+6f3pOWVr811C52CPfts5v7f9YOc8m+1/ep/StjM/b/v/pUz/zvlsln06
+        nW1Ps4d72/v75w+2Hx5k+fa9yfmn093zh/cOzoNc7v+/M/3KBx+U5X9fbpEH
+        cxidXHnw9S2nWB68YPX4j7L8+oTK/Dbxq/sj0OXKEoZ9mE8I5K2EgZFHkDiU
+        //h/lyzEhiru/KYxUH/fKDsTrxhaoCn3T+ErT6DxZkJH/kex7XvJC/z6b0Jg
+        AhCdiQ9FoJe5HeKl/6/Iw60HRJ3/XAkHUPxRdp/a4FsmVKRFRyxuCne/MbFA
+        jEI4DbHN/wfk4IYRUG8/m4yP3ln/FzIjhvcjb1JX/y9h8VhTD+yt2juWBgki
+        DQKOJpbut/jZ4WjiBfETKHCOs8T/B5j65kFQhz+bfM0I9JI3qtGJ3WnMyFua
+        X3/k+Th5YNJFWgQCcbPnQzPPtP+GJIJTLJsY6v8rUnHjQKjT/xdIhkEzApAw
+        +H+JSMSaemB77TcM6r35/yYXh+aXKfzh/A8DRUgRwDjD/H+A828aAnX3s8nz
+        6J6Zu8v2kVepr/+PcnesvWNr0CDSIOBqYut+i/fnavdHkAFSvmEh5GQ5AdyY
+        /vk5YmyHoGHq/fs7wYD9EZpf9TP+QR/+kv8HrHpFqRp+AAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - ae8f4df3-0f5d-40f1-a86b-0c9aa92ac5dd
+      X-Ms-Correlation-Request-Id:
+      - ae8f4df3-0f5d-40f1-a86b-0c9aa92ac5dd
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220722Z:ae8f4df3-0f5d-40f1-a86b-0c9aa92ac5dd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:21 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - cd06677f-0432-41da-8e12-84482f185896
+      X-Ms-Correlation-Request-Id:
+      - cd06677f-0432-41da-8e12-84482f185896
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220722Z:cd06677f-0432-41da-8e12-84482f185896
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:22 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dae7cde6-aa72-4cb6-b535-0bba68bbf9db
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - cfa6fefc-7480-4224-8676-1d15f8ce6d81
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220723Z:cfa6fefc-7480-4224-8676-1d15f8ce6d81
+      Date:
+      - Fri, 20 Nov 2015 22:07:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dvnr50ch+Wszw2d1mPWmmdbFqi2rZ3N3/dO98Lzs/2M4/fZBv7+9MP91+
+        eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2tV83dRfGLsh+s63z37qquLotZ
+        Xjd3vyimddVU5+34Rd5eVfXbu0v5+TqfruuivdZ3Q5TyNrsAUt+9+/t+dC/7
+        dDKbPHiwfS/fn2zv359Oth8+mO5s55NP7z2YTGfn+XT39/3Ie7m9XvEob9m1
+        92ZZTTMMH2/nWdOu/S9pTKu8bou8oa8tTeWLy6Kh14rlxes2a7nz1+vpNM9n
+        +cxBoKaWYGsh+v6nD/cezLIH27P7s9n2/uzebPvhbGdv+2H+YLK/ez6Z3ct2
+        AgCNov5qXTIeOsXyeEjhsdM9y8+zddluZ2VZXW3Xs5UPEs//a1jgbjC+uzcj
+        /iGMIg+mLzqv8uDrW86uPHihraZViXZvpj2UqYVQ7GVVt6+y5QUD/Fak2Sxv
+        2mLJDBm0vXfv4GGkuUA9ns1oSpqXdX5evEPrGyDfqn1Go21Ano+OMRORFqu6
+        qDBv1GZ3Z2en32BW1PkUHVKLj86Wk2q9nH0Utvol/p/eH9/3oBHqzBKGdZhP
+        COSt5ICR/0livrPlE+7fA4zn/z1iEBvl3RvR/3+hMBCnGUqiKQ8hLWT607bO
+        zs+LaXpeV4uUZDz9yS8a+jL9yRenbyKwqHMrWDEulRkIRCXWjFAyzH9jWwHZ
+        k5GfLOp2nZU6j5H3vD7e/+X3krZP738z4haA6Ex8KEDHYOznVTZ7kpXZcprX
+        Q+z4/wFpuvVY/r8tWhhlWtIw04mOMwKPEPh/iXj1ZiXyqtdN7/1YV+8tVLv9
+        Fj87QvU0X14TTkOc9/9uKboB+f/3iw0GwLankPk0khN5k7r6f4mAxJp6YG/V
+        3gkESBBpEMgDCUS/xc+OPBA7iZvz5bqNc9X/u0XiZvz/3y8VPIa0Wrc8p0Ym
+        1JqQsMBRayv76498NidNTLpIi0CcbvbZiHmY9t+QPJ0t27zexJP/H5CpG8fw
+        /xu5MiONACQM/l8iULGmHthe+w2Dem/puck5IxZhCn+49MA4ElIEMM5z/++W
+        m5uw/3+/xGAELBpdoYm8Sn39f1Q2Yu2dUIAGkQaBTJBQ9Fu8v0y4P4Ksm7Id
+        i/B5RngRwI0pt58bsXD43c3r1YP7B8FY/cGZX/UzowvsMKz8f3H2E470P0fD
+        MjKt74Yo+SI8vX++O7uXz7bv7We72/sP7k+3Hx482Nne2Znu3d+5f2+yv7Pn
+        i/D/p5ZKJnvTvU8P7m3v7+6Qeto539+eEGm3H+7vTe9nkwezh+d7AYBgKYEg
+        bORXM92qRTesOAg2d3/OWeCDlkrel1HkwfRF51UefH3L2ZUHL1iF/aOlEn1C
+        rX2bsNr9EShtZQnDOswnBPJWcsDII4gdyuz8v0YMYqOUeGET+v8vFAbiNENJ
+        NOUhUGTN02+cnjBS6IfdBAcPOreCFeNSmYFAVGLNCCXD/De2FZA9Gbkxcvb6
+        eP+X30vaEDh8E+IWgOhMfChAvUT2EDv+f0Cabj2W/2+LFkb5o6USaoNvmVCR
+        Fh2huika/8aECoEQ4TTEef/vlqIbkP9/v9hgAGx7CplPIzmRN6mr/5cISKyp
+        B/ZW7Z1AgASRBoE8kED0W/zsyAOxk7g5FNvHuer/3SJxM/7/75cKHkMvO6XW
+        hIQFjhqldM2vP/LZnDQx6SItAnG62Wcj5mHaf0PyxEmkTTz5/wGZunEM/7+R
+        KzPSCEDC4P8lAhVr6oHttd8wqPeWnpucM2IRpvCHSw+MIyFFAOM89/9uubkJ
+        +//3SwxGwKLRFZrIq9TX/0dlI9beCQVoEGkQyAQJRb/F+8uE+yPIuinbsQjz
+        UgQB3Jhy+7kRC4cf3jv49NNgrP7gzK/6Gf+gD3/J/wN/+xj0bDIAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 58d95674-84d9-47ed-99aa-2f2c0609424d
+      X-Ms-Correlation-Request-Id:
+      - 58d95674-84d9-47ed-99aa-2f2c0609424d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220723Z:58d95674-84d9-47ed-99aa-2f2c0609424d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:23 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 899a1fb5-bf4e-4c08-970b-bd128ee2aec5
+      X-Ms-Correlation-Request-Id:
+      - 899a1fb5-bf4e-4c08-970b-bd128ee2aec5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220724Z:899a1fb5-bf4e-4c08-970b-bd128ee2aec5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:24 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 55f1c328-0aa4-4abf-80f0-4f3d46fff999
+      X-Ms-Correlation-Request-Id:
+      - 55f1c328-0aa4-4abf-80f0-4f3d46fff999
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220725Z:55f1c328-0aa4-4abf-80f0-4f3d46fff999
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 20 Nov 2015 22:07:25 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2731,11 +3885,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2758,20 +3912,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
       X-Ms-Request-Id:
-      - c303ccc4-09e0-4f9b-aeaf-a7757e368df6
+      - b433e001-3c05-4bbb-a8dd-9afd45d85596
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14876'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 3b4a9019-465d-4aa1-a0a3-9e4b91938cad
+      - 7f301680-b6f3-4bbc-8a3b-c7f0dd7324d5
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192116Z:3b4a9019-465d-4aa1-a0a3-9e4b91938cad
+      - NORTHCENTRALUS:20151120T220725Z:7f301680-b6f3-4bbc-8a3b-c7f0dd7324d5
       Date:
-      - Tue, 10 Nov 2015 19:21:15 GMT
+      - Fri, 20 Nov 2015 22:07:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2803,7 +3957,7 @@ http_interactions:
         TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
         H7C8EAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2816,11 +3970,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2843,20 +3997,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
       X-Ms-Request-Id:
-      - 2d444234-abdf-4a6e-b563-8dce0e024ae4
+      - 550cf941-fe17-4da5-b9f2-714b15aded38
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14885'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 18b52b23-4354-4697-9c5d-739a888171b2
+      - 6e3b60c1-ab62-4e5f-8765-83e3979956e7
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192116Z:18b52b23-4354-4697-9c5d-739a888171b2
+      - NORTHCENTRALUS:20151120T220726Z:6e3b60c1-ab62-4e5f-8765-83e3979956e7
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Fri, 20 Nov 2015 22:07:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2904,7 +4058,7 @@ http_interactions:
         fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
         3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2917,11 +4071,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2940,17 +4094,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
+      - '14996'
       X-Ms-Request-Id:
-      - 8a6f16dc-4047-4723-ae61-e36918f20122
+      - 27690250-170a-44f3-860d-ccf8943cfffb
       X-Ms-Correlation-Request-Id:
-      - 8a6f16dc-4047-4723-ae61-e36918f20122
+      - 27690250-170a-44f3-860d-ccf8943cfffb
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192117Z:8a6f16dc-4047-4723-ae61-e36918f20122
+      - NORTHCENTRALUS:20151120T220727Z:27690250-170a-44f3-860d-ccf8943cfffb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Fri, 20 Nov 2015 22:07:26 GMT
       Content-Length:
       - '133'
     body:
@@ -2960,7 +4114,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:17 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2973,11 +4127,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -2996,17 +4150,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14903'
+      - '14996'
       X-Ms-Request-Id:
-      - 636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - 25365b1c-a42e-4879-9dc1-e1a5c6fdd3ec
       X-Ms-Correlation-Request-Id:
-      - 636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - 25365b1c-a42e-4879-9dc1-e1a5c6fdd3ec
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192117Z:636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - NORTHCENTRALUS:20151120T220727Z:25365b1c-a42e-4879-9dc1-e1a5c6fdd3ec
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Fri, 20 Nov 2015 22:07:26 GMT
       Content-Length:
       - '133'
     body:
@@ -3016,7 +4170,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:17 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3029,11 +4183,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3052,17 +4206,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14997'
       X-Ms-Request-Id:
-      - 8c433189-24f1-45d6-95f1-4559049980f2
+      - 8cd13f27-f654-4649-a930-8cf2cd8ea8ab
       X-Ms-Correlation-Request-Id:
-      - 8c433189-24f1-45d6-95f1-4559049980f2
+      - 8cd13f27-f654-4649-a930-8cf2cd8ea8ab
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:8c433189-24f1-45d6-95f1-4559049980f2
+      - NORTHCENTRALUS:20151120T220728Z:8cd13f27-f654-4649-a930-8cf2cd8ea8ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:19 GMT
+      - Fri, 20 Nov 2015 22:07:28 GMT
       Content-Length:
       - '133'
     body:
@@ -3072,7 +4226,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3085,11 +4239,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3108,17 +4262,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14902'
+      - '14997'
       X-Ms-Request-Id:
-      - 44f6db10-b25b-435b-845f-ff636d64dce1
+      - 69ecb71a-0885-4ac0-9fbb-927fda40a482
       X-Ms-Correlation-Request-Id:
-      - 44f6db10-b25b-435b-845f-ff636d64dce1
+      - 69ecb71a-0885-4ac0-9fbb-927fda40a482
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:44f6db10-b25b-435b-845f-ff636d64dce1
+      - NORTHCENTRALUS:20151120T220729Z:69ecb71a-0885-4ac0-9fbb-927fda40a482
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Fri, 20 Nov 2015 22:07:29 GMT
       Content-Length:
       - '133'
     body:
@@ -3128,7 +4282,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3141,11 +4295,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3164,17 +4318,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14899'
+      - '14996'
       X-Ms-Request-Id:
-      - 27af5ee5-07c7-4207-9374-294c45078141
+      - 97f339e6-82c3-4c25-aea9-3597dade9641
       X-Ms-Correlation-Request-Id:
-      - 27af5ee5-07c7-4207-9374-294c45078141
+      - 97f339e6-82c3-4c25-aea9-3597dade9641
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:27af5ee5-07c7-4207-9374-294c45078141
+      - NORTHCENTRALUS:20151120T220729Z:97f339e6-82c3-4c25-aea9-3597dade9641
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Fri, 20 Nov 2015 22:07:29 GMT
       Content-Length:
       - '133'
     body:
@@ -3184,7 +4338,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3197,11 +4351,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3224,20 +4378,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
       X-Ms-Request-Id:
-      - 364bdb9a-98ff-46ce-8ba0-97fd129a0fa5
+      - 699a9ebf-0ba5-4877-ae2c-fc40efe21636
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 72e1ccd3-f367-461a-a7be-3f7b28cf1363
+      - c93aa64b-2126-4b92-b36a-697e1182c6ab
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:72e1ccd3-f367-461a-a7be-3f7b28cf1363
+      - NORTHCENTRALUS:20151120T220730Z:c93aa64b-2126-4b92-b36a-697e1182c6ab
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Fri, 20 Nov 2015 22:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3262,78 +4416,7 @@ http_interactions:
         3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
         tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 1e56ec3f-5b83-47ef-a623-76d4c630ba2a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
-      X-Ms-Correlation-Request-Id:
-      - 5fda7017-e071-4afe-9db5-b431dd23af33
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:5fda7017-e071-4afe-9db5-b431dd23af33
-      Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3t3d3
-        3uw+fLS3S//7ZGfn0c7OR6bxL5Ffvo8fv4RBANO3wFCpYmny0TITqCfz/Hyb
-        yDJzfUap6b2LZwNFm/V0muez3IOIx1H0bHledb4jNEOC+mDTIYhdyuzsvdl9
-        8Gh/99H93fH9g9179+91KUR0Mb8ylfTv7zPcj/J3bb5Ep0BBR25HbSn2RTGt
-        q6Y6b8dn1Phi3jbjn/ziaZFdLKumLabN67xtCetGO/U76BPWgX8vgg4R8/0J
-        OUDE+0THe+MH+/c+ffjwfkBEYawo5tVVXqPn/G69XqJDr5tbI0ySYt6WRkLA
-        3zj5Jf8PLXm+oVoEAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
@@ -3346,11 +4429,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3373,20 +4456,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f78436a4-e5e4-47f3-8a9e-ab257e6bc589
+      - 2050e4d5-1a37-4083-9829-2dc5bb3dacdd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14901'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 59d07b75-8d1a-49fe-bb78-29d59b0dacff
+      - a764b7fe-7ff7-43a7-aef3-39ff2367c2ec
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:59d07b75-8d1a-49fe-bb78-29d59b0dacff
+      - NORTHCENTRALUS:20151120T220732Z:a764b7fe-7ff7-43a7-aef3-39ff2367c2ec
       Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
+      - Fri, 20 Nov 2015 22:07:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3408,151 +4491,7 @@ http_interactions:
         ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
         Ae0xubNkBwAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"98077b54-1aca-4f76-aec9-c6bdf31d49f2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 962d3dde-f1e0-4508-95b8-1a606fcaf5c0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14890'
-      X-Ms-Correlation-Request-Id:
-      - 5a51b4be-d7bb-42ca-82ee-5269226fb8ce
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:5a51b4be-d7bb-42ca-82ee-5269226fb8ce
-      Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/eniw8+DB5P7+9m42zbb3
-        zx98up3l04fb008ns/N7u7P9h+d7v+9H+mJ7veIR3qJTfaOsphkGjLfyrGnX
-        5gsawSqv24JaPkqZfvLhZdFQ82J58brNWu7s9Xo6zfNZrthTM+pByLIW0s52
-        7s12dh/Mtj+d7BAtD/bOtx/uTSfbD3cn2eTezr17NEb7crFSHPHm/s74wafj
-        3YcPxw8ObAs7ltJg/0Xezol69MLTa5rlYmrbFrMyf1Ms8mrdni2/KJbrlge0
-        b79fnVTL8+JiXTMg+krHiu8Y4t0fFl8s5efZss3r82xKfDHFe/TK7P7ezt0O
-        pg19MOUPdj8SjH8JftA/v+T/AbZb5zfuAgAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 282c33a7-d110-45d5-81a0-235a168007ca
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14877'
-      X-Ms-Correlation-Request-Id:
-      - 0d9efbd9-10cd-4834-80d8-3de2afed84a9
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:0d9efbd9-10cd-4834-80d8-3de2afed84a9
-      Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbS398nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBfVk17QV1vP80vXbdR2nmv49lA
-        v2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2C2CXOzu6bnf1H+wdElvHuvU/v
-        7+097BCJSGN+ZULp399nuB9Nqqp9WmQXSyJLMQUeOmYa7bKpyvz1tM7zZTOv
-        2idlNfmqLqjJR/O2XTWP7t6dzvPzVV3N7u/u7Ywn9P14WtX5+KpYzqqrZrzM
-        27voYOY62F7RT9B/tn0+Pb83m+bT7fPJwWx7/+H5/e2Hs4Pp9mT3fj6bnp8/
-        2Nmf3vWna3ybN8aNRXg8WayYDMob+buWviACY5g6yzpa+tYwyBfFtK6a6rwd
-        n1Hji3nbjH/yC49Er/O2pRlqGDLBxg8lZp+JHPj3Yp4hxnl/ptnMMAf39u/v
-        fRowjNAqhvmXr9FtfpckOK+zsvhB0M+tMSYl4EOQhsO9vqyu8hpv53dneVaW
-        1ZR+/bod+xCkoUzfb5z8kv8HgBrmiLIFAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
@@ -3565,11 +4504,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3592,20 +4531,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b5cdf354-8db1-4689-9ac1-9a0ec7cbbe5a
+      - 663f3c3b-5e16-44c3-bb76-564d1c9de86a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 7642b49c-6cc6-40d0-89e9-cc9192efe371
+      - 16e16bf8-29ff-496d-94a5-e7c583d229e9
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:7642b49c-6cc6-40d0-89e9-cc9192efe371
+      - NORTHCENTRALUS:20151120T220733Z:16e16bf8-29ff-496d-94a5-e7c583d229e9
       Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
+      - Fri, 20 Nov 2015 22:07:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3626,292 +4565,7 @@ http_interactions:
         sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
         23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f33cabb6-c276-4b69-93d7-b9b0acfcab70
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
-      X-Ms-Correlation-Request-Id:
-      - 4cb5e0c9-4108-4ac0-82a3-3cfd93da1dfb
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:4cb5e0c9-4108-4ac0-82a3-3cfd93da1dfb
-      Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - b7af4ba1-d8a9-4765-9e13-65079dbe99bd
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14876'
-      X-Ms-Correlation-Request-Id:
-      - 9d597001-cccc-4651-9287-0fe1e837937d
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192123Z:9d597001-cccc-4651-9287-0fe1e837937d
-      Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR375OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBO5/l5k9eXeb3reo2Sznsbzwby
-        NevpNM9n+cxBxOPId7Y8rzrfEaIh9Xyw6RDELm12dt/s7D/av/do//5458H9
-        B/s7ux0aEWXMr0wn/fv7DPej/F2b0xTQNBBUHbkdtaXZF8W0rprqvB2fUeOL
-        eduMf/KLp0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5EYi7u7t3T/4
-        NGQ0Ya0o5tVVXqPn/O4sz8qymtKvfle3RppEw4cgDYWQv3HyS/4fgM2Crk8E
-        AAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 88bf2a94-dafd-4ca8-9a75-78142baa3b8e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
-      X-Ms-Correlation-Request-Id:
-      - 98f8dd2f-a707-4da3-adc9-30f873c19770
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192123Z:98f8dd2f-a707-4da3-adc9-30f873c19770
-      Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
-        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
-        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
-        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
-        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
-        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
-        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
-        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
-        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
-        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 8af9ccbd-6538-428e-882a-08649a74ed73
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14889'
-      X-Ms-Correlation-Request-Id:
-      - e46f3407-c4eb-4f82-a3e3-04b6951cfecf
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:e46f3407-c4eb-4f82-a3e3-04b6951cfecf
-      Date:
-      - Tue, 10 Nov 2015 19:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbS3/8nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBPX710vUVJ5r2FZwPZmvV0muez
-        fOYg4nFkO1ueV53vCMGQaj7YdAhilyY7u2929h/t33u0f3+88+nOzsGD+x3a
-        EEXMr0wf/fv7DPej/F2bE+mJ/ARVR25HbWn1RTGtq6Y6b8dn1Phi3jbjn/zi
-        aZFdLKumLabN67xtCetGO/U76BPWgX8vgg4R8/0JuZGIu3t79w8+vRcQUVgq
-        hvmXr9FtfpeYOa+zsvhB0M+tMSZ58CFIw+FeX1ZXeY2387uzPCvLakq/ft2O
-        fQjSUKbvN05+yf8DKJMver0EAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
@@ -3924,11 +4578,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -3951,20 +4605,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f9059a0b-7d52-4a73-b276-56bef8feb5e0
+      - bb5b5d09-334a-4979-91c0-b27c6fb33c47
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 281c80ea-9394-4448-a6a7-5e4cf9986e2e
+      - 4c9f7883-3341-44e1-a6e7-255cc64ff410
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:281c80ea-9394-4448-a6a7-5e4cf9986e2e
+      - NORTHCENTRALUS:20151120T220733Z:4c9f7883-3341-44e1-a6e7-255cc64ff410
       Date:
-      - Tue, 10 Nov 2015 19:21:23 GMT
+      - Fri, 20 Nov 2015 22:07:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3985,147 +4639,7 @@ http_interactions:
         IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
         AA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8bbd00ba-fc75-4623-9ada-956ec0f1f438
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
-      X-Ms-Correlation-Request-Id:
-      - e0d0859c-7976-4d37-a02f-73e943fd2142
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:e0d0859c-7976-4d37-a02f-73e943fd2142
-      Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 06ff7c20-f60e-4341-b7d8-5b2ae831bdae
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
-      X-Ms-Correlation-Request-Id:
-      - 4e6988e1-bcd3-431d-ad86-b710172145ce
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192125Z:4e6988e1-bcd3-431d-ad86-b710172145ce
-      Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR3/5OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
-        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQewSZWf3zc7+o/17j/bvj3ce3H+wv7Pb
-        IQ6RxPzKBNK/v89wP8rftTnRnuhPUHXkdtSOWMW0rprqvB2fUeOLeduMf/KL
-        p0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5EYi7u7t3T/49F5AROGp
-        KObVVV6j5/zuLM/KsprSr35Xt0aaZMKHIA2FkL9x8kv+HypTnSpIBAAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:25 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
@@ -4138,11 +4652,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -4165,20 +4679,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0b3e3582-f719-435c-82e1-8912ef5670d5
+      - 275df3ee-5d5b-4fe3-ad8c-d6356aa15f22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14896'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 1cc564f5-c087-486f-b873-89031ee016be
+      - c10f6026-beeb-464c-a3ee-1eb81e24f971
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192125Z:1cc564f5-c087-486f-b873-89031ee016be
+      - NORTHCENTRALUS:20151120T220734Z:c10f6026-beeb-464c-a3ee-1eb81e24f971
       Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
+      - Fri, 20 Nov 2015 22:07:33 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4199,148 +4713,7 @@ http_interactions:
         XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
         PwuqUY4PBwAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4e97cd2a-450b-4f55-9bdd-4a419916bc49
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14882'
-      X-Ms-Correlation-Request-Id:
-      - 253a3708-594e-498f-a0d1-2697a9ef699e
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192126Z:253a3708-594e-498f-a0d1-2697a9ef699e
-      Date:
-      - Tue, 10 Nov 2015 19:21:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 236380c9-25c8-4fdf-a626-1176f2ac5bae
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
-      X-Ms-Correlation-Request-Id:
-      - 5d31a0a4-0d08-4b64-afdf-63c567de6cc7
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:5d31a0a4-0d08-4b64-afdf-63c567de6cc7
-      Date:
-      - Tue, 10 Nov 2015 19:21:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
-        uztvdh8+2tt9tPfgk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoH5x
-        9hMn1WK1bvNd12uUdN7beDaQr1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcg
-        dmmzs/tmZ//R/t6j+w/GD3Y//XRv56BDI6KM+ZXpRH8rSDs6S5tZ1maE19v/
-        31Hm3t7ew9373wBl9lyvP78ogx/fZ7gf5e/anMSWRJeg6sjtqC3FviimddVU
-        5+34jBpfzNtm/JNfPC2yi2XVtMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcT
-        8eH+g/sPdgMi9lnJYl5d5TV6zu/O8qwsqyn96nd1a6RJnfoQpKEQ8jdOfsn/
-        A5mzpgJIBgAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
@@ -4353,11 +4726,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -4380,20 +4753,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 17a36f6d-92b2-4fdc-9dc6-5a66e05489ff
+      - 64909df4-d6d1-4197-af73-00d222462cff
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14896'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - cd705775-0f05-48a4-bcd1-ab16178594cb
+      - 755021a1-1d05-4cd8-b0fd-cea32d4ff6a5
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:cd705775-0f05-48a4-bcd1-ab16178594cb
+      - NORTHCENTRALUS:20151120T220735Z:755021a1-1d05-4cd8-b0fd-cea32d4ff6a5
       Date:
-      - Tue, 10 Nov 2015 19:21:26 GMT
+      - Fri, 20 Nov 2015 22:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4414,10 +4787,10 @@ http_interactions:
         6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
         +ueX/D+V0+PkOQcAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4427,11 +4800,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -4450,408 +4823,44 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ff854fcc-5084-42e7-b9a2-894f534d4191
+      - 93f64c8d-da6b-4749-8808-0d2f06db18f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 21ed37da-9650-48f0-acf5-56083bb8cac7
+      - dc492b63-b82d-4cab-ac30-eb5432796f1d
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:21ed37da-9650-48f0-acf5-56083bb8cac7
+      - NORTHCENTRALUS:20151120T220736Z:dc492b63-b82d-4cab-ac30-eb5432796f1d
       Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
+      - Fri, 20 Nov 2015 22:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - cacfdae5-c56d-4639-85c4-1004af7062d1
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
-      X-Ms-Correlation-Request-Id:
-      - 86e2e449-051c-4ab1-9d66-34e317207d86
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:86e2e449-051c-4ab1-9d66-34e317207d86
-      Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbT34JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
-        PnMQ8TjKnS3Pq853hEBIOB9sOgSxS5ad3Tc7+4/2Dx7tfzre2fv04e69DnWI
-        JuZXppD+/X0G+9GkqtqnRXaxrJq2mAINHTINdtlUZf56Wuf5splX7ZOymnxV
-        F9Tko3nbrppHd+82q3y627RVTTO7O55Qg/G0qvPxVbGcVVfNeJm3d9HDzPWw
-        jXcuFzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94vscdbP/k
-        Fzvj27QeNxbX8WSxYgooP/RnV4dJ373XrA7N6PvP5uaZPHi4/+m9vWAqZShR
-        zKurvEbP+d1ZnpVlNaVf/a5ujTSJpg9BGgq//MbJL/l/AI8MyTfPBAAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2ce2d8c8-8577-42d9-a3a9-8e30dc1607bf"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5a56d238-ef80-42e0-8ca7-650a6fdbcc7b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14884'
-      X-Ms-Correlation-Request-Id:
-      - 4f9460ca-900f-4359-a97c-74faf6366c25
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:4f9460ca-900f-4359-a97c-74faf6366c25
-      Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9HeNN+bHUwPtg/u
-        P3iwvb83e7id3csebh/k93Zm091Pdx5Mzn/fj/TF9nrFQ7xFp/pGWU0zjBhv
-        5VnTrs0XNIJVXrcFtXyUMgHlw8uioebF8uJ1m7Xc2ev1dJrns3wmb1IzS5e1
-        0Pb+wcPp7s6DfaLjbHd7//5ksv1w7+DB9iR7cP7pp9P9h0RP+3KxOqmW58XF
-        umbE0P335KvU4IHHTmexmnL7XQMBz/+bJvVud0T0QQzlrzvr8mBuehMmD766
-        xbTJQ42LS2py9vJ4NiNaANpHuztj/Hd/sGlp+OiLvJ1XTPun1zRDxbTzCk0I
-        kYq+DzCkL37YE3ZZ1O06K/VPna6ffHH65i6hQCg2d1/zz+3dj3xMf0k4nLLK
-        Zk+yMltO8/pJNn2bL2dKtpdVVYJ2lnfl6QybQPywB+6jrMN+/uTupI/8XR0Q
-        /giJQGTw//z+ME3OlpNqvZy9yNpX65I58/8j9ChCxO++evpy+ye/2NlIBveH
-        /Vx/MRT6aLZsXudtS3IIWtjBy+f1JWFAH3/PNKcvstWqLPLZ0/B7+drw4kf5
-        MpuUJIbPqvoqq2cEnVqdZ2WTmxbK7V9k03mxhPi7rr85en/5xcuv3pz+5Bev
-        o/TW6TCCp6goxR1pmWL0zy/5fwAzzH7ZtQcAAA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 19928ad9-0635-4e67-91d4-a341383d4d3b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
-      X-Ms-Correlation-Request-Id:
-      - 466b7179-c8c3-49fd-a370-f8f436d938fb
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:466b7179-c8c3-49fd-a370-f8f436d938fb
-      Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR38MnOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
-        nzmIeBzlzpbnVec7QiAknA82HYLYJcvO7pud/Uf7B4/2Px3v7d//dGenSx4i
-        ivmVSaR/f5/hfjSpqvZpkV0sq6YtpsBDx0yjXTZVmb+e1nm+bOZV+6SsJl/V
-        BTX5aN62q+bR3bvNKp/uNm1V09TujifUYDyt6nx8VSxn1VUzXubtXfQwcz1s
-        453LBWE+uZ/tZfvn27uzTx9s7+/O8u1sd2+6fW93tvNg99OHe5/uEWGp8fZP
-        frE7vk3rcWNxHU8WK6aAMkR/enWY9N17TevQlL7/dG6eyod79+8d3AumUoYS
-        xby6ymv0nN+d5VlZVlP61e/q1kiTbPoQpKHwy2+c/JL/BymctvTQBAAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ae5753ad-843b-447c-ad44-b9866332d3f2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9b89e9b4-130b-4dbf-85ae-1b194753a39c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
-      X-Ms-Correlation-Request-Id:
-      - 86c41dc2-313b-4b85-be1b-6f675c7782fa
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:86c41dc2-313b-4b85-be1b-6f675c7782fa
-      Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1GW339w/1422z7Y
-        vzfZ3t9/MN3OZvv725OHB59+eu/e3uze+d7v+5G+2F6veIi36FTfKKtphhHj
-        rTxr2rX5gkawyuu2oJaPUiagfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZumy
-        Fto+2Jnd37l/f297b+98d3v//qf59mS2d779cLJ7vpvf2z8/z3fsy8XqpFqe
-        FxfrmhFD99+Tr1KDBx47ncVqyu2VePL8v2lS73ZHRB/EUP66sy4P5qY3YfLg
-        q1tMmzzUuLikJmcvj2czogWgfbS7M8Z/+4NNS8NHX+TtvGLaP72mGSqmnVdo
-        QohU9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGU
-        VTZ7kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/q
-        gPBHSAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cVmMrg/
-        7Of6i6HQR7Nl8zpvW5JD0MIOXj6vLwkD+vh7pjl9ka1WZZHPnobfy9eGFz/K
-        l9mkJDF8VtVXWT0j6NTqPCub3LRQbv8im86LJcTfdf3N0fvLL15+9eb0J794
-        HaW3TocRPEVFKe5IyxSjf37J/wOqI1T/tQcAAA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 6df2f525-3182-476f-bde7-11c04f04c0bb
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
-      X-Ms-Correlation-Request-Id:
-      - 636c6230-426c-4524-8e54-ed59ba1394a5
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:636c6230-426c-4524-8e54-ed59ba1394a5
-      Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
-        uztvdh8+2tt9tPfwk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
-        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
-        domzs/tmZ//R/oNH9x+Od/Ye7N7ffdAhEpHG/MqE0r+/z3A/mlRV+7TILpZV
-        0xZT4KFjptEum6rMX0/rPF8286p9UlaTr+qCmnw0b9tV8+ju3eV1ffFw92B/
-        PKHvxtOqzsdXxXJWXTXjZd7eBfCZA77dGNpvT2fnO9n5g4fb93b2Z9v7swf3
-        th9Op/e3D+7f353sPpxN850Hd/2pGt/mjXFjkR1PFismgfJF/q6lL4i4GKLO
-        sI6UvjXM8UUxraumOm/HZ9T4Yt4245/8wiPP67xtaXYahkyw8UMJ2WcgB/69
-        GGeIad6fYTYyy+7ezsOdh/sBswitophXV3mNnvO7szwry2pKv/pd3Rpp0gE+
-        BGkohPyNk1/y/wBRIBNE/QQAAA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
@@ -4864,11 +4873,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -4891,20 +4900,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 00034cd1-21fe-4c59-99d2-8e514d07308a
+      - 7347b7ba-30e6-4977-96ce-577ceeec87f2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14890'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - e1b424c0-8206-478a-b084-ad377c4a64fb
+      - b82ba289-15a4-4a3f-823b-8bee7d8ee08b
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:e1b424c0-8206-478a-b084-ad377c4a64fb
+      - NORTHCENTRALUS:20151120T220736Z:b82ba289-15a4-4a3f-823b-8bee7d8ee08b
       Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
+      - Fri, 20 Nov 2015 22:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4925,7 +4934,8442 @@ http_interactions:
         q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
         VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Fri, 20 Nov 2015 22:07:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d474eb81-d30f-482c-ab91-a21cc45f8762
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - e9aff67a-8cbc-464a-8333-7f25491d9385
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220737Z:e9aff67a-8cbc-464a-8333-7f25491d9385
+      Date:
+      - Fri, 20 Nov 2015 22:07:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e884096f-a45e-448b-990f-4ba44e6ac57f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - a43309db-0566-4a5c-954c-08d942106eff
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220738Z:a43309db-0566-4a5c-954c-08d942106eff
+      Date:
+      - Fri, 20 Nov 2015 22:07:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3ed3d9d4-e8b5-468f-ad80-820f127bbbcc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 28052d0f-8755-412e-9f8e-b61260daac13
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220738Z:28052d0f-8755-412e-9f8e-b61260daac13
+      Date:
+      - Fri, 20 Nov 2015 22:07:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 11f92420-a7e5-4be1-a6da-85c318673359
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 8a321e3c-e432-4090-9ada-6389ccd7ab41
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220739Z:8a321e3c-e432-4090-9ada-6389ccd7ab41
+      Date:
+      - Fri, 20 Nov 2015 22:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - c45fb3a9-aeff-4d9b-9259-5ebb4b3cb152
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 7566c5f6-1866-4cc7-8657-c43de5393759
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220740Z:7566c5f6-1866-4cc7-8657-c43de5393759
+      Date:
+      - Fri, 20 Nov 2015 22:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
+        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3t/d2
+        3uztPdp58Gh/55OdnUc7Ox+Zxr9Efvk+fvwSBgFM3wJDpYqlyUfLTKCezPPz
+        bSLLzPUZpab3Lp4NFG3W02mez3IPIh5H0bPledX5jtAMCeqDTYcgdimzs/dm
+        l8iy++j+7vj+we69+/d2OxQiuphfmUr69/cZ7kf5uzZfolOgoCO3o7YU+6KY
+        1lVTnbfjM2p8MW+b8U9+8bTILpZV0xbT5nXetoR1o536HfQJ68C/F0GHiPn+
+        hBwg4n2i473xg/17nz58eD8gojBWFPPqKq/Rc363Xi/RodfNrREmSTFvSyMh
+        4G+c/JL/Bx9DRJ9aBAAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7e1bc7bb-1831-422f-aff0-bcb7f9070128
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 2c3da16f-b2ff-4cc1-a4b6-4016808e712d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220740Z:2c3da16f-b2ff-4cc1-a4b6-4016808e712d
+      Date:
+      - Fri, 20 Nov 2015 22:07:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"98077b54-1aca-4f76-aec9-c6bdf31d49f2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 227f7251-0235-457f-950e-ffaac2172c71
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - c2f033f9-8065-453e-bdaf-99b235687982
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220741Z:c2f033f9-8065-453e-bdaf-99b235687982
+      Date:
+      - Fri, 20 Nov 2015 22:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
+        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
+        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/eniw8+DB5P7+9m42zbb3
+        zx98up3l04fb008ns/N7u7P9h+d7v+9H+mJ7veIR3qJTfaOsphkGjLfyrGnX
+        5gsawSqv24JaPkqZfvLhZdFQ82J58brNWu7s9Xo6zfNZrthTM+pByLIW0s52
+        7s12dh/Mtj+d7BAtD/bOtx/uTSfbD3cn2eTezr17NEb7crFSHPHm/s74wafj
+        3YcPxw8ObAs7ltJg/0Xezol69MLTa5rlYmrbFrMyf1Ms8mrdni2/KJbrlge0
+        b79fnVTL8+JiXTMg+krHiu8Y4t0fFl8s5efZss3r82xKfDHFe/TK7P7ezt0O
+        pg19MOUPdj8SjH8JftA/v+T/AbZb5zfuAgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5d76e517-77bc-45ed-a086-7c7c0ebc7f1f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 172764c6-f69e-4634-af3e-67fc7386429c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220742Z:172764c6-f69e-4634-af3e-67fc7386429c
+      Date:
+      - Fri, 20 Nov 2015 22:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e868a346-3e72-4259-ad78-94a71863e337
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 63c07d2e-bbc4-4dba-bdb7-8b311a917426
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220742Z:63c07d2e-bbc4-4dba-bdb7-8b311a917426
+      Date:
+      - Fri, 20 Nov 2015 22:07:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 41cb72a6-0c3d-4ae5-abcb-6fd9e8c27742
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 8e4282f7-5c09-43b0-a17b-612f2305cda3
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220743Z:8e4282f7-5c09-43b0-a17b-612f2305cda3
+      Date:
+      - Fri, 20 Nov 2015 22:07:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c648d41b-ab34-4da1-b709-ce196aca963b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 37d1e59a-64ea-4032-a501-f7ef61ceee10
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220744Z:37d1e59a-64ea-4032-a501-f7ef61ceee10
+      Date:
+      - Fri, 20 Nov 2015 22:07:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1e7db03f-fd30-4c22-9f47-978c35245086
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - ab41a7ec-a52a-4bbf-841b-375206352ae5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220744Z:ab41a7ec-a52a-4bbf-841b-375206352ae5
+      Date:
+      - Fri, 20 Nov 2015 22:07:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d4c4c040-b427-4a70-8c8e-7a275910e57d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 19d4acab-ed25-45ab-a10a-714a2bb5d7c2
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220745Z:19d4acab-ed25-45ab-a10a-714a2bb5d7c2
+      Date:
+      - Fri, 20 Nov 2015 22:07:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 28d1ee63-1cbf-4539-afad-54cdefa84fc0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 6a2493d4-f23d-44c7-a9cd-c16c105c1e31
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220745Z:6a2493d4-f23d-44c7-a9cd-c16c105c1e31
+      Date:
+      - Fri, 20 Nov 2015 22:07:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8d0d9b50-9a3b-4ed7-8731-2db2e492abb5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 4aa2be93-224e-43eb-880a-51e24102c5b1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220746Z:4aa2be93-224e-43eb-880a-51e24102c5b1
+      Date:
+      - Fri, 20 Nov 2015 22:07:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ab192501-c13e-4db9-95cb-dba78b829a56
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 54738e98-cb34-452c-a696-b277029753a0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220747Z:54738e98-cb34-452c-a696-b277029753a0
+      Date:
+      - Fri, 20 Nov 2015 22:07:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ea98cb83-664b-4bb7-9eac-52a541d9d512
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 62258ceb-3b75-48bb-b660-e8bf4c42c338
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220749Z:62258ceb-3b75-48bb-b660-e8bf4c42c338
+      Date:
+      - Fri, 20 Nov 2015 22:07:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9d82391e-1969-40f9-a8ac-571fd2415a4a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 32f18137-99db-4861-9308-f565bf5a0b09
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220749Z:32f18137-99db-4861-9308-f565bf5a0b09
+      Date:
+      - Fri, 20 Nov 2015 22:07:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - 90f0a9b5-451e-434f-a170-720a252fb949
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 1e325df2-f0c7-4ee7-920b-6b70514840d5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220750Z:1e325df2-f0c7-4ee7-920b-6b70514840d5
+      Date:
+      - Fri, 20 Nov 2015 22:07:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu08eHR/55OdnUc7
+        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+rJr2grrefppfum6jtPNex7OB
+        fs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoEsUucnd03O/uP9g+ILOPde5/e
+        39t72CESkcb8yoTSv7/PcD+aVFX7tMgulkSWYgo8dMw02mVTlfnraZ3ny2Ze
+        tU/KavJVXVCTj+Ztu2oe3b07nefnq7qa3d/d2xlP6PvxtKrz8VWxnFVXzXiZ
+        t3fRwcx1sL2in6D/bPt8en5vNs2n2+eTg9n2/sPz+9sPZwfT7cnu/Xw2PT9/
+        sLM/vetP1/g2b4wbi/B4slgxGZQ38nctfUEExjB1lnW09K1hkC+KaV011Xk7
+        PqPGF/O2Gf/kFx6JXudtSzPUMGSCjR9KzD4TOfDvxTxDjPP+TLOZYQ7u7d/f
+        +zRgGKFVDPMvX6Pb/C5JcF5nZfGDoJ9bY0xKwIcgDYd7fVld5TXezu/O8qws
+        qyn9+nU79iFIQ5m+3zj5Jf8PBPLLbrIFAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 40b0fcd5-8a9e-43cc-92fe-5345fb0716bd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 4199fcb3-53af-4678-8aa9-853dc69a2363
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220750Z:4199fcb3-53af-4678-8aa9-853dc69a2363
+      Date:
+      - Fri, 20 Nov 2015 22:07:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 80f78256-eeca-44be-b043-f7fc7e805317
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 36903f3e-e95c-4ff5-84d5-f37602605e8b
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220751Z:36903f3e-e95c-4ff5-84d5-f37602605e8b
+      Date:
+      - Fri, 20 Nov 2015 22:07:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
+        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
+        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
+        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
+        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
+        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
+        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
+        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
+        SP8S/KB/fsn/AwfrPqbVAgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 50b01e89-1ca0-4f42-aef8-13e0c3cc0331
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - c86ff47c-3906-4dc3-8166-5aacc9d05fae
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220752Z:c86ff47c-3906-4dc3-8166-5aacc9d05fae
+      Date:
+      - Fri, 20 Nov 2015 22:07:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7107a42e-0c4a-48d3-a9f7-b398a700d2c4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - e6122905-7b90-40d0-9e1d-a9e53674661e
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220753Z:e6122905-7b90-40d0-9e1d-a9e53674661e
+      Date:
+      - Fri, 20 Nov 2015 22:07:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d3d570ac-f8bf-4bd3-9fd8-889472656639
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 83a19289-cd28-49e5-912f-e6622a1770c5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220753Z:83a19289-cd28-49e5-912f-e6622a1770c5
+      Date:
+      - Fri, 20 Nov 2015 22:07:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5b6976a1-7bef-44b3-93bc-b16f42f80c13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - a58e2f16-a764-4f54-a9db-4e72db68b162
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220754Z:a58e2f16-a764-4f54-a9db-4e72db68b162
+      Date:
+      - Fri, 20 Nov 2015 22:07:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 05986fb6-3010-45ce-93c3-3bbd3a3e005b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 49645885-e633-4460-b96a-02b6b6f42039
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220755Z:49645885-e633-4460-b96a-02b6b6f42039
+      Date:
+      - Fri, 20 Nov 2015 22:07:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 31e35a7d-6fad-48e8-8c25-262310787e8f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - be2199e8-b708-42fc-a045-5473824b18b7
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220756Z:be2199e8-b708-42fc-a045-5473824b18b7
+      Date:
+      - Fri, 20 Nov 2015 22:07:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5871d339-b5c2-432b-b675-65acd33c3ca5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 3a4660d0-cd0c-43ce-9321-7dd8de1d8817
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220757Z:3a4660d0-cd0c-43ce-9321-7dd8de1d8817
+      Date:
+      - Fri, 20 Nov 2015 22:07:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 789edff3-46d5-45c1-b791-4edbb813c060
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 482f8c94-558b-476b-aabd-2bb2060ddacf
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220757Z:482f8c94-558b-476b-aabd-2bb2060ddacf
+      Date:
+      - Fri, 20 Nov 2015 22:07:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 74f6ace4-a29e-4025-ab88-21aa308e65b5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 4324a3df-490c-4a32-97be-c341b17bf0a9
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220758Z:4324a3df-490c-4a32-97be-c341b17bf0a9
+      Date:
+      - Fri, 20 Nov 2015 22:07:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3a4da3a0-d765-4447-9e80-38108d621475
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - f5b81096-d887-4add-be6c-58c66bd7c4e6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220759Z:f5b81096-d887-4add-be6c-58c66bd7c4e6
+      Date:
+      - Fri, 20 Nov 2015 22:07:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2d72560b-defc-46a3-a5b0-284e209e0d99
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - a18d8e95-6707-44f8-9502-06de1a489394
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220759Z:a18d8e95-6707-44f8-9502-06de1a489394
+      Date:
+      - Fri, 20 Nov 2015 22:07:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:07:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - a69ace8a-25d1-4710-933c-c04db8b25d96
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 41a8d04b-d0f0-4ea7-a079-572fa9f99960
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220800Z:41a8d04b-d0f0-4ea7-a079-572fa9f99960
+      Date:
+      - Fri, 20 Nov 2015 22:08:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu0cPNrZ+WRnh/79
+        yDT+JfLL9/HjlzAIIPUWyCgB7PA/WmYCdTrPz5u8vszrXddrlHTe23g2kK9Z
+        T6d5PstnDiIeR76z5XnV+Y4QDanng02HIHZps7P7Zmf/0f69R/v3xzsP7j/Y
+        39nt0IgoY35lOunf32e4H+Xv2pymgKaBoOrI7agtzb4opnXVVOft+IwaX8zb
+        ZvyTXzwtsotl1bTFtHmdty1h3Winfgd9wjrw70XQIWK+PyE3EnF3b+/+waf3
+        AiIKa0Uxr67yGj3nd2d5VpbVlH71u7o10iQaPgRpKIT8jZNf8v8AyuczFU8E
+        AAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a8403d7e-0af2-4258-b4e2-cdeeb44f77e7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - a89db168-43c8-43ac-a334-a30d93ef7426
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220800Z:a89db168-43c8-43ac-a334-a30d93ef7426
+      Date:
+      - Fri, 20 Nov 2015 22:08:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 733ae566-a4d8-4230-95a7-37eb697dee82
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 05360f08-d67b-49e3-a648-c4912297ac94
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220801Z:05360f08-d67b-49e3-a648-c4912297ac94
+      Date:
+      - Fri, 20 Nov 2015 22:08:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - edeb441d-22a7-4aed-85cd-6b55fcfa1a01
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - e2d7d1e2-c1d2-4def-b733-5f05e5d8c441
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220802Z:e2d7d1e2-c1d2-4def-b733-5f05e5d8c441
+      Date:
+      - Fri, 20 Nov 2015 22:08:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f90f01d2-8c4c-4308-ae18-b6bc7866ab6f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 7eb15893-b09d-429e-9c63-344ab24602ae
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220802Z:7eb15893-b09d-429e-9c63-344ab24602ae
+      Date:
+      - Fri, 20 Nov 2015 22:08:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3e491189-eca7-49b2-94d8-6a5e3aea1193
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - d1288f65-882d-442d-b3c3-ad55079bd6d8
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220803Z:d1288f65-882d-442d-b3c3-ad55079bd6d8
+      Date:
+      - Fri, 20 Nov 2015 22:08:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8862bfd3-721a-47d7-8289-7a19a38725ab
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 897dc4ea-bdae-47c9-91ad-3fac61f94083
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220804Z:897dc4ea-bdae-47c9-91ad-3fac61f94083
+      Date:
+      - Fri, 20 Nov 2015 22:08:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ce9bf930-0b61-437f-80a3-46c2bbf2b37f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - ee35975f-48a7-4475-8fe3-dba6c2e2108a
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220804Z:ee35975f-48a7-4475-8fe3-dba6c2e2108a
+      Date:
+      - Fri, 20 Nov 2015 22:08:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ae596384-ac15-49a3-8082-4f9925abf714
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - c430a916-3004-41ca-b9c9-6477e34553c1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220805Z:c430a916-3004-41ca-b9c9-6477e34553c1
+      Date:
+      - Fri, 20 Nov 2015 22:08:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7e243e26-20a6-496d-a775-d1809255ee68
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 45186396-c45d-4b81-8021-5cf2a9a84000
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220805Z:45186396-c45d-4b81-8021-5cf2a9a84000
+      Date:
+      - Fri, 20 Nov 2015 22:08:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4d1a9bb0-9481-42ed-803b-d9eb6b45f8e0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - d1bd58eb-9774-4ba6-98d4-f2de7170787f
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220806Z:d1bd58eb-9774-4ba6-98d4-f2de7170787f
+      Date:
+      - Fri, 20 Nov 2015 22:08:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0964e88a-0ec8-4d07-879e-2368f537276d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - cf3fd690-daaf-4cd6-a04f-9ec801ae6825
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220806Z:cf3fd690-daaf-4cd6-a04f-9ec801ae6825
+      Date:
+      - Fri, 20 Nov 2015 22:08:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b48ba74b-799b-49ee-a678-b91ddddb0451
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - f2dd2290-17c2-4992-927b-35afe06fa1dd
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220807Z:f2dd2290-17c2-4992-927b-35afe06fa1dd
+      Date:
+      - Fri, 20 Nov 2015 22:08:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - 6ff870c5-0a22-4135-a64f-5a98ae749e8a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - d0cbae21-70c7-4c2b-af74-c5c12e6b9284
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220807Z:d0cbae21-70c7-4c2b-af74-c5c12e6b9284
+      Date:
+      - Fri, 20 Nov 2015 22:08:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu0cPNp58MnOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBPX710vUVJ5r2FZwPZmvV0muez
+        fOYg4nFkO1ueV53vCMGQaj7YdAhilyY7u2929h/t33u0f3+88+nOzsGD+x3a
+        EEXMr0wf/fv7DPej/F2bE+mJ/ARVR25HbWn1RTGtq6Y6b8dn1Phi3jbjn/zi
+        aZFdLKumLabN67xtCetGO/U76BPWgX8vgg4R8/0JuZGIu3t79w8+vRcQUVgq
+        hvmXr9FtfpeYOa+zsvhB0M+tMSZ58CFIw+FeX1ZXeY2387uzPCvLakq/ft2O
+        fQjSUKbvN05+yf8Dsl4fY70EAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9cf20ca7-0800-4c63-91e3-77a8b83a1cbc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 50c84523-da8e-4121-b476-258629132c2d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220808Z:50c84523-da8e-4121-b476-258629132c2d
+      Date:
+      - Fri, 20 Nov 2015 22:08:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f296446f-f89d-484d-bf0c-82b2ba776c0d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 56ae5f91-75cd-4af5-aa11-1cad652a73a6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220809Z:56ae5f91-75cd-4af5-aa11-1cad652a73a6
+      Date:
+      - Fri, 20 Nov 2015 22:08:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
+        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
+        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
+        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
+        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
+        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
+        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
+        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
+        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
+        MQDoSbwCAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e1e42a8f-dddf-4c3e-bf0d-f8e14035c7a3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 1a3442d4-a4d6-4a83-9e7d-31890acfb967
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220809Z:1a3442d4-a4d6-4a83-9e7d-31890acfb967
+      Date:
+      - Fri, 20 Nov 2015 22:08:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7aa7b6ca-286a-4e03-9f06-a9e422f37a78
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - a9b2e097-348b-4d93-a80f-6340e35e6fc1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220810Z:a9b2e097-348b-4d93-a80f-6340e35e6fc1
+      Date:
+      - Fri, 20 Nov 2015 22:08:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6d742a9a-82a1-47be-87ac-eb0690ce630a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 53633784-0d8f-449c-a9da-f1f0a207cc88
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220811Z:53633784-0d8f-449c-a9da-f1f0a207cc88
+      Date:
+      - Fri, 20 Nov 2015 22:08:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3eb0b71e-742f-4cba-8f1f-2f4a5bfc4d6f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 6b36a7e1-5004-4ab9-b612-b2308e52bcb0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220811Z:6b36a7e1-5004-4ab9-b612-b2308e52bcb0
+      Date:
+      - Fri, 20 Nov 2015 22:08:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3efa99ba-8181-4b8d-affc-9bf4dc43f3c2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - f598504c-2401-496f-8090-7d0e30f823fc
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220812Z:f598504c-2401-496f-8090-7d0e30f823fc
+      Date:
+      - Fri, 20 Nov 2015 22:08:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8940ff9e-b198-47a0-87e8-4090575f02fc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 8367ca25-a9a6-40b4-b5cf-7b0169828aa1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220813Z:8367ca25-a9a6-40b4-b5cf-7b0169828aa1
+      Date:
+      - Fri, 20 Nov 2015 22:08:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 39494d12-798e-40c3-a136-0b69bd136f96
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - b989ea8a-0e65-4e2f-8551-fe6608415515
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220814Z:b989ea8a-0e65-4e2f-8551-fe6608415515
+      Date:
+      - Fri, 20 Nov 2015 22:08:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2d905221-43dc-4f9b-9f06-b3f9c7bbd0ba
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - a65c0156-18a7-4e1c-9324-0cb7cc6e65d0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220814Z:a65c0156-18a7-4e1c-9324-0cb7cc6e65d0
+      Date:
+      - Fri, 20 Nov 2015 22:08:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6b174f7d-86a2-4929-a41b-5dac24fecb8f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - f7c56e07-42ee-42a3-b951-2d6e6ddb9f18
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220815Z:f7c56e07-42ee-42a3-b951-2d6e6ddb9f18
+      Date:
+      - Fri, 20 Nov 2015 22:08:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8c5123dd-f086-4d05-8341-45a5225118b1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 6259b4d0-fef2-4f6b-8fce-12a050a8b585
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220816Z:6259b4d0-fef2-4f6b-8fce-12a050a8b585
+      Date:
+      - Fri, 20 Nov 2015 22:08:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b1376a90-71a8-40fd-9b36-4f7c07fb5ca3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - f6912aba-3f3a-4d59-a460-37d39851a91b
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220817Z:f6912aba-3f3a-4d59-a460-37d39851a91b
+      Date:
+      - Fri, 20 Nov 2015 22:08:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - f5373af4-4f4f-42f7-80e8-3c50043b4cd3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 8c3276bb-be00-4426-b84a-ad454d62fba0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220818Z:8c3276bb-be00-4426-b84a-ad454d62fba0
+      Date:
+      - Fri, 20 Nov 2015 22:08:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu0cPNp98MnOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlC/OPuJPdddlGbea3g20K1ZT6d5
+        PstnDiIeR7ez5XnV+Y4wDMnmg02HIHaJsrP7Zmf/0f69R/v3xzsP7j/Y39nt
+        EIdIYn5lAunf32e4H+Xv2pxoT/QnqDpyO2pHrGJaV0113o7PqPHFvG3GP/nF
+        0yK7WFZNW0yb13nbEtaNdup30CesA/9eBB0i5vsTciMRd/f27h98ei8govBU
+        FPPqKq/Rc353lmdlWU3pV7+rWyNNMuFDkIZCyN84+SX/D4DIkOFIBAAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d083f4d6-a0ad-4f00-aadd-083e66247f72
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 3eb92168-ff78-4ac5-ae2c-9acb10427c7d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220818Z:3eb92168-ff78-4ac5-ae2c-9acb10427c7d
+      Date:
+      - Fri, 20 Nov 2015 22:08:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d99246dd-18e9-4de3-98b9-331f32e0d522
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 431df166-57de-455f-be2d-1b3174b4942d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220819Z:431df166-57de-455f-be2d-1b3174b4942d
+      Date:
+      - Fri, 20 Nov 2015 22:08:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
+        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
+        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
+        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
+        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
+        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
+        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
+        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
+        D8aATOm/AgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e0b9440f-f9ba-44ae-a5fb-de841e70b926
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - b994c83e-8d31-4567-a2a4-76ac386dc868
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220819Z:b994c83e-8d31-4567-a2a4-76ac386dc868
+      Date:
+      - Fri, 20 Nov 2015 22:08:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c68d6ff6-3d6b-45e1-a631-d3bcc33b0c88
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 6ea359c1-385c-4056-a5a8-8049fd9f2035
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220820Z:6ea359c1-385c-4056-a5a8-8049fd9f2035
+      Date:
+      - Fri, 20 Nov 2015 22:08:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 768359da-0b4f-42cb-91f8-ebbbe398d2b5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - da0b3632-0cc6-4ea1-855b-cdb40fc6c4b1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220820Z:da0b3632-0cc6-4ea1-855b-cdb40fc6c4b1
+      Date:
+      - Fri, 20 Nov 2015 22:08:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 217d10f4-c080-4d9e-87b0-6456d47595be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 73509519-9083-4a9b-adc2-3b458b7f346e
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220821Z:73509519-9083-4a9b-adc2-3b458b7f346e
+      Date:
+      - Fri, 20 Nov 2015 22:08:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4bd1a19c-f2a8-4904-b3c4-5f4487385cf5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 45e3ab6b-c570-4185-8ec6-cb3e1f942288
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220821Z:45e3ab6b-c570-4185-8ec6-cb3e1f942288
+      Date:
+      - Fri, 20 Nov 2015 22:08:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9b4f1b88-48a6-4eaf-b4cf-36ed739e2f5e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 63eee5ac-1bd0-4991-96b3-bbc9a562b012
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220822Z:63eee5ac-1bd0-4991-96b3-bbc9a562b012
+      Date:
+      - Fri, 20 Nov 2015 22:08:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d2685c3e-1d6f-43fa-b41f-696d8188b041
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - c9b9d89c-f485-45a7-910c-cda35f850ec0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220822Z:c9b9d89c-f485-45a7-910c-cda35f850ec0
+      Date:
+      - Fri, 20 Nov 2015 22:08:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 455021b5-2720-45d6-a5d7-0f0f0800a5f2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - c7c6a6b0-6677-4bd8-baa0-1a240f1e9e77
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220823Z:c7c6a6b0-6677-4bd8-baa0-1a240f1e9e77
+      Date:
+      - Fri, 20 Nov 2015 22:08:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ebcb7bb0-20e5-471e-a272-cc3ced292bfa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 320aca4d-bfef-4dfe-806e-6b80b7e46296
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220824Z:320aca4d-bfef-4dfe-806e-6b80b7e46296
+      Date:
+      - Fri, 20 Nov 2015 22:08:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c603dc38-b4b9-498c-92a0-c7461b50ead0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 9f4b619c-a81a-42d1-98c1-1520e51eebe4
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220824Z:9f4b619c-a81a-42d1-98c1-1520e51eebe4
+      Date:
+      - Fri, 20 Nov 2015 22:08:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4f858e1a-5c7c-484b-921b-bec079a6059c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 5415979d-b644-4dea-80c8-5ec49bd27163
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220825Z:5415979d-b644-4dea-80c8-5ec49bd27163
+      Date:
+      - Fri, 20 Nov 2015 22:08:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - cc6b03ae-5f75-4c0d-bc33-d2921c37b184
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 9ad45db5-7468-4758-8e60-7450e799482d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220825Z:9ad45db5-7468-4758-8e60-7450e799482d
+      Date:
+      - Fri, 20 Nov 2015 22:08:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
+        eztv9vYe7Rw82rv/yc7Oo52dj0zjXyK/fB8/fgmDAFJvgYwSwA7/o2UmUL84
+        +4mTarFat/mu6zVKOu9tPBvI16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQ
+        u7TZ2X2zs/9of+/R/QfjB7uffrq3c9ChEVHG/Mp0or8VpB2dpc0sazPC6+3/
+        7yhzb2/v4W6Xe4gS5tdbU2bP9frzizL48X2G+1H+rs1JbEl0CaqO3I7aUuyL
+        YlpXTXXejs+o8cW8bcY/+cXTIrtYVk1bTJvXedsS1o126nfQJ6wD/14EHSLm
+        +xNyMxEf7j+4/2A3IGKflSzm1VVeo+f87izPyrKa0q9+V7dGmtSpD0EaCiF/
+        4+SX/D8NpoHaSAYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 11152b6b-6c90-45c3-8d4f-0dd34d1f5347
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 964fa057-aea4-48c1-83f1-77e809f9e2c5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220826Z:964fa057-aea4-48c1-83f1-77e809f9e2c5
+      Date:
+      - Fri, 20 Nov 2015 22:08:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a7ad4690-041d-48c6-afc4-a2ac4cf84054
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 05878f0a-93bc-4ada-be6a-617c8985c917
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220826Z:05878f0a-93bc-4ada-be6a-617c8985c917
+      Date:
+      - Fri, 20 Nov 2015 22:08:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
+        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
+        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
+        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
+        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
+        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
+        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
+        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
+        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
+        +EH//JL/B0wm3MTUAgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 30c82dfb-9144-4417-beca-aa4d67a0d4c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - fd426d6c-5608-44f9-8976-83e8b49c6688
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220827Z:fd426d6c-5608-44f9-8976-83e8b49c6688
+      Date:
+      - Fri, 20 Nov 2015 22:08:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 96a133e4-e7eb-4138-8fa9-282b4eeacfca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 511e30ee-4573-4eb5-bb84-98d2158f7499
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220827Z:511e30ee-4573-4eb5-bb84-98d2158f7499
+      Date:
+      - Fri, 20 Nov 2015 22:08:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9b002d7c-d8fd-481b-8ba7-5ca54e65c66c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 5a4a22ff-649d-486e-8a95-5672e9c3c735
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220828Z:5a4a22ff-649d-486e-8a95-5672e9c3c735
+      Date:
+      - Fri, 20 Nov 2015 22:08:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e3c9f015-b73f-49ae-aada-3b8f72d7afe7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 2325ab07-c103-404a-8543-59a24f9f99b5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220828Z:2325ab07-c103-404a-8543-59a24f9f99b5
+      Date:
+      - Fri, 20 Nov 2015 22:08:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 172545a5-8315-447f-b5c0-cda3a80a0194
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 75d88f5f-5104-44fd-bbe1-b1033d5672dc
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220829Z:75d88f5f-5104-44fd-bbe1-b1033d5672dc
+      Date:
+      - Fri, 20 Nov 2015 22:08:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fec08efa-936a-4f9c-b440-74135445d29c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 06469aef-e3eb-4440-918f-f9b11ddf8794
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220829Z:06469aef-e3eb-4440-918f-f9b11ddf8794
+      Date:
+      - Fri, 20 Nov 2015 22:08:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8cb568e5-bf83-477d-b2a5-da911d577bb3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 0ebabbbb-7aa0-4198-8969-37b0b8528deb
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220830Z:0ebabbbb-7aa0-4198-8969-37b0b8528deb
+      Date:
+      - Fri, 20 Nov 2015 22:08:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1e91c813-1150-49eb-b146-fabb2962c448
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 3e2c5cd5-feac-4e44-8aff-e5dde2147e79
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220834Z:3e2c5cd5-feac-4e44-8aff-e5dde2147e79
+      Date:
+      - Fri, 20 Nov 2015 22:08:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7f78cd20-f835-497f-9098-06d8013f901c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - d1f62612-1bbd-481e-8dfd-f3f10d2d41d6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220834Z:d1f62612-1bbd-481e-8dfd-f3f10d2d41d6
+      Date:
+      - Fri, 20 Nov 2015 22:08:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d534df4f-16f5-49b6-8450-229308b7de15
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 34118907-7ff0-4d44-a5a1-130c7730d3f6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220835Z:34118907-7ff0-4d44-a5a1-130c7730d3f6
+      Date:
+      - Fri, 20 Nov 2015 22:08:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3515225f-7dfd-43e7-ba8c-68a33a0d10e9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - a3240ce9-1efe-4724-917c-106b73158888
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220835Z:a3240ce9-1efe-4724-917c-106b73158888
+      Date:
+      - Fri, 20 Nov 2015 22:08:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - 17ad9edf-e6a8-4ccf-81d9-761c2aa4334b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 5802b862-ecba-4bb8-a604-e3b5d7e96253
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220836Z:5802b862-ecba-4bb8-a604-e3b5d7e96253
+      Date:
+      - Fri, 20 Nov 2015 22:08:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu0cPLr36Sc7O492
+        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUCtGjRxHUap5r2IZwPlmvV0muez
+        fOYg4nGUO1ueV53vCIGQcD7YdAhilyw7u2929h/tHzza/3S8s/fpw917HeoQ
+        TcyvTCH9+/sM9qNJVbVPi+xiWTVtMQUaOmQa7LKpyvz1tM7zZTOv2idlNfmq
+        LqjJR/O2XTWP7t5tVvl0t2mrmmZ2dzyhBuNpVefjq2I5q66a8TJv76KHmeth
+        G+9cLna282z3QZ7t7W9ns2y2vb8/vbedHRw83N7Z2b93Ptnbvf/wfI872P7J
+        L3bGt2k9biyu48lixRRQfujPrg6TvnuvWR2a0fefzc0zefBw/9N7e8FUylCi
+        mFdXeY2e87uzPCvLakq/+l3dGmkSTR+CNBR++Y2TX/L/AMNZcKrPBAAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2ce2d8c8-8577-42d9-a3a9-8e30dc1607bf"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 611dd440-713b-42f0-86a7-3d25000b38dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 0793c289-dabd-4afa-b6fa-eeb50d357a16
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220837Z:0793c289-dabd-4afa-b6fa-eeb50d357a16
+      Date:
+      - Fri, 20 Nov 2015 22:08:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9HeNN+bHUwPtg/u
+        P3iwvb83e7id3csebh/k93Zm091Pdx5Mzn/fj/TF9nrFQ7xFp/pGWU0zjBhv
+        5VnTrs0XNIJVXrcFtXyUMgHlw8uioebF8uJ1m7Xc2ev1dJrns3wmb1IzS5e1
+        0Pb+wcPp7s6DfaLjbHd7//5ksv1w7+DB9iR7cP7pp9P9h0RP+3KxOqmW58XF
+        umbE0P335KvU4IHHTmexmnL7XQMBz/+bJvVud0T0QQzlrzvr8mBuehMmD766
+        xbTJQ42LS2py9vJ4NiNaANpHuztj/Hd/sGlp+OiLvJ1XTPun1zRDxbTzCk0I
+        kYq+DzCkL37YE3ZZ1O06K/VPna6ffHH65i6hQCg2d1/zz+3dj3xMf0k4nLLK
+        Zk+yMltO8/pJNn2bL2dKtpdVVYJ2lnfl6QybQPywB+6jrMN+/uTupI/8XR0Q
+        /giJQGTw//z+ME3OlpNqvZy9yNpX65I58/8j9ChCxO++evpy+ye/2NlIBveH
+        /Vx/MRT6aLZsXudtS3IIWtjBy+f1JWFAH3/PNKcvstWqLPLZ0/B7+drw4kf5
+        MpuUJIbPqvoqq2cEnVqdZ2WTmxbK7V9k03mxhPi7rr85en/5xcuv3pz+5Bev
+        o/TW6TCCp6goxR1pmWL0zy/5fwAzzH7ZtQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9bae8b7f-9630-4035-a083-35486c249734
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 2e397cea-6f03-4f01-9ccd-ad34324081e4
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220837Z:2e397cea-6f03-4f01-9ccd-ad34324081e4
+      Date:
+      - Fri, 20 Nov 2015 22:08:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6c0bcc78-5e82-439a-b639-c0550540359a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 36670885-1c83-4926-bc6f-9ab47e80b228
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220838Z:36670885-1c83-4926-bc6f-9ab47e80b228
+      Date:
+      - Fri, 20 Nov 2015 22:08:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 53632a7c-3d64-4666-b46f-07bafdf080fd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - eb217797-0aad-45fa-89ff-59dcfc7d0973
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220838Z:eb217797-0aad-45fa-89ff-59dcfc7d0973
+      Date:
+      - Fri, 20 Nov 2015 22:08:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0eb60f9b-0424-4871-ad34-da71cc5ffddf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - cf791421-b808-4400-817a-824c392152cc
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220839Z:cf791421-b808-4400-817a-824c392152cc
+      Date:
+      - Fri, 20 Nov 2015 22:08:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4254234f-841c-4186-b37f-ac361db878c4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - aa2631a8-872d-4bfe-be33-56f119253036
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220839Z:aa2631a8-872d-4bfe-be33-56f119253036
+      Date:
+      - Fri, 20 Nov 2015 22:08:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 993036e4-3bcb-4baf-8bb0-efec5ae71dd0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 8fedba96-487c-4081-bdc3-2e6729be0315
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220840Z:8fedba96-487c-4081-bdc3-2e6729be0315
+      Date:
+      - Fri, 20 Nov 2015 22:08:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b93e93cf-a853-49b1-97d5-4c92716ff5c5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 2f377d03-0d89-4a50-a9e3-3cf52d36c6a5
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220841Z:2f377d03-0d89-4a50-a9e3-3cf52d36c6a5
+      Date:
+      - Fri, 20 Nov 2015 22:08:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 864d31fc-6941-48df-9904-aa7ea3f27764
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 778163ce-dc6f-4bc1-aaf7-d7441b6938a4
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220841Z:778163ce-dc6f-4bc1-aaf7-d7441b6938a4
+      Date:
+      - Fri, 20 Nov 2015 22:08:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1bdeb682-eb6e-4c31-82b7-fa554ecbfc1a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 15027560-415e-4b44-b5c3-16054f43ca9c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220842Z:15027560-415e-4b44-b5c3-16054f43ca9c
+      Date:
+      - Fri, 20 Nov 2015 22:08:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 207e0573-dfc8-49ec-866d-154b6eda32e4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - d3be8b09-7a98-4c05-b429-4bf1bb929fc3
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220842Z:d3be8b09-7a98-4c05-b429-4bf1bb929fc3
+      Date:
+      - Fri, 20 Nov 2015 22:08:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2b24434f-7436-4588-9b05-7fc2b8cc7953
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 8f9323c1-7cbf-493a-8460-0d73b08bbe3f
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220843Z:8f9323c1-7cbf-493a-8460-0d73b08bbe3f
+      Date:
+      - Fri, 20 Nov 2015 22:08:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - 6ea2a16c-809e-4c7c-9040-0cb09481d8a1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - aa5a2c77-1830-461b-85b1-aa00d4d9e0a2
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220843Z:aa5a2c77-1830-461b-85b1-aa00d4d9e0a2
+      Date:
+      - Fri, 20 Nov 2015 22:08:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u723s7b/b2Hu0cPNq/98nOzqOd
+        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
+        nzmIeBzlzpbnVec7QiAknA82HYLYJcvO7pud/Uf7RJZPx3v79z/d2TnokIeI
+        Yn5lEunf32e4H02qqn1aZBfLqmmLKfDQMdNol01V5q+ndZ4vm3nVPimryVd1
+        QU0+mrftqnl0926zyqe7TVvVNLW74wk1GE+rOh9fFctZddWMl3l7Fz3MXA/b
+        eOdyQZhP7md72f759u7s0wfb+7uzfDvb3Ztu39ud7TzY/fTh3qd7RFhqvP2T
+        X+yOb9N63Fhcx5PFiimgDNGfXh0mffde0zo0pe8/nZun8uHe/XsHIafLUKKY
+        V1d5jZ7zu7M8K8tqSr/6Xd0aaZJNH4I0FH75jZNf8v8A8Y12ftAEAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"ae5753ad-843b-447c-ad44-b9866332d3f2"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6a9fbe46-f45a-4589-a262-dbf4b83a0312
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - d70b34ad-d948-4ba3-8a78-48bea86d936c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220844Z:d70b34ad-d948-4ba3-8a78-48bea86d936c
+      Date:
+      - Fri, 20 Nov 2015 22:08:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
+        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
+        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
+        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1GW339w/1422z7Y
+        vzfZ3t9/MN3OZvv725OHB59+eu/e3uze+d7v+5G+2F6veIi36FTfKKtphhHj
+        rTxr2rX5gkawyuu2oJaPUiagfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZumy
+        Fto+2Jnd37l/f297b+98d3v//qf59mS2d779cLJ7vpvf2z8/z3fsy8XqpFqe
+        FxfrmhFD99+Tr1KDBx47ncVqyu2VePL8v2lS73ZHRB/EUP66sy4P5qY3YfLg
+        q1tMmzzUuLikJmcvj2czogWgfbS7M8Z/+4NNS8NHX+TtvGLaP72mGSqmnVdo
+        QohU9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGU
+        VTZ7kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/q
+        gPBHSAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cVmMrg/
+        7Of6i6HQR7Nl8zpvW5JD0MIOXj6vLwkD+vh7pjl9ka1WZZHPnobfy9eGFz/K
+        l9mkJDF8VtVXWT0j6NTqPCub3LRQbv8im86LJcTfdf3N0fvLL15+9eb0J794
+        HaW3TocRPEVFKe5IyxSjf37J/wOqI1T/tQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f673e4d4-6ff7-4ebf-908a-1eba6e7bb1d3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - e0c6787c-7c90-4204-9d35-ae443715bb9e
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220844Z:e0c6787c-7c90-4204-9d35-ae443715bb9e
+      Date:
+      - Fri, 20 Nov 2015 22:08:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
+        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
+        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
+        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
+        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
+        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
+        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
+        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
+        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
+        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
+        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
+        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
+        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
+        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
+        Ae0xubNkBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d4a7dc46-4567-44ac-9639-3bf057fb9cbc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 735ff3a5-c680-4258-b614-9789d464292d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220845Z:735ff3a5-c680-4258-b614-9789d464292d
+      Date:
+      - Fri, 20 Nov 2015 22:08:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
+        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
+        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
+        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
+        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
+        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
+        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
+        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
+        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
+        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
+        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
+        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
+        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1c83952e-bfb6-40e8-9967-407546d7f458
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 976b35d8-5e7b-4031-9033-1cd35b898df1
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220846Z:976b35d8-5e7b-4031-9033-1cd35b898df1
+      Date:
+      - Fri, 20 Nov 2015 22:08:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
+        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
+        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
+        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
+        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
+        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
+        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
+        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
+        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
+        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
+        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
+        AA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 51a9581f-5f45-4108-a48a-7770817bface
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 7742f0e3-a123-4fa2-932a-62011c69a73c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220846Z:7742f0e3-a123-4fa2-932a-62011c69a73c
+      Date:
+      - Fri, 20 Nov 2015 22:08:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
+        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
+        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
+        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
+        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
+        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
+        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
+        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
+        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
+        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
+        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
+        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
+        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
+        PwuqUY4PBwAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7a984082-69f4-4f3b-9740-8e9e5170c385
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 9c59ae9a-6e25-4104-9dc8-8b98b10e50cd
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220847Z:9c59ae9a-6e25-4104-9dc8-8b98b10e50cd
+      Date:
+      - Fri, 20 Nov 2015 22:08:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
+        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
+        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
+        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
+        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
+        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
+        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
+        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
+        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
+        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
+        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
+        +ueX/D+V0+PkOQcAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5e3908ba-2e14-4a8c-a54d-439a698fa46e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 43a4583a-ad11-4d1c-b9f1-53436c514149
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220848Z:43a4583a-ad11-4d1c-b9f1-53436c514149
+      Date:
+      - Fri, 20 Nov 2015 22:08:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
+        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
+        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
+        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
+        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
+        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
+        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
+        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
+        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
+        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
+        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b49eaf01-6f5d-42fd-b3f2-aa650f01849f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 1c103eee-f73b-454d-b427-c95c176fbf46
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220849Z:1c103eee-f73b-454d-b427-c95c176fbf46
+      Date:
+      - Fri, 20 Nov 2015 22:08:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute2853?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2e4e3e2e-b105-46ec-9641-94187dedba07"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6f3874de-3652-491b-a46d-0e542c327ce8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - cfc162cb-16de-4fb7-8afe-3bb9a19eb739
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220849Z:cfc162cb-16de-4fb7-8afe-3bb9a19eb739
+      Date:
+      - Fri, 20 Nov 2015 22:08:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfO/g
+        /r2PRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
+        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
+        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR3v5fn4v38u3
+        J7s797f3P82n2w8/3d/dfri/e/Bgls8m2c6D3/cjfbG9XvFgb9GzvlFW0wzD
+        xlt51rRr8wUNY5XXbUEtH6VMSvnwsmioebG8eN1mLXf2ej2d5jmhIm9SM0uc
+        tRB48unB3r2H9z/dvndv8un2/sHkYHuyT2SdfvrpQXb//H62c2/HvlysTqrl
+        eXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig3qzJ
+        g69uMXfyUOPikpqcvTyezYgggPbR7s4Y/3062LQ0zPRF3s4rnoCn1zRNxbT7
+        ynpSFlN6wwIPUKUWP+zp62BE0/fF2U/ou3sf+cj9knAohCFNPSH7cz2Cy6Ju
+        11mpfwavEQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlvgmmSj6vLwkf
+        +vh7pjl9ka1WZZHPnobfy9eGfh/ly2xSEts8q+qrrJ4RdGp1npVNbloQ0hjL
+        63y6rov2mulBbRwCP2waxxCidj1OYQLSP7/k/wF6GS1DgwYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/pubtest450?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1f5cabcd-0205-4c5e-8a2f-390fd75fd6bb"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1616c81e-5c70-4cf8-91cb-31513c2922ad
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - fa06c716-9318-4bec-b436-e7e807d42881
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220850Z:fa06c716-9318-4bec-b436-e7e807d42881
+      Date:
+      - Fri, 20 Nov 2015 22:08:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWetHnT7t/f+WjE
+        XxQzfHy3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd39g72
+        9me7s9n+wf27dd5U63qaf15X61Vz96RarNZt/pNfNHdXdXVZzPK6uftFMa2r
+        pjpvxy/y9qqq395dys+zZZvX59k0p9ZdlPI2uwBS3737+360e35/mk2mM+p6
+        5/72/vR+vn2Q7Z1v33u4cz57cP989ulk8vt+pC+21yse5C161TfKapphyHgr
+        z5p2bb6gIazyui2o5aOUSSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZwqyF
+        uJ/u3tvfyWc727P797Lt/dnD2fbkfLK/nWUHu/v39vbOH9zbty8Xq5NqeV5c
+        rGtGDN1/T75KDR547IQWqym33zUQ8Py/albvdodEH8Rw/rrTLg8mpzdj8uCr
+        W8ybPNS4uKQmZy+PZzMiBqB9tLszxn8PBpuWhpG+yNt5xcR/ek1TVEy7r6wn
+        ZTGlNyzwAFVq8cOeug5Gbuo+8hH7JeEwCDuackL05xr7y6Ju11mpfwavEQ6E
+        Y3N3lp9n67IzHPeH/VV/+b6O9KPZsnmdty3xTDBN8nl9SfjQx98zzemLbLUq
+        i3z2NPxevjb0+yhfZpOSWOZZVV9l9YygU6vzrGxy04KQxlhe59N1XbTXTA9q
+        4xD4YdM4hhC9EXAJE4/++SX/D3EINSBvBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/erp758?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"689dbcd4-e90b-4d83-bc0a-ec9fb9509d84"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 50e70562-a52c-4293-9f72-cc125ad797a4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 6f2d17e4-cdb7-4e76-ba9b-2d24b7d18048
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220851Z:6f2d17e4-cdb7-4e76-ba9b-2d24b7d18048
+      Date:
+      - Fri, 20 Nov 2015 22:08:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9XD+4ffDTiD4sZ
+        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
+        2Wz/4P7dOm+qdT3NP6+r9aq5uyh+UfaDdZ3v3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP8+WbV6fZ9O8uRtgk7fZBfD57t3f96NPDx7OJtPZ/nb+cGey
+        vT87uLc9me5k2/mUcHl4f+fh7GD/9/1IX2yvVzy2W/Sob5TVNMNo8VaeNe3a
+        fEHor/K6Lajlo5QpJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmarIWu091s
+        snO+e3/73u75w+39vUlGhNy9t713//7Dhw/u53v5/Yf25WJ1Ui3Pi4t1zYih
+        ++/JV6nBA4+dx2I15fa7BgKe/7dM6N3uaOiDGLpfd8blwbz0JksefHWLKZOH
+        GheX1OTs5fFsRnQAtI92d8a7453x/mDT0vDQF3k7r5juT69pdopp95X1pCym
+        9IYFHqBKLX7Is9ZBiGbt9NXLj3ycfkk4AkKMZppw/DlG/LKo23VW6p/+W4QB
+        YdjcneXn2bpsw8G4P+yv+sv3dZwfzZbN67xtiVmC+ZHP60tChz7+nmlOX2Sr
+        VVnks6fh9/K1od5H+TKblMQrz6r6KqtnBJ1anWdlk5sWhDSG8jqfruuivWZq
+        UBuHwA+ZwjF8fPZgutE/v+T/AWPpEplVBgAA
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces/miq866?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f44a79cd-989d-48aa-ab6f-e90faf3ea160"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6d2e72da-dde7-4248-8673-5b8811bc6606
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 46ef8a6b-de2a-4a74-9de3-93614e4dc7e8
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220851Z:46ef8a6b-de2a-4a74-9de3-93614e4dc7e8
+      Date:
+      - Fri, 20 Nov 2015 22:08:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8ooNPP/1oxB8W
+        M3x0t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863d/YO9vZn
+        u7PZ/sH9u3XeVOt6mn9eV+tVc5egZj9Y1/nu3VVdXRazvG7uflFM66qpztvx
+        i7y9quq3d5fy82zZ5vV5Ns35PYdN3mYXwOe7d3/fj87397MHD6ez7YcHD2fb
+        +wdZtp1NPj3fzh/unGfn9/Js99Od3/cjfbG9XvHYbtGjvlFW0wyjxVt51rRr
+        8wWhv8rrtqCWj1KmnHx4WTTUvFhevG6zljt7vZ5O83yWz+RNamZpsha6Th/s
+        Tz99ONnffjg7/3R7/+H9fHuyN9mlf2hw0/P79w+yA/tysTqplufFxbpmxND9
+        9+Sr1OCBx85jsZpy+10DAc//Wyb0bnc09EEM3a874/JgXnqTJQ++usWUyUON
+        i0tqcvbyeDYjOgDaR7s7493xzvj+YNPS8NAXeTuvmO5Pr2l2imn3lfWkLKb0
+        hgUeoEotfsiz1kGIZu2Ls5/4yMfpl4QjIMRopgnHn2PEL4u6XWel/um/RRgQ
+        hs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWmCWYH/m8viR06OPvmeb0RbZa
+        lUU+exp+L18b6n2UL7NJSbzyrKqvsnpG0KnVeVY2uWlBSGMor/Ppui7aa6YG
+        tXEI/JApHMOH2ln2YLrRP7/k/wGEsn/4VQYAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130916208942824042
+      X-Ms-Request-Id:
+      - 3d56306f-e6b3-497e-bc4c-579ff94d4c03
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 440d925c-bb74-4193-bcd3-8a46b7d0dd33
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220852Z:440d925c-bb74-4193-bcd3-8a46b7d0dd33
+      Date:
+      - Fri, 20 Nov 2015 22:08:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
+        eztv9vYe7Rw8ur/3yc7Oo52dj0zjXyK/fB8/fgmDAFJvgYwSwA7/o2UmUF9n
+        Zd6cV/U0/+q16zZKO+91PBvo16yn0zyf5TMHEY+j39nyvOp8R5iG5PPBpkMQ
+        u8TZ2X2zs/9o/8Gj+w/HO3sPdu/vPugQiUhjfmVC6d/fZ7gfTaqqfVpkF8uq
+        aYsp8NAx02iXTVXmr6d1ni+bedU+KavJV3VBTT6at+2qeXT37vK6vni4e7A/
+        ntB342lV5+OrYjmrrprxMm/vAvjMAd9uDO23p7Pznez8wcPtezv7s+392YN7
+        2w+n0/vbB/fv7052H86m+c6Du/5UjW/zxrixyI4nixWTQPkif9fSF0RcDFFn
+        WEdK3xrm+KKY1lVTnbfjM2p8MW+b8U9+4ZHndd62NDsNQybY+KGE7DOQA/9e
+        jDPENO/PMBuZZXdv5+HOw/2AWYRWUcyrq7xGz/ndWZ6VZTWlX/2ubo006QAf
+        gjQUQv7GyS/5fwBPKt0r/QQAAA==
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2dcaedc2-53e7-49af-8300-e85c3490d90b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 97c62599-1f35-4b92-9f3b-51b154aeef73
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20151120T220852Z:97c62599-1f35-4b92-9f3b-51b154aeef73
+      Date:
+      - Fri, 20 Nov 2015 22:08:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
+        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
+        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
+        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
+        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
+        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
+        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
+        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
+        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
+        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
+        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
+        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
+        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
+        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
+    http_version: 
+  recorded_at: Fri, 20 Nov 2015 22:08:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
@@ -4938,11 +13382,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -4965,20 +13409,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1e38e10f-4e45-48ac-ba5f-c14dd2e3bc31
+      - dbdd5d0c-51a4-46d7-9275-deb78ff3ab75
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 2fa08fdd-5de8-4b71-9ce0-aa7f54e985e3
+      - df65b082-8d1c-4487-b78d-24092c148421
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:2fa08fdd-5de8-4b71-9ce0-aa7f54e985e3
+      - NORTHCENTRALUS:20151120T220853Z:df65b082-8d1c-4487-b78d-24092c148421
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Fri, 20 Nov 2015 22:08:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4995,7 +13439,7 @@ http_interactions:
         VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
         55f8P07bQ1vOAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -5008,11 +13452,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -5033,19 +13477,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - 7f254107-8231-41ff-8652-22bc29f46572
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - 7f254107-8231-41ff-8652-22bc29f46572
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192130Z:c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - NORTHCENTRALUS:20151120T220854Z:7f254107-8231-41ff-8652-22bc29f46572
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Fri, 20 Nov 2015 22:08:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5062,7 +13506,7 @@ http_interactions:
         9H2TTyuQ2X/7u7l5u6E31s2X5y+lB/ouu8yKEqh43742MILvCbE2uwDl8ZvM
         6Y289NEv+f4vSf4fxlUpaegCAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:30 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:54 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts/chefprod5120/listKeys?api-version=2015-05-01-preview
@@ -5075,11 +13519,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
       Content-Length:
       - '0'
   response:
@@ -5102,19 +13546,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - a265e5b1-4056-4a66-9412-c460482c2d89
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - a265e5b1-4056-4a66-9412-c460482c2d89
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192130Z:b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - NORTHCENTRALUS:20151120T220855Z:a265e5b1-4056-4a66-9412-c460482c2d89
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Fri, 20 Nov 2015 22:08:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5127,7 +13571,7 @@ http_interactions:
         Xv/U6ezdu/b3Xk0e/qJqXv7UT7av6x9cXM1/etLunX1n9nufn3y1u/ypqy8+
         P6Yefkny/wD0cfTdxgAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:30 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:55 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/?comp=list
@@ -5140,13 +13584,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Fri, 20 Nov 2015 22:08:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:wbgGtIeoc1ovC2HxePvE2aeO5NM4pJteZ6Ll3Rx4oCw=
+      - SharedKey chefprod5120:xcRIUHVhn3JOoxjUflx5P05nSURhYUQmmFxXnyNNW6E=
   response:
     status:
       code: 200
@@ -5159,11 +13603,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d30b6f0f-0001-0085-1fed-1b0615000000
+      - d7093c4d-0001-005e-77e0-23a2c3000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Fri, 20 Nov 2015 22:08:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5190,7 +13634,7 @@ http_interactions:
         dGFpbmVyPjwvQ29udGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRp
         b25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:56 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-postgresd-fcf3dcec-fb8d-49f5-9d8c-b15edcff704c?comp=list&restype=container
@@ -5203,13 +13647,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:xCJMkXlQDd2p0a8vLeFWt0I/iu1NxGqH1JyWwF0Gt3s=
+      - SharedKey chefprod5120:igef/+m1Us5PSPVSA4KT6910EB74ye+ZgJW8iurclEs=
   response:
     status:
       code: 200
@@ -5222,11 +13666,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4f8dc838-0001-0010-19ed-1b6726000000
+      - 8b20d299-0001-0023-76e0-233e0b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Fri, 20 Nov 2015 22:08:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5237,7 +13681,7 @@ http_interactions:
         ZjUtOWQ4Yy1iMTVlZGNmZjcwNGMiPjxCbG9icyAvPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:56 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/system?comp=list&restype=container
@@ -5250,13 +13694,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Xh45YfOojfHpS9vPybOLRReme6kYfx1EA69yuR8P0oE=
+      - SharedKey chefprod5120:Up0VD1JcbHw8ufXFYu38cRkdRAAo3YJckaftltVxZaQ=
   response:
     status:
       code: 200
@@ -5269,11 +13713,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 175acb5c-0001-0050-57ed-1b4ec8000000
+      - 35f45b7b-0001-004d-38e0-239722000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Fri, 20 Nov 2015 22:08:57 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5360,7 +13804,7 @@ http_interactions:
         cm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVt
         ZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:57 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5373,13 +13817,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:57 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:9B+LOUYDtfXxHG/9IixpVFI5svFqK4zjhG3LRuTmmvI=
+      - SharedKey chefprod5120:9aROIvycS2N89mvLpVOo6XCv3jKkQ0IccX0tzVJVtPo=
   response:
     status:
       code: 200
@@ -5392,11 +13836,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d2491dff-0001-0011-1aed-1b66db000000
+      - 62f79ba2-0001-003b-2fe0-23139e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Fri, 20 Nov 2015 22:08:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5416,8 +13860,8 @@ http_interactions:
         PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
         L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5D
         aGVmLVByb2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
-        PlR1ZSwgMTAgTm92IDIwMTUgMTA6MTQ6MDIgR01UPC9MYXN0LU1vZGlmaWVk
-        PjxFdGFnPjB4OEQyRTlCN0E4NEY1M0JBPC9FdGFnPjxDb250ZW50LUxlbmd0
+        PlR1ZSwgMTcgTm92IDIwMTUgMDk6NTA6MDggR01UPC9MYXN0LU1vZGlmaWVk
+        PjxFdGFnPjB4OEQyRUYzNDdBMzVENjIyPC9FdGFnPjxDb250ZW50LUxlbmd0
         aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
         cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
         dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
@@ -5454,7 +13898,7 @@ http_interactions:
         cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:57 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5467,13 +13911,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:57 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:zF0gDzDVNEcJpAyrKvlBaVZSZPT+BfYiyRDi6R6fsAc=
+      - SharedKey chefprod5120:d1bpqGrdWLi1O2uo6aUXwkC0OxujwSBfN38J3EqSeF8=
   response:
     status:
       code: 200
@@ -5494,7 +13938,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cd78618e-0001-0071-23ed-1b23f9000000
+      - bf33dfaa-0001-0029-48e0-232782000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5524,12 +13968,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:23:36 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:58 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psg/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5542,13 +13986,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:58 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:PCLFb7t0R+xKAZAZnNqEU3osge/CbNJYyCBfxApJ+38=
+      - SharedKey chefprod5120:Nwuz7l+BULBJY9wFX+yXqRYH/bi3yanQE2FN3CPzN18=
   response:
     status:
       code: 200
@@ -5569,7 +14013,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c0a548dc-0001-005e-53ed-1ba2c3000000
+      - f84f179c-0001-0067-6be0-23e267000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5599,12 +14043,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:18:59 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:58 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psgcont/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5617,13 +14061,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Fri, 20 Nov 2015 22:08:58 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:5AS9zQdQrwuq2lN2U2JcQHiRxa3u6cyXf7/TrS6Ae3g=
+      - SharedKey chefprod5120:mdV0Cm17gI2DMc+FL1Mx6SbV75THAo8VVDOyvROYEoU=
   response:
     status:
       code: 200
@@ -5644,7 +14088,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4f1efffb-0001-0036-78ed-1bfc92000000
+      - b9fae482-0001-0078-0be0-233977000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5674,12 +14118,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:21:32 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Fri, 20 Nov 2015 22:08:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -5692,11 +14136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -5717,19 +14161,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - 8a4ae0b8-97cd-417b-9053-9a67a7f514fb
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - 8a4ae0b8-97cd-417b-9053-9a67a7f514fb
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192132Z:6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - NORTHCENTRALUS:20151120T220859Z:8a4ae0b8-97cd-417b-9053-9a67a7f514fb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5748,7 +14192,7 @@ http_interactions:
         P3zwcOfhw4e3ZOwAl1vzdfgWvoy+xXw7+Bp/G32vZV4Yeo+/jbxHHKMD9tjS
         EZ+ovJmp6TMwZoxtCfTXYcvv/5Lk/wEjcGCNjAUAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:00 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/computevms1392/listKeys?api-version=2015-05-01-preview
@@ -5761,11 +14205,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
       Content-Length:
       - '0'
   response:
@@ -5788,19 +14232,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - b4b1ef5d-d1ee-4616-a4cf-f5b9d5ff9306
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - b4b1ef5d-d1ee-4616-a4cf-f5b9d5ff9306
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192132Z:04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - NORTHCENTRALUS:20151120T220907Z:b4b1ef5d-d1ee-4616-a4cf-f5b9d5ff9306
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Fri, 20 Nov 2015 22:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5813,7 +14257,7 @@ http_interactions:
         iydfXK+/mkx3f+LN3peftG9f/j6/1/zL5f6bt8/X7+59+eL3WZ3OL/euXp79
         oqf7F9TDL0n+H9NZ3UDGAAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:08 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/?comp=list
@@ -5826,13 +14270,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Fri, 20 Nov 2015 22:09:08 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:lw56fYr4qXY1L28H3fejbD3jMNx1f4WVb5zw/eARDrg=
+      - SharedKey computevms1392:XrlR8lxzW8evryslj6AJ3ws705RCOoS9uM7zG1Px+Go=
   response:
     status:
       code: 200
@@ -5845,11 +14289,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 21493640-0001-0041-7ded-1beef9000000
+      - debc0530-0001-000f-4ce0-232b1c000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Fri, 20 Nov 2015 22:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5869,7 +14313,7 @@ http_interactions:
         L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjwvQ29u
         dGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:08 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/system?comp=list&restype=container
@@ -5882,13 +14326,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Fri, 20 Nov 2015 22:09:08 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:b8QK6EGi14bs7z2eok+bz6I7sEaKvpfCN7J/HM8Fwn0=
+      - SharedKey computevms1392:bfCcMQl72Em90WF+NVTjBz467OWbwRr4VsaAHP2ytcY=
   response:
     status:
       code: 200
@@ -5901,11 +14345,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ea7937fb-0001-007d-0ced-1b5a22000000
+      - 1f970e26-0001-0035-7be0-2368bf000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Fri, 20 Nov 2015 22:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5941,7 +14385,7 @@ http_interactions:
         UHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51
         bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:09 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5954,13 +14398,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Fri, 20 Nov 2015 22:09:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:LX/0YRvHuz4HB/1mWh0jXccRXOTepGW4C2lYUWYCRi4=
+      - SharedKey computevms1392:DtgFQ67YQaT2LPT/d/TOCQgDYGzetbtgPkQekoIR/SA=
   response:
     status:
       code: 200
@@ -5973,11 +14417,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8c53abeb-0001-0067-3eed-1b754d000000
+      - dd37a36e-0001-0084-30e0-2390c2000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Fri, 20 Nov 2015 22:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6153,7 +14597,7 @@ http_interactions:
         bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxO
         ZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:10 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd
@@ -6166,13 +14610,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Fri, 20 Nov 2015 22:09:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:2Wj09dP9EWNQ0GTltqYYjo8dy7SPo3Tdzfo2185DuCs=
+      - SharedKey computevms1392:X/EzPCXm+c3uGGEwBOjRonn6JidgKwR9xw0i+vIjieY=
   response:
     status:
       code: 200
@@ -6193,7 +14637,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 611a3532-0001-0060-7eed-1b83c8000000
+      - c32469cc-0001-0083-05e0-236647000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -6223,12 +14667,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:53:18 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Fri, 20 Nov 2015 22:09:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:10 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/MIQCompute2.vhd
@@ -6241,13 +14685,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Fri, 20 Nov 2015 22:09:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:qu7EKW36gi674jWmHkZKKKqMAvmAJmnvK2qeO9Eg8s8=
+      - SharedKey computevms1392:ZFKLpwvzFGoyutGk2albaPGIr9y4a6itzcHCJsSOGJg=
   response:
     status:
       code: 200
@@ -6268,7 +14712,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 81019259-0001-0062-0eed-1b8132000000
+      - 98e93c7b-0001-006d-71e0-236cc4000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -6290,12 +14734,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 18:38:50 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Fri, 20 Nov 2015 22:09:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:10 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/pubtest.vhd
@@ -6308,13 +14752,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Fri, 20 Nov 2015 22:09:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:7kxMuvbZMZbVVpHhJlrkOVkxfv3jFYvBfplrQ8og6DU=
+      - SharedKey computevms1392:MIloF34LW+7IfNXhUbfNHqoQ1n5GxaI1gCaqcsw+OtY=
   response:
     status:
       code: 200
@@ -6335,7 +14779,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f5f2444e-0001-000e-2ded-1b2ae1000000
+      - 65ec90af-0001-0058-5ce0-23c291000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -6357,12 +14801,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 19:08:18 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Fri, 20 Nov 2015 22:09:10 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:11 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/spec1storage1/listKeys?api-version=2015-05-01-preview
@@ -6375,11 +14819,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
       Content-Length:
       - '0'
   response:
@@ -6402,19 +14846,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - 4869910c-cba1-403a-8b01-0e52f4007a97
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - 4869910c-cba1-403a-8b01-0e52f4007a97
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192139Z:13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - NORTHCENTRALUS:20151120T220912Z:4869910c-cba1-403a-8b01-0e52f4007a97
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Fri, 20 Nov 2015 22:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6427,7 +14871,7 @@ http_interactions:
         Nl88/fzs5f5Pvn795envdTXP3l5e59XznS9evdv9ielPPz9/+MnBF6ffvrtq
         L97eRQ+/JPl/AL0oAMzGAAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:39 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:12 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/?comp=list
@@ -6440,13 +14884,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:6dy7gH0SHTFglwxbVmxyWYJMNHp+2alYEiIktJVhGr4=
+      - SharedKey spec1storage1:6l9Edfv/e/KYxtnajNNxCMeiGYN8jjtWOHugrgXSasM=
   response:
     status:
       code: 200
@@ -6459,11 +14903,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 93e009fc-0001-0000-69ed-1b5f42000000
+      - 59c5fd01-0001-0014-5be0-239c26000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6491,7 +14935,7 @@ http_interactions:
         ZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:39 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:13 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm0-ea17ea24-adad-44c3-a889-0043fb2159f2?comp=list&restype=container
@@ -6504,13 +14948,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:6tiWlhUEAIhhVS1IujWbF7Kc5zvqxzjl9cFuY0Yo+II=
+      - SharedKey spec1storage1:WbCjkC4jd8MEoEMuhD2SJgoFUZsOgR7npT36yK7a3ZE=
   response:
     status:
       code: 200
@@ -6523,11 +14967,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ddb5f435-0001-006f-71ed-1bf796000000
+      - 1124d149-0001-0065-5ce0-23ee1f000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6550,7 +14994,7 @@ http_interactions:
         cGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVy
         YXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:14 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm1-0b5a2a4f-1d67-41de-a12c-31d07169262e?comp=list&restype=container
@@ -6563,13 +15007,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Fri, 20 Nov 2015 22:09:14 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:XWHnlWbQAHteKVCCn/lzy6XHUtsE6fDG4g/JjmNO+fg=
+      - SharedKey spec1storage1:UYfdpU+NBUM4gVi9ZV9pQhy2UD+EXylmehZvKK6ykzs=
   response:
     status:
       code: 200
@@ -6582,11 +15026,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 91b7df6b-0001-0050-49ed-1b404a000000
+      - 48eceadf-0001-0067-4ce0-23ece5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6608,7 +15052,7 @@ http_interactions:
         PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:14 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6621,13 +15065,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Fri, 20 Nov 2015 22:09:14 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:LWLumiBG5P2d/INhQzla38vmBcR+KfdC3sIU60MorIM=
+      - SharedKey spec1storage1:AlMcb80uk/x2QqIA1cZfiW9fzgKGpBtJXQgu53CslKQ=
   response:
     status:
       code: 200
@@ -6640,11 +15084,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ddb5f579-0001-006f-1eed-1bf796000000
+      - 7c1f9238-0001-0054-32e0-23b5c8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6702,7 +15146,7 @@ http_interactions:
         L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0Vu
         dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6715,11 +15159,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -6740,19 +15184,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - 6a20d139-0876-4442-a7dc-5c79cfb8c3c4
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14879'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - 6a20d139-0876-4442-a7dc-5c79cfb8c3c4
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192140Z:d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - NORTHCENTRALUS:20151120T220915Z:6a20d139-0876-4442-a7dc-5c79cfb8c3c4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Fri, 20 Nov 2015 22:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6761,7 +15205,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6774,11 +15218,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -6799,19 +15243,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 130e7789-a40b-4ad4-af58-70e65ee1371b
+      - 8df436fb-eed4-4822-ae42-d11977d6aca5
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14879'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 130e7789-a40b-4ad4-af58-70e65ee1371b
+      - 8df436fb-eed4-4822-ae42-d11977d6aca5
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192140Z:130e7789-a40b-4ad4-af58-70e65ee1371b
+      - NORTHCENTRALUS:20151120T220916Z:8df436fb-eed4-4822-ae42-d11977d6aca5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Fri, 20 Nov 2015 22:09:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6820,7 +15264,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:41 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6833,11 +15277,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -6858,19 +15302,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 243a7c73-c1f9-462e-9a12-63a7ba428402
+      - c0aedff1-3b16-4106-a545-4ac40eed2c8c
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14878'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 243a7c73-c1f9-462e-9a12-63a7ba428402
+      - c0aedff1-3b16-4106-a545-4ac40eed2c8c
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192141Z:243a7c73-c1f9-462e-9a12-63a7ba428402
+      - NORTHCENTRALUS:20151120T220917Z:c0aedff1-3b16-4106-a545-4ac40eed2c8c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:41 GMT
+      - Fri, 20 Nov 2015 22:09:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6887,7 +15331,7 @@ http_interactions:
         vm/yaQVS+29/NzdvN/TGuvny/KX0QN9ll1lRAhXv29cGRvA9IdZmF6A+fpN5
         vZGjPvol3/8lyf8D6+XAwe4CAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:42 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:17 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts/miqazure15827/listKeys?api-version=2015-05-01-preview
@@ -6900,11 +15344,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
       Content-Length:
       - '0'
   response:
@@ -6927,19 +15371,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - b3095a09-b525-4b3d-8f58-7c20e9738fdb
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - b3095a09-b525-4b3d-8f58-7c20e9738fdb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192142Z:f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - NORTHCENTRALUS:20151120T220917Z:b3095a09-b525-4b3d-8f58-7c20e9738fdb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Fri, 20 Nov 2015 22:09:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6952,7 +15396,7 @@ http_interactions:
         NM93zy/eHM/qTz/ZefPJ3a8ud/dPLp/WT36f78ya79yb3H36iz6ffbLMJ+38
         6Zvru1fUwy9J/h+s9SVmxgAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:42 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:17 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/?comp=list
@@ -6965,13 +15409,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Fri, 20 Nov 2015 22:09:17 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:ipbIFnOeT+azlZ4+OoDvMAI01RETbC0vYC7eSOJr2Bs=
+      - SharedKey miqazure15827:Kko4SqoR+CbuSVr43SovIJUNycZAJZV6q1urrnEfXk4=
   response:
     status:
       code: 200
@@ -6984,11 +15428,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6b574251-0001-00af-29ed-1b0a6d000000
+      - ffa539b8-0001-0010-80e0-231e1b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Fri, 20 Nov 2015 22:09:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7003,7 +15447,7 @@ http_interactions:
         cj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVz
         dWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:18 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/vhds?comp=list&restype=container
@@ -7016,13 +15460,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Fri, 20 Nov 2015 22:09:18 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:dyOu5On23zwBh7bTI8023zuDvcKsW6hW+WM6Pozkbq8=
+      - SharedKey miqazure15827:gJdEWwkF9pw9oq5UNp0vItdRINjHM3eN78euTj9CBLY=
   response:
     status:
       code: 200
@@ -7035,11 +15479,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dfdef052-0001-0036-33ed-1b85af000000
+      - 02de11b9-0001-00b6-34e0-232605000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Fri, 20 Nov 2015 22:09:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7095,7 +15539,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:19 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/ERP.vhd
@@ -7108,13 +15552,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Fri, 20 Nov 2015 22:09:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:8sgedD63p7C0YsIH1XiNcOViUOAS1upGKGsUgeVYAzU=
+      - SharedKey miqazure15827:4BLjIGw/pLtF9ATAJH2oMN2aTCMi3RQ0K3+/pOJy83I=
   response:
     status:
       code: 200
@@ -7135,7 +15579,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fea043b4-0001-003d-2fed-1b9ddb000000
+      - 41888b7e-0001-0082-66e0-2389ad000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7157,12 +15601,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:31:28 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Fri, 20 Nov 2015 22:09:19 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:19 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/MIQ.vhd
@@ -7175,13 +15619,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Fri, 20 Nov 2015 22:09:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:GZqIGwI86moCSLMYkM/kFOvK6V9vNevcylQsN8cTId4=
+      - SharedKey miqazure15827:1gOkFtGO+zFE2ELhPIpcTq+ZeSVFTh2e0dPKAHKGRgk=
   response:
     status:
       code: 200
@@ -7202,7 +15646,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dfd04c59-0001-006a-44ed-1b7456000000
+      - f5b4ec51-0001-0026-07e0-23b349000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7224,12 +15668,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:33:10 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Fri, 20 Nov 2015 22:09:20 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7242,11 +15686,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -7267,19 +15711,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - 448ada08-6aaa-477f-bfc0-29a418cdc23e
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - 448ada08-6aaa-477f-bfc0-29a418cdc23e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - NORTHCENTRALUS:20151120T220920Z:448ada08-6aaa-477f-bfc0-29a418cdc23e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Fri, 20 Nov 2015 22:09:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7288,7 +15732,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7301,11 +15745,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -7326,19 +15770,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1b74c414-303c-45a3-8963-94ceab47a24a
+      - 995a1f15-3bf2-4c1c-9344-52ee12d74f3d
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 1b74c414-303c-45a3-8963-94ceab47a24a
+      - 995a1f15-3bf2-4c1c-9344-52ee12d74f3d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:1b74c414-303c-45a3-8963-94ceab47a24a
+      - NORTHCENTRALUS:20151120T220921Z:995a1f15-3bf2-4c1c-9344-52ee12d74f3d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Fri, 20 Nov 2015 22:09:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7347,7 +15791,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7360,11 +15804,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
   response:
     status:
       code: 200
@@ -7385,19 +15829,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - 0844405e-4216-42e3-99f7-44d275889320
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - 0844405e-4216-42e3-99f7-44d275889320
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - NORTHCENTRALUS:20151120T220922Z:0844405e-4216-42e3-99f7-44d275889320
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Fri, 20 Nov 2015 22:09:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7413,7 +15857,7 @@ http_interactions:
         iL7SZpN4J/xF5JVfYgf3PEZjouhl0dCnxfKCKNgC9uv1dJrns3xG3zf02br5
         8vylwKBvs8usKNEZQLfZBWiF32QWbpz1j37J939J8v8ApmXS5o0CAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:22 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts/nyrg9184/listKeys?api-version=2015-05-01-preview
@@ -7426,11 +15870,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDgwNTY5MDYsIm5iZiI6MTQ0ODA1NjkwNiwiZXhwIjoxNDQ4MDYwODA2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.dLWWs6jFnPi_HdRd2qMmz8ZM0MDFkoZL7SmBimlNtj3fbGdWGx4Qsen8wOWH5cdIgDaHqIfw6Q6EmMDs5fab58VkkZ3L6uypbSeXTI13Ew7-_I8hQZj9_di6M_IP-7veDB9pnPiyKTSXeqY-lthn2ERLzrybwq54u98efbmRi3lozPD17KCH6zhZau0ah6tUn8QYIoC6-KCCSCe-Xt3bBklzO5edjaRlFtwxXIuE8FGPXkrjMERPwDWv5PhDB5-Uign4VzIlyugSgyMHsI5m6Gi9VXbrtXnSCXTOMj_F3v_5z18RU8Dmh3fL39QYO5ZAoIqzBsDJ5ZA427khb8heHQ
       Content-Length:
       - '0'
   response:
@@ -7453,19 +15897,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4e772978-89c7-47b7-960e-c8550988b675
+      - 525474bf-9b22-4eb5-b85c-e0bea6325089
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 4e772978-89c7-47b7-960e-c8550988b675
+      - 525474bf-9b22-4eb5-b85c-e0bea6325089
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192145Z:4e772978-89c7-47b7-960e-c8550988b675
+      - NORTHCENTRALUS:20151120T220923Z:525474bf-9b22-4eb5-b85c-e0bea6325089
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Fri, 20 Nov 2015 22:09:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7478,7 +15922,7 @@ http_interactions:
         ExeLVyfPPzm92rt+9vDz3/vdV7/o8tXDr3Z3fp/rez85+/zpt8vfq9mp2rNv
         n/wEevglyf8D3ICuGMYAAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:45 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:23 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/?comp=list
@@ -7491,13 +15935,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Fri, 20 Nov 2015 22:09:23 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:7feVVPt4UN+oJs8ofTSGATDlhkt06chxRQHbkEdkZ0E=
+      - SharedKey nyrg9184:buiMKlQn5ysAQGpl6G0iW6hh/EatXG+r+oC6VpI0wAE=
   response:
     status:
       code: 200
@@ -7510,11 +15954,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - eeca8276-0001-006e-34ed-1b5337000000
+      - 3421e659-0001-004d-63e0-233cfc000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Fri, 20 Nov 2015 22:09:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7536,7 +15980,7 @@ http_interactions:
         PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
         dHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:45 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:24 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/bootdiagnostics-salesforc-cdf0af79-304d-4d73-9cc5-8551b19dce07?comp=list&restype=container
@@ -7549,13 +15993,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Fri, 20 Nov 2015 22:09:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:v67PesFHtuZBivE6cNjiH2u99oqNYsYBXmEnoPAES/w=
+      - SharedKey nyrg9184:PcxpWqT0ecakVbxycWstooXe5hsRpey/m5OUSvv1KY8=
   response:
     status:
       code: 200
@@ -7568,11 +16012,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a2071c53-0001-0032-64ed-1ba2ce000000
+      - faa7719b-0001-00e7-15e0-23ea13000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Fri, 20 Nov 2015 22:09:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7595,7 +16039,7 @@ http_interactions:
         b3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1l
         cmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:46 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:24 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/vhds?comp=list&restype=container
@@ -7608,13 +16052,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:46 GMT
+      - Fri, 20 Nov 2015 22:09:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:+0zPdhWERhuNoCWtstpFLPLqEXsfZJpKT+30VxXy0UQ=
+      - SharedKey nyrg9184:mqBnXTRHYEaAJizr1mzVWRMJkLKWXXuo69qtr6+R1Ts=
   response:
     status:
       code: 200
@@ -7627,11 +16071,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fbfed245-0001-0001-35ed-1bfbe3000000
+      - 0eb3967a-0001-007d-32e0-2366d6000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Fri, 20 Nov 2015 22:09:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7665,5 +16109,5 @@ http_interactions:
         bj48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48
         L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:46 GMT
+  recorded_at: Fri, 20 Nov 2015 22:09:24 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This PR adds support to the Azure refresh parser for network security groups and firewall rules, including the relationship between security groups and virtual machines.

I've also included some specs.