### PR TITLE
migrate to merge_from_template_if_missing

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -20,9 +20,8 @@ class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
     super
 
     path = [:workers, :worker_base, :event_catcher]
-    configuration.merge_from_template_if_missing(*path)
 
-    ec_settings = configuration.config.fetch_path(*path)
+    ec_settings = configuration.fetch_with_fallback(*path)
     unless ec_settings.key?(:defaults)
       subclasses = %w(redhat vmware openstack).collect { |k| "event_catcher_#{k}".to_sym }
       _log.info("Migrating Settings")

--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -18,9 +18,8 @@ class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerB
 
     old_path = [:workers, :worker_base, :queue_worker_base, :perf_collector_worker]
     new_path = [:workers, :worker_base, :queue_worker_base, :ems_metrics_collector_worker]
-    configuration.merge_from_template_if_missing(*new_path)
 
-    new_collector_worker_settings = configuration.config.fetch_path(*new_path)
+    new_collector_worker_settings = configuration.fetch_with_fallback(*new_path)
     old_collector_worker_settings = configuration.config.fetch_path(*old_path)
     unless old_collector_worker_settings.nil?
       # The subclass list should be discoverable and not hardcoded here

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -24,9 +24,8 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
     super
 
     path = [:workers, :worker_base, :queue_worker_base, :ems_refresh_worker]
-    configuration.merge_from_template_if_missing(*path)
 
-    refresh_worker_settings = configuration.config.fetch_path(*path)
+    refresh_worker_settings = configuration.fetch_with_fallback(*path)
     unless refresh_worker_settings.key?(:defaults)
       subclasses = ExtManagementSystem.types.collect { |k| "ems_refresh_worker_#{k}".to_sym }
       _log.info("Migrating Settings")

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -41,8 +41,7 @@ module ManageIQ::Providers
     # are merged in upon startup.
     #
     def self.merge_config_settings(cfg = VMDB::Config.new("vmdb"))
-      path = [:ems, :ems_redhat, :service, :read_timeout]
-      cfg.merge_from_template_if_missing(*path)
+      cfg.merge_from_template_if_missing(:ems, :ems_redhat, :service, :read_timeout)
     end
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
@@ -14,17 +14,13 @@ class ManageIQ::Providers::Openstack::CloudManager::EventCatcher < ::MiqEventCat
     end
   end
 
-  def self.validate_config_settings(configuration = VMDB::Config.new("vmdb"))
+  def self.validate_config_settings(config = VMDB::Config.new("vmdb"))
     super
 
     # make sure that new configurations for :topics and :duration are loaded
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack, :topics]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack, :duration]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack, :capacity]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack, :amqp_port]
-    configuration.merge_from_template_if_missing(*path)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack, :topics)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack, :duration)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack, :capacity)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack, :amqp_port)
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -18,17 +18,13 @@ class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCat
     end
   end
 
-  def self.validate_config_settings(configuration = VMDB::Config.new("vmdb"))
+  def self.validate_config_settings(config = VMDB::Config.new("vmdb"))
     super
 
     # make sure that new configurations for :topics and :duration are loaded
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :topics]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :duration]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :capacity]
-    configuration.merge_from_template_if_missing(*path)
-    path = [:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :amqp_port]
-    configuration.merge_from_template_if_missing(*path)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :topics)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :duration)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :capacity)
+    config.merge_from_template_if_missing(:workers, :worker_base, :event_catcher, :event_catcher_openstack_infra, :amqp_port)
   end
 end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -361,12 +361,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     storage_inventory_full_refresh_schedule = [:storage, :inventory, :full_refresh_schedule]
 
     cfg = VMDB::Config.new("vmdb")
