### PR TITLE
Add container statuses summary

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -122,4 +122,24 @@ module ContainerGroupHelper::TextualSummary
       )
     }
   end
+
+  def textual_container_statuses_summary
+    %i(waiting running terminated)
+  end
+
+  def container_statuses_summary
+    @container_statuses_summary ||= @record.container_states_summary
+  end
+
+  def textual_waiting
+    container_statuses_summary[:waiting] || 0
+  end
+
+  def textual_running
+    container_statuses_summary[:running] || 0
+  end
+
+  def textual_terminated
+    container_statuses_summary[:terminated] || 0
+  end
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -25,6 +25,7 @@ class ContainerGroup < ActiveRecord::Base
   has_many :vim_performance_states, :as => :resource
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
+  virtual_column :running_containers_summary, :type => :string
 
   # Needed for metrics
   delegate :my_zone, :to => :ext_management_system
@@ -35,6 +36,15 @@ class ContainerGroup < ActiveRecord::Base
 
   def ready_condition_status
     ready_condition.try(:status) || 'None'
+  end
+
+  def container_states_summary
+    containers.group(:state).count.symbolize_keys
+  end
+
+  def running_containers_summary
+    summary = container_states_summary
+    "#{summary[:running] || 0}/#{summary.values.sum}"
   end
 
   # validates :restart_policy, :inclusion => { :in => %w(always onFailure never) }

--- a/app/views/container_group/_main.html.haml
+++ b/app/views/container_group/_main.html.haml
@@ -15,3 +15,5 @@
                                                                           :items => textual_group_conditions}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
                                                                     :items => textual_group_smart_management}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Container Statuses Summary"),
+                                                               :items => textual_container_statuses_summary}

--- a/product/views/ContainerGroup.yaml
+++ b/product/views/ContainerGroup.yaml
@@ -24,6 +24,7 @@ cols:
 - phase
 - restart_policy
 - dns_policy
+- running_containers_summary
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -44,6 +45,7 @@ col_order:
 - ext_management_system.name
 - container_project.name
 - ready_condition_status
+- running_containers_summary
 - phase
 - restart_policy
 - dns_policy
@@ -54,6 +56,7 @@ headers:
 - Provider
 - Project Name
 - Ready
+- Containers
 - Phase
 - Restart Policy
 - DNS Policy
@@ -73,6 +76,7 @@ sortby:
 - restart_policy
 - dns_policy
 - ready_condition_status
+- running_containers_summary
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION
Summarize containers statuses in the pod views: 

![con_sum_2911](https://cloud.githubusercontent.com/assets/11769555/11457000/2d96099c-96a5-11e5-9ad6-c4bac4a957d3.png)

![con_next](https://cloud.githubusercontent.com/assets/11769555/11528039/fa2585e8-98ec-11e5-9cc7-47fb63af29d1.png)

