### PR TITLE
remove 2 extra queries from header

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -376,19 +376,18 @@ class EmsCluster < ActiveRecord::Base
   end
 
   def self.node_types
-    return :mixed_clusters if count_of_openstack_clusters > 0 && count_of_non_openstack_clusters > 0
-    return :openstack      if count_of_openstack_clusters > 0
-    :non_openstack
+    return :non_openstack unless openstack_clusters_exists?
+    non_openstack_clusters_exists? ? :mixed_clusters : :openstack
   end
 
-  def self.count_of_openstack_clusters
+  def self.openstack_clusters_exists?
     ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    EmsCluster.where(:ems_id => ems).count
+    ems.empty? ? false : EmsCluster.where(:ems_id => ems).exists?
   end
 
-  def self.count_of_non_openstack_clusters
+  def self.non_openstack_clusters_exists?
     ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    EmsCluster.where(EmsCluster.arel_table[:ems_id].not_in(ems)).count
+    EmsCluster.where.not(:ems_id => ems).exists?
   end
 
   def openstack_cluster?

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1934,19 +1934,18 @@ class Host < ActiveRecord::Base
   end
 
   def self.node_types
-    return :mixed_hosts if count_of_openstack_hosts > 0 && count_of_non_openstack_hosts > 0
-    return :openstack   if count_of_openstack_hosts > 0
-    :non_openstack
+    return :non_openstack unless openstack_hosts_exists?
+    non_openstack_hosts_exists? ? :mixed_hosts : :openstack
   end
 
-  def self.count_of_openstack_hosts
+  def self.openstack_hosts_exists?
     ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    Host.where(:ems_id => ems).count
+    ems.empty? ? false : Host.where(:ems_id => ems).exists?
   end
 
-  def self.count_of_non_openstack_hosts
+  def self.non_openstack_hosts_exists?
     ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    Host.where(Host.arel_table[:ems_id].not_in(ems)).count
+    Host.where.not(:ems_id => ems).exists?
   end
 
   def openstack_host?


### PR DESCRIPTION
1. No reason to query the database if `ems_id == []`.
2. changing the order of the logic removes a (cached) query as well.

These are in the header and every page.

/cc @dmetzger57 negligible performance but 2 fewer queries per page is nicw. trivial changes