### PR TITLE
Bearer type authentication doesn't need userid

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -909,7 +909,7 @@ module EmsCommon
       creds[:ssh_keypair] = {:userid => @edit[:new][:ssh_keypair_userid], :auth_key => @edit[:new][:ssh_keypair_password]}
     end
     if ems.supports_authentication?(:bearer) && !@edit[:new][:bearer_token].blank?
-      creds[:bearer] = {:auth_key => @edit[:new][:bearer_token], :userid => "_"} # Must have userid
+      creds[:bearer] = {:auth_key => @edit[:new][:bearer_token]}
     end
     if ems.supports_authentication?(:auth_key) && !@edit[:new][:service_account].blank?
       creds[:default] = {:auth_key => @edit[:new][:service_account], :userid => "_"}

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -136,7 +136,7 @@ module AuthenticationMixin
         value[:auth_key] = '-----BEGIN RSA PRIVATE KEY-----' + fixed_auth_key + '-----END RSA PRIVATE KEY-----'
       end
 
-      unless value[:userid].blank?
+      unless value.key?(:userid) && value[:userid].blank?
         current[:new] = {:user => value[:userid], :password => value[:password], :auth_key => value[:auth_key]}
       end
       current[:old] = {:user => cred.userid, :password => cred.password, :auth_key => cred.auth_key} if cred
@@ -148,7 +148,7 @@ module AuthenticationMixin
       next if current[:old] == current[:new]
 
       # Check if it is a delete
-      if value[:userid].blank?
+      if value.key?(:userid) && value[:userid].blank?
         current[:new] = nil
         next if options[:save] == false
         authentication_delete(type)

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -24,8 +24,6 @@ describe ApiController do
   let(:openshift_credentials) do
     {
       "auth_type" => "bearer",
-      "userid"    => "foo",
-      "password"  => "bar",
       "auth_key"  => SecureRandom.hex
     }
   end


### PR DESCRIPTION
Bearer type authentication should not need a userid to be present. The
code that assigns the authentication to the provider made certain
assumptions about the userid - that its presence indicated a change, and
its absence indicated a delete. This updates it to ensure that an
authentication can be added without a userid.

The change also removes the password from the spec's openshift
credentials, because this was never needed (the UI just provides fields
for username and token).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1284005

@miq-bot add-label api, core, bug