### PR TITLE
Hide download PDF button when PdfGenerator is not available.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -115,7 +115,7 @@ class ApplicationHelper::ToolbarBuilder
             if bsi.key?(:separator)
               props = {"id" => "sep_#{bg_idx}_#{bsi_idx}", "type" => "separator", :hidden => !any_visible}
             else
-              next if bsi[:image] == 'pdf' && !PdfGenerator.available?
+              next if download_pdf_buttons.include?(bsi[:button]) && !PdfGenerator.available?
               next if build_toolbar_hide_button(bsi[:pressed] || bsi[:button])  # Use pressed, else button name
               bs_children = true
               props = {
@@ -155,7 +155,7 @@ class ApplicationHelper::ToolbarBuilder
             sep_needed = true                                       # Need a separator from now on
           end
         elsif bgi.key?(:button)                                 # button node found
-          next if bgi[:image] == 'pdf' && !PdfGenerator.available?
+          next if download_pdf_buttons.include?(bgi[:button]) && !PdfGenerator.available?
           button_hide = build_toolbar_hide_button(bgi[:button])
           if button_hide
             # These buttons need to be present even if hidden as we show/hide them dynamically
@@ -225,6 +225,18 @@ class ApplicationHelper::ToolbarBuilder
 
     toolbar = nil if toolbar.empty?
     toolbar
+  end
+
+  def download_pdf_buttons
+    %w(chargeback_download_pdf
+       download_pdf
+       download_view
+       drift_pdf
+       miq_capacity_download_pdf
+       render_report_pdf
+       timeline_pdf
+       vm_download_pdf
+      )
   end
 
   def create_custom_button_hash(input, record, options = {})

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2883,4 +2883,35 @@ describe ApplicationHelper do
       true
     end
   end
+
+  context "build_toolbar" do
+    before do
+      controller.instance_variable_set(:@sb, :active_tree => :foo_tree)
+      @pdf_button = {"id"       => "download_choice__download_pdf",
+                     "type"     => "button",
+                     "img"      => "download_pdf.png",
+                     "imgdis"   => "download_pdf.png",
+                     :icon      => "fa fa-file-pdf-o fa-lg",
+                     "text"     => "Download as PDF",
+                     "title"    => "Download this report in PDF format",
+                     :name      => "download_choice__download_pdf",
+                     :hidden    => false,
+                     :pressed   => nil,
+                     :onwhen    => nil,
+                     :url       => "/download_data",
+                     :url_parms => "?download_type=pdf"}
+    end
+
+    it "Hides PDF button when PdfGenerator is not available" do
+      PdfGenerator.stub(:available? => false)
+      buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button['id'] == "download_choice" }.compact.flatten
+      buttons.should_not include(@pdf_button)
+    end
+
+    it "Displays PDF button when PdfGenerator is available" do
+      PdfGenerator.stub(:available? => true)
+      buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button['id'] == "download_choice" }.compact.flatten
+      buttons.should include(@pdf_button)
+    end
+  end
 end


### PR DESCRIPTION
This broke in commit 7823ba2502995382cfd52946910e88dbc41d25ba where toolbar button images were replaced by font awesome icons

Fixes #5518 
@dclarizio please review.