### PR TITLE
Include reflections of descendant classes when building model details for reporting and expression editors

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -174,6 +174,10 @@ class Host < ActiveRecord::Base
   before_create :make_smart
   after_save    :process_events
 
+  def self.include_descendant_classes_in_expressions?
+    true
+  end
+
   def authentication_check_role
     'smartstate'
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -7,6 +7,10 @@ class Vm < VmOrTemplate
     Vm
   end
 
+  def self.include_descendant_classes_in_expressions?
+    true
+  end
+
   def self.corresponding_model
     if self == Vm
       MiqTemplate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -872,6 +872,8 @@ en:
       ManageIQ::Providers::BaseManager:               Provider
       #ManageIQ::Providers::BaseManager::VmOrTemplate: VM or Template
       #ManageIQ::Providers::BaseManager::Vm:           VM and Instance
+      ManageIQ::Providers::ConfigurationManager:      Configuration Manager
+      ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Foreman Configured System
       ManageIQ::Providers::CloudManager:              Cloud Provider
       ManageIQ::Providers::CloudManager::Vm:          Instance
       ManageIQ::Providers::CloudManager::Template:    Image
@@ -1031,6 +1033,9 @@ en:
       miq_custom_attribute:        EVM Custom Attribute
       miq_custom_attributes:       EVM Custom Attributes
       miq_event_definition:        Event
+      manageiq_providers_foreman_configuration_manager_configuration_profile: Configuration Profile (Foreman)
+      manageiq_providers_openstack_infra_manager_cloud_networks: Cloud Networks (Openstack)
+      manageiq_providers_openstack_cloud_manager_cloud_tenant: Cloud Tenants (Openstack)
       miq_provision:               Provision
       miq_provision_template:      Provisioned From Template
       miq_provision_vms:           Provisioned VMs

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -360,6 +360,23 @@ describe MiqExpression do
     end
   end
 
+  context ".build_relats" do
+    it "includes reflections from descendant classes of Vm" do
+      relats = MiqExpression.get_relats(Vm)
+      relats[:reflections][:cloud_tenant].should_not be_blank
+    end
+
+    it "includes reflections from descendant classes of Host" do
+      relats = MiqExpression.get_relats(Host)
+      relats[:reflections][:cloud_networks].should_not be_blank
+    end
+
+    it "excludes reflections from descendant classes of VmOrTemplate " do
+      relats = MiqExpression.get_relats(VmOrTemplate)
+      relats[:reflections][:cloud_tenant].should be_blank
+    end
+  end
+
   context "Date/Time Support" do
     context "Testing expression conversion ruby, sql and human with static dates and times" do
       it "should generate the correct ruby expression with an expression having static dates and times with no time zone" do


### PR DESCRIPTION
- Enabled only for Vm and Host models
- Enables inclusion of cloud tenants under an openstack VM in reports and expressions
- Enables inclusion of cloud networks under an openstack Host

https://bugzilla.redhat.com/show_bug.cgi?id=1236001