### PR TITLE
Refactor OrchestrationStack to return all VMs

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -16,9 +16,14 @@ class OrchestrationStack < ActiveRecord::Base
   belongs_to :orchestration_template
   belongs_to :cloud_tenant
 
-  has_many   :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
-  has_many   :security_groups
-  has_many   :cloud_networks
+  has_many   :direct_vms,             :class_name => "ManageIQ::Providers::CloudManager::Vm"
+  has_many   :direct_security_groups, :class_name => "SecurityGroup"
+  has_many   :direct_cloud_networks,  :class_name => "CloudNetwork"
+
+  virtual_has_many :vms, :class_name => "ManageIQ::Providers::CloudManager::Vm"
+  virtual_has_many :security_groups
+  virtual_has_many :cloud_networks
+
   has_many   :parameters, :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackParameter"
   has_many   :outputs,    :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackOutput"
   has_many   :resources,  :dependent => :destroy, :foreign_key => :stack_id, :class_name => "OrchestrationStackResource"
@@ -42,6 +47,26 @@ class OrchestrationStack < ActiveRecord::Base
   def total_cloud_networks
     cloud_networks.size
   end
+
+  def vms
+    directs_and_indirects(:direct_vms)
+  end
+
+  def security_groups
+    directs_and_indirects(:direct_security_groups)
+  end
+
+  def cloud_networks
+    directs_and_indirects(:direct_cloud_networks)
+  end
+
+  def directs_and_indirects(direct_attrs)
+    return send(direct_attrs) if descendants.blank?
+
+    indirects = descendants.inject([]) { |arr, child| arr << child.send(direct_attrs) }
+    (indirects << send(direct_attrs)).flatten
+  end
+  private :directs_and_indirects
 
   def self.create_stack(orchestration_manager, stack_name, template, options = {})
     klass = orchestration_manager.class::OrchestrationStack

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -75,6 +75,18 @@ class ServiceOrchestration < Service
     converter.stack_create_options.merge(tenant_option)
   end
 
+  def indirect_vms
+    all_vms - direct_vms
+  end
+
+  def direct_vms
+    orchestration_stack.try(:direct_vms) || []
+  end
+
+  def all_vms
+    orchestration_stack.try(:vms) || []
+  end
+
   private
 
   def build_stack_create_options

--- a/spec/models/miq_expression/model_details_spec.rb
+++ b/spec/models/miq_expression/model_details_spec.rb
@@ -132,7 +132,7 @@ describe MiqExpression do
       end
 
       it "one_to_many relation" do
-        @ref = OrchestrationStack.reflect_on_association(:vms)
+        @ref = OrchestrationStack.reflections_with_virtual[:vms]
         expect(subject).to eq(@ref.klass.model_name.plural)
       end
     end

--- a/spec/models/orchestration_stack_spec.rb
+++ b/spec/models/orchestration_stack_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe OrchestrationStack do
+  describe 'direct_<resource> methods' do
+    let(:root_stack) do
+      stack1 = FactoryGirl.create(:orchestration_stack)
+      stack2 = FactoryGirl.create(:orchestration_stack, :parent => stack1)
+
+      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack1)
+      FactoryGirl.create(:cloud_network, :orchestration_stack => stack1)
+      FactoryGirl.create(:security_group, :orchestration_stack => stack1)
+
+      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack2)
+      FactoryGirl.create(:cloud_network, :orchestration_stack => stack2)
+      FactoryGirl.create(:security_group, :orchestration_stack => stack2)
+
+      stack1
+    end
+
+    it 'defines a set of methods for vms' do
+      root_stack.direct_vms.size.should == 1
+      root_stack.vms.size.should == 2
+      root_stack.total_vms.should == 2
+    end
+
+    it 'defines a set of methods for cloud_networks' do
+      root_stack.direct_cloud_networks.size.should == 1
+      root_stack.cloud_networks.size.should == 2
+      root_stack.total_cloud_networks.should == 2
+    end
+
+    it 'defines a set of methods for security_groups' do
+      root_stack.direct_security_groups.size.should == 1
+      root_stack.security_groups.size.should == 2
+      root_stack.total_security_groups.should == 2
+    end
+  end
+end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ServiceTemplate do
+describe ServiceOrchestration do
   let(:manager_by_setter)  { FactoryGirl.create(:ems_amazon) }
   let(:template_by_setter) { FactoryGirl.create(:orchestration_template) }
   let(:manager_by_dialog)  { FactoryGirl.create(:ems_amazon) }
@@ -155,6 +155,27 @@ describe ServiceTemplate do
       status, message = service_with_deployed_stack.orchestration_stack_status
       status.should == 'check_status_failed'
       message.should == 'test failure'
+    end
+  end
+
+  context '#all_vms' do
+    it 'returns all vms from a deployed stack' do
+      vm1 = double
+      vm2 = double
+      allow(deployed_stack).to receive(:vms).and_return([vm1, vm2])
+      allow(deployed_stack).to receive(:direct_vms).and_return([vm1])
+
+      expect(service_with_deployed_stack.all_vms).to eq([vm1, vm2])
+      expect(service_with_deployed_stack.direct_vms).to eq([vm1])
+      expect(service_with_deployed_stack.indirect_vms).to eq([vm2])
+      expect(service_with_deployed_stack.vms).to eq([vm1, vm2])
+    end
+
+    it 'returns no vm if no stack is deployed' do
+      expect(service.all_vms).to be_empty
+      expect(service.direct_vms).to be_empty
+      expect(service.indirect_vms).to be_empty
+      expect(service.vms).to be_empty
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1283425

1. `OrchestratiosStack` has methods to return all VMs or direct VMs, and similarly for security groups and cloud networks
The orchestration stack summary page therefore now shows all VMs including the ones from nested stacks.
2. `ServiceOrchestration` delegates `OrchestrationStack#all_vms` and `#direct_vms`
The service summary page now is able to show all VMs including nested ones from the stack in the service.
3. Add rspec tests. 
