### PR TITLE
Clean up UI code around ApplicationController::Filter#adv_search_build_lists

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1621,21 +1621,23 @@ module ApplicationController::Filter
 
   # Build the pulldown lists for the adv search box
   def adv_search_build_lists
-    # converting expressions into Array here, so Global views can be pushed into it and be shown on the top with Global Prefix in load pull down
-    global_expressions = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                   :search_type => "global")
-    @edit[@expkey][:exp_search_expressions] = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                                        :search_type => "user",
-                                                                        :search_key  => session[:userid])
-    @edit[@expkey][:exp_search_expressions] = Array(@edit[@expkey][:exp_search_expressions]).sort
-    global_expressions = Array(global_expressions).sort unless global_expressions.blank?
-    unless global_expressions.blank?
-      global_expressions.each_with_index do |ge, i|
-        global_expressions[i][0] = "Global - #{ge[0]}"
-        @edit[@expkey][:exp_search_expressions] = @edit[@expkey][:exp_search_expressions].unshift(global_expressions[i])
-      end
-    end
+    db = @edit[@expkey][:exp_model]
+    global_expressions = MiqSearch.get_expressions(
+      :db          => db,
+      :search_type => "global"
+    )
+    user_expressions = MiqSearch.get_expressions(
+      :db          => db,
+      :search_type => "user",
+      :search_key  => session[:userid]
+    )
+
+    user_expressions = Array(user_expressions).sort
+    global_expressions = Array(global_expressions).sort
+    global_expressions.each { |ge| ge[0] = "Global - #{ge[0]}" }
+    @edit[@expkey][:exp_search_expressions] = global_expressions + user_expressions
   end
+  private :adv_search_build_lists
 
   # Build a string from an array of expression symbols by recursively traversing the MiqExpression object
   #   and inserting sequential tokens for each expression part

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -650,20 +650,8 @@ module ApplicationController::Filter
         if s.save
           #         AuditEvent.success(build_created_audit(s, s_old))
           add_flash(_("%{model} \"%{name}\" was saved") % {:model => "#{ui_lookup(:model => @edit[@expkey][:exp_model])} search", :name => @edit[:new_search_name]})
-          # converting expressions into Array here, so Global views can be oushed into it and be shown on the top with Global Prefix in load pull down
-          global_expressions = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                         :search_type => "global")
-          @edit[@expkey][:exp_search_expressions] = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                                              :search_type => "user",
-                                                                              :search_key  => session[:userid])      # Rebuild the list of searches
-          @edit[@expkey][:exp_search_expressions] = Array(@edit[@expkey][:exp_search_expressions]).sort
-          global_expressions = Array(global_expressions).sort unless global_expressions.blank?
-          unless global_expressions.blank?
-            global_expressions.each_with_index do |ge, i|
-              global_expressions[i][0] = "Global - #{ge[0]}"
-              @edit[@expkey][:exp_search_expressions] = @edit[@expkey][:exp_search_expressions].unshift(global_expressions[i])
-            end
-          end
+          adv_search_build_lists
+
           @edit[@expkey][:exp_last_loaded] = {:id => s.id, :name => s.name, :description => s.description, :typ => s.search_type}     # Save the last search loaded (saved)
           # @edit[@expkey][:selected] = @edit[@expkey][:exp_last_loaded] = {:id=>s.id, :name=>s.name, :description=>s.description, :typ=>s.search_type}      # Save the last search loaded (saved)
           @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description]
@@ -725,20 +713,9 @@ module ApplicationController::Filter
                  :userid       => session[:userid]}
         AuditEvent.success(audit)
       end
-      # converting expressions into Array here, so Global views can be oushed into it and be shown on the top with Global Prefix in load pull down
-      global_expressions = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                     :search_type => "global")
-      @edit[@expkey][:exp_search_expressions] = MiqSearch.get_expressions(:db          => @edit[@expkey][:exp_model],
-                                                                          :search_type => "user",
-                                                                          :search_key  => session[:userid])      # Rebuild the list of searches
-      @edit[@expkey][:exp_search_expressions] = Array(@edit[@expkey][:exp_search_expressions]).sort
-      global_expressions = Array(global_expressions).sort unless global_expressions.blank?
-      unless global_expressions.blank?
-        global_expressions.each_with_index do |ge, i|
-          global_expressions[i][0] = "Global - #{ge[0]}"
-          @edit[@expkey][:exp_search_expressions] = @edit[@expkey][:exp_search_expressions].unshift(global_expressions[i])
-        end
-      end
+
+      adv_search_build_lists
+
     when "reset"
       add_flash(_("The current search details have been reset"), :warning)
 

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -31,7 +31,7 @@ class MiqSearch < ActiveRecord::Base
   end
 
   def self.get_expressions(options)
-    all(:conditions => options).each_with_object({}) do |r, hash|
+    where(options).each_with_object({}) do |r, hash|
       hash[r.description] = r.id unless r.filter.nil?
     end
   end

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -67,7 +67,7 @@
       .form-horizontal
         .form-group
           %label.control-label.col-md-5
-            = _("Save this %s search as:") % @edit[@expkey][:exp_model]
+            = _("Save this %s search as:") % ui_lookup(:model => @edit[@expkey][:exp_model])
           .col-md-6
             %span#search_name_span
               = text_field_tag("search_name",

--- a/spec/factories/miq_search.rb
+++ b/spec/factories/miq_search.rb
@@ -1,5 +1,19 @@
 FactoryGirl.define do
   factory :miq_search do
-    name     "Test Search"
+    sequence(:name)        { |n| "miq_search_#{seq_padded_for_sorting(n)}" }
+    sequence(:description) { |n| "MiqSearch #{seq_padded_for_sorting(n)}" }
+    db          "Vm"
+    search_type "default"
+
+    filter { MiqExpression.new("CONTAINS" => {"tag" => "Vm.managed-environment", "value" => "prod"}) }
+  end
+
+  factory :miq_search_global, :parent => :miq_search do
+    search_type "global"
+  end
+
+  factory :miq_search_user, :parent => :miq_search do
+    search_type "user"
+    search_key  { FactoryGirl.create(:user).id }
   end
 end


### PR DESCRIPTION
This started as a dedup exercise of code that was already in a method, but not using the method (a75f845).

Then I wrote some specs, and found that there was a bug in the method anyway where global searches that should have been sorted ended up being reverse sorted because of the way the loop was written.  So I added specs, factories, refactored, and fixed the bug (8fa85d5).

The specs were emitting deprecations in MiqSearch, so I cleaned that up (b6b93c3).

Then when testing through the UI I found that the Advanced Search save screen was not properly translating the model, so I fixed that (e036725).

Before 
![screen shot 2015-11-18 at 2 10 01 pm](https://cloud.githubusercontent.com/assets/52120/11253910/2714271c-8e0c-11e5-8def-4ec31439ae6f.png)

After
![screen shot 2015-11-18 at 3 45 07 pm](https://cloud.githubusercontent.com/assets/52120/11253932/3d1a1724-8e0c-11e5-8d53-c3b716ba9b15.png)


@dclarizio or @h-kataria Please review
cc @chessbyte @martinpovolny 