### PR TITLE
Display MIQ/Red Hat Automate domain current/available version in the UI.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -170,6 +170,7 @@ class MiqAeClassController < ApplicationController
       # need to set record as Domain record if it's a domain, editable_domains, enabled_domains,
       # visible domains methods returns list of Domains, need this for toolbars to hide/disable correct records.
       @record = MiqAeDomain.find_by_id(from_cid(id[1])) if @record.domain?
+      @version_message = domain_version_message(@record) if @record.domain?
       if @record.nil?
         set_root_node
       else
@@ -189,12 +190,24 @@ class MiqAeClassController < ApplicationController
       end
     else
       @grid_data = User.current_tenant.visible_domains
+      add_all_domains_version_message(@grid_data)
       @record = nil
       @right_cell_text = "Datastore"
       @sb[:active_tab] = "namespaces"
       set_right_cell_text(x_node)
     end
     x_history_add_item(:id => x_node, :text => @right_cell_text)
+  end
+
+  def domain_version_message(domain)
+    version = domain.version
+    available_version = domain.available_version
+    return if version.nil? || available_version.nil?
+    _("%s domain: Currently version - %s, Available version - %s") % [domain.name, version, available_version] if version != available_version
+  end
+
+  def add_all_domains_version_message(domains)
+    @version_messages = domains.collect { |dom| domain_version_message(dom) }.compact
   end
 
   # Tree node selected in explorer

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -1,5 +1,6 @@
 #ns_details_div
   - unless @in_a_form
+    = render :partial => 'layouts/info_msg', :locals => {:message => @version_message} if @version_message
     = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_ns_details"}
     %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -1,5 +1,8 @@
 #ns_list_div
   - if !@in_a_form
+    - unless @version_messages.blank?
+      - @version_messages.each do |msg|
+        = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead


### PR DESCRIPTION
Added changes to Display MIQ/Red Hat Automate domain current/available versions in the UI if they both don't match.

https://bugzilla.redhat.com/show_bug.cgi?id=1283037


@mkanoor @gmcculloug please review, This PR should be merged after https://github.com/ManageIQ/manageiq/pull/5548 is merged..