### PR TITLE
remove unused allows_all for authentication

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -84,30 +84,6 @@ class MiqUserRole < ActiveRecord::Base
     role.allows_any?(options)
   end
 
-  def allows_all?(options = {})
-    scope = options[:scope] || :sub
-    raise ":scope must be one of #{SCOPES.inspect}" unless SCOPES.include?(scope)
-
-    options[:scope] ||= :sub
-    idents = options[:identifiers].to_miq_a
-    return false if idents.empty?
-
-    if [:base, :sub].include?(scope)
-      # Check passed in identifiers
-      return true if idents.all? { |i| self.allows?(:identifier => i) }
-    end
-    return false if scope == :base
-
-    # Check children of passed in identifiers (scopes :one and :base)
-    idents.all? { |i| self.allows_all_children?(:scope => (scope == :one ? :base : :sub), :identifier => i) }
-  end
-
-  def self.allows_all?(role, options = {})
-    role = get_role(role)
-    return false if role.nil?
-    role.allows_all?(options)
-  end
-
   def allows_any_children?(options = {})
     ident = options.delete(:identifier)
     return false if ident.nil? || !MiqProductFeature.feature_exists?(ident)
@@ -120,20 +96,6 @@ class MiqUserRole < ActiveRecord::Base
     role = get_role(role)
     return false if role.nil?
     role.allows_any_children?(options)
-  end
-
-  def allows_all_children?(options = {})
-    ident = options.delete(:identifier)
-    return false if ident.nil? || !MiqProductFeature.feature_exists?(ident)
-
-    child_idents = MiqProductFeature.feature_children(ident)
-    self.allows_all?(options.merge(:identifiers => child_idents))
-  end
-
-  def self.allows_all_children?(role, options = {})
-    role = get_role(role)
-    return false if role.nil?
-    role.allows_all_children?(options)
   end
 
   def self.get_role(role)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,11 +151,6 @@ class User < ActiveRecord::Base
     miq_user_role.allows_any?(options)
   end
 
-  def role_allows_all?(options = {})
-    return false if miq_user_role.nil?
-    miq_user_role.allows_all?(options)
-  end
-
   def miq_user_role_name
     miq_user_role.try(:name)
   end

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -74,66 +74,40 @@ describe MiqUserRole do
       MiqUserRole.allows?(@role1.id, :identifier => ident).should == true
     end
 
-    it "should return the correct answer calling allows_*? with scope => :base)" do
+    it "should return the correct answer calling allows_any? with scope => :base)" do
       MiqUserRole.allows_any?(@role1.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role1.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == false
 
       MiqUserRole.allows_any?(@role2.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role2.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
 
-      MiqUserRole.allows_all?(@role3.name, :scope => :base, :identifiers => ["host_show_list", "host_scan", "host_edit"]).should == true
-      MiqUserRole.allows_all?(@role3.name, :scope => :base, :identifiers => ["host_view"]).should == false
       MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["host_view"]).should == false
       MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_all?(@role3.name, :scope => :base, :identifiers => ["vm"]).should == false
       MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["everything"]).should == false
     end
 
-    it "should return the correct answer calling allows_*? with scope => :one)" do
+    it "should return the correct answer calling allows_any? with scope => :one)" do
       MiqUserRole.allows_any?(@role1.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role1.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == false
 
       MiqUserRole.allows_any?(@role2.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role2.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == false
 
-      MiqUserRole.allows_all?(@role3.name, :scope => :one, :identifiers => ["host_show_list", "host_scan", "host_edit"]).should == false
-      MiqUserRole.allows_all?(@role3.name, :scope => :one, :identifiers => ["host_view"]).should == false
       MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["host_view"]).should == true
       MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_all?(@role3.name, :scope => :one, :identifiers => ["vm"]).should == false
       MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["everything"]).should == false
     end
 
-    it "should return the correct answer calling allows_*? with default scope => :sub" do
+    it "should return the correct answer calling allows_any? with default scope => :sub" do
       MiqUserRole.allows_any?(@role1.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role1.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == false
-
       MiqUserRole.allows_any?(@role2.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_all?(@role2.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-
-      MiqUserRole.allows_all?(@role3.name, :identifiers => ["host_show_list", "host_scan", "host_edit"]).should == true
-      MiqUserRole.allows_all?(@role3.name, :identifiers => ["host_view"]).should == false
       MiqUserRole.allows_any?(@role3.name, :identifiers => ["host_view"]).should == true
       MiqUserRole.allows_any?(@role3.name, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_all?(@role3.name, :identifiers => ["vm"]).should == false
       MiqUserRole.allows_any?(@role3.name, :identifiers => ["everything"]).should == true
     end
 
-    it "should return the correct answer calling allows_*_children?" do
+    it "should return the correct answer calling allows_any_children?" do
       MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows_all_children?(@role1.name, :identifier => "dashboard_admin").should == true
-
       MiqUserRole.allows_any_children?(@role2.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows_all_children?(@role2.name, :identifier => "dashboard_admin").should == true
-
       MiqUserRole.allows_any_children?(@role2.name, :identifier => "everything").should == true
-      MiqUserRole.allows_all_children?(@role2.name, :identifier => "everything").should == true
-
       MiqUserRole.allows_any_children?(@role1.name, :identifier => "everything").should == true
-      MiqUserRole.allows_all_children?(@role1.name, :identifier => "everything").should == false
-
       MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard").should == true
-      MiqUserRole.allows_all_children?(@role1.name, :identifier => "dashboard").should == false
     end
   end
 


### PR DESCRIPTION
`MiqUserRoles` are complex enough as it is.
Remove concept of checking that all features are enabled. I can not find it used anywhere.

/cc @gtanzillo @Fryguy I went in to add a check on children, but all these various forms made the code intimidating for me.