### PR TITLE
Fix deprecation messages to report proper calling location.

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -673,7 +673,7 @@ module RelationshipMixin
   def self.deprecate_of_type_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead") unless Rails.env.production?
+    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead", caller(2)) unless Rails.env.production?
 
     options = args.extract_options!
     [options.merge(:of_type => args.first)]
@@ -682,12 +682,12 @@ module RelationshipMixin
   def self.deprecate_of_type_and_rel_type_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead") unless Rails.env.production?
+    Vmdb::Deprecation.deprecation_warning("of_type parameter without hash symbol", "use :of_type => 'Type' style instead", caller(2)) unless Rails.env.production?
 
     options = args.extract_options!
 
     if args.length > 1
-      Vmdb::Deprecation.deprecation_warning("relationship_type parameter", "use with_relationship_type method before calling instead") unless Rails.env.production?
+      Vmdb::Deprecation.deprecation_warning("relationship_type parameter", "use with_relationship_type method before calling instead", caller(2)) unless Rails.env.production?
     end
 
     [options.merge(:of_type => args.first)]
@@ -696,7 +696,7 @@ module RelationshipMixin
   def self.deprecate_start_parameter(*args)
     return args if args.empty? || args.first.kind_of?(Hash)
 
-    Vmdb::Deprecation.deprecation_warning("start parameter") unless Rails.env.production?
+    Vmdb::Deprecation.deprecation_warning("start parameter", nil, caller(2)) unless Rails.env.production?
 
     [args.extract_options!]
   end

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -25,7 +25,7 @@ class VimPerformanceDaily < MetricRollup
   def self.find(cnt, *args)
     raise "Unsupported finder value #{cnt}" unless cnt == :all
 
-    Vmdb::Deprecation.deprecation_warning(:find, :find_entries)
+    Vmdb::Deprecation.deprecation_warning(:find, :find_entries, caller(1))
 
     options = args.last.kind_of?(Hash) ? args.last : {}
     ext_options = options.delete(:ext_options) || {}


### PR DESCRIPTION
Each of these locations were reporting the file:line location of the
deprecation_warning call, not the location of the offending caller.