### PR TITLE
Stop validating appliance hostname when SSHing to provider hosts

### DIFF
--- a/gems/pending/util/MiqSshUtilV2.rb
+++ b/gems/pending/util/MiqSshUtilV2.rb
@@ -253,10 +253,6 @@ class MiqSshUtil
   def run_session
     first_try = true
 
-    # Make a call to ensure we can resolve our own hostname before we continue
-    # otherwise the SSH layer will raise an unclear error.
-    MiqSockUtil.getFullyQualifiedDomainName
-
     begin
       Net::SSH.start(@host, @user, @options) do |ssh|
         yield(ssh)


### PR DESCRIPTION
No longer validate source hostname with MiqSshUtil
    
[MiqSshUtil](https://github.com/ManageIQ/manageiq/blob/67d32405d5b8290f74df09b6f7c099bd56496fb9/gems/pending/util/MiqSshUtilV2.rb#L256-L258) used to make sure that the appliance had a valid hostname before attempting to SSH from the appliance to another box.  The reasoning at the time was that the SSH gem would ignore a failure caused by having an invalid appliance hostname, but then later blow up because of the invalid appliance hostname.
    
It does not appears that SSH even cares about the appliance's hostname anymore when establishing an SSH connection to another server (in fact, it was surprising that it even would care).
    
With this check removed, validating a host's SSH credentials will no longer throw a misleading "getaddrinfo" error when the appliance has a bad hostname.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1278904