### PR TITLE
[api] Include user identity in main entrypoint

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -52,6 +52,21 @@ class ApiController
       end
     end
 
+    def auth_identity
+      user  = @auth_user_obj
+      group = user.current_group
+      {
+        :userid     => user.userid,
+        :name       => user.name,
+        :user_href  => "#{@req[:api_prefix]}/users/#{user.id}",
+        :group      => group.description,
+        :group_href => "#{@req[:api_prefix]}/groups/#{group.id}",
+        :role       => group.miq_user_role_name,
+        :tenant     => group.tenant.name,
+        :groups     => user.miq_groups.pluck(:description)
+      }
+    end
+
     def userid_to_userobj(userid)
       User.find_by_userid(userid)
     end

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -10,6 +10,7 @@ class ApiController
         :description => @description,
         :version     => @version,
         :versions    => entrypoint_versions,
+        :identity    => auth_identity,
         :collections => entrypoint_collections
       }
       render_resource :entrypoint, res
@@ -20,7 +21,7 @@ class ApiController
         if version_specification.key?(:ident)
           {
             :name => version_specification[:name],
-            :href => "#{@req[:base]}#{@prefix}/#{version_specification[:ident]}"
+            :href => "#{@req[:api_prefix]}/#{version_specification[:ident]}"
           }
         end
       end.compact

--- a/app/controllers/api_controller/normalizer.rb
+++ b/app/controllers/api_controller/normalizer.rb
@@ -89,7 +89,7 @@ class ApiController
     #
     def normalize_url(_type, value)
       svalue = value.to_s
-      pref   = "#{@req[:base]}#{@req[:prefix]}"
+      pref   = @req[:api_prefix]
       svalue.match(pref) ? svalue : "#{pref}/#{svalue}"
     end
 

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -18,6 +18,7 @@ class ApiController
           @req[:prefix]    = "#{@req[:prefix]}/#{ver}"     # /api/v#.#
         end
       end
+      @req[:api_prefix]    = "#{@req[:base]}#{@req[:prefix]}"
 
       @req[:collection]    = params[:collection]
       @req[:c_id]          = params[:c_id]

--- a/app/controllers/api_controller/results.rb
+++ b/app/controllers/api_controller/results.rb
@@ -11,25 +11,25 @@ class ApiController
     end
 
     def add_href_to_result(hash, type, id)
-      hash[:href] = "#{@req[:base]}#{@req[:prefix]}/#{type}/#{id}"
+      hash[:href] = "#{@req[:api_prefix]}/#{type}/#{id}"
       hash
     end
 
     def add_parent_href_to_result(hash)
-      hash[:href] = "#{@req[:base]}#{@req[:prefix]}/#{@req[:collection]}/#{@req[:c_id]}"
+      hash[:href] = "#{@req[:api_prefix]}/#{@req[:collection]}/#{@req[:c_id]}"
       hash
     end
 
     def add_task_to_result(hash, task_id)
       hash[:task_id]   = task_id
-      hash[:task_href] = "#{@req[:base]}#{@req[:prefix]}/tasks/#{task_id}"
+      hash[:task_href] = "#{@req[:api_prefix]}/tasks/#{task_id}"
       hash
     end
 
     def add_tag_to_result(hash, tag_spec)
       hash[:tag_category] = tag_spec[:category] if tag_spec[:category].present?
       hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
-      hash[:tag_href]     = "#{@req[:base]}#{@req[:prefix]}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
+      hash[:tag_href]     = "#{@req[:api_prefix]}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
       hash
     end
 
@@ -37,13 +37,13 @@ class ApiController
       return hash if object.blank?
       ctype_pref = ctype.to_s.singularize
       hash["#{ctype_pref}_id".to_sym]   = object.id
-      hash["#{ctype_pref}_href".to_sym] = "#{@req[:base]}#{@req[:prefix]}/#{ctype}/#{object.id}"
+      hash["#{ctype_pref}_href".to_sym] = "#{@req[:api_prefix]}/#{ctype}/#{object.id}"
       hash
     end
 
     def add_report_result_to_result(hash, result_id)
       hash[:result_id] = result_id
-      hash[:result_href] = "#{@req[:base]}#{@req[:prefix]}/results/#{result_id}"
+      hash[:result_href] = "#{@req[:api_prefix]}/results/#{result_id}"
       hash
     end
 

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -95,7 +95,7 @@ describe ApiController do
     let(:group1) { FactoryGirl.create(:miq_group, :description => "Group1", :miq_user_role => @role) }
     let(:group2) { FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role) }
 
-    before(:each) do
+    before do
       @user.miq_groups = [group1, group2, @user.current_group]
       @user.current_group = group1
     end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -14,6 +14,8 @@ describe ApiController do
     Vmdb::Application
   end
 
+  ENTRYPOINT_KEYS = %w(name description version versions identity collections)
+
   context "Basic Authentication" do
     it "test basic authentication with bad credentials" do
       basic_authorize "baduser", "badpassword"
@@ -29,7 +31,7 @@ describe ApiController do
       run_get entrypoint_url
 
       expect_single_resource_query
-      expect_result_to_have_keys(%w(name description version versions collections))
+      expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
     it "test basic authentication with a user without a role" do
@@ -89,6 +91,36 @@ describe ApiController do
     end
   end
 
+  context "Authentication/Authorization Identity" do
+    let(:group1) { FactoryGirl.create(:miq_group, :description => "Group1", :miq_user_role => @role) }
+    let(:group2) { FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role) }
+
+    before(:each) do
+      @user.miq_groups = [group1, group2, @user.current_group]
+      @user.current_group = group1
+    end
+
+    it "basic authentication with a secondary group" do
+      api_basic_authorize
+
+      run_get entrypoint_url, :headers => {"miq_group" => group2.description}
+
+      expect_single_resource_query
+      expect_result_to_have_keys(ENTRYPOINT_KEYS)
+      expect_result_to_match_hash(
+        @result["identity"],
+        "userid"     => @user.userid,
+        "name"       => @user.name,
+        "user_href"  => "/api/users/#{@user.id}",
+        "group"      => group2.description,
+        "group_href" => "/api/groups/#{group2.id}",
+        "role"       => @role.name,
+        "tenant"     => @group.tenant.name
+      )
+      expect(@result["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
+    end
+  end
+
   context "Token Based Authentication" do
     it "gets a token based identifier" do
       api_basic_authorize
@@ -118,7 +150,7 @@ describe ApiController do
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
       expect_single_resource_query
-      expect_result_to_have_keys(%w(name description version versions collections))
+      expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
     it "authentication using a valid token updates the token's expiration time" do
@@ -140,7 +172,7 @@ describe ApiController do
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
       expect_single_resource_query
-      expect_result_to_have_keys(%w(name description version versions collections))
+      expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
 
     it "gets a token based identifier with the default API based token_ttl" do

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -275,7 +275,7 @@ module ApiSpecHelper
     fetch_value(attr_hash).each do |key, value|
       expect(result).to have_key(key)
       value = fetch_value(value)
-      if key == "href" || value.kind_of?(Regexp)
+      if key == "href" || key.ends_with?("_href") || value.kind_of?(Regexp)
         expect(result[key]).to match(value)
       else
         expect(result[key]).to eq(value)


### PR DESCRIPTION
- Return user authentication and authorization details with the main /api entrypoint via the "identity" attribute.
- Added specsfor main entrypoint "identity"

https://trello.com/c/B5qeEXIG/149-api-api-endpoint-should-return-additional-information