-    # TODO: change to merge_from_template_if_missing() after beta.
-    cfg.merge_from_template(*storage_metrics_collection_schedule)
-    cfg.merge_from_template(*storage_metrics_hourly_rollup_schedule)
-    cfg.merge_from_template(*storage_metrics_daily_rollup_schedule)
-    cfg.merge_from_template(*storage_metrics_purge_schedule)
-    cfg.merge_from_template(*storage_inventory_full_refresh_schedule)
+    cfg.merge_from_template_if_missing(*storage_metrics_collection_schedule)
+    cfg.merge_from_template_if_missing(*storage_metrics_hourly_rollup_schedule)
+    cfg.merge_from_template_if_missing(*storage_metrics_daily_rollup_schedule)
+    cfg.merge_from_template_if_missing(*storage_metrics_purge_schedule)
+    cfg.merge_from_template_if_missing(*storage_inventory_full_refresh_schedule)
 
     # Schedule - Storage metrics collection
     sched = cfg.config.fetch_path(*storage_metrics_collection_schedule)

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -129,8 +129,7 @@ class MiqStorageMetric < ActiveRecord::Base
   def self.purge_date(type)
     cfg = VMDB::Config.new("vmdb")
     vpath = [:storage, :metrics_history, type.to_sym]
-    # TODO: change to merge_from_template_if_missing() after beta.
-    cfg.merge_from_template(*vpath)
+    cfg.merge_from_template_if_missing(*vpath)
     value = cfg.config.fetch_path(*vpath)
     return nil if value.nil?
 

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -128,9 +128,7 @@ class MiqStorageMetric < ActiveRecord::Base
 
   def self.purge_date(type)
     cfg = VMDB::Config.new("vmdb")
-    vpath = [:storage, :metrics_history, type.to_sym]
-    cfg.merge_from_template_if_missing(*vpath)
-    value = cfg.config.fetch_path(*vpath)
+    value = cfg.fetch_with_fallback(:storage, :metrics_history, type.to_sym)
     return nil if value.nil?
 
     value = value.to_i.days if value.kind_of?(Fixnum) # Default unit is days

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -28,7 +28,7 @@ class MiqUiWorker < MiqWorker
   def self.validate_config_settings(configuration = VMDB::Config.new("vmdb"))
     if configuration.config.fetch_path(:workers, :worker_base, :ui_worker).nil?
       _log.info("Migrating Settings")
-      configuration.merge_from_template(:workers, :worker_base, :ui_worker)
+      configuration.merge_from_template_if_missing(:workers, :worker_base, :ui_worker)
       roles = configuration.config.fetch_path(:server, :role).split(',')
       unless roles.include?(REQUIRED_ROLE)
         _log.info("Adding Default Role #{REQUIRED_ROLE}")

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -18,7 +18,7 @@ class MiqWebServiceWorker < MiqWorker
   def self.validate_config_settings(configuration = VMDB::Config.new("vmdb"))
     if configuration.config.fetch_path(:workers, :worker_base, :web_service_worker).nil?
       _log.info("Migrating Settings")
-      configuration.merge_from_template(:workers, :worker_base, :web_service_worker)
+      configuration.merge_from_template_if_missing(:workers, :worker_base, :web_service_worker)
       roles = configuration.config.fetch_path(:server, :role).split(',')
       unless roles.include?(REQUIRED_ROLE)
         _log.info("Adding Default Role #{REQUIRED_ROLE}")

--- a/app/models/mixins/ontap_derived_metric_mixin.rb
+++ b/app/models/mixins/ontap_derived_metric_mixin.rb
@@ -24,14 +24,9 @@ module OntapDerivedMetricMixin
       @baseCounterNames = nil
       @metadataClass    = (name + "Metadata").constantize
 
-      cfg_base = [:storage, :metrics_collection]
-      storage_metrics_collection_interval = cfg_base + [:collection_interval]
-      storage_metrics_max_gap_to_fill   = cfg_base + [:max_gap_to_fill]
       cfg = VMDB::Config.new("vmdb")
-      cfg.merge_from_template_if_missing(*storage_metrics_collection_interval)
-      cfg.merge_from_template_if_missing(*storage_metrics_max_gap_to_fill)
-      @storageMetricsCollectionInterval = cfg.config.fetch_path(*storage_metrics_collection_interval).to_i_with_method
-      @storageMetricsMaxGapToFill = cfg.config.fetch_path(*storage_metrics_max_gap_to_fill).to_i_with_method
+      @storageMetricsCollectionInterval = cfg.fetch_with_fallback(:storage, :metrics_collection, :collection_interval).to_i_with_method
+      @storageMetricsMaxGapToFill       = cfg.fetch_with_fallback(:storage, :metrics_collection, :max_gap_to_fill).to_i_with_method
     end
 
     def metadataClass

--- a/app/models/mixins/ontap_derived_metric_mixin.rb
+++ b/app/models/mixins/ontap_derived_metric_mixin.rb
@@ -28,13 +28,10 @@ module OntapDerivedMetricMixin
       storage_metrics_collection_interval = cfg_base + [:collection_interval]
       storage_metrics_max_gap_to_fill   = cfg_base + [:max_gap_to_fill]
       cfg = VMDB::Config.new("vmdb")
-      # TODO: change to merge_from_template_if_missing() after beta.
-      cfg.merge_from_template(*storage_metrics_collection_interval)
-      @storageMetricsCollectionInterval = cfg.config.fetch_path(*storage_metrics_collection_interval)
-      @storageMetricsCollectionInterval = @storageMetricsCollectionInterval.to_i_with_method
-      cfg.merge_from_template(*storage_metrics_max_gap_to_fill)
-      @storageMetricsMaxGapToFill = cfg.config.fetch_path(*storage_metrics_max_gap_to_fill)
-      @storageMetricsMaxGapToFill = @storageMetricsMaxGapToFill.to_i_with_method
+      cfg.merge_from_template_if_missing(*storage_metrics_collection_interval)
+      cfg.merge_from_template_if_missing(*storage_metrics_max_gap_to_fill)
+      @storageMetricsCollectionInterval = cfg.config.fetch_path(*storage_metrics_collection_interval).to_i_with_method
+      @storageMetricsMaxGapToFill = cfg.config.fetch_path(*storage_metrics_max_gap_to_fill).to_i_with_method
     end
 
     def metadataClass

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -184,14 +184,18 @@ module VMDB
     end
 
     def merge_from_template(*args)
-      args << template_configuration.fetch_path(*args)
-      config.store_path(*args)
-      save
+      template_configuration.fetch_path(*args).tap do |value|
+        args << value
+        config.store_path(*args)
+        save
+      end
     end
 
-    def merge_from_template_if_missing(*args)
-      merge_from_template(*args) if config.fetch_path(*args).nil?
+    def fetch_with_fallback(*args)
+      value = config.fetch_path(*args)
+      value.nil? ? merge_from_template(*args) : value
     end
+    alias_method :merge_from_template_if_missing, :fetch_with_fallback
 
     def get(section, key = nil)
       # get(section, key) -> value

--- a/spec/support/vmdb_configuration_helper.rb
+++ b/spec/support/vmdb_configuration_helper.rb
@@ -3,6 +3,7 @@ module VMDBConfigurationHelper
     configuration = double(:config                         => config,
                            :merge_from_template_if_missing => nil,
                            :merge_from_template            => nil)
+    allow(configuration).to receive(:fetch_with_fallback).and_return { |*arg| config.fetch_path(arg) }
     allow(VMDB::Config).to receive(:new).with(config_name).and_return(configuration)
   end
 end


### PR DESCRIPTION
I was in this code and this caught my eye. It is a tangent and not fixing a bug.

1) removes comment from 2013:

```
# TODO: change to merge_from_template_if_missing() after beta
```

2) Replace a common pattern when reading a configuration value and falling back to the template value.

```ruby
cfg = VMDB::Config.new("vmdb")

database_metrics_collection_schedule = [:database, :metrics_collection, :collection_schedule]
cfg.merge_from_template_if_missing(*database_metrics_collection_schedule)
sched = cfg.config.fetch_path(*database_metrics_collection_schedule)

```
and replaces with:
```ruby
cfg = VMDB::Config.new("vmdb")

sched = cfg.fetch_with_fallback(:database, :metrics_collection, :collection_schedule)
```

/cc @matthewd @Fryguy @jrafanie :scissors: let me know if you'd prefer a different course of action.