### PR TITLE
Add deprecated warnings when passing parse_ws_string string arguments

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -370,7 +370,6 @@ class MiqRequestWorkflow
   def self.parse_request_parameter_hash(parameter_hash, options = {})
     parameter_hash.each_with_object({}) do |param, hash|
       key, value = param
-      next if value.blank?
       key = key.strip.downcase.to_sym unless options[:modify_key_name] == false
       hash[key] = value
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -351,6 +351,11 @@ class MiqRequestWorkflow
   def self.parse_ws_string(text_input, options = {})
     return parse_request_parameter_hash(text_input, options) if text_input.kind_of?(Hash)
     return {} unless text_input.kind_of?(String)
+
+    deprecated_warn = "method: parse_ws_string, arg Type => String"
+    solution = "arg should be a hash"
+    MiqAeMethodService::Deprecation.deprecation_warning(deprecated_warn, solution)
+
     result = {}
     text_input.split('|').each do |value|
       next if value.blank?

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -12,36 +12,44 @@ describe MiqHostProvisionWorkflow do
 
         FactoryGirl.create(:user_admin)
 
-        @templateFields = "mac_address=aa:bb:cc:dd:ee:ff|ipmi_address=127.0.0.1|"
-        @requester      = "owner_email=tester@miq.com|owner_first_name=tester|owner_last_name=tester"
-        @hostFields = <<-HOST_FIELDS
-                          pxe_server_id=127.0.0.1|
-                          pxe_image_id=ESXi 4.1-260247|
-                          root_password=smartvm|
-                          addr_mode=dhcp|
-                      HOST_FIELDS
+        @template_fields = {'mac_address' => 'aa:bb:cc:dd:ee:ff', 'ipmi_address' => '127.0.0.1'}
+        @requester = {'owner_email' => 'tester@miq.com', 'owner_first_name' => 'tester', 'owner_last_name' => 'tester'}
+        @host_fields = {'pxe_server_id' => '127.0.0.1', 'pxe_image_id' => 'ESXi 4.1-260247',
+                           'root_password' => 'smartvm', 'addr_mode' => 'dhcp'}
 
         FactoryGirl.create(:miq_dialog_host_provision)
       end
 
       context "Without a Valid IPMI Host," do
         it "should not create an MiqRequest when calling from_ws" do
-          -> { MiqHostProvisionWorkflow.from_ws("1.1", user, @templateFields, @hostFields, @requester, false, nil, nil) }.should raise_error(RuntimeError)
+          lambda do
+            MiqHostProvisionWorkflow.from_ws("1.1", user, @template_fields, @host_fields, @requester, false, nil, nil)
+              .should raise_error(RuntimeError)
+          end
         end
       end
 
       context "With a Valid IPMI Host," do
         before(:each) do
-          ems        = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => @server.zone)
-          host       = FactoryGirl.create(:host_with_ipmi, :ext_management_system => ems)
-          pxe_server = FactoryGirl.create(:pxe_server, :name => 'PXE on 127.0.0.1', :uri_prefix => 'nfs', :uri => 'nfs://127.0.0.1/srv/tftpboot')
-          pxe_image  = FactoryGirl.create(:pxe_image, :name => 'VMware ESXi 4.1-260247', :pxe_server => pxe_server)
+          ems = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => @server.zone)
+          FactoryGirl.create(:host_with_ipmi, :ext_management_system => ems)
+          pxe_server = FactoryGirl.create(:pxe_server,
+                                          :name       => 'PXE on 127.0.0.1',
+                                          :uri_prefix => 'nfs',
+                                          :uri        => 'nfs://127.0.0.1/srv/tftpboot')
+          FactoryGirl.create(:pxe_image,
+                             :name       => 'VMware ESXi 4.1-260247',
+                             :pxe_server => pxe_server
+                            )
         end
 
         it "should create an MiqRequest when calling from_ws" do
-          request = MiqHostProvisionWorkflow.from_ws("1.1", user, @templateFields, @hostFields, @requester, false, nil, nil)
+          request = MiqHostProvisionWorkflow.from_ws("1.1", user,
+                                                     @template_fields,
+                                                     @host_fields,
+                                                     @requester, false, nil, nil)
           request.should be_a_kind_of(MiqRequest)
-          opt = request.options
+          request.options
         end
       end
     end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -69,38 +69,12 @@ describe MiqProvisionWorkflow do
           MiqPassword.decrypt(request.options[:root_password]).should == password_input
         end
 
-        it "should set values when extra '|' are passed in" do
-          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
-            nil, nil, {'abc' => 'tr|ue', 'blah' => 'nah'}, nil, nil)
-
-          expect(request.options[:ws_values]).to include(:abc => "tr|ue")
-        end
-
         it "should set values when extra '|' are passed in for multiple values" do
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
             "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
             nil, nil, {'abc' => 'tr|ue', 'blah' => 'na|h'}, nil, nil)
 
           expect(request.options[:ws_values]).to include(:blah => "na|h")
-        end
-
-        it "should set values" do
-          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
-            nil, nil, {'abc' => 'true', 'blah' => 'nah'}, nil, nil)
-
-          expect(request.options[:ws_values]).to include(:abc => "true")
-        end
-
-        it "should set values correctly when a string is passed" do
-          Vmdb::Deprecation.silenced do
-            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-              "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
-              nil, nil, "abc=true|blah=nah", nil, nil)
-
-            expect(request.options[:ws_values]).to include(:abc => "true")
-          end
         end
 
         it "should set values when only a single key value pair is passed in as a string" do
@@ -118,16 +92,6 @@ describe MiqProvisionWorkflow do
             request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
               "1.1", admin, "name=template", "vm_name=spec_test",
               nil, nil, "abc=true", nil, nil)
-
-            expect(request.options[:ws_values]).to include(:abc => "true")
-          end
-        end
-
-        it "should set values when only a single key value pair is passed in" do
-          Vmdb::Deprecation.silenced do
-            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-              "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
-              nil, nil, {'abc' => 'true'}, nil, nil)
 
             expect(request.options[:ws_values]).to include(:abc => "true")
           end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -23,19 +23,26 @@ describe MiqProvisionWorkflow do
 
       context "With a Valid Template," do
         before(:each) do
-          @ems         = FactoryGirl.create(:ems_vmware,  :name => "Test EMS",  :zone => server.zone)
-          @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on', :ext_management_system => @ems)
-          @vm_template = FactoryGirl.create(:template_vmware, :name => "template", :ext_management_system => @ems, :host => @host)
-          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro", :memory_mb => 512, :cpu_sockets => 2)
+          @ems         = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => server.zone)
+          @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on',
+                                            :ext_management_system => @ems)
+          @vm_template = FactoryGirl.create(:template_vmware, :name => "template", :ext_management_system => @ems,
+                                            :host => @host)
+          @hardware    = FactoryGirl.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro",
+                                            :memory_mb => 512,
+                                            :cpu_sockets => 2)
           @switch      = FactoryGirl.create(:switch, :name => 'vSwitch0', :ports => 32, :host => @host)
           @lan         = FactoryGirl.create(:lan, :name => "VM Network", :switch => @switch)
-          @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan, :device_type => 'ethernet', :controller_type => 'ethernet', :address => '00:50:56:ba:10:6b', :present => false, :start_connected => true)
+          @ethernet    = FactoryGirl.create(:guest_device, :hardware => @hardware, :lan => @lan,
+                                            :device_type => 'ethernet',
+                                            :controller_type => 'ethernet', :address => '00:50:56:ba:10:6b',
+                                            :present => false, :start_connected => true)
         end
 
         it "should create an MiqRequest when calling from_ws" do
           FactoryGirl.create(:classification_cost_center_with_tags)
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.0", admin, "template", "target", false, "cc|001|environment|test","")
+            "1.0", admin, "template", "target", false, "cc|001|environment|test", "")
           request.should be_a_kind_of(MiqRequest)
 
           expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
@@ -44,7 +51,8 @@ describe MiqProvisionWorkflow do
         it "should set tags" do
           FactoryGirl.create(:classification_cost_center_with_tags)
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, "name=template", "vm_name=spec_test", nil, "cc=001|environment=test", nil, nil, nil)
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'}, nil,
+            {'cc' => '001', 'environment' => 'test'}, nil, nil, nil)
           request.should be_a_kind_of(MiqRequest)
 
           expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
@@ -53,19 +61,76 @@ describe MiqProvisionWorkflow do
         it "should encrypt fields" do
           password_input = "secret"
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, "name=template", "vm_name=spec_test|root_password=#{password_input}",
-            "owner_email=admin|owner_first_name=test|owner_last_name=test", nil, nil, nil, nil)
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test', 'root_password' => "#{password_input}"},
+            {'owner_email' => 'admin'}, {'owner_first_name' => 'test'},
+            {'owner_last_name' => 'test'}, nil, nil, nil, nil)
 
           MiqPassword.encrypted?(request.options[:root_password]).should be_true
           MiqPassword.decrypt(request.options[:root_password]).should == password_input
         end
 
+        it "should set values when extra '|' are passed in" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+            nil, nil, {'abc' => 'tr|ue', 'blah' => 'nah'}, nil, nil)
+
+          expect(request.options[:ws_values]).to include(:abc => "tr|ue")
+        end
+
+        it "should set values when extra '|' are passed in for multiple values" do
+          request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+            nil, nil, {'abc' => 'tr|ue', 'blah' => 'na|h'}, nil, nil)
+
+          expect(request.options[:ws_values]).to include(:blah => "na|h")
+        end
+
         it "should set values" do
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, "name=template", "vm_name=spec_test",
-            nil, nil, "abc=true", nil, nil)
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+            nil, nil, {'abc' => 'true', 'blah' => 'nah'}, nil, nil)
 
           expect(request.options[:ws_values]).to include(:abc => "true")
+        end
+
+        it "should set values correctly when a string is passed" do
+          Vmdb::Deprecation.silenced do
+            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+              "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+              nil, nil, "abc=true|blah=nah", nil, nil)
+
+            expect(request.options[:ws_values]).to include(:abc => "true")
+          end
+        end
+
+        it "should set values when only a single key value pair is passed in as a string" do
+          Vmdb::Deprecation.silenced do
+            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+              "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+              nil, nil, "abc=true", nil, nil)
+
+            expect(request.options[:ws_values]).to include(:abc => "true")
+          end
+        end
+
+        it "should set values when all args are passed in as a string" do
+          Vmdb::Deprecation.silenced do
+            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+              "1.1", admin, "name=template", "vm_name=spec_test",
+              nil, nil, "abc=true", nil, nil)
+
+            expect(request.options[:ws_values]).to include(:abc => "true")
+          end
+        end
+
+        it "should set values when only a single key value pair is passed in" do
+          Vmdb::Deprecation.silenced do
+            request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
+              "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'},
+              nil, nil, {'abc' => 'true'}, nil, nil)
+
+            expect(request.options[:ws_values]).to include(:abc => "true")
+          end
         end
       end
 


### PR DESCRIPTION
parse_ws_string always accepted arguments as a hash
And in the case of this bug: sending multiple '|' delimited
arguments as a hash solves the original problem.  This fix
adds deprecation warnings to parse_ws_string when arguments
are sent as a string - noting the solution in the warning text.