### PR TITLE
Simplify `sort_by{}.first` by replacing it with `min_by{}`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -846,7 +846,7 @@ class ApplicationController < ActionController::Base
     tp = TimeProfile.default_time_profile if tp.nil?
 
     if tp.nil? && !session[:time_profiles].blank?
-      first_id_in_hash = Array(session[:time_profiles].invert).sort_by(&:first).first.last
+      first_id_in_hash = Array(session[:time_profiles].invert).min_by(&:first).last
       tp = TimeProfile.find_by_id(first_id_in_hash)
     end
     tp

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -337,7 +337,7 @@ module ApplicationController::Tags
     end
 
     # Set to first category, if not already set
-    @edit[:cat] ||= cats.sort_by(&:description).first
+    @edit[:cat] ||= cats.min_by(&:description)
 
     @tagitems = @tagging.constantize.find(@object_ids).sort_by { |t| t.name.downcase } unless @object_ids.blank?
 

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -13,7 +13,7 @@ module ComplianceMixin
   def last_compliance
     return @last_compliance unless @last_compliance.nil?
     @last_compliance = if association_cache.include?(:compliances)
-                         compliances.sort_by(&:timestamp).last
+                         compliances.max_by(&:timestamp)
                        else
                          compliances.order("timestamp DESC").first
                        end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
@@ -19,7 +19,7 @@ prov.eligible_hosts.each do |h|
   nvms = h.vms.length
 
   if min_registered_vms.nil? || nvms < min_registered_vms
-    s = h.storages.sort_by(&:free_space).last
+    s = h.storages.max_by(&:free_space)
     unless s.nil?
       host    = h
       storage = s

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -29,7 +29,7 @@ module ReportFormatter
         maxval = 0
         mri.graph[:columns].each_with_index do |col, col_idx|
           next if col_idx >= maxcols
-          newmax = mri.table.data.collect { |r| r[col].nil? ? 0 : r[col] }.sort.last
+          newmax = mri.table.data.collect { |r| r[col].nil? ? 0 : r[col] }.max
           maxval = newmax if newmax > maxval
         end
         if maxval > 10.gigabytes

--- a/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
@@ -31,7 +31,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
     it "treats openstack timestamp as UTC" do
       ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("cpu_util").last)
       _counters, values_by_id_and_ts = @vm.perf_collect_metrics("realtime")
-      ts = Time.parse(values_by_id_and_ts[@vm.ems_ref].keys.sort.last)
+      ts = Time.parse(values_by_id_and_ts[@vm.ems_ref].keys.max)
 
       ts_as_utc.should eq ts
     end

--- a/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
     it "treats openstack timestamp as UTC" do
       ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("hardware.system_stats.cpu.util").last)
       _counters, values_by_id_and_ts = @host.perf_collect_metrics("realtime")
-      ts = Time.parse(values_by_id_and_ts[@host.ems_ref].keys.sort.last)
+      ts = Time.parse(values_by_id_and_ts[@host.ems_ref].keys.max)
 
       ts_as_utc.should eq ts
     end


### PR DESCRIPTION
Same applies to `sort_by{}.last` =>`max_by`, `sort.first` => `min`, `sort.last` => `max`.

Besides better readability, it also should improve performance a little.