### PR TITLE
Fix rollup creation in `Storage#perf_capture`

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -809,9 +809,7 @@ class Storage < ActiveRecord::Base
             vm_perf   = obj_perfs.fetch_path(vm.class.name, vm.id, interval_name, hour)
             vm_perf ||= obj_perfs.store_path(vm.class.name, vm.id, interval_name, hour, vm.send(meth).build(:timestamp => hour, :capture_interval_name => interval_name))
 
-            vm_attrs.reverse_merge!(vm_perf.attributes)
-            vm_attrs.merge!(Metric::Processing.process_derived_columns(vm, vm_attrs))
-            vm_perf.update_attributes(vm_attrs)
+            update_vm_perf(vm, vm_perf, vm_attrs)
           end
         end
 
@@ -828,6 +826,12 @@ class Storage < ActiveRecord::Base
     end
 
     _log.info "#{log_header} Capture for #{log_target}...Complete - Timings: #{t.inspect}"
+  end
+
+  def update_vm_perf(vm, vm_perf, vm_attrs)
+    vm_attrs.reverse_merge!(vm_perf.attributes.symbolize_keys)
+    vm_attrs.merge!(Metric::Processing.process_derived_columns(vm, vm_attrs))
+    vm_perf.update_attributes(vm_attrs)
   end
 
   def vm_scan_affinity

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -445,4 +445,17 @@ describe Storage do
       expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(true)
     end
   end
+
+  describe "#update_vm_perf" do
+    it "will update a vm_perf with an attributes hash keyed with symbols" do
+      storage = FactoryGirl.create(:storage)
+      vm = FactoryGirl.create(:vm)
+      metric_rollup = FactoryGirl.build(:metric_rollup)
+      attrs = {:resource_name => "test vm"}
+
+      storage.update_vm_perf(vm, metric_rollup, attrs)
+
+      expect(metric_rollup.resource_name).to eq("test vm")
+    end
+  end
 end


### PR DESCRIPTION
Because of the change in Rails 4 to `Model#attributes` which returns a
hash keyed by strings instead of symbols, a bug was introduced in
`#perf_capture` when merging attributes. It can be illustrated by the
following example:

```ruby
class Person < ActiveRecord::Base
  # persons table has id, name
end

attrs = {:name => "Alice"}
attrs.reverse_merge!(Person.new.attributes)
attrs # => {:name => "Alice", "name" => nil}
Person.new(attrs).name # => nil
```

The fix here is to call `#symbolize_keys` on `Person#attributes` so that
the `reverse_merge` won't merge in a nil value.

To better isolate and test where this was going wrong a utility method
was extracted that moves the crucial hash manipulation code into it. It
is otherwise identical to the code in `#perf_capture` apart from the
added `symbolize_keys` and can be seen failing without it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1267390

cc @gtanzillo @jrafanie 