### PR TITLE
Add default settings for display view of providers, instances and VMs

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -197,6 +197,9 @@ module UiConstants
       :drift                                    => "expanded",
       :drift_mode                               => "details",
       :emscluster                               => "grid",
+      :emscloud                                 => "grid",
+      :emsinfra                                 => "grid",
+      :emscontainer                             => "grid",
       :filesystem                               => "list",
       :flavor                                   => "list",
       :host                                     => "grid",
@@ -241,8 +244,10 @@ module UiConstants
       :tagging                                  => "grid",
       :treesize                                 => "20",
       :vm                                       => "grid",
+      :vmcloud                                  => "grid",
       :vmortemplate                             => "grid",
       :vmcompare                                => "compressed",
+      :vminfra                                  => "grid"
     },
     :perpage   => { # Items per page, by view setting
       :grid    => 20,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1283093

Default view set to "grid" for:
 clouds:cloud providers,instances
 infrastructure:Infrastructure providers,vms
 container: container providers

before
![screen shot 2015-11-23 at 15 00 30](https://cloud.githubusercontent.com/assets/14937244/11338190/fb6ed022-91f2-11e5-8fb8-56c276cf0975.png)

add
![after](https://cloud.githubusercontent.com/assets/14937244/11337995/92c0a862-91f1-11e5-887d-c6012400cfec.png)
