### PR TITLE
Squash `starts_with?(x) || starts_with?(y)` into `starts_with?(x, y)`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -702,7 +702,7 @@ class ApplicationController < ActionController::Base
   def build_audit_msg(new, current, msg_in)
     msg_arr = []
     new.each_key do |k|
-      if !(k.to_s.ends_with?("password2") || k.to_s.ends_with?("verify")) &&
+      if !k.to_s.ends_with?("password2", "verify") &&
          (current.nil? || (new[k] != current[k]))
         if password_field?(k) # Asterisk out password fields
           msg_arr << "#{k}:[*]#{' to [*]' unless current.nil?}"

--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -73,8 +73,8 @@ class AvailabilityZoneController < ApplicationController
     params[:display] = @display if ["images", "instances"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
-    if params[:pressed].starts_with?("image_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("instance_")
+    if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
+                                     "instance_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/cim_instance_controller.rb
+++ b/app/controllers/cim_instance_controller.rb
@@ -21,11 +21,11 @@ class CimInstanceController < ApplicationController
     @edit = session[:edit]                          # Restore @edit for adv search box
     params[:display] = @display if ["host", "vms", "storages"].include?(@display) # Were we displaying vms/storages
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_") ||
-       params[:pressed].starts_with?("storage_") ||
-       params[:pressed].starts_with?("host_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "storage_",
+                                     "host_")
 
       scanhosts if params[:pressed] == "host_scan"
       analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -14,11 +14,11 @@ class CloudTenantController < ApplicationController
     params[:display] = @display if %w(vms instances images).include?(@display)
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
     return tag("CloudTenant") if params[:pressed] == 'cloud_tenant_tag'
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_") ||
-       params[:pressed].starts_with?("image_") ||
-       params[:pressed].starts_with?("instance_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "image_",
+                                     "instance_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -56,7 +56,7 @@ class ConfigurationController < ApplicationController
       @refresh_div = "flash_msg_div"
     end
 
-    if params[:pressed].ends_with?("_edit") || params[:pressed].ends_with?("_copy")
+    if params[:pressed].ends_with?("_edit", "_copy")
       render :update do |page|
         page.redirect_to :action => @refresh_partial, :id => @redirect_id
       end

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -137,11 +137,11 @@ class EmsClusterController < ApplicationController
     @edit = session[:edit]                                  # Restore @edit for adv search box
     params[:display] = @display if ["all_vms", "vms", "hosts", "resource_pools"].include?(@display)  # Were we displaying sub-items
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed][0..5] == "guest_" ||
-       params[:pressed][0..4] == "host_" ||
-       params[:pressed][0..2] == "rp_"
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "host_",
+                                     "rp_")
 
       scanhosts if params[:pressed] == "host_scan"
       analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -455,14 +455,14 @@ module EmsCommon
     params[:display] = @display if ["vms", "hosts", "storages", "instances", "images"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_") ||
-       params[:pressed].starts_with?("image_") ||
-       params[:pressed].starts_with?("instance_") ||
-       params[:pressed].starts_with?("storage_") ||
-       params[:pressed].starts_with?("ems_cluster_") ||
-       params[:pressed].starts_with?("host_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "image_",
+                                     "instance_",
+                                     "storage_",
+                                     "ems_cluster_",
+                                     "host_")
 
       scanhosts if params[:pressed] == "host_scan"
       analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -57,8 +57,8 @@ class FlavorController < ApplicationController
     params[:display] = @display if ["images", "instances"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
-    if params[:pressed].starts_with?("image_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("instance_")
+    if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
+                                     "instance_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -468,10 +468,10 @@ class HostController < ApplicationController
     @edit = session[:edit]                                  # Restore @edit for adv search box
     params[:display] = @display if ["vms", "storages"].include?(@display)  # Were we displaying vms/storages
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_") ||
-       params[:pressed].starts_with?("storage_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "storage_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -218,8 +218,7 @@ module MiqPolicyController::Policies
   end
 
   def excluded_event?(event)
-    event.name.end_with?("compliance_check") ||
-      event.name.end_with?("perf_complete")
+    event.name.end_with?("compliance_check", "perf_complete")
   end
 
   def policy_get_all_folders(parent = nil)

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -774,8 +774,8 @@ class OpsController < ApplicationController
     i = 0
     @edit[:new].each_key do |k|
       if @edit[:new][k] != @edit[:current][k]
-        if k.to_s.ends_with?("password2") || k.to_s.ends_with?("verify")      # do nothing
-        elsif k.to_s.ends_with?("password") || k.to_s.ends_with?("_pwd")  # Asterisk out password fields
+        if k.to_s.ends_with?("password2", "verify")      # do nothing
+        elsif k.to_s.ends_with?("password", "_pwd")  # Asterisk out password fields
           msg = msg + k.to_s + ":[*] to [*]"
         else
           msg += ", " if i > 0

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1718,7 +1718,7 @@ module ReportController::Reports::Editor
       f_len = fields.length
       for f_idx in 1..f_len # Go thru fields in reverse
         f_key = fields[f_len - f_idx].last
-        next if f_key.ends_with?("_cost") || f_key.ends_with?("-owner_name") || f_key.ends_with?("_metric")
+        next if f_key.ends_with?("_cost", "-owner_name", "_metric")
         headers.delete(f_key)
         col_formats.delete(f_key)
         fields.delete_at(f_len - f_idx)

--- a/app/controllers/repository_controller.rb
+++ b/app/controllers/repository_controller.rb
@@ -158,9 +158,9 @@ class RepositoryController < ApplicationController
     @edit = session[:edit]                          # Restore @edit for adv search box
     params[:display] = "vms" if @display == "vms"   # Were we displaying vms
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -117,9 +117,9 @@ class ResourcePoolController < ApplicationController
     params[:display] = @display if ["all_vms", "vms", "resource_pools"].include?(@display)  # Were we displaying sub-items
     if ["all_vms", "vms", "resource_pools"].include?(@display)                  # Need to check, since RPs contain RPs
 
-      if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-         params[:pressed].starts_with?("miq_template_") ||
-         params[:pressed].starts_with?("guest_")
+      if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                       "miq_template_",
+                                       "guest_")
 
         pfx = pfx_for_vm_button_pressed(params[:pressed])
         process_vm_buttons(pfx)

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -57,8 +57,8 @@ class SecurityGroupController < ApplicationController
     params[:display] = @display if ["images", "instances"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
-    if params[:pressed].starts_with?("image_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("instance_")
+    if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
+                                     "instance_")
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       process_vm_buttons(pfx)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -89,10 +89,10 @@ class StorageController < ApplicationController
     @edit = session[:edit]                                  # Restore @edit for adv search box
     params[:display] = @display if %w(all_vms vms hosts).include?(@display) # Were we displaying vms or hosts
 
-    if params[:pressed].starts_with?("vm_") || # Handle buttons from sub-items screen
-       params[:pressed].starts_with?("miq_template_") ||
-       params[:pressed].starts_with?("guest_") ||
-       params[:pressed].starts_with?("host_")
+    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
+                                     "miq_template_",
+                                     "guest_",
+                                     "host_")
 
       scanhosts if params[:pressed] == "host_scan"
       analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -429,8 +429,8 @@ module ApplicationHelper
       title += ": Optimize"
     elsif layout.starts_with?("miq_request")
       title += ": Requests"
-    elsif layout.starts_with?("cim_") ||
-          layout.starts_with?("snia_")
+    elsif layout.starts_with?("cim_",
+                              "snia_")
       title += ": Storage - #{ui_lookup(:tables => layout)}"
     elsif layout == "login"
       title += ": Login"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -593,7 +593,7 @@ module ApplicationHelper
   # Determine the type of report (performance/trend/chargeback) based on the model
   def model_report_type(model)
     if model
-      if model.ends_with?("Performance") || model.ends_with?("MetricsRollup")
+      if model.ends_with?("Performance", "MetricsRollup")
         return :performance
       elsif model == UiConstants::TREND_MODEL
         return :trend

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -533,7 +533,7 @@ class ApplicationHelper::ToolbarBuilder
     return false if id == "show_summary" && !@explorer
 
     # need to hide add buttons when on sub-list view screen of a CI.
-    return true if (id.ends_with?("_new") || id.ends_with?("_discover")) &&
+    return true if id.ends_with?("_new", "_discover") &&
                    @lastaction == "show" && @display != "main"
 
     if id == "summary_reload"                             # Show reload button if
@@ -569,7 +569,7 @@ class ApplicationHelper::ToolbarBuilder
     return false if ["button_cancel"].include?(id)
 
     # buttons on compare/drift screen are allowed if user has access to compare/drift
-    return false if id.starts_with?("compare_") || id.starts_with?("drift_") || id.starts_with?("comparemode_") || id.starts_with?("driftmode_")
+    return false if id.starts_with?("compare_", "drift_", "comparemode_", "driftmode_")
 
     # Allow custom buttons on CI show screen, user can see custom button if they can get to show screen
     return false if id.starts_with?("custom_")
@@ -591,7 +591,7 @@ class ApplicationHelper::ToolbarBuilder
       return res
     end
 
-    if @layout == "pxe" || id.starts_with?("pxe_") || id.starts_with?("customization_template_")
+    if @layout == "pxe" || id.starts_with?("pxe_", "customization_template_")
       res = build_toolbar_hide_button_pxe(id)
       return res
     end

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -571,7 +571,7 @@ class MiqExpression
 
     rt = rel_time.downcase
 
-    if rt.starts_with?("this") || rt.starts_with?("last")
+    if rt.starts_with?("this", "last")
       # Convert these into the time spec form: <value> <interval> Ago
       value, interval = rt.split
       rt = "#{value == "this" ? 0 : 1} #{interval} ago"

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -613,7 +613,7 @@ class MiqExpression
 
   def self.date_time_value_is_relative?(value)
     v = value.downcase
-    v.starts_with?("this") || v.starts_with?("last") || v.ends_with?("ago") || ["today", "yesterday", "now"].include?(v)
+    v.starts_with?("this", "last") || v.ends_with?("ago") || ["today", "yesterday", "now"].include?(v)
   end
 
   def to_sql(tz = nil)

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1479,7 +1479,7 @@ class MiqExpression
       @reporting_available_fields[model.to_s] ||= {}
       @reporting_available_fields[model.to_s][interval.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif model.to_s == "Chargeback"
-      @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?("_cost") || c.last.ends_with?("_metric") || c.last.ends_with?("-owner_name") }
+      @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?("_cost", "_metric", "-owner_name") }
     else
       @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true)
     end

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1456,7 +1456,7 @@ class MiqExpression
     [:exp_available_fields, :exp_available_counts, :exp_available_finds].each { |what| miq_adv_search_lists(model, what) }
 
     # Build reporting lists
-    reporting_available_fields(model) unless model == model.ends_with?("Trend") || model.ends_with?("Performance") # Can't do trend/perf models at startup
+    reporting_available_fields(model) unless model == model.ends_with?("Trend", "Performance") # Can't do trend/perf models at startup
   end
 
   def self.miq_adv_search_lists(model, what)

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -78,7 +78,7 @@ class RssFeed < ActiveRecord::Base
 
   def self.eval_item_attr(script, rec)
     _ = rec # used by eval
-    if script.starts_with?("<script>") || script.starts_with?("<SCRIPT>")
+    if script.starts_with?("<script>", "<SCRIPT>")
       code = script.sub(/<script>|<SCRIPT>/, "").sub(/<\/script>|<\/SCRIPT>/, "").strip
       result = eval(code)
     else

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -591,7 +591,7 @@ module VimPerformanceAnalysis
     end
 
     result.each do |_k, h|
-      h[:min_max] = h.keys.find_all { |k| k.to_s.starts_with?("min") || k.to_s.starts_with?("max") }.inject({}) do |mm, k|
+      h[:min_max] = h.keys.find_all { |k| k.to_s.starts_with?("min", "max") }.inject({}) do |mm, k|
         val = h.delete(k)
         mm[k] = val unless val.nil?
         mm

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -212,7 +212,7 @@ class VimPerformanceDaily < MetricRollup
   def self.process_only_cols(options)
     unless options[:only_cols].nil?
       options[:only_cols] =  options[:only_cols].collect(&:to_sym) if options[:only_cols]
-      options[:only_cols] += options[:only_cols].collect { |c| c.to_s[4..-1].to_sym if c.to_s.starts_with?("min_") || c.to_s.starts_with?("max_") }.compact
+      options[:only_cols] += options[:only_cols].collect { |c| c.to_s[4..-1].to_sym if c.to_s.starts_with?("min_", "max_") }.compact
       options[:only_cols] += options[:only_cols].collect { |c| c.to_s.split("_")[2..-2].join("_").to_sym if c.to_s.starts_with?("abs_") }.compact
       options[:only_cols] += [:cpu_ready_delta_summation, :cpu_wait_delta_summation, :cpu_used_delta_summation] if options[:only_cols].find { |c| c.to_s.starts_with?("v_pct_") }
       options[:only_cols] += [:derived_storage_total, :derived_storage_free] if options[:only_cols].include?(:v_derived_storage_used)

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -179,7 +179,7 @@ class VimPerformanceDaily < MetricRollup
     results.each do |h|
       min_max = h.delete(:min_max)
 
-      h[:min_max] = h.keys.find_all { |k| k.to_s.starts_with?("min") || k.to_s.starts_with?("max") }.inject({}) do |mm, k|
+      h[:min_max] = h.keys.find_all { |k| k.to_s.starts_with?("min", "max") }.inject({}) do |mm, k|
         val = h.delete(k)
         mm[k] = val unless val.nil?
         mm

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -124,7 +124,7 @@ class VimPerformanceTagValue < ActiveRecord::Base
       col, tag = key.to_s.split(TAG_SEP)
       category = tag.split("/").first
       tag_name = tag.split("/").last
-      Metric::Aggregation::Process.average(key, nil, result, counts) unless col.to_s.starts_with?("assoc_ids") || col.to_s.starts_with?("derived_storage_vm_count")
+      Metric::Aggregation::Process.average(key, nil, result, counts) unless col.to_s.starts_with?("assoc_ids", "derived_storage_vm_count")
       new_rec = {
         :association_type => association_type,
         :category         => category,

--- a/app/models/vim_performance_trend.rb
+++ b/app/models/vim_performance_trend.rb
@@ -215,7 +215,7 @@ class VimPerformanceTrend < ActsAsArModel
   end
 
   def self.trend_limit_cols(db, col, interval)
-    col = col.starts_with?("min_") || col.starts_with?("max_") ? col[4..-1] : col
+    col = col.starts_with?("min_", "max_") ? col[4..-1] : col
     return [] unless TREND_COLS[db.to_sym]
     return [] unless TREND_COLS[db.to_sym][col.to_sym]
     return [] unless TREND_COLS[db.to_sym][col.to_sym][:limit_cols]

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -29,7 +29,7 @@
           miqSelectPickerEvent("cbtag_cat", "#{url}")
 
   - unless @edit[:new][:cbshow_typ].nil? || @edit[:new][:cbshow_typ] == "nil"
-    - if !@edit[:new][:cbshow_typ].ends_with?("-tags") || (@edit[:new][:cbshow_typ].ends_with?("-tags") && !@edit[:new][:cbtag_cat].blank?)
+    - if !@edit[:new][:cbshow_typ].ends_with?("-tags") || @edit[:new][:cbtag_cat].present?
       %hr
       %h3
         = _('Selections')


### PR DESCRIPTION
See [the docs](http://ruby-doc.org/core-2.2.3/String.html#method-i-start_with-3F). I also did the same for the `ends_with?` method.

@chessbyte I know this PR isn't extraordinary small. Initially I intended to send it as separate pull requests, but then I realized that 30 requests might be too many. Anyway, if you still want me to break this PR down - just let me know, I can easily do it semi-automatically with a script.