### PR TITLE
Remove Default instance values so class schema values will be used.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/default.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestQuotaVerification.class/default.yaml
@@ -7,7 +7,4 @@ object:
     name: Default
     inherits: 
     description: 
-  fields:
-  - ValidateQuotas:
-      value: "/System/Commonmethods/quota/vm_quota"
-      on_entry: "#"
+  fields: []


### PR DESCRIPTION
Old infrastructure quota class "Default" instance mistakenly points to new consolidated quota.  Removing instance values enables old behavior of using class schema values.  
 
https://bugzilla.redhat.com/show_bug.cgi?id=1283795