### PR TITLE
Schedule worker DRY 1

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -44,6 +44,10 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     @queue.length
   end
 
+  def enqueue(object)
+    @queue.enq object
+  end
+
   def load_system_schedules
     schedules_for_all_roles
     schedules_for_scheduler_role
@@ -88,13 +92,13 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Log current system configuration
     every = worker_setting_or_default(:log_active_configuration_interval, 1.days)
     @schedules[:all] << system_schedule_every(every, :tags => [:vmdb_appliance_log_config, schedule_category]) do
-      @queue.enq :vmdb_appliance_log_config
+      enqueue :vmdb_appliance_log_config
     end
 
     # Schedule - Log current database statistics and bloat
     every = worker_setting_or_default(:log_database_statistics_interval, 1.days)
     @schedules[:all] << system_schedule_every(every, :tags => [:log_all_database_statistics, schedule_category]) do
-      @queue.enq :vmdb_database_log_all_database_statistics
+      enqueue :vmdb_database_log_all_database_statistics
     end
 
     # Schedule - Update Server Statistics
@@ -103,7 +107,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       every,
       :first_in => every,
       :tags     => [:status_update, schedule_category]
-    ) { @queue.enq :miq_server_status_update }
+    ) { enqueue :miq_server_status_update }
 
     # Schedule - Log Server and Worker Statistics
     every = worker_setting_or_default(:server_log_stats_interval)
@@ -111,7 +115,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       every,
       :first_in => every,
       :tags     => [:log_status, schedule_category]
-    ) { @queue.enq :miq_server_worker_log_status }
+    ) { enqueue :miq_server_worker_log_status }
 
     # Schedule - Periodic logging of database statistics
     interval = worker_setting_or_default(:db_diagnostics_interval, 30.minutes)
@@ -119,7 +123,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       interval,
       :first_in => 1.minute,
       :tags     => [:log_statistics, schedule_category]
-    ) { @queue.enq :miq_db_config_log_statistics }
+    ) { enqueue :miq_db_config_log_statistics }
 
     # Schedule - Periodic check for updates on appliances only
     if MiqEnvironment::Command.is_appliance?
@@ -128,7 +132,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
         interval,
         :first_in => 1.minute,
         :tags     => [:server_updates, schedule_category]
-      ) { @queue.enq :miq_server_queue_update_registration_status }
+      ) { enqueue :miq_server_queue_update_registration_status }
     end
 
     # Schedule - Periodic resync of RHN Mirror
@@ -138,7 +142,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
         interval,
         :first_in => 1.minute,
         :tags     => [:rhn_mirror, schedule_category]
-      ) { @queue.enq :miq_server_resync_rhn_mirror }
+      ) { enqueue :miq_server_resync_rhn_mirror }
     end
   end
 
@@ -150,71 +154,71 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Check for VMs to scan
     every = worker_setting_or_default(:vm_scan_interval)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq :host_check_for_vms_to_scan
+      enqueue :host_check_for_vms_to_scan
     end
 
     # Schedule - Check for timed out jobs
     every = worker_setting_or_default(:job_timeout_interval)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq :job_check_jobs_for_timeout
+      enqueue :job_check_jobs_for_timeout
     end
 
     # Schedule - Check for Retired Services
     every = worker_setting_or_default(:service_retired_interval)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq :service_retirement_check
+      enqueue :service_retirement_check
     end
 
     # Schedule - Check for Retired VMs
     every = worker_setting_or_default(:vm_retired_interval)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq :vm_retirement_check
+      enqueue :vm_retirement_check
     end
 
     # Schedule - Check for Retired Orchestration Stacks
     every = worker_setting_or_default(:orchestration_stack_retired_interval)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq :orchestration_stack_retirement_check
+      enqueue :orchestration_stack_retirement_check
     end
 
     # Schedule - Periodic validation of authentications
     every = worker_setting_or_default(:authentication_check_interval, 1.day)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
       # Queue authentication checks for CIs with credentials
-      @queue.enq :host_authentication_check_schedule
-      @queue.enq :ems_authentication_check_schedule
-      @queue.enq :storage_authentication_check_schedule
+      enqueue :host_authentication_check_schedule
+      enqueue :ems_authentication_check_schedule
+      enqueue :storage_authentication_check_schedule
     end
 
     # Schedule - Check for session timeouts
     @schedules[:scheduler] << system_schedule_every(worker_setting_or_default(:session_timeout_interval)) do
       # Session is global to the region, therefore, run it only once on the scheduler's server
