### PR TITLE
BZ 1207826 - speed up metric pruning

### DIFF
--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -57,9 +57,7 @@ module Metric::Purging
   def self.purge_count(older_than, interval)
     scope = scope_for_interval(interval)
 
-    oldest = scope.select(:timestamp).order(:timestamp).first
-    oldest = oldest.nil? ? older_than : oldest.timestamp
-
+    oldest = scope.minimum(:timestamp) || older_than
     scope.where(:timestamp => oldest..older_than).count
   end
 
@@ -75,8 +73,7 @@ module Metric::Purging
 
       oldest = nil
       Benchmark.realtime_block(:query_oldest) do
-        oldest = scope.select(:timestamp).order(:timestamp).first
-        oldest = oldest.nil? ? older_than : oldest.timestamp
+        oldest = scope.minimum(:timestamp) || older_than
       end
 
       loop do

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -77,12 +77,12 @@ module Metric::Purging
       end
 
       loop do
-        batch, = Benchmark.realtime_block(:query_batch) do
-          scope.select(:id).where(:timestamp => (oldest..older_than)).limit(window)
+        current_limit = window
+        ids, = Benchmark.realtime_block(:query_batch) do
+          scope.where(:timestamp => (oldest..older_than)).limit(current_limit).pluck(:id)
         end
         break if batch.empty?
 
-        ids = batch.collect(&:id)
         ids = ids[0, limit - total] if limit && total + ids.length > limit
 
         _log.info("Purging #{ids.length} #{interval} metrics.")

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -50,26 +50,23 @@ module Metric::Purging
     end
   end
 
-  def self.klass_for_interval(interval)
-    klass, conditions = case interval
-                        when 'realtime' then [Metric,       {}]
-                        else             [MetricRollup, {:capture_interval_name => interval}]
-                        end
+  def self.scope_for_interval(interval)
+    interval == 'realtime' ? Metric : MetricRollup.where(:capture_interval_name => interval)
   end
 
   def self.purge_count(older_than, interval)
-    klass, conditions = klass_for_interval(interval)
+    scope = scope_for_interval(interval)
 
-    oldest = klass.select(:timestamp).where(conditions).order(:timestamp).first
+    oldest = scope.select(:timestamp).order(:timestamp).first
     oldest = oldest.nil? ? older_than : oldest.timestamp
 
-    klass.where(conditions).where(:timestamp => oldest..older_than).count
+    scope.where(:timestamp => oldest..older_than).count
   end
 
   def self.purge(older_than, interval, window = nil, limit = nil)
     _log.info("Purging #{limit.nil? ? "all" : limit} #{interval} metrics older than [#{older_than}]...")
 
-    klass, conditions = klass_for_interval(interval)
+    scope = scope_for_interval(interval)
 
     total = 0
     total_tag_values = 0
@@ -78,13 +75,13 @@ module Metric::Purging
 
       oldest = nil
       Benchmark.realtime_block(:query_oldest) do
-        oldest = klass.select(:timestamp).where(conditions).order(:timestamp).first
+        oldest = scope.select(:timestamp).order(:timestamp).first
         oldest = oldest.nil? ? older_than : oldest.timestamp
       end
 
       loop do
         batch, = Benchmark.realtime_block(:query_batch) do
-          klass.select(:id).where(conditions).where(:timestamp => (oldest..older_than)).limit(window)
+          scope.select(:id).where(:timestamp => (oldest..older_than)).limit(window)
         end
         break if batch.empty?
 
@@ -93,7 +90,7 @@ module Metric::Purging
 
         _log.info("Purging #{ids.length} #{interval} metrics.")
         count, = Benchmark.realtime_block(:purge_metrics) do
-          klass.delete_all(:id => ids)
+          scope.unscoped.delete_all(:id => ids)
         end
         total += count
 
@@ -104,7 +101,7 @@ module Metric::Purging
           _log.info("Purging associated tag values.")
           ids.each_slice(50) do |vp_ids|
             tv_count, = Benchmark.realtime_block(:purge_vim_performance_tag_values) do
-              VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => klass.name)
+              VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => scope.name)
             end
             count_tag_values += tv_count
             total_tag_values += tv_count


### PR DESCRIPTION
This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1207826 and [1226429](https://bugzilla.redhat.com/show_bug.cgi?id=1226429)

This simplifies the Cap&U metric purging code. Goal is to reduce the cost of pruning, so we don't have to introduce different batching mechanisms.

From here, we can possibly move more of the id fetching into a temp table or something.

/cc @dmetzger57 once our log gets lower, I want to improve so we don't bring back so many records from the db
/cc @akrzos fyi - and thanks

area|before|after
---|---|---
metrics deleted|11,222|11,222
tags deleted|0|0
code|231ms|115ms
sql|288ms|215ms
queries|40|27
memory|18,102kb|6,508kb
objects|206,528|132,625

---

Timings from the log

name|before|after
---|---|---
query_oldest|0.0630779|
query_batch|0.0027899|0.095520
purge_metrics|0.2500097|0.241861
total_time|0.8555488|0.558689
