### PR TITLE
disabled link to entities in containers dashboard when entity count is zero

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_utils.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_utils.js
@@ -95,6 +95,9 @@ angular.module('containerDashboard').factory('ContainerDashboardUtils', [functio
           count: data.warningCount
         };
       }
+
+      if (statusObject.count == 0)
+          statusObject.href = "";
     } else {
       statusObject.count = 0;
     }


### PR DESCRIPTION
@jeff-phillips-18 @abonas 
This is standard in the rest of miq.