-      @queue.enq :session_check_session_timeout
+      enqueue :session_check_session_timeout
     end
 
     # Schedule - Check for rogue EVM snapshots
     every               = worker_setting_or_default(:evm_snapshot_interval, 1.hour)
     job_not_found_delay = worker_setting_or_default(:evm_snapshot_delete_delay_for_job_not_found, 1.hour)
     @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-      @queue.enq [:job_check_for_evm_snapshots, job_not_found_delay]
+      enqueue [:job_check_for_evm_snapshots, job_not_found_delay]
     end
 
     # Queue a JobProxyDispatcher dispatch task at high priority unless there's already one on the queue
     # This dispatch method goes through all pending jobs to see if there's a free proxy available to work on one of them
     # It is very expensive to constantly do this, hence the need to ensure only one is on the queue at one time
     @schedules[:scheduler] << system_schedule_every(worker_setting_or_default(:job_proxy_dispatcher_interval)) do
-      @queue.enq :job_proxy_dispatcher_dispatch
+      enqueue :job_proxy_dispatcher_dispatch
     end
 
     stale_interval = worker_setting_or_default(:job_proxy_dispatcher_stale_message_check_interval, 60.seconds)
     threshold_seconds = worker_setting_or_default(:job_proxy_dispatcher_stale_message_timeout, 2.minutes)
     @schedules[:scheduler] << system_schedule_every(stale_interval) do
-      @queue.enq [:check_for_stuck_dispatch, threshold_seconds]
+      enqueue [:check_for_stuck_dispatch, threshold_seconds]
     end
 
     # Schedule - Hourly Alert Evaluation Timer
     @schedules[:scheduler] << system_schedule_every(1.hour, :first_in => 5.minutes) do
-      @queue.enq :miq_alert_evaluate_hourly_timer
+      enqueue :miq_alert_evaluate_hourly_timer
     end
 
     # Schedule every 24 hours
@@ -227,11 +231,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     @schedules[:scheduler] << system_schedule_every(
       worker_setting_or_default(:storage_file_collection_interval),
       :first_at => time_at
-    ) { @queue.enq :storage_scan_timer }
+    ) { enqueue :storage_scan_timer }
 
     schedule_settings_for_ems_refresh.each do |klass, every|
       @schedules[:scheduler] << system_schedule_every(every, :first_in => every) do
-        @queue.enq [:ems_refresh_timer, klass]
+        enqueue [:ems_refresh_timer, klass]
       end
     end
   end
@@ -249,7 +253,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       sched,
       :tags => [:database_operations, :database_metrics_collection_schedule],
       :job  => true
-    ) { @queue.enq :vmdb_database_capture_metrics_timer }
+    ) { enqueue :vmdb_database_capture_metrics_timer }
 
     sched = cfg.fetch_with_fallback(:database, :metrics_collection, :daily_rollup_schedule)
     _log.info("database_metrics_daily_rollup_schedule: #{sched}")
@@ -257,7 +261,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       sched,
       :tags => [:database_operations, :database_metrics_daily_rollup_schedule],
       :job  => true
-    ) { @queue.enq :vmdb_database_rollup_metrics_timer }
+    ) { enqueue :vmdb_database_rollup_metrics_timer }
 
     sched = cfg.fetch_with_fallback(:database, :metrics_history, :purge_schedule)
     _log.info("database_metrics_purge_schedule: #{sched}")
@@ -265,7 +269,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       sched,
       :tags => [:database_operations, :database_metrics_purge_schedule],
       :job  => true
-    ) { @queue.enq :metric_purge_all_timer }
+    ) { enqueue :metric_purge_all_timer }
 
     @schedules[:database_operations]
   end
@@ -285,7 +289,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       sched,
       :tags => [:ldap_synchronization, :ldap_synchronization_schedule],
       :job  => true
-    ) { @queue.enq :ldap_server_sync_data_from_timer }
+    ) { enqueue :ldap_server_sync_data_from_timer }
   end
 
   def schedules_for_ems_metrics_coordinator_role
@@ -300,7 +304,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       every,
       :first_in => first_in,
       :tags     => [:ems_metrics_coordinator, :perf_capture_timer]
-    ) { @queue.enq :metric_capture_perf_capture_timer }
+    ) { enqueue :metric_capture_perf_capture_timer }
 
     every    = worker_setting_or_default(:performance_realtime_purging_interval, 15.minutes)
     first_in = worker_setting_or_default(:performance_realtime_purging_start_delay, 5.minutes)
@@ -308,7 +312,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       every,
       :first_in => first_in,
       :tags     => [:ems_metrics_coordinator, :purge_realtime_timer]
-    ) { @queue.enq :metric_purging_purge_realtime_timer }
+    ) { enqueue :metric_purging_purge_realtime_timer }
 
     every    = worker_setting_or_default(:performance_rollup_purging_interval, 4.hours)
     first_in = worker_setting_or_default(:performance_rollup_purging_start_delay, 5.minutes)
@@ -316,7 +320,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       every,
       :first_in => first_in,
       :tags     => [:ems_metrics_coordinator, :purge_rollup_timer]
-    ) { @queue.enq :metric_purging_purge_rollup_timer }
+    ) { enqueue :metric_purging_purge_rollup_timer }
   end
 
   def schedules_for_event_role
@@ -330,7 +334,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       interval,
       :first_in => "300s",
       :tags     => [:ems_event, :purge_schedule]
-    ) { @queue.enq :ems_event_purge_timer }
+    ) { enqueue :ems_event_purge_timer }
 
     # Schedule - Policy Event Purging
     interval = worker_setting_or_default(:policy_events_purge_interval, 1.day)
@@ -338,7 +342,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       interval,
       :first_in => "300s",
       :tags     => [:policy_event, :purge_schedule]
-    ) { @queue.enq :policy_event_purge_timer }
+    ) { enqueue :policy_event_purge_timer }
   end
 
   def schedules_for_storage_metrics_coordinator_role
@@ -352,14 +356,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     sched = cfg.fetch_with_fallback(:storage, :metrics_collection, :collection_schedule)
     _log.info("storage_metrics_collection_schedule: #{sched}")
     @schedules[:storage_metrics_coordinator] << @system_scheduler.cron(sched, :job => true) do
-      @queue.enq :storage_refresh_metrics
+      enqueue :storage_refresh_metrics
     end
 
     # Schedule - Storage metrics hourly rollup
     sched = cfg.fetch_with_fallback(:storage, :metrics_collection, :hourly_rollup_schedule)
     _log.info("storage_metrics_hourly_rollup_schedule: #{sched}")
     @schedules[:storage_metrics_coordinator] << @system_scheduler.cron(sched, :job => true) do
-      @queue.enq :storage_metrics_rollup_hourly
+      enqueue :storage_metrics_rollup_hourly
     end
 
     # Schedule - Storage metrics daily rollup
@@ -369,7 +373,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       sched = "#{base_sched} #{tz}"
       _log.info("storage_metrics_daily_rollup_schedule: #{sched}")
       @schedules[:storage_metrics_coordinator] << @system_scheduler.cron(sched, :job => true) do
-        @queue.enq [:storage_metrics_rollup_daily, tp.id]
+        enqueue [:storage_metrics_rollup_daily, tp.id]
       end
     end
 
@@ -377,14 +381,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     sched = cfg.fetch_with_fallback(:storage, :metrics_history, :purge_schedule)
     _log.info("storage_metrics_purge_schedule: #{sched}")
     @schedules[:storage_metrics_coordinator] << @system_scheduler.cron(sched, :job => true) do
-      @queue.enq :miq_storage_metric_purge_all_timer
+      enqueue :miq_storage_metric_purge_all_timer
     end
 
     # Schedule - Storage inventory collection
     sched = cfg.fetch_with_fallback(:storage, :inventory, :full_refresh_schedule)
     _log.info("storage_inventory_full_refresh_schedule: #{sched}")
     @schedules[:storage_metrics_coordinator] << @system_scheduler.cron(sched, :job => true) do
-      @queue.enq :storage_refresh_inventory
+      enqueue :storage_refresh_inventory
     end
   end
 
@@ -435,7 +439,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     options[:job] = true
 
     @schedules[:scheduler] << @user_scheduler.send(method, interval, options) do |rufus_job|
-      @queue.enq [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
+      enqueue [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
     end
   end
 
@@ -449,7 +453,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     sch = MiqSchedule.find(schedule_id)
     next_run = sch.next_interval_time
     @schedules[:scheduler] << @user_scheduler.send(method, next_run, options) do |rufus_job|
-      @queue.enq [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
+      enqueue [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
     end
 
     # Schedule every X months for up to 5 years in the future
@@ -457,7 +461,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     remaining_months.times do
       next_run += months.months
       @schedules[:scheduler] << @user_scheduler.send(method, next_run, options) do |rufus_job|
-        @queue.enq [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
+        enqueue [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
       end
     end
     @schedules[:scheduler]


### PR DESCRIPTION
This is the first of low hanging fruit from #4071

Just want to chip away at this and get rid of the changes that we all agree upon.

/cc @imtayadeway I prefer `enq` but you had `enqueue` - I just deferred to your commit. Preference?
/cc @Fryguy thanks for linking me across
/cc @matthewd you were on original thread.