### PR TITLE
BZ1271104 - Fix for inability to create service dialog with a dynamic drop down list

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -698,7 +698,7 @@ module MiqAeCustomizationController::Dialogs
         add_flash(_("%s is required") % "Element Type", :error)
         res = false
       end
-      if @edit[:field_typ] == "DialogFieldDropDownList" && @edit[:field_values].empty?
+      if needs_dropdown_values?
         add_flash(_("Dropdown elements require some entries"), :error)
         res = false
       end
@@ -1386,5 +1386,9 @@ module MiqAeCustomizationController::Dialogs
 
   def needs_entry_point?
     @edit[:field_dynamic] && @edit[:field_entry_point].blank?
+  end
+
+  def needs_dropdown_values?
+    @edit[:field_typ] == "DialogFieldDropDownList" && @edit[:field_values].empty? && !@edit[:field_dynamic]
   end
 end

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -133,5 +133,20 @@ describe MiqAeCustomizationController do
       controller.send(:dialog_validate)
       assigns(:flash_array).first[:message].should include("Dropdown elements require some entries")
     end
+
+    it "does not require values for a dynamic drop down" do
+      controller.stub(:x_node) { 'root_-0_-0_-0' }
+      controller.instance_variable_set(:@sb, :node_typ => 'element')
+      session[:edit] = {
+        :field_typ         => "DialogFieldDropDownList",
+        :field_values      => [],
+        :field_label       => 'Dropdown 1',
+        :field_name        => 'Dropdown1',
+        :field_dynamic     => true,
+        :field_entry_point => "entry point"
+      }
+      controller.send(:dialog_validate)
+      assigns(:flash_array).should eq(nil)
+    end
   end
 end


### PR DESCRIPTION
Allow saving DialogFieldDropDownList without values when it is dynamic. The values will come from the dynamic method that is chosen so the check for the values is not necessary.

https://bugzilla.redhat.com/show_bug.cgi?id=1271104

@gmcculloug Please Review