### PR TITLE
Use model type to filter provision templates instead of vendor column

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -60,8 +60,8 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
     super(message, {'platform' => 'amazon'})
   end
 
-  def self.allowed_templates_vendor
-    'amazon'
+  def self.provider_model
+    ManageIQ::Providers::Amazon::CloudManager
   end
 
   def security_group_to_availability_zones(src)

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,6 +1,11 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
   default_value_for :cloud, true
 
+  def self.eligible_for_provisioning
+    super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
+                            ManageIQ::Providers::Openstack::CloudManager::Template))
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/microsoft/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision_workflow.rb
@@ -9,8 +9,8 @@ class ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow < ::MiqPro
     }
   end
 
-  def self.allowed_templates_vendor
-    'microsoft'
+  def self.provider_model
+    ManageIQ::Providers::Microsoft::InfraManager
   end
 
   def update_field_visibility(_options = {})

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     super(message, {'platform' => 'openstack'})
   end
 
-  def self.allowed_templates_vendor
-    'openstack'
+  def self.provider_model
+    ManageIQ::Providers::Openstack::CloudManager
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb
@@ -5,8 +5,8 @@ class ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow < MiqProvisio
     'miq_provision_dialogs'
   end
 
-  def self.allowed_templates_vendor
-    'redhat'
+  def self.provider_model
+    ManageIQ::Providers::Redhat::InfraManager
   end
 
   def supports_pxe?

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -108,8 +108,8 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     SYSPREP_TIMEZONES.collect(&:reverse)
   end
 
-  def self.allowed_templates_vendor
-    'vmware'
+  def self.provider_model
+    ManageIQ::Providers::Vmware::InfraManager
   end
 
   def update_field_visibility

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -216,4 +216,17 @@ describe MiqProvisionVirtWorkflow do
       expect(workflow.validate_memory_reservation(nil, values.merge(:memory_reserve => 2048), {}, {}, nil)).to eq(error)
     end
   end
+
+  context "#allowed_template_condition" do
+    it "without a provider model defined" do
+      expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id IS NOT NULL", true])
+    end
+
+    it "with a provider model defined" do
+      ems = FactoryGirl.create(:ems_vmware)
+      expect(workflow.class).to receive(:provider_model).once.and_return(ems.class)
+
+      expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id in (?)", true, [ems.id]])
+    end
+  end
 end


### PR DESCRIPTION
For catalog items filtering will pass the IDs of the specified provider type.
For Lifecycle -> Provisioning for Cloud we now pass the supported provider model names.  (This remove Azure templates from showing in the list.)  Lifecycle -> Infrastructure provision already does this.

https://bugzilla.redhat.com/show_bug.cgi?id=1284049