### PR TITLE
Skip AR instantiation work if not debug.

### DIFF
--- a/config/initializers/instantiation_listener.rb
+++ b/config/initializers/instantiation_listener.rb
@@ -1,8 +1,10 @@
 ActiveSupport::Notifications.subscribe('instantiation.active_record') do |name, start, finish, _id, payload|
-  elapsed = finish - start
-  name = payload[:class_name]
-  count = payload[:record_count]
   logger = ActiveRecord::Base.logger
+  if logger.debug?
+    elapsed = finish - start
+    name = payload[:class_name]
+    count = payload[:record_count]
 
-  logger.debug('  %s Inst Including Associations (%.1fms - %drows)' % [name || 'SQL', (elapsed * 1000), count])
+    logger.debug('  %s Inst Including Associations (%.1fms - %drows)' % [name || 'SQL', (elapsed * 1000), count])
+  end
 end


### PR DESCRIPTION
It's not that expensive but it runs on each query and we throw it out
at info level.