### PR TITLE
Fix RenameMiqSearchDb migration

### DIFF
--- a/db/migrate/20151111165020_rename_miq_search_db.rb
+++ b/db/migrate/20151111165020_rename_miq_search_db.rb
@@ -1,4 +1,8 @@
 class RenameMiqSearchDb < ActiveRecord::Migration
+  class MiqSearch < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   NAME_HASH = Hash[*%w(
     TemplateInfra ManageIQ::Providers::InfraManager::Template
     VmInfra       ManageIQ::Providers::InfraManager::Vm

--- a/db/migrate/20151111165020_rename_miq_search_db.rb
+++ b/db/migrate/20151111165020_rename_miq_search_db.rb
@@ -10,10 +10,11 @@ class RenameMiqSearchDb < ActiveRecord::Migration
     VmCloud       ManageIQ::Providers::CloudManager::Vm
   )]
 
-  def change
-    MiqSearch.all.each do |search|
-      search.db = NAME_HASH[search.db] if NAME_HASH.key?(search.db)
-      search.save!
+  def up
+    say_with_time("Rename MiqSearch db values") do
+      MiqSearch.all.each do |search|
+        search.update_attributes!(:db => NAME_HASH[search.db]) if NAME_HASH.key?(search.db)
+      end
     end
   end
 end

--- a/spec/migrations/20151111165020_rename_miq_search_db_spec.rb
+++ b/spec/migrations/20151111165020_rename_miq_search_db_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require_migration
+
+describe RenameMiqSearchDb do
+  let(:search_stub) { migration_stub(:MiqSearch) }
+
+  migration_context :up do
+    it "renames known MiqSearch db values" do
+      to_be_renamed = described_class::NAME_HASH.keys.collect do |old_db|
+        search_stub.create!(:db => old_db)
+      end
+      to_be_ignored = search_stub.create!(:db => "Vm")
+
+      migrate
+
+      to_be_renamed.zip(described_class::NAME_HASH.values) do |search, new_db|
+        expect(search.reload.db).to eq(new_db)
+      end
+      expect(to_be_ignored.reload.db).to eq("Vm")
+    end
+  end
+end


### PR DESCRIPTION
Cleanup after https://github.com/ManageIQ/manageiq/pull/5406 because it 

- Didn't have a spec
- Didn't handle a down migration properly, since it used change
- Should not access models directly, and should use a migration stub
- Should use say_with_time around the data migration piece.

@martinpovolny Please review.