### PR TITLE
Remember user.current_group in the session

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -13,11 +13,13 @@ module ApplicationController::CurrentUser
   def clear_current_user
     User.current_user = nil
     session[:userid]  = nil
+    session[:group] = nil
   end
 
   def current_user=(db_user)
     User.current_user = db_user
     session[:userid]  = db_user.userid
+    session[:group]   = db_user.current_group_id
   end
 
   def admin_user?
@@ -29,7 +31,11 @@ module ApplicationController::CurrentUser
   end
 
   def current_user
-    @current_user ||= User.find_by_userid(session[:userid]) if current_userid
+    if current_userid
+      @current_user ||= User.find_by_userid(current_userid).tap do |u|
+        u.current_group_id = session[:group] if session[:group]
+      end
+    end
     @current_user
   end
 

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -6,6 +6,7 @@ module AuthHelper
   def login_as(user)
     User.current_user = user
     session[:userid]  = user.userid
+    session[:group]   = user.current_group_id
     user
   end
 end


### PR DESCRIPTION
**NOTE:** Pending discussion. (code is complete)

**High Level:**
When an admin changes the group of a user, the `user#current_group` changes in the database. We need to determine if we want to continue using the group at login, or if we want to reset the session to update the values.

**Details:**
In 5.4, we used the `current_group` at the time of login, but in many places fell back to the value in the database. Therefore it was not consistent.

In 5.5, the code has been changed to pass around the user object, which is consistent. But it is always reading the group from the database. This potentially changes the `current_user#current_group` but has values from the old group in `session`/`@sb`.

**After:**
`current_group` remains as the value in the login.
Added a block in `application_controller` to detect a change and act accordingly. We need to determin what should happen.

Also of note, after this change, a single user should be able to be logged in as 2 different groups (via 2 different browsers).


/cc @Fryguy @chessbyte Not sure if we want to target 5.5 or 5.6 for this.
/cc @dclarizio This is what we discussed