### PR TITLE
[WIP] Update the Sat5 default update repo names

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -34,7 +34,7 @@ class MiqDatabase < ActiveRecord::Base
 
   def self.registration_default_value_for_update_repo_name(type = "sm_hosted")
     case type
-    when "rhn_satellite" then ""
+    when "rhn_satellite" then "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1"
     else                      "cf-me-5.5-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
     end
   end

--- a/db/migrate/20151124161527_update_sat5_default_update_repo_names.rb
+++ b/db/migrate/20151124161527_update_sat5_default_update_repo_names.rb
@@ -1,0 +1,29 @@
+class UpdateSat5DefaultUpdateRepoNames < ActiveRecord::Migration
+  class MiqDatabase < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  REPO_NAME_HASH = {
+    "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1" => "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1",
+    ""                                                            => "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1",
+  }
+
+  def up
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH)
+    end
+  end
+
+  def down
+    say_with_time("Updating update_repo_name") do
+      update(REPO_NAME_HASH.reject { |k, _v| k == "" }.invert)
+    end
+  end
+
+  def update(hash)
+    db = MiqDatabase.first
+    return unless db
+    new_repo = hash[db.update_repo_name]
+    db.update_attributes(:update_repo_name => new_repo) if new_repo
+  end
+end

--- a/spec/migrations/20151124161527_update_sat5_default_update_repo_names_spec.rb
+++ b/spec/migrations/20151124161527_update_sat5_default_update_repo_names_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require_migration
+
+describe UpdateSat5DefaultUpdateRepoNames do
+  let(:db_stub) { migration_stub(:MiqDatabase) }
+
+  migration_context :up do
+    [
+      ["Satellite 5 from old", "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1", "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1"],
+      ["Satellite 5 from empty", "", "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1"],
+    ].each do |name, existing_repo, desired_repo|
+      it name do
+        db = db_stub.create!(:update_repo_name => existing_repo)
+
+        migrate
+
+        expect(db.reload.update_repo_name).to eq(desired_repo)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "restores the old sat5 repos" do
+      existing_repo = "rhel-x86_64-server-7-cf-me-4.0 rhel-x86_64-server-7-rhscl-1"
+      desired_repo  = "rhel-x86_64-server-6-cf-me-3.2 rhel-x86_64-server-6-rhscl-1"
+      db = db_stub.create!(:update_repo_name => existing_repo)
+
+      migrate
+
+      expect(db.reload.update_repo_name).to eq(desired_repo)
+    end
+  end
+end


### PR DESCRIPTION
Updated the default in the model and added a
migration to change from both the old names and
an empty string which was added in 92193a203aa2053667f7904920f55964ebac289f

https://bugzilla.redhat.com/show_bug.cgi?id=1284682