### PR TITLE
Handle VMware VMs reportedly having 0 CPU Sockets

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -811,7 +811,10 @@ module ManageIQ::Providers
 
         if inv["numCpu"].present?
           result[:cpu_total_cores]      = inv["numCpu"].to_i
-          result[:cpu_cores_per_socket] = (config.try(:fetch_path, "hardware", "numCoresPerSocket") || 1).to_i
+
+          # cast numCoresPerSocket to an integer so that we can check for nil and 0
+          cpu_cores_per_socket          = config.try(:fetch_path, "hardware", "numCoresPerSocket").to_i
+          result[:cpu_cores_per_socket] = (cpu_cores_per_socket.zero?) ? 1 : cpu_cores_per_socket
           result[:cpu_sockets]          = result[:cpu_total_cores] / result[:cpu_cores_per_socket]
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -21,6 +21,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     assert_specific_storage
     assert_specific_host
     assert_specific_vm
+    assert_cpu_layout
     assert_relationship_tree
   end
 
@@ -432,6 +433,30 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :is_datacenter => false,
 
       :folder_path   => "Datacenters/Prod/vm/JFitzgerald"
+    )
+  end
+
+  def assert_cpu_layout
+    # Test a VM that has numCoresPerSocket = 0
+    v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by_ems_ref("vm-12443")
+    v.should have_attributes(
+      :cpu_total_cores => 2,
+    )
+    v.hardware.should have_attributes(
+      :cpu_total_cores      => 2,
+      :cpu_cores_per_socket => 1,
+      :cpu_sockets          => 2,
+    )
+
+    # Test a VM that has numCoresPerSocket = 2
+    v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by_ems_ref("vm-12203")
+    v.should have_attributes(
+      :cpu_total_cores => 4,
+    )
+    v.hardware.should have_attributes(
+      :cpu_total_cores      => 4,
+      :cpu_cores_per_socket => 2,
+      :cpu_sockets          => 2,
     )
   end
 

--- a/spec/tools/vim_data/miq_vim_inventory/virtualMachinesByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/virtualMachinesByMor.yml
@@ -12167,6 +12167,14 @@
         __iv__@vimType: 
         __iv__@xsiType: :OptionValue
     hardware: !map:VimHash 
+      numCPU: !str:VimString
+        str: "4"
+        "@vimType":
+        "@xsiType": :"SOAP::SOAPInt"
+      numCoresPerSocket: !str:VimString
+        str: "2"
+        "@vimType":
+        "@xsiType": :"SOAP::SOAPInt"
       device: !seq:VimArray 
         - !map:VimHash 
           busNumber: !str:VimString 
@@ -14429,6 +14437,14 @@
         __iv__@vimType: 
         __iv__@xsiType: :OptionValue
     hardware: !map:VimHash 
+      numCPU: !str:VimString
+        str: "2"
+        "@vimType":
+        "@xsiType": :"SOAP::SOAPInt"
+      numCoresPerSocket: !str:VimString
+        str: "0"
+        "@vimType":
+        "@xsiType": :"SOAP::SOAPInt"
       device: !seq:VimArray 
         - !map:VimHash 
           busNumber: !str:VimString 


### PR DESCRIPTION
VMware has been seen to return inventory stating that a VM has
0 CPU sockets causing a ZeroDivisionError exception in the
vmware refresh_parser.

There is an existing check for numCoresPerSocket being nil,
so expand on that to check for 0 as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1282851