### PR TITLE
Allow infinity tenant quotas

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -146,17 +146,30 @@ module OpsHelper::TextualSummary
     return "#{fmt_value} #{text_modifier}"
   end
 
+  def convert_to_format_with_default_text(format, text_modifier, value, metric)
+    is_zero_value = value.nil? || value == 0
+    can_display_default_text = !TenantQuota.default_text_for(metric).nil?
+
+    if is_zero_value && can_display_default_text
+      return TenantQuota.default_text_for(metric)
+    end
+
+    convert_to_format(format, text_modifier, value)
+  end
+
   def get_tenant_quota_allocations
     rows = @record.combined_quotas.values.to_a
     rows.collect do |row|
       {
-          :title  => row[:description],
-          :name   => row[:description],
-          :in_use =>  convert_to_format(row[:format], row[:text_modifier], row[:used]),
-          :allocated  => convert_to_format(row[:format], row[:text_modifier], row[:allocated]),
-          :available => convert_to_format(row[:format], row[:text_modifier], row[:available]),
-          :total => convert_to_format(row[:format], row[:text_modifier], row[:value]),
-          :explorer => true
+        :title => row[:description],
+        :name => row[:description],
+        :in_use => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:used], :in_use),
+        :allocated => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:allocated],
+                                                          :allocated),
+        :available => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:available],
+                                                          :available),
+        :total => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:value], :total),
+        :explorer => true
       }
     end
   end

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -139,8 +139,10 @@ class TenantQuota < ActiveRecord::Base
 
     # Check if the parent has enough quota available to give to the child
     parent_quota = tenant.parent.tenant_quotas.send(name).take
-    if parent_quota.nil? || parent_quota.available < diff
-      errors.add(name, "quota is over allocated, parent tenant does not have enough quota")
+    unless parent_quota.nil?
+      if parent_quota.available < diff
+        errors.add(name, "quota is over allocated, parent tenant does not have enough quota")
+      end
     end
   end
 end

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -29,6 +29,11 @@ class TenantQuota < ActiveRecord::Base
     }
   }
 
+  DEFAULT_TEXT_FOR_ZERO_VALUES = {
+    :total     => "Not defined".freeze,
+    :available => "Not applicable".freeze
+  }
+
   NAMES = QUOTA_BASE.keys.map(&:to_s)
 
   validates :name, :inclusion => {:in => NAMES}
@@ -46,6 +51,10 @@ class TenantQuota < ActiveRecord::Base
 
   before_validation(:on => :create) do
     self.unit = default_unit unless unit.present?
+  end
+
+  def self.default_text_for(metric)
+    DEFAULT_TEXT_FOR_ZERO_VALUES[metric]
   end
 
   def self.quota_definitions

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -73,5 +73,7 @@
   .row
     .col-md-12.col-lg-10
       = render :partial => "shared/summary/textual_listview", :locals => {:title => _("Tenant Quota"), :items => textual_group_tenant_quota_allocations}
+      %p
+        = _("Note: Total quota can be restricted by quotas defined at upper levels")
       %hr/
   = render :partial => "rbac_tag_box"

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -56,10 +56,16 @@ describe TenantQuota do
         described_class.new(:tenant => grandchild_tenant1, :name => "cpu_allocated", :value => 9).should_not be_valid
       end
 
-      it "connot have less quota than the amount that has already been used" do
+      it "cannot have less quota than the amount that has already been used" do
         nq = described_class.new(:tenant => grandchild_tenant2, :name => "cpu_allocated", :value => 1)
         nq.stub(:used => 2)
         nq.should_not be_valid
+      end
+    end
+
+    context "grandchild tenant, parent with infinity(undefined) quota" do
+      it "can have unlimited quota" do
+        described_class.new(:tenant => grandchild_tenant1, :name => "cpu_allocated", :value => 1000).should be_valid
       end
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1278907

It is allowed when parent tenant doesn't have defined related tenant quota.
Also added default text is for columns 'Available' and 'Total Quota' when they have not defined tenant quota in table  'Tenant Quota'

before
![screen shot 2015-11-20 at 16 14 23](https://cloud.githubusercontent.com/assets/14937244/11303171/cf13c562-8fa1-11e5-9029-2cf79c2ecdf5.png)

after
![tenant_after](https://cloud.githubusercontent.com/assets/14937244/11303162/be2a9d02-8fa1-11e5-9669-388d9b58d162.png)

