### PR TITLE
Performance feature lookup

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,10 +130,11 @@ class User < ActiveRecord::Base
   def role_allows?(options = {})
     return false if miq_user_role.nil?
     feature = MiqProductFeature.find_by_identifier(options[:identifier])
-    identifiers = {:identifiers => [options[:identifier]]}
     if feature.try(:hidden)
       parent_feature = MiqProductFeature.parent_for_feature(options[:identifier])
-      # always return true for common features that are hidden and are under hidden parent
+      identifiers = {:identifiers => MiqProductFeature.feature_children(parent_feature.identifier) }
+      # return true for common features that are hidden and are under hidden parent
+      # return true if any visible siblings are entitled
       parent_feature.try(:hidden) ? true : miq_user_role.allows_any?(identifiers)
     else
       miq_user_role.allows?(options)

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -76,4 +76,28 @@ describe MiqProductFeature do
       expect(status_seed[:created]).to match_array %w(everything one two)
     end
   end
+
+  describe "#feature_details" do
+    it "returns data for visible features" do
+      EvmSpecHelper.seed_specific_product_features("container_dashboard")
+      expect(MiqProductFeature.feature_details("container_dashboard")).to be
+    end
+
+    it "eats hidden features" do
+      EvmSpecHelper.seed_specific_product_features("widget_refresh")
+      expect(MiqProductFeature.feature_details("widget_refresh")).not_to be
+    end
+  end
+
+  describe "#feature_hidden" do
+    it "detects visible features" do
+      EvmSpecHelper.seed_specific_product_features("container_dashboard")
+      expect(MiqProductFeature.feature_hidden("container_dashboard")).not_to be
+    end
+
+    it "detects hidden features" do
+      EvmSpecHelper.seed_specific_product_features("widget_refresh")
+      expect(MiqProductFeature.feature_hidden("widget_refresh")).to be
+    end
+  end
 end


### PR DESCRIPTION
Since features are in memory, use that instead of hitting the database.

This also fixes a bug where hidden features were still displayed
and fixes a bug where sibling features were still displayed.


empty dashboard - 3rd refresh - saves 38 sql queries and 60ms per page.

Rendering Before|time|queries|db time
---|---|---|---|---
`layouts/_page_header_navbar`|58.4ms|43 sql|8.0ms
Response|328ms

Rendering After|time|queries|db time
---|---|---|---|---
`layouts/_page_header_navbar`|10.2ms|3 sql|0.6ms
Response|285ms

/cc @jrafanie @Fryguy @dmetzger57 here you go
/cc @h-kataria thanks for help