### PR TITLE
Do not log "a group seed changed" when it did not

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -96,9 +96,11 @@ class MiqGroup < ActiveRecord::Base
         group.group_type    = SYSTEM_GROUP
         group.tenant        = root_tenant
 
-        mode = group.new_record? ? "Created" : "Added"
-        group.save!
-        _log.info("#{mode} Group: #{group.description} with Role: #{user_role.name}")
+        if group.changed?
+          mode = group.new_record? ? "Created" : "Updated"
+          group.save!
+          _log.info("#{mode} Group: #{group.description} with Role: #{user_role.name}")
+        end
 
         seq += 1
       end


### PR DESCRIPTION
Before:

```
MIQ(EvmDatabase.seed) Seeding MiqGroup
MIQ(MiqGroup.seed) Added Group: EvmGroup-super_administrator with Role: EvmRole-super_administrator
MIQ(MiqGroup.seed) Added Group: EvmGroup-operator with Role: EvmRole-operator
MIQ(MiqGroup.seed) Added Group: EvmGroup-user with Role: EvmRole-user
MIQ(MiqGroup.seed) Added Group: EvmGroup-administrator with Role: EvmRole-administrator
MIQ(MiqGroup.seed) Added Group: EvmGroup-approver with Role: EvmRole-approver
MIQ(MiqGroup.seed) Added Group: EvmGroup-auditor with Role: EvmRole-auditor
MIQ(MiqGroup.seed) Added Group: EvmGroup-support with Role: EvmRole-support
MIQ(MiqGroup.seed) Added Group: EvmGroup-vm_user with Role: EvmRole-vm_user
MIQ(MiqGroup.seed) Added Group: EvmGroup-security with Role: EvmRole-security
MIQ(MiqGroup.seed) Added Group: EvmGroup-desktop with Role: EvmRole-desktop
MIQ(MiqGroup.seed) Added Group: EvmGroup-user_self_service with Role: EvmRole-user_self_service
MIQ(MiqGroup.seed) Added Group: EvmGroup-user_limited_self_service with Role: EvmRole-user_limited_self_service
MIQ(MiqGroup.seed) Added Group: EvmGroup-tenant_administrator with Role: EvmRole-tenant_administrator
MIQ(MiqGroup.seed) Added Group: EvmGroup-tenant_quota_administrator with Role: EvmRole-tenant_quota_administrator
```

after:

```
MIQ(EvmDatabase.seed) Seeding MiqGroup
```

/cc @jrafanie @Fryguy 