### PR TITLE
Array object was not being cached leading to Drb Recycled Object error

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -109,9 +109,9 @@ module MiqAeMethodService
         if results.nil?
           ret = nil
         elsif results.kind_of?(Array)
-          ret = results.collect { |r| wrap_results(r) }
+          ret = drb_return(results.collect { |r| wrap_results(r) })
         elsif results.kind_of?(ActiveRecord::Relation)
-          ret = results.collect { |r| wrap_results(r) }
+          ret = drb_return(results.collect { |r| wrap_results(r) })
         elsif results.kind_of?(ActiveRecord::Base)
           klass = MiqAeMethodService.const_get("MiqAeService#{results.class.name.gsub(/::/, '_')}")
           ret = drb_return(klass.new(results))

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -99,6 +99,15 @@ module MiqAeServiceSpec
           expect(miq_ae_service.vmdb(name)).to be("#{prefix}#{name}".constantize)
         end
       end
+
+      it "cache object references" do
+        FactoryGirl.create(:vm_vmware)
+        FactoryGirl.create(:vm_vmware)
+
+        vms = miq_ae_service.vmdb('vm').find(:all)
+        cache = miq_ae_service.instance_variable_get(:@drb_server_references)
+        expect(cache.any? { |x| x.object_id == vms.object_id }).to be_true
+      end
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1284573

The Array object that is sent back to the Automate Method via Drb
is not being cached, leading to intermittent Recycled Object error
The individual objects in the Array were cached but not the Array
itself.