### PR TITLE
Don't use raw sql in association where

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -99,7 +99,7 @@ class Host < ActiveRecord::Base
   include EventMixin
 
   include CustomAttributeMixin
-  has_many :ems_custom_attributes, -> { where("source = 'VC'") }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
   has_many :filesystems_custom_attributes, :through => :filesystems, :source => 'custom_attributes'
 
   acts_as_miq_taggable

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -72,8 +72,8 @@ class Host < ActiveRecord::Base
 
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy
-  has_many                  :users, -> { where("accttype = 'user'") }, :class_name => "Account", :foreign_key => "host_id"
-  has_many                  :groups, -> { where("accttype = 'group'") }, :class_name => "Account", :foreign_key => "host_id"
+  has_many                  :users,  -> { where(:accttype => 'user') },  :class_name => "Account", :foreign_key => "host_id"
+  has_many                  :groups, -> { where(:accttype => 'group') }, :class_name => "Account", :foreign_key => "host_id"
 
   has_many                  :advanced_settings, :as => :resource, :dependent => :destroy
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -67,8 +67,8 @@ class Host < ActiveRecord::Base
   has_many                  :miq_events, :as => :target, :dependent => :destroy
 
   has_many                  :filesystems, :as => :resource, :dependent => :destroy
-  has_many                  :directories, -> { where("rsc_type = 'dir'") }, :as => :resource, :class_name => "Filesystem"
-  has_many                  :files,       -> { where("rsc_type = 'file'") }, :as => :resource, :class_name => "Filesystem"
+  has_many                  :directories, -> { where(:rsc_type => 'dir') },  :as => :resource, :class_name => "Filesystem"
+  has_many                  :files,       -> { where(:rsc_type => 'file') }, :as => :resource, :class_name => "Filesystem"
 
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -23,6 +23,13 @@ describe Host do
     expect(described_class.joins(:files, :directories)).to eq [host1]
   end
 
+  it "#ems_custom_attributes" do
+    ems_attr   = FactoryGirl.create(:custom_attribute, :source => 'VC')
+    other_attr = FactoryGirl.create(:custom_attribute, :source => 'NOTVC')
+    host       = FactoryGirl.create(:host_vmware, :custom_attributes => [ems_attr, other_attr])
+    expect(host.ems_custom_attributes).to eq [ems_attr]
+  end
+
   it "#save_drift_state" do
     # TODO: Beef up with more data
     host = FactoryGirl.create(:host_vmware)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -1,6 +1,17 @@
 require "spec_helper"
 
 describe Host do
+  it "groups and users joins" do
+    user1  = FactoryGirl.create(:account_user)
+    user2  = FactoryGirl.create(:account_user)
+    group  = FactoryGirl.create(:account_group)
+    host1  = FactoryGirl.create(:host_vmware, :users => [user1], :groups => [group])
+    host2  = FactoryGirl.create(:host_vmware, :users => [user2])
+    expect(described_class.joins(:users)).to match_array([host1, host2])
+    expect(described_class.joins(:groups)).to eq [host1]
+    expect(described_class.joins(:users, :groups)).to eq [host1]
+  end
+
   it "#save_drift_state" do
     # TODO: Beef up with more data
     host = FactoryGirl.create(:host_vmware)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -12,6 +12,17 @@ describe Host do
     expect(described_class.joins(:users, :groups)).to eq [host1]
   end
 
+  it "directories and files joins" do
+    file1  = FactoryGirl.create(:filesystem, :rsc_type => "file")
+    file2  = FactoryGirl.create(:filesystem, :rsc_type => "file")
+    dir    = FactoryGirl.create(:filesystem, :rsc_type => "dir")
+    host1  = FactoryGirl.create(:host_vmware, :files => [file1], :directories => [dir])
+    host2  = FactoryGirl.create(:host_vmware, :files => [file2])
+    expect(described_class.joins(:files)).to match_array([host1, host2])
+    expect(described_class.joins(:directories)).to eq [host1]
+    expect(described_class.joins(:files, :directories)).to eq [host1]
+  end
+
   it "#save_drift_state" do
     # TODO: Beef up with more data
     host = FactoryGirl.create(:host_vmware)


### PR DESCRIPTION
Don't use raw sql in the where clause unless it's required.

Raw sql would require you to disambiguate which table the referenced column is coming from.
In the attached cases, we don't need to use raw sql since a single key/value hash pair does exactly what we want and we can allow rails to determine the table.

Fixes errors of the following types when joining on associations:
```
PG::AmbiguousColumn: ERROR:  column reference "accttype" is ambiguous
       LINE 1: ..." ON "groups_hosts"."host_id" = "hosts"."id" AND (accttype =...
                                                                    ^
       : SELECT "hosts".* FROM "hosts" INNER JOIN "accounts" ON "accounts"."host_id" = "hosts"."id" AND (accttype = 'user') INNER JOIN "accounts" "groups_hosts" ON "groups_hosts"."host_id" = "hosts"."id" AND (accttype = 'group')
```