### PR TITLE
containers: smart state: fix error handling

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -147,7 +147,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
 
     begin
       pod = client.get_pod(options[:pod_name], options[:pod_namespace])
-    rescue SocketError, KubeException => e
+    rescue KubeException => e
       if e.error_code == ERRCODE_POD_NOTFOUND
         _log.info("pod #{pod_full_name} not found, skipping delete")
         return queue_signal(:finish)

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -185,7 +185,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   private
 
   def target_entity
-    target_class.constantize.find(target_id)
+    target_class.constantize.find_by_id(target_id)
   end
 
   def ext_management_system

--- a/spec/models/container_scan_spec.rb
+++ b/spec/models/container_scan_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+class MockClient
+  def create_pod(*_args)
+    nil
+  end
+
+  def proxy_url(*_args)
+    'http://test.com'
+  end
+
+  def headers(*_args)
+    []
+  end
+
+  def get_pod(*_args)
+    RecursiveOpenStruct.new(
+      :metadata => {
+        :annotations => {
+          'manageiq.org/jobid' => '5'
+        }
+      }
+    )
+  end
+end
+
+describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
+  context "A single Container Scan Job," do
+    before(:each) do
+      @server = EvmSpecHelper.local_miq_server
+
+      described_class.any_instance.stub(:kubernetes_client => MockClient.new)
+
+      @ems = FactoryGirl.create(
+        :ems_kubernetes, :hostname => "test.com", :zone => @server.zone, :port => 8443,
+        :authentications => [AuthToken.new(:name => "test", :type => 'AuthToken', :auth_key => "a secret")]
+      )
+
+      @image = FactoryGirl.create(
+        :container_image, :ext_management_system => @ems, :name => 'test',
+        :image_ref => 'docker://3629a651e6c11d7435937bdf41da11cf87863c03f2587fa788cf5cbfe8a11b9a'
+      )
+
+      @image.class.any_instance.stub(:scan_metadata) do |_args|
+        @job.signal(:data, '<summary><scanmetadata></scanmetadata></summary>')
+      end
+
+      @image.class.any_instance.stub(:sync_metadata) do |_args|
+        @job.signal(:data, '<summary><syncmetadata></syncmetadata></summary>')
+      end
+
+      @job = @image.scan
+      MiqQueue.stub(:put_unless_exists) do |args|
+        @job.signal(*args[:args])
+      end
+    end
+
+    it 'should report success' do
+      VCR.use_cassette(described_class.name.underscore, :record => :none) do # needed for health check
+        @job.state.should eq 'waiting_to_start'
+        @job.signal(:start)
+        @job.state.should eq 'finished'
+        @job.status.should eq 'ok'
+      end
+    end
+
+    context 'when the job is called with a non existing image' do
+      before(:each) do
+        @image.delete
+      end
+
+      it 'should report the error' do
+        @job.signal(:start)
+        @job.state.should eq 'finished'
+        @job.status.should eq 'error'
+        @job.message.should eq "no image found"
+      end
+    end
+
+    context 'when create pod throws exception' do
+      CODE = 0
+      CLIENT_MESSAGE = 'error'
+      before(:each) do
+        MockClient.any_instance.stub(:create_pod) do |*_args|
+          raise KubeException.new(CODE, CLIENT_MESSAGE, nil)
+        end
+      end
+
+      it 'should report the error' do
+        @job.signal(:start)
+        @job.state.should eq 'finished'
+        @job.status.should eq 'error'
+        @job.message.should eq "pod creation for management-infra/manageiq-img-scan-3629a651e6c1" \
+                               " failed: HTTP status code #{CODE}, #{CLIENT_MESSAGE}"
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/scanning/job.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/scanning/job.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://test.com/healthz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: Moved Temporarily
+    headers:
+      Server:
+      - nginx/1.7.12
+      Date:
+      - Mon, 07 Dec 2015 14:16:18 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '161'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=20
+      Location:
+      - https://www.test.com/
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>302 Found</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>302
+        Found</h1></center>\r\n<hr><center>nginx/1.7.12</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 07 Dec 2015 14:16:18 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
COMMIT: containers: smart state: missing attribute in exception handling
Allows getting [1] instead of [2] when for example the network is unplugged since SocketError has no error code

COMMIT: containers: smart state: return nil if no image
Avoid throwing exception when the job's image is not found.  
This allows error handling to proceed as intended.

COMMIT: containers: smart state: fix error handling
Persist message and status by calling job.process_abort. 
Also solves reporting of errors coming from the infrastructure. These include exceptions thrown by the job and timeouts.

COMMIT: containers: smart state: tests
Test job outcome (state, status and message) when the job completes successfully and when two types
of error occur.

[1] 
[----] E, [2015-11-23T23:39:36.036341 #23083:feb988] ERROR -- : Q-task_id([ac48b4e4-922a-11e5-aada-0242f322b913]) MIQ(MiqQueue#deliver) Message id: [7400], Error: [getaddrinfo: No address associated with hostname]
[----] E, [2015-11-23T23:39:36.036716 #23083:feb988] ERROR -- : Q-task_id([ac48b4e4-922a-11e5-aada-0242f322b913]) [SocketError]: getaddrinfo: No address associated with hostname  Method:[rescue in deliver]
[----] E, [2015-11-23T23:39:36.036789 #23083:feb988] ERROR -- : Q-task_id([ac48b4e4-922a-11e5-aada-0242f322b913]) /home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:879:in `initialize'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:879:in `open'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:879:in `block in connect'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:74:in `timeout'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:878:in `connect'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:863:in `do_start'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/net/http.rb:852:in `start'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/rest-client-2.0.0.rc1/lib/restclient/request.rb:494:in `transmit'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/rest-client-2.0.0.rc1/lib/restclient/request.rb:202:in `execute'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/rest-client-2.0.0.rc1/lib/restclient/request.rb:52:in `execute'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/rest-client-2.0.0.rc1/lib/restclient/resource.rb:51:in `get'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/kubeclient-0.8.0/lib/kubeclient/common.rb:171:in `block in get_entity'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/kubeclient-0.8.0/lib/kubeclient/common.rb:45:in `handle_exception'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/kubeclient-0.8.0/lib/kubeclient/common.rb:169:in `get_entity'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/kubeclient-0.8.0/lib/kubeclient/common.rb:88:in `block (2 levels) in define_entity_methods'
/home/mtayer/dev/manageiq/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb:143:in `cleanup'
/home/mtayer/dev/manageiq/app/models/job/state_machine.rb:29:in `signal'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:346:in `block in deliver'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:89:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:104:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:342:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:106:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:151:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:145:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:145:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:335:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:332:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:332:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:154:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:129:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:29:in `start_worker'
/home/mtayer/dev/manageiq/lib/workers/bin/worker.rb:2:in `<top (required)>'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/runner.rb:60:in `load'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/runner.rb:60:in `<top (required)>'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:123:in `require'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:90:in `runner'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands.rb:17:in `<top (required)>'
/home/mtayer/dev/manageiq/bin/rails:4:in `require'
/home/mtayer/dev/manageiq/bin/rails:4:in `<main>'

[2]
[----] E, [2015-11-23T23:37:37.002684 #22174:d6798c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [7334], Error: [undefined local variable or method `error_code' for #<ManageIQ::Providers::Kubernetes::ContainerM
anager::Scanning::Job:0x0000000462ba20>]
[----] E, [2015-11-23T23:37:37.002879 #22174:d6798c] ERROR -- : [NameError]: undefined local variable or method `error_code' for #<ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job:0x0000000462ba2
0>  Method:[rescue in deliver]
[----] E, [2015-11-23T23:37:37.002947 #22174:d6798c] ERROR -- : /home/mtayer/.rvm/gems/ruby-2.2.1/gems/activemodel-4.2.5/lib/active_model/attribute_methods.rb:433:in `method_missing'
/home/mtayer/dev/manageiq/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb:145:in `rescue in cleanup'
/home/mtayer/dev/manageiq/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb:142:in `cleanup'
/home/mtayer/dev/manageiq/app/models/job/state_machine.rb:29:in `signal'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:346:in `block in deliver'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:89:in `block in timeout'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `block in catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:34:in `catch'
/home/mtayer/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/timeout.rb:104:in `timeout'
/home/mtayer/dev/manageiq/app/models/miq_queue.rb:342:in `deliver'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:106:in `deliver_queue_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:134:in `deliver_message'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:151:in `block in do_work'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:145:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_queue_worker_base/runner.rb:145:in `do_work'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:335:in `block in do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:332:in `loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:332:in `do_work_loop'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:154:in `run'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:129:in `start'
/home/mtayer/dev/manageiq/app/models/miq_worker/runner.rb:29:in `start_worker'
/home/mtayer/dev/manageiq/lib/workers/bin/worker.rb:2:in `<top (required)>'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/runner.rb:60:in `load'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/runner.rb:60:in `<top (required)>'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:123:in `require'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:90:in `runner'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/mtayer/.rvm/gems/ruby-2.2.1/gems/railties-4.2.5/lib/rails/commands.rb:17:in `<top (required)>'
/home/mtayer/dev/manageiq/bin/rails:4:in `require'
/home/mtayer/dev/manageiq/bin/rails:4:in `<main>'