### PR TITLE
Fix refresh of dynamic dropdown list

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -60,7 +60,8 @@ var dialogFieldRefresh = {
       dropdownOptions.push(option);
     });
 
-    $('.dynamic-drop-down-' + fieldId).html(dropdownOptions);
+    $('.dynamic-drop-down-' + fieldId + '.selectpicker').html(dropdownOptions);
+    $('.dynamic-drop-down-' + fieldId + '.selectpicker').selectpicker('refresh');
 
     miqSparkle(false);
   },

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -4,7 +4,7 @@ describe('dialogFieldRefresh', function() {
 
     beforeEach(function() {
       var html = "";
-      html += '<select class="dynamic-drop-down-345">';
+      html += '<select class="dynamic-drop-down-345 selectpicker">';
       html += '</select>';
       setFixtures(html);
     });
@@ -24,7 +24,7 @@ describe('dialogFieldRefresh', function() {
 
         it('selects the option that corresponds to the checked value', function() {
           dialogFieldRefresh.addOptionsToDropDownList(data, 345);
-          expect($('.dynamic-drop-down-345').val()).toBe('123');
+          expect($('.dynamic-drop-down-345.selectpicker').val()).toBe('123');
         });
       });
     });
@@ -36,7 +36,7 @@ describe('dialogFieldRefresh', function() {
 
       it('selects the first option', function() {
         dialogFieldRefresh.addOptionsToDropDownList(data, 345);
-        expect($('.dynamic-drop-down-345').val()).toBe('test');
+        expect($('.dynamic-drop-down-345.selectpicker').val()).toBe('test');
       });
     });
   });


### PR DESCRIPTION
Previous selector would incorrectly select two elements
instead of one, i.e. in the end the updated options would
be added to incorrect element.

Also, after updating Bootstrap select, we need to 'refresh'
it to pick up the changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1283733