### PR TITLE
Replace #miq_grid_checks with ManageIQ.gridChecks

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1310,10 +1310,11 @@ function miqToolbarOnClick(e) {
     }
   }
 
-  collect_log_buttons = [ 'support_vmdb_choice__collect_logs',
-                          'support_vmdb_choice__collect_current_logs',
-                          'support_vmdb_choice__zone_collect_logs',
-                          'support_vmdb_choice__zone_collect_current_logs'
+  var collect_log_buttons = [
+    'support_vmdb_choice__collect_logs',
+    'support_vmdb_choice__collect_current_logs',
+    'support_vmdb_choice__zone_collect_logs',
+    'support_vmdb_choice__zone_collect_current_logs'
   ];
   if (jQuery.inArray(button.attr('name'), collect_log_buttons) >= 0 && button.data('prompt')) {
     tb_url = miqSupportCasePrompt(tb_url);

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -406,7 +406,7 @@ function miqUpdateAllCheckboxes(button_div, override) {
       miqGridCheckAll(state);
       var crows = miqGridGetCheckedRows();
 
-      $('#miq_grid_checks').val(crows.join(','));
+      ManageIQ.gridChecks = crows;
       miqSetButtons(crows.length, button_div);
     }
   }
@@ -1327,8 +1327,8 @@ function miqToolbarOnClick(e) {
   var params;
   if (button.data("url_parms")) {
     if (button.data('url_parms').match("_div$")) {
-      if (miqDomElementExists('miq_grid_checks')) {
-        params = "miq_grid_checks=" + $('#miq_grid_checks').val();
+      if (ManageIQ.gridChecks.length) {
+        params = "miq_grid_checks=" + ManageIQ.gridChecks.join(',');
       } else {
         params = miqSerializeForm(button.data('url_parms'));
       }

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -71,5 +71,6 @@ if (typeof(ManageIQ) === 'undefined') {
       dashboardUrl: null, // set dashboard widget drag drop url
       menuXml: null,
     },
+    gridChecks: [], // list of checked checkboxes in current list grid
   }
 };

--- a/app/assets/javascripts/miq_grid.js
+++ b/app/assets/javascripts/miq_grid.js
@@ -4,11 +4,6 @@
     var checkall = table.find('thead > tr > th > input.checkall');
     var checkboxes = table.find("tbody > tr > td > input[type='checkbox']");
 
-    // Maintain a list of checked IDs in a hidden input field for backwards compatibility
-    // TODO: implement this inside the miq_toolbar JS when it was updated to PatternFly
-    var checklist = $("<input type='hidden' id='miq_grid_checks'>").val('')
-    table.append(checklist);
-
     // table-selectable
     if (table.hasClass('table-clickable')) {
       var url = table.find('tbody').data('click-url');
@@ -20,12 +15,12 @@
     }
 
     // table-checkable
-    if(table.hasClass('table-checkable')) {
+    if (table.hasClass('table-checkable')) {
       checkboxes.click(function (e) {
         var checked = $.map(checkboxes.filter(':checked'), function (cb) {
           return cb.value;
         });
-        checklist.val(checked.join(','));
+        ManageIQ.gridChecks = checked;
         miqSetButtons(checked.length, 'center_tb');
         if (checked.length == checkboxes.length) {
           $('input.checkall').prop('checked', true);

--- a/app/assets/javascripts/miq_list_grid.js
+++ b/app/assets/javascripts/miq_list_grid.js
@@ -47,7 +47,7 @@ function miqGridOnCheck(elem, button_div) {
   }
 
   var crows = miqGridGetCheckedRows();
-  $('#miq_grid_checks').val(crows.join(','));
+  ManageIQ.gridChecks = crows;
 
   if (miqDomElementExists('center_tb')) {
     miqSetButtons(crows.length, "center_tb");

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1533,7 +1533,7 @@ class ApplicationController < ActionController::Base
 
   # Common routine to find checked items on a page (checkbox ids are "check_xxx" where xxx is the item id or index)
   def find_checked_items(prefix = nil)
-    unless params[:miq_grid_checks].blank?
+    if !params[:miq_grid_checks].blank?
       return params[:miq_grid_checks].split(",").collect { |c| from_cid(c) }
     else
       prefix = "check" if prefix.nil?

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2015,11 +2015,8 @@ class MiqAeClassController < ApplicationController
 
   # Common routine to find checked items on a page (checkbox ids are "check_xxx" where xxx is the item id or index)
   def find_checked_items(_prefix = nil)
-    if !params[:miq_grid_checks].blank?
-      return params[:miq_grid_checks].split(",")
-    elsif !params[:miq_grid_checks2].blank?
-      return params[:miq_grid_checks2].split(",")
-    end
+    # AE can't use ApplicationController#find_checked_items because that one expects non-prefixed ids
+    params[:miq_grid_checks].split(",") unless params[:miq_grid_checks].blank?
   end
 
   def field_attributes

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -1,7 +1,5 @@
-%input{:type  => 'hidden',
-       :name  => "miq_grid_checks",
-       :id    => "miq_grid_checks",
-       :value => ''}
+:javascript
+  ManageIQ.gridChecks = [];
 
 - grid_name  = options[:grid_name]
 - grid_id    = options[:grid_id]

--- a/spec/javascripts/miq_grid_spec.js
+++ b/spec/javascripts/miq_grid_spec.js
@@ -6,12 +6,7 @@ describe('miq_grid.js', function () {
     $('table').miqGrid();
   });
 
-  it('creates the list of selected items', function () {
-    expect($('#miq_grid_checks').length).toEqual(1);
-  });
-
   describe('.checkall', function () {
-
     it('checks itself if all checkboxes were checked', function () {
       $('.checkall').trigger('click');
       expect($('.checkall').prop('checked')).toEqual(true);
@@ -45,9 +40,9 @@ describe('miq_grid.js', function () {
 
   it('appends checked elements to the list of selected items', function () {
     $(".noclick > input[type='checkbox']").first().trigger('click');
-    expect($('#miq_grid_checks').val()).toEqual('check_1');
+    expect(ManageIQ.gridChecks.join(',')).toEqual('check_1');
     $(".noclick > input[type='checkbox']").last().trigger('click');
-    expect($('#miq_grid_checks').val()).toEqual('check_1,check_3');
+    expect(ManageIQ.gridChecks.join(',')).toEqual('check_1,check_3');
   });
 
   it('sends an ajax POST request when clicking on a table row', function () {


### PR DESCRIPTION
the miq_grid_checks logic failed when more than one list was present in the DOM at the same time (multiple #miq_grid_checks elements -> jquery retrieved random one)
    
This changes the affected code to use a global variable instead of an element.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1283745