### PR TITLE
Chargeback rates: correctly render tree nodes with no cb rates

### DIFF
--- a/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/app/presenters/tree_builder_chargeback_assignments.rb
@@ -18,8 +18,7 @@ class TreeBuilderChargebackAssignments < TreeBuilder
     # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
     case options[:type]
     when :cb_assignments, :cb_rates
-      rates = ChargebackRate.all
-      rate_types = rates.collect(&:rate_type).uniq.sort
+      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
 
       if count_only
         rate_types.length

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -18,8 +18,7 @@ class TreeBuilderChargebackRates < TreeBuilder
     # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
     case options[:type]
     when :cb_assignments, :cb_rates
-      rates = ChargebackRate.all
-      rate_types = rates.collect(&:rate_type).uniq.sort
+      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
 
       if count_only
         rate_types.length

--- a/spec/presenters/tree_builder_chargeback_assignments.rb
+++ b/spec/presenters/tree_builder_chargeback_assignments.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe TreeBuilderChargebackAssignments do
+  context "#x_get_tree_roots" do
+    it "correctly renders storage and compute nodes when no rates are available" do
+      tree = TreeBuilderChargebackAssignments.new("cb_rates_tree", "cb_rates", {})
+      keys = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['key'] }
+      titles = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['title'] }
+      rates = ChargebackRate.all
+
+      rates.should be_empty
+      keys.should match_array %w(xx-Compute xx-Storage)
+      titles.should match_array %w(Compute Storage)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_chargeback_rates_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_rates_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe TreeBuilderChargebackRates do
+  context "#x_get_tree_roots" do
+    it "correctly renders storage and compute nodes when no rates are available" do
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      keys = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['key'] }
+      titles = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['title'] }
+      rates = ChargebackRate.all
+
+      rates.should be_empty
+      keys.should match_array %w(xx-Compute xx-Storage)
+      titles.should match_array %w(Compute Storage)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -32,7 +32,16 @@ describe TreeBuilder do
     it "builds tree object and sets all settings and add nodes to tree object" do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
       nodes = [{:key      => "root",
-                :children => [],
+                :children => [{:key     => "xx-Compute",
+                               :icon    => "hardware-processor.png",
+                               :title   => "Compute",
+                               :expand  => true,
+                               :tooltip => "Compute"},
+                              {:key     => "xx-Storage",
+                               :icon    => "hardware-disk.png",
+                               :title   => "Storage",
+                               :expand  => true,
+                               :tooltip => "Storage"}],
                 :expand   => true,
                 :title    => "Rates",
                 :tooltip  => "Rates",


### PR DESCRIPTION
Chargeback rates tree builder needs to be able to create / render
storage and compute tree nodes even when there are no chargeback
rates available in the database.

https://bugzilla.redhat.com/show_bug.cgi?id=1284014