### PR TITLE
Send use_cloud_init to start when provisioning RHEV 3.5.5+ with cloud-init

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -13,6 +13,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   def configure_cloud_init
     return unless content = customization_template_content
     get_provider_destination.cloud_init = content
+
+    if Gem::Version.new(source.ext_management_system.api_version) >= Gem::Version.new("3.5.5.0")
+      phase_context[:boot_with_cloud_init] = true
+    end
   end
 
   def configure_container

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -69,6 +69,17 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
     end
   end
 
+  def autostart_destination
+    if get_option(:vm_auto_start)
+      message = "Starting"
+      _log.info("#{message} #{for_destination}")
+      update_and_notify_parent(:message => message)
+      get_provider_destination.start { |action| action.use_cloud_init(true) if phase_context[:boot_with_cloud_init] }
+    end
+
+    signal :post_create_destination
+  end
+
   private
 
   def powered_off_in_provider?

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -34,7 +34,7 @@ gem "net-sftp",                "~>2.1.2",           :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false
 gem "openshift_client",        "=0.2.0",            :require => false
-gem "ovirt",                   "~>0.7.0",           :require => false
+gem "ovirt",                   "~>0.7.1",           :require => false
 gem "parallel",                "~>0.5.21",          :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
   let(:template)      { FactoryGirl.create(:template_redhat, :ext_management_system => ems) }
   let(:vm)            { FactoryGirl.create(:vm_redhat) }
 
-  before { task.stub(:get_provider_destination => rhevm_vm) }
+  before { allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Provision).to receive(:get_provider_destination).and_return(rhevm_vm) }
 
   context "#attach_floppy_payload" do
     it "should attach floppy if customization template provided" do
@@ -31,6 +31,32 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration do
       expect(rhevm_vm).to receive(:cloud_init=).with('#some_script')
 
       task.configure_cloud_init
+    end
+
+    context "set phase_context[:boot_with_cloud_init]" do
+      it "old RHEV" do
+        allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:api_version).and_return("3.5.0.0")
+        task.options[:customization_template_id] = cust_template.id
+
+        expect(task).to     receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+        expect(rhevm_vm).to receive(:cloud_init=).with('#some_script')
+
+        task.configure_cloud_init
+
+        expect(task.phase_context[:boot_with_cloud_init]).to be_nil
+      end
+
+      it "new RHEV" do
+        allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:api_version).and_return("3.5.5.0")
+        task.options[:customization_template_id] = cust_template.id
+
+        expect(task).to     receive(:prepare_customization_template_substitution_options).and_return('key' => 'value')
+        expect(rhevm_vm).to receive(:cloud_init=).with('#some_script')
+
+        task.configure_cloud_init
+
+        expect(task.phase_context[:boot_with_cloud_init]).to eq(true)
+      end
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -54,6 +54,44 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       end
     end
 
+    context "#autostart_destination" do
+      it "with use_cloud_init" do
+        expect(@task).to receive(:phase_context).and_return(:boot_with_cloud_init => true)
+        expect(@task).to receive(:get_option).with(:vm_auto_start).and_return(true)
+        allow(@task).to receive(:for_destination)
+        expect(@task).to receive(:update_and_notify_parent)
+
+        rhevm_vm = double("RHEVM VM")
+        expect(@task).to receive(:get_provider_destination).and_return(rhevm_vm)
+
+        xml = double("XML")
+        expect(xml).to receive(:use_cloud_init).with(true)
+        expect(rhevm_vm).to receive(:start).and_yield(xml)
+
+        expect(@task).to receive(:post_create_destination)
+
+        @task.autostart_destination
+      end
+
+      it "without use_cloud_init" do
+        expect(@task).to receive(:phase_context).and_return({})
+        expect(@task).to receive(:get_option).with(:vm_auto_start).and_return(true)
+        allow(@task).to receive(:for_destination)
+        expect(@task).to receive(:update_and_notify_parent)
+
+        rhevm_vm = double("RHEVM VM")
+        expect(@task).to receive(:get_provider_destination).and_return(rhevm_vm)
+
+        xml = double("XML")
+        expect(xml).not_to receive(:use_cloud_init)
+        expect(rhevm_vm).to receive(:start).and_yield(xml)
+
+        expect(@task).to receive(:post_create_destination)
+
+        @task.autostart_destination
+      end
+    end
+
     it "#customize_destination" do
       @task.stub(:get_provider_destination).and_return(nil)
       @task.stub(:update_and_notify_parent)


### PR DESCRIPTION
- Send a raw start with use_cloud_init(true) to the Ovirt::Vm if using cloud-init provisioning on Ovirt 3.5.5.0 and above.
- Upgrade ovirt gem to collect the correct version number since the 3rd digit is now important and won't be correct until v3.6.
https://bugzilla.redhat.com/show_bug.cgi?id=1282618

Related RHEV BZs:
- Initialization data no longer used in cloud-init user data: https://bugzilla.redhat.com/show_bug.cgi?id=1269534
- Version field incorrect: https://bugzilla.redhat.com/show_bug.cgi?id=1284654