### PR TITLE
Re-adding provider will adopt old hosts

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -138,8 +138,9 @@ module EmsRefresh::SaveInventoryInfra
             found = ems.hosts.detect { |e| e.name.downcase == h[:name].downcase }
           elsif ["localhost", "localhost.localdomain", "127.0.0.1"].include_none?(h[:hostname], h[:ipaddress])
             # host = Host.find_by_hostname(hostname) has a risk of creating duplicate hosts
-            _log.debug "#{log_header} Host database lookup - hostname: [#{h[:hostname]}] IP: [#{h[:ipaddress]}]"
-            found = Host.lookUpHost(h[:hostname], h[:ipaddress], :ems_ref => h[:ems_ref], :ems_id => ems.id)
+            # allow a deleted EMS to be re-added an pick up old orphaned hosts
+            _log.debug "#{log_header} Host database lookup - hostname: [#{h[:hostname]}] IP: [#{h[:ipaddress]}] ems_ref: [#{h[:ems_ref]}]"
+            found = Host.lookUpHost(h[:hostname], h[:ipaddress], :ems_ref => h[:ems_ref])
           end
         end
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -337,30 +337,45 @@ describe Host do
     end
     context "when hosts have duplicate hostnames" do
       before do
-        @fqdn_hostname            = "test1.fake.com"
-        @ipaddress_1              = "1.1.1.1"
-        @ipaddress_2              = "2.2.2.2"
-        @ems_id_1                 = 1
-        @ems_id_2                 = 2
-        @ems_ref_1                = "host-1"
-        @ems_ref_2                = "host-2"
-        @host = FactoryGirl.create(:host_vmware, :hostname => @fqdn_hostname, :ipaddress => @ipaddress_1,
-                                   :ems_ref => @ems_ref_1, :ems_id => @ems_id_1)
+        @fqdn_hostname_1 = "test1.fake.com"
+        @fqdn_hostname_2 = "test2.fake.com"
+        @ipaddress_1     = "1.1.1.1"
+        @ipaddress_2     = "2.2.2.2"
+        @ems_id_1        = 1
+        @ems_id_2        = 2
+        @ems_ref_1       = "host-1"
+        @ems_ref_2       = "host-2"
+        @host            = FactoryGirl.create(:host_vmware, :hostname => @fqdn_hostname_1, :ipaddress => @ipaddress_1,
+                                              :ems_ref => @ems_ref_1, :ems_id => @ems_id_1)
+        # when an EMS is removed, the host is left behind with a nil ems_id
+        @host_no_ems_id  = FactoryGirl.create(:host_vmware, :hostname => @fqdn_hostname_2, :ipaddress => @ipaddress_2,
+                                              :ems_ref => @ems_ref_2)
       end
+
       it "with only fqdn and ipaddress" do
-        Host.lookUpHost(@fqdn_hostname, @ipaddress_1).should == @host
+        Host.lookUpHost(@fqdn_hostname_1, @ipaddress_1).should == @host
       end
+
       it "with fqdn, ipaddress, and ems_ref finds right host" do
-        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1).should == @host
+        Host.lookUpHost(@fqdn_hostname_1, @ipaddress_1, :ems_ref => @ems_ref_1).should == @host
       end
+
+      it "with fqdn, ipaddress, and ems_ref finds right host without an ems_id" do
+        # this allows a recently deleted EMS to be re-added and pick up the
+        # old orphaned host
+        Host.lookUpHost(@fqdn_hostname_2, @ipaddress_2, :ems_ref => @ems_ref_2).should == @host_no_ems_id
+      end
+
       it "with fqdn, ipaddress, and different ems_ref returns nil" do
-        Host.lookUpHost(@fqdn_hostname, @ipaddress_2, :ems_ref => @ems_ref_2).should be_nil
+        Host.lookUpHost(@fqdn_hostname_1, @ipaddress_2, :ems_ref => @ems_ref_2).should be_nil
       end
+
       it "with ems_ref and ems_id" do
-        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_1).should == @host
+        Host.lookUpHost(@fqdn_hostname_1, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_1).should == @host
       end
+
       it "with ems_ref and other ems_id" do
-        Host.lookUpHost(@fqdn_hostname, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_2).should be_nil
+        Host.lookUpHost(@fqdn_hostname_1, @ipaddress_1, :ems_ref => @ems_ref_1, :ems_id => @ems_id_2).should be_nil
       end
     end
   end


### PR DESCRIPTION
When an Infrastructure Provider is deleted, the hosts associated with that Provider are left behind with a nil ems_id.  If the same Infrastructure Provider is re-added, it is supposed to pick up the old orphaned hosts.

[f4aa37](https://github.com/agrare/manageiq/commit/f4aa372a570c934f99a5d789aaffafb8ac84c6c9) introduced a bug where re-adding a previously deleted Provider would fail to pick up orphaned hosts.  It resulted in the following situation:

1. Add Provider for the first time
> Hosts
> 1: `name:"hostname.domain.com", ems_id:1`

2. Delete the provider
> Hosts
> 1: `name:"hostname.domain.com", :ems_id:nil`

3. Re-add the provider
> Hosts
> 1: `name:"hostname.domain.com", ems_id:nil`
> 2: `name:"hostname.domain.com - 1", ems_id:2`

This patch changes the third step to:

`3.` Re-add the provider
> Hosts
> 1: `name:"hostname.domain.com", ems_id:2`



https://bugzilla.redhat.com/show_bug.cgi?id=1283195