### PR TITLE
Update default repo names

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -34,8 +34,8 @@ class MiqDatabase < ActiveRecord::Base
 
   def self.registration_default_value_for_update_repo_name(type = "sm_hosted")
     case type
-    when "rhn_satellite" then "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1"
-    else                      "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"
+    when "rhn_satellite" then ""
+    else                      "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
     end
   end
 

--- a/db/migrate/20151119202643_update_default_update_repo_names.rb
+++ b/db/migrate/20151119202643_update_default_update_repo_names.rb
@@ -1,0 +1,30 @@
+class UpdateDefaultUpdateRepoNames < ActiveRecord::Migration
+  class MiqDatabase < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  REPO_NAME_HASH = {
+    "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1" => "",
+    "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"          => "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+  }
+
+  def up
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH)
+    end
+  end
+
+  def down
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH.invert)
+    end
+  end
+
+  def update(hash)
+    db = MiqDatabase.first
+    if db
+      new_repo = hash[db.update_repo_name]
+      db.update_attributes(:update_repo_name => new_repo) if new_repo
+    end
+  end
+end

--- a/spec/migrations/20151119202643_update_default_update_repo_names_spec.rb
+++ b/spec/migrations/20151119202643_update_default_update_repo_names_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require_migration
+
+describe UpdateDefaultUpdateRepoNames do
+  let(:db_stub) { migration_stub(:MiqDatabase) }
+
+  migration_context :up do
+    [
+      ["Satellite 5", "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1", ""],
+      ["Satellite 6", "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms", "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"]
+    ].each do |name, existing_repo, desired_repo|
+      it name do
+        db = db_stub.create!(:update_repo_name => existing_repo)
+
+        migrate
+
+        expect(db.reload.update_repo_name).to eq(desired_repo)
+      end
+    end
+  end
+
+  migration_context :down do
+    [
+      ["Satellite 5", "", "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1"],
+      ["Satellite 6", "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms", "cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms"]
+    ].each do |name, existing_repo, desired_repo|
+      it name do
+        db = db_stub.create!(:update_repo_name => existing_repo)
+
+        migrate
+
+        expect(db.reload.update_repo_name).to eq(desired_repo)
+      end
+    end
+  end
+end

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -11,7 +11,7 @@ describe MiqDatabase do
         db = MiqDatabase.first
         expect(db.csrf_secret_token_encrypted).to be_encrypted
         expect(db.session_secret_token_encrypted).to be_encrypted
-        expect(db.update_repo_name).to eq("cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms")
+        expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         expect(db.registration_type).to eq("sm_hosted")
         expect(db.registration_server).to eq("subscription.rhn.redhat.com")
       end
@@ -29,7 +29,7 @@ describe MiqDatabase do
           db = MiqDatabase.first
           expect(db.csrf_secret_token_encrypted).to be_encrypted
           expect(db.session_secret_token_encrypted).to be_encrypted
-          expect(db.update_repo_name).to eq("cf-me-5.4-for-rhel-6-rpms rhel-server-rhscl-6-rpms")
+          expect(db.update_repo_name).to eq("cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         end
 
         it "will not change existing values" do

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -189,7 +189,7 @@ describe MiqServer do
     reg_system.should_receive(:enable_repo).twice
 
     @server.enable_repos
-    expect(@server.upgrade_message).to eq("enabling rhel-server-rhscl-6-rpms")
+    expect(@server.upgrade_message).to eq("enabling rhel-server-rhscl-7-rpms")
   end
 
   it "#check_updates" do


### PR DESCRIPTION
Added new repos for Satellite 6 and RHN and removed the default repos for Satellite 5 until we know what they are.

This migration will update the RHN/Sat6 repo names and change the default names for Sat5 to empty strings in the miq_databases table

https://bugzilla.redhat.com/show_bug.cgi?id=1266951