### PR TITLE
Fix missing check all (paging controls) in Configure > Tasks

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -841,25 +841,12 @@ function miqEnterPressed(e) {
 }
 
 // Send login authentication via ajax
-function miqAjaxAuth(button) {
-  if (button == null) {
-    miqEnableLoginFields(false);
-    miqJqueryRequest(
-      '/dashboard/authenticate',
-      {beforeSend: true, data: miqSerializeForm('login_div')}
-    );
-  } else if (button == 'more' || button == 'back') {
-    miqJqueryRequest(
-      '/dashboard/authenticate?' +
-      miqSerializeForm('login_div') + '&button=' + button
-    );
-  } else {
-    miqEnableLoginFields(false);
-    miqAsyncAjax(
-      '/dashboard/authenticate?' +
-      miqSerializeForm('login_div') + '&button=' + button
-    );
-  }
+function miqAjaxAuth() {
+  miqEnableLoginFields(false);
+  miqJqueryRequest('/dashboard/authenticate', {
+    beforeSend: true,
+    data: miqSerializeForm('login_div'),
+  });
 }
 
 function miqEnableLoginFields(enabled) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,13 +125,6 @@ class ApplicationController < ActionController::Base
   end
   hide_action :render_exception
 
-  # Put out error msg if user's role is not authorized for an action
-  def auth_error
-    add_flash(_("The user is not authorized for this task or item."), :error)
-    add_flash(_("Press your browser's Back button or click a tab to continue"))
-    #   render(:text=>"User is not authorized for this task . . . press your browser's Back button to continue")
-  end
-
   def change_tab
     redirect_to(:action => params[:tab], :id => params[:id])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1956,7 +1956,7 @@ class ApplicationController < ActionController::Base
 
     render :update do |page|                        # Use RJS to update the display
       page.replace(:flash_msg_div, :partial => "layouts/flash_msg")           # Replace the flash message
-      page << "miqSetButtons(0,'center_tb');" # Reset the center toolbar
+      page << "miqSetButtons(0, 'center_tb');" # Reset the center toolbar
       unless @layout == "dashboard" && ["show", "change_tab", "auth_error"].include?(@controller.action_name) ||
              %w(about all_tasks all_ui_tasks configuration diagnostics miq_ae_automate_button
                 miq_ae_customization miq_ae_export miq_ae_logs miq_ae_tools miq_policy miq_policy_export

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1957,11 +1957,7 @@ class ApplicationController < ActionController::Base
     render :update do |page|                        # Use RJS to update the display
       page.replace(:flash_msg_div, :partial => "layouts/flash_msg")           # Replace the flash message
       page << "miqSetButtons(0, 'center_tb');" # Reset the center toolbar
-      unless @layout == "dashboard" && ["show", "change_tab", "auth_error"].include?(@controller.action_name) ||
-             %w(about all_tasks all_ui_tasks configuration diagnostics miq_ae_automate_button
-                miq_ae_customization miq_ae_export miq_ae_logs miq_ae_tools miq_policy miq_policy_export
-                miq_policy_logs miq_request_ae miq_request_configured_system miq_request_host
-                miq_request_vm my_tasks my_ui_tasks report rss server_build).include?(@layout)
+      if layout_uses_listnav?
         page.replace(:listnav_div, :partial => "layouts/listnav")               # Replace accordion, if list_nav_div is there
       end
       if @grid_hash

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -616,6 +616,12 @@ class DashboardController < ApplicationController
     end
   end
 
+  # Put out error msg if user's role is not authorized for an action
+  def auth_error
+    add_flash(_("The user is not authorized for this task or item."), :error)
+    add_flash(_("Press your browser's Back button or click a tab to continue"))
+  end
+
   private
 
   def tl_toggle_button_enablement(button_id, enablement, typ)

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -73,6 +73,7 @@ class MiqTaskController < ApplicationController
       get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
         page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
+        page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
     else                      # Came in from non-ajax, just get the jobs

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -8,10 +8,8 @@ class MiqTaskController < ApplicationController
     @tabform = nil
     @tabform ||= "tasks_1" if role_allows(:feature => "job_my_smartproxy")
     @tabform ||= "tasks_2" if role_allows(:feature => "miq_task_my_ui")
-    @tabform ||= "tasks_3" if role_allows(:feature => "job_all_smartproxy") &&
-                              role_allows(:feature => "job_all_smartproxy")
-    @tabform ||= "tasks_4" if role_allows(:feature => "miq_task_all_ui") &&
-                              role_allows(:feature => "miq_task_all_ui")
+    @tabform ||= "tasks_3" if role_allows(:feature => "job_all_smartproxy")
+    @tabform ||= "tasks_4" if role_allows(:feature => "miq_task_all_ui")
     jobs
     render :action => "jobs"
   end
@@ -38,14 +36,15 @@ class MiqTaskController < ApplicationController
       @tabs ||= [["2", ""]]
       @tabs.push(["2", "My Other UI Tasks"])
     end
-    if role_allows(:feature => "job_all_smartproxy") && role_allows(:feature => "job_all_smartproxy")
+    if role_allows(:feature => "job_all_smartproxy")
       @tabs ||= [["3", ""]]
       @tabs.push(["3", "All VM Analysis Tasks"])
     end
-    if role_allows(:feature => "miq_task_all_ui") && role_allows(:feature => "miq_task_all_ui")
+    if role_allows(:feature => "miq_task_all_ui")
       @tabs ||= [["4", ""]]
       @tabs.push(["4", "All Other Tasks"])
     end
+
     case @tabform
     when "tasks_1"
       @tabs[0][0] = "1"

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -82,22 +82,21 @@ class MiqTaskController < ApplicationController
   end
 
   def get_jobs(conditions)
+    @lastaction = "jobs"
+
     if @tabform == "tasks_1"
       @layout = "my_tasks"
-      @lastaction = "jobs"
       @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => "My VM Analysis Tasks", :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_2"
       # My UI Tasks
       @layout = "my_ui_tasks"
-      @lastaction = "ui_jobs"
       @view, @pages = get_view(MiqTask, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => "My Other UI Tasks", :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_3" || @tabform == "alltasks_1"
       @layout = "all_tasks"
-      @lastaction = "all_jobs"
       @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => "All VM Analysis Tasks", :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = Job.distinct("userid").pluck("userid").delete_if(&:blank?)
@@ -105,7 +104,6 @@ class MiqTaskController < ApplicationController
     elsif @tabform == "tasks_4" || @tabform == "alltasks_2"
       # All UI Tasks
       @layout = "all_ui_tasks"
-      @lastaction = "all_ui_jobs"
       @view, @pages = get_view(MiqTask, :conditions => conditions)  # Get the records (into a view) and the paginator
       drop_breadcrumb(:name => "All Other Tasks", :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = MiqTask.distinct("userid").pluck("userid").delete_if(&:blank?)

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -270,10 +270,10 @@ class MiqTaskController < ApplicationController
     render :update do |page|                    # Use RJS to update the display
       unless @refresh_partial.nil?
         if @refresh_div == "flash_msg_div"
-          page << "miqSetButtons(0,'center_tb');"                             # Reset the center toolbar
+          page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace(@refresh_div, :partial => @refresh_partial)
         else
-          page << "miqSetButtons(0,'center_tb');"                             # Reset the center toolbar
+          page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace_html("main_div", :partial => @refresh_partial)
         end
       end
@@ -315,7 +315,7 @@ class MiqTaskController < ApplicationController
 
     render :update do |page|
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-      page << "miqSetButtons(0,'center_tb');"                             # Reset the center toolbar
+      page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
       page << "miqSparkle(false);"
     end

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -273,6 +273,7 @@ class MiqTaskController < ApplicationController
         else
           page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace_html("main_div", :partial => @refresh_partial)
+          page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         end
       end
     end
@@ -315,6 +316,7 @@ class MiqTaskController < ApplicationController
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
+      page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -37,6 +37,16 @@ module ApplicationHelper::PageLayouts
     true
   end
 
+  def layout_uses_paging?
+    # listnav always implies paging, this only handles the non-listnav case
+    %w(
+      all_tasks
+      all_ui_tasks
+      my_tasks
+      my_ui_tasks
+    ).include? @layout
+  end
+
   def layout_uses_tabs?
     if (["timeline"].include?(@layout) && ! @in_a_form) ||
        ["login", "authenticate", "auth_error"].include?(controller.action_name) ||

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -1,20 +1,40 @@
 module ApplicationHelper::PageLayouts
   def layout_uses_listnav?
-    if !(@layout == "dashboard" && ["show", "change_tab", "auth_error"].include?(controller.action_name) ||
-         @layout == "report" ||
-         @layout == "exception" ||
-         @layout == "chargeback" ||
-         @layout == "container_topology" ||
-         @layout == "container_dashboard" ||
-         @layout.starts_with?("miq_request") ||
-         %w(about all_tasks all_ui_tasks configuration diagnostics miq_ae_automate_button miq_ae_export
-            miq_ae_logs miq_ae_tools miq_policy miq_policy_export miq_policy_logs my_tasks my_ui_tasks
-            ops pxe rss server_build).include?(@layout)) &&
-       @showtype != "dialog_provision" && !controller.action_name.end_with?("tagging_edit")
-      return true
-    else
-      return false
-    end
+    return false if %w(
+      about
+      all_tasks
+      all_ui_tasks
+      chargeback
+      configuration
+      container_dashboard
+      container_topology
+      diagnostics
+      exception
+      miq_ae_automate_button
+      miq_ae_export
+      miq_ae_logs
+      miq_ae_tools
+      miq_policy
+      miq_policy_export
+      miq_policy_logs
+      my_tasks
+      my_ui_tasks
+      ops
+      pxe
+      report
+      rss
+      server_build
+    ).include?(@layout)
+
+    return false if @layout == "dashboard" && ["show", "change_tab", "auth_error"].include?(controller.action_name)
+
+    return false if @layout.starts_with?("miq_request")
+
+    return false if @showtype == "dialog_provision"
+
+    return false if controller.action_name.end_with?("tagging_edit")
+
+    true
   end
 
   def layout_uses_tabs?

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -26,7 +26,7 @@ module ApplicationHelper::PageLayouts
       server_build
     ).include?(@layout)
 
-    return false if @layout == "dashboard" && ["show", "change_tab", "auth_error"].include?(controller.action_name)
+    return false if dashboard_no_listnav?
 
     return false if @layout.starts_with?("miq_request")
 
@@ -60,5 +60,13 @@ module ApplicationHelper::PageLayouts
       "my_ui_tasks",
       "all_tasks",
       "all_ui_tasks"].include?(@layout)
+  end
+
+  def dashboard_no_listnav?
+    @layout == "dashboard" && %w(
+      auth_error
+      change_tab
+      show
+    ).include?(controller.action_name)
   end
 end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -11,6 +11,7 @@ module ApplicationHelper::PageLayouts
       diagnostics
       exception
       miq_ae_automate_button
+      miq_ae_customization
       miq_ae_export
       miq_ae_logs
       miq_ae_tools

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -101,7 +101,7 @@
         .col-md-2.col-md-pull-10.sidebar-pf.sidebar-pf-left
           = render :partial => "layouts/listnav"
 
-      - elsif  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
+      - elsif dashboard_no_listnav?
         .col-md-12.max-height
           .row.toolbar-pf#toolbar
             .col-md-12

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -63,16 +63,9 @@
           = yield :left
         #custom_left_cell
 - else
-  -#.container-fluid.resizable-sidebar{:style => "overflow: hidden; height: 100%; background: #fff;"}ű
   .container-fluid{:style => "overflow: hidden; height: 100%;"}
     .row.scrollable-sm#center_div{:style => "height: 100%"}
       - if layout_uses_listnav?
-        -# Helper variables for the sidebar
-          - session[:sidebar] ||= {}
-          - sidewidth = session[:sidebar][params[:controller]] ||= 2
-          - maindiv = 12 - sidewidth
-          - sidebar = sidewidth == 0 ? 'hidden-md hidden-lg col-md-0' : "col-md-#{sidewidth} col-md-pull-#{maindiv}"
-        -# .max-height.resizable{:class => "col-md-#{maindiv} col-md-push-#{sidewidth}"}
         .col-md-10.col-md-push-2.max-height
           - if !@in_a_form && taskbar_in_header?
             .row.toolbar-pf#toolbar
@@ -105,15 +98,6 @@
                                            :headers    => @view.headers,
                                            :button_div => 'center_tb'})
 
-          -# Resizing buttons for the resizable sidebar
-            .resizer.hidden-xs
-              .resizer-box
-                .btn-group
-                  .btn.btn-default.resize-left
-                    %span.fa.fa-angle-left
-                  .btn.btn-default.resize-right{:class => sidewidth == 5 ? 'btn-disabled' : ''}
-                    %span.fa.fa-angle-right
-        -#.sidebar-pf.sidebar-pf-left.scrollable-lg.resizable{:class => sidebar}
         .col-md-2.col-md-pull-10.sidebar-pf.sidebar-pf-left
           = render :partial => "layouts/listnav"
 

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -119,37 +119,6 @@
               .row
                 .col-md-12
                   = yield
-      - elsif layout_uses_paging?
-        .col-md-12.max-height
-          - if !@in_a_form && taskbar_in_header?
-            .row.toolbar-pf#toolbar
-              .col-md-12
-                .toolbar-pf-actions
-                  = render :partial => "layouts/taskbar"
-          #main-content.row
-            .col-md-12
-              .row
-                .col-md-12
-                  = render :partial => "layouts/breadcrumbs"
-              - if layout_uses_tabs?
-                .row
-                  .col-md-12
-                    = render :partial => 'layouts/tabs'
-              .row
-                .col-md-12
-                  = yield
-          - unless @in_a_form
-            .row.toolbar-pf#paging_div
-              .col-md-12
-                .toolbar-pf-actions
-                  - unless @embedded
-                    - if @pages && @items_per_page != ONE_MILLION
-                      = render(:partial => '/layouts/pagingcontrols',
-                              :locals => {:pages      => @pages,
-                                           :action_url => action_url_for_views,
-                                           :db         => @view.db,
-                                           :headers    => @view.headers,
-                                           :button_div => 'center_tb'})
       - else
         .col-md-12.max-height
           - if !@in_a_form && taskbar_in_header?
@@ -169,6 +138,19 @@
               .row
                 .col-md-12
                   = yield
+          - if layout_uses_paging? && !@in_a_form
+            .row.toolbar-pf#paging_div
+              .col-md-12
+                .toolbar-pf-actions
+                  - unless @embedded
+                    - if @pages && @items_per_page != ONE_MILLION
+                      = render(:partial => '/layouts/pagingcontrols',
+                              :locals => {:pages      => @pages,
+                                           :action_url => action_url_for_views,
+                                           :db         => @view.db,
+                                           :headers    => @view.headers,
+                                           :button_div => 'center_tb'})
+
 - if show_advanced_search?
   :javascript
     #{javascript_show_if_exists("adv_searchbox_div")}

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -119,6 +119,37 @@
               .row
                 .col-md-12
                   = yield
+      - elsif layout_uses_paging?
+        .col-md-12.max-height
+          - if !@in_a_form && taskbar_in_header?
+            .row.toolbar-pf#toolbar
+              .col-md-12
+                .toolbar-pf-actions
+                  = render :partial => "layouts/taskbar"
+          #main-content.row
+            .col-md-12
+              .row
+                .col-md-12
+                  = render :partial => "layouts/breadcrumbs"
+              - if layout_uses_tabs?
+                .row
+                  .col-md-12
+                    = render :partial => 'layouts/tabs'
+              .row
+                .col-md-12
+                  = yield
+          - unless @in_a_form
+            .row.toolbar-pf#paging_div
+              .col-md-12
+                .toolbar-pf-actions
+                  - unless @embedded
+                    - if @pages && @items_per_page != ONE_MILLION
+                      = render(:partial => '/layouts/pagingcontrols',
+                              :locals => {:pages      => @pages,
+                                           :action_url => action_url_for_views,
+                                           :db         => @view.db,
+                                           :headers    => @view.headers,
+                                           :button_div => 'center_tb'})
       - else
         .col-md-12.max-height
           - if !@in_a_form && taskbar_in_header?


### PR DESCRIPTION
This introduces a new _content layout variant which has no listnav but has paging controls - controlled by (new) `layout_uses_paging?` and adds a page.replace for pagingcontrols on update.

\+ various cleanup and refactors in related code:
   * `miqAjaxAuth` (js) is only ever called without args, removed unused logic
   * `auth_error` is only used on `DashboardController`, moved there from `ApplicationController`
   * `ApplicationControlller#replace_gtl_main_div` - condition around listnav replacement looked suspiciously like `layout_uses_listnav?`, using that now
   * `MiqTaskController` would do some feature checks twice in a row, fixed
   * `layout_uses_listnav?` had a complex condition - split up
   * replaced all layout=dashboard & action=show|change_tab|auth_error conditions with a new helper (`dashboard_no_listnav?`)
   * removed commented out code from _content layout template

https://bugzilla.redhat.com/show_bug.cgi?id=1276789