### PR TITLE
Dashboard edit - make it possible to drop into an empty column

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -30,7 +30,7 @@ $login-container-details-border-color-rgba: rgba(0, 0, 0, 0.5);
 
 
 .login-pf #brand img { // sets size of brand.svg on login screen (upstream only)
-	height: 38px;
+  height: 38px;
 }
 
 body.whitelabel {

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -329,7 +329,14 @@ iframe, .iframe {
 /* adds scrollbar to group switcher  */
 
 .scrollable-menu {
-    height: auto;
-    max-height: 400px;
-    overflow-x: hidden;
+  height: auto;
+  max-height: 400px;
+  overflow-x: hidden;
+}
+
+/* make it possible to drop a dashboard widget into a previously empty column */
+
+.db_widgets_target {
+  padding-top: 20px;  // same as .panel's margin-bottom
+  min-height: 78px; // .panel.height + (2 * 20px)
 }

--- a/app/views/report/_db_widgets.html.haml
+++ b/app/views/report/_db_widgets.html.haml
@@ -13,21 +13,22 @@
                   options_for_select(@widgets_options, @edit[:new][:widget].to_s),
                   :class => "selectpicker")
   .row#modules
-    .col-md-4#col1
+    .col-md-4#col1{:class => @in_a_form ? 'db_widgets_target' : ''}
       - edit[:new][:col1].each do |w|
         - widget = MiqWidget.find_by_id(w)
         - if widget && widget.enabled
           = render :partial => 'db_widget', :locals => {:widget => widget}
-    .col-md-4#col2
+    .col-md-4#col2{:class => @in_a_form ? 'db_widgets_target' : ''}
       - edit[:new][:col2].each do |w|
         - widget = MiqWidget.find_by_id(w)
         - if widget && widget.enabled
           = render :partial => 'db_widget', :locals => {:widget => widget}
-    .col-md-4#col3
+    .col-md-4#col3{:class => @in_a_form ? 'db_widgets_target' : ''}
       - edit[:new][:col3].each do |w|
         - widget = MiqWidget.find_by_id(w)
         - if widget && widget.enabled
           = render :partial => 'db_widget', :locals => {:widget => widget}
+
 :javascript
   miqInitSelectPicker();
   miqSelectPickerEvent("widget", "#{combo_url}")


### PR DESCRIPTION
Go to CI > Reports > Dashboards.. and edit a dashboard.

Move all widgets out from one column.. it will be impossible to move them back, because that column will have height of 0 or 1 pixels.

This forces a height of at least 1 widget even if empty, in edit mode.

https://bugzilla.redhat.com/show_bug.cgi?id=1287178