### PR TITLE
Hide empty form group on toolbar.

### DIFF
--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -15,6 +15,7 @@ module ToolbarHelper
                      first_button[:name] =~ /^view_/
 
       cls = view_buttons ? 'toolbar-pf-view-selector ' : ''
+      cls += 'hidden ' unless buttons.find { |button| !button[:hidden] }
       content_tag(:div, :class => "#{cls} form-group") do # form-group aroung each toolbar section
         if view_buttons
           view_mode_buttons(buttons)

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -114,8 +114,8 @@ module ToolbarHelper
   # Render drop-down top button
   #
   def toolbar_top_button_select(props)
-    content_tag(:div, :class => 'btn-group dropdown') do
-      cls = props[:hidden] ? 'hidden ' : ''
+    cls = props[:hidden] ? 'hidden ' : ''
+    content_tag(:div, :class => "#{cls}btn-group dropdown") do
       cls += 'disabled ' if props['enabled'].to_s == 'false'
       out = []
       out << content_tag(:button,

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -9,10 +9,11 @@ module ToolbarHelper
     groups = split_to_groups(Array(buttons_in))
 
     groups.collect do |buttons|
+      buttons = Array(buttons)
+
       # exceptional behavior for view toolbar view mode buttons
-      first_button = Array(buttons)[0]
-      view_buttons = first_button.present? &&
-                     first_button[:name] =~ /^view_/
+      view_buttons = buttons.first.present? &&
+                     buttons.first[:name] =~ /^view_/
 
       cls = view_buttons ? 'toolbar-pf-view-selector ' : ''
       cls += 'hidden ' unless buttons.find { |button| !button[:hidden] }
@@ -67,7 +68,7 @@ module ToolbarHelper
   # Render a group of normal toolbar buttons
   #
   def normal_toolbar_buttons(buttons)
-    Array(buttons).collect do |button|
+    buttons.collect do |button|
       toolbar_top_button(button)
     end.join('').html_safe
   end


### PR DESCRIPTION
Hide empty form group on toolbar.

The group is just hidden so can be dynamically show when a button would be shown.

## Before

![form-grp-pre](https://cloud.githubusercontent.com/assets/51095/11421116/e3584a8a-9432-11e5-89fd-97e70ea5abd9.png)

## After

![form-grp-post](https://cloud.githubusercontent.com/assets/51095/11421123/f1811542-9432-11e5-9e8f-8be25693b482.png)

Can be tested by e.g. adding a custom button group to VMs and assigning no buttons to that group. But the change is general.