### PR TITLE
queue_captures - do not look up config every time

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -109,6 +109,7 @@ module Metric::Capture
     end
 
     # Queue the captures for each target
+    use_historical = historical_days != 0
     targets.each do |target|
       interval_name = perf_target_to_interval_name(target)
 
@@ -126,7 +127,7 @@ module Metric::Capture
       end
       target.perf_capture_queue(interval_name, options)
 
-      if !target.kind_of?(Storage) && target.last_perf_capture_on.nil? && historical_days != 0
+      if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
         target.perf_capture_queue('historical')
       end
     end


### PR DESCRIPTION
**before:**

In Cap&U, for every non-storage object that we are capturing, we were reading the configuration table to verify whether we were running historical values. (even for realtime metrics).

**after:**
Check whether we are running historical values once up front.

**result:**

This saves more than 1 query per object. for 12 only VMS, this removed 28 queries and saved 2kb (27k objects).

Low risk, big benefit.

---

running cap and U, for 12 VMS:

before: 154ms  104queries@  23ms 6,909kb     92,437obj
after:  118ms   76queries@  18ms 4,597kb     65,376obj

/cc @dmetzger57 there is one more hiding in the queueing - we don't need 76 queries + 16 transaction begin/end pairs to add 18 rows into the queue. (Especially if these records already exist in miq_queue)