### PR TITLE
hide empty multilabel tables

### DIFF
--- a/app/views/shared/summary/_textual_multilabel.html.haml
+++ b/app/views/shared/summary/_textual_multilabel.html.haml
@@ -1,4 +1,4 @@
-- if items
+- if items && items[:values].present?
   %table.table.table-bordered.table-striped
     %thead
       %tr


### PR DESCRIPTION
This aligns with the default table behaviour, 'textual'

![manageiq projects](https://cloud.githubusercontent.com/assets/3010449/11273462/109058be-8edc-11e5-8340-3da841374761.png)
![manageiq projects after](https://cloud.githubusercontent.com/assets/3010449/11273463/109290d4-8edc-11e5-9da3-8ca99ecb2ea4.png)
