### PR TITLE
MiqRequestMethods - sort_template_grid should call sort_grid('template', ...)

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -256,7 +256,7 @@ module ApplicationController::MiqRequestMethods
   # get the sort column that was clicked on, else use the current one
   def sort_template_grid
     @edit = session[:edit]
-    sort_grid('script', @edit[:wf].get_field(:customization_template_id, :customize)[:values])
+    sort_grid('template', @edit[:wf].get_field(:customization_template_id, :customize)[:values])
   end
 
   private ############################


### PR DESCRIPTION
There is no build_script_grid, no prov_script_div, etc.

The other sort_*_grid allways pass the * to sort_grid, and so should sort_template_grid.

https://bugzilla.redhat.com/show_bug.cgi?id=1283604