### PR TITLE
Clean up ApplicationHelper::ToolbarChooser spec

### DIFF
--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -12,18 +12,19 @@ describe ApplicationHelper do
     end
 
     context "#center_toolbar_filename_classic" do
-      it "miq_request summary screen" do
-        @lastaction = "show"
+      before do
         @view = true
         @layout = "miq_request_vm"
+      end
+
+      it "miq_request summary screen" do
+        @lastaction = "show"
         toolbar_name = center_toolbar_filename_classic
         toolbar_name.should == "miq_request_center_tb"
       end
 
       it "miq_request list screen" do
         @lastaction = "show_list"
-        @view = true
-        @layout = "miq_request_vm"
         toolbar_name = center_toolbar_filename_classic
         toolbar_name.should == "miq_requests_center_tb"
       end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -2,11 +2,6 @@ require "spec_helper"
 
 describe ApplicationHelper do
   context "ToolbarChooser" do
-    before do
-      controller.send(:extend, ApplicationHelper)
-      self.class.send(:include, ApplicationHelper)
-    end
-
     def method_missing(sym, *args)
       b = _toolbar_chooser
       if b.respond_to?(sym, true)

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -1,85 +1,87 @@
 require "spec_helper"
 
 describe ApplicationHelper do
-  before do
-    controller.send(:extend, ApplicationHelper)
-    self.class.send(:include, ApplicationHelper)
-  end
-
-  def method_missing(sym, *args)
-    b = _toolbar_chooser
-    if b.respond_to?(sym, true)
-      b.send(sym, *args)
-    else
-      super
-    end
-  end
-
-  context "#center_toolbar_filename_classic" do
-    it "miq_request summary screen" do
-      @lastaction = "show"
-      @view = true
-      @layout = "miq_request_vm"
-      toolbar_name = center_toolbar_filename_classic
-      toolbar_name.should == "miq_request_center_tb"
+  context "ToolbarChooser" do
+    before do
+      controller.send(:extend, ApplicationHelper)
+      self.class.send(:include, ApplicationHelper)
     end
 
-    it "miq_request list screen" do
-      @lastaction = "show_list"
-      @view = true
-      @layout = "miq_request_vm"
-      toolbar_name = center_toolbar_filename_classic
-      toolbar_name.should == "miq_requests_center_tb"
+    def method_missing(sym, *args)
+      b = _toolbar_chooser
+      if b.respond_to?(sym, true)
+        b.send(sym, *args)
+      else
+        super
+      end
     end
-  end
 
-  describe "generate explorer toolbar file names" do
-    context "#center_toolbar_filename_automate" do
-      before do
-        @sb = {:active_tree => :ae_tree,
-               :trees       => {:ae_tree => {:tree => :ae_tree}}}
+    context "#center_toolbar_filename_classic" do
+      it "miq_request summary screen" do
+        @lastaction = "show"
+        @view = true
+        @layout = "miq_request_vm"
+        toolbar_name = center_toolbar_filename_classic
+        toolbar_name.should == "miq_request_center_tb"
       end
 
-      it "should return domains toolbar on root node" do
-        x_node_set('root', :ae_tree)
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_domains_center_tb")
+      it "miq_request list screen" do
+        @lastaction = "show_list"
+        @view = true
+        @layout = "miq_request_vm"
+        toolbar_name = center_toolbar_filename_classic
+        toolbar_name.should == "miq_requests_center_tb"
       end
+    end
 
-      it "should return namespaces toolbar on domain node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
-        x_node_set("aen-#{n1.id}", :ae_tree)
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_domain_center_tb")
-      end
+    describe "generate explorer toolbar file names" do
+      context "#center_toolbar_filename_automate" do
+        before do
+          @sb = {:active_tree => :ae_tree,
+                 :trees       => {:ae_tree => {:tree => :ae_tree}}}
+        end
 
-      it "should return namespace toolbar on namespace node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
-        x_node_set("aen-#{n1.id}", :ae_tree)
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_namespace_center_tb")
-      end
+        it "should return domains toolbar on root node" do
+          x_node_set('root', :ae_tree)
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_domains_center_tb")
+        end
 
-      it "should return tab specific toolbar on class node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
-        c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
-        x_node_set("aec-#{c1.id}", :ae_tree)
+        it "should return namespaces toolbar on domain node" do
+          n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
+          x_node_set("aen-#{n1.id}", :ae_tree)
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_domain_center_tb")
+        end
 
-        @sb[:active_tab] = "props"
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_class_center_tb")
+        it "should return namespace toolbar on namespace node" do
+          n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+          x_node_set("aen-#{n1.id}", :ae_tree)
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_namespace_center_tb")
+        end
 
-        @sb[:active_tab] = "methods"
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_methods_center_tb")
+        it "should return tab specific toolbar on class node" do
+          n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+          c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+          x_node_set("aec-#{c1.id}", :ae_tree)
 
-        @sb[:active_tab] = "schema"
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_fields_center_tb")
+          @sb[:active_tab] = "props"
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_class_center_tb")
 
-        @sb[:active_tab] = ""
-        toolbar_name = center_toolbar_filename_automate
-        toolbar_name.should eq("miq_ae_instances_center_tb")
+          @sb[:active_tab] = "methods"
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_methods_center_tb")
+
+          @sb[:active_tab] = "schema"
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_fields_center_tb")
+
+          @sb[:active_tab] = ""
+          toolbar_name = center_toolbar_filename_automate
+          toolbar_name.should eq("miq_ae_instances_center_tb")
+        end
       end
     end
   end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -2,16 +2,7 @@ require "spec_helper"
 
 describe ApplicationHelper do
   context "ToolbarChooser" do
-    def method_missing(sym, *args)
-      b = _toolbar_chooser
-      if b.respond_to?(sym, true)
-        b.send(sym, *args)
-      else
-        super
-      end
-    end
-
-    context "#center_toolbar_filename_classic" do
+    context "#center_toolbar_filename_classic (private)" do
       before do
         @view   = true
         @layout = "miq_request_vm"
@@ -19,34 +10,34 @@ describe ApplicationHelper do
 
       it "miq_request summary screen" do
         @lastaction = "show"
-        expect(center_toolbar_filename_classic).to eq("miq_request_center_tb")
+        expect(_toolbar_chooser.send(:center_toolbar_filename_classic)).to eq("miq_request_center_tb")
       end
 
       it "miq_request list screen" do
         @lastaction = "show_list"
-        expect(center_toolbar_filename_classic).to eq("miq_requests_center_tb")
+        expect(_toolbar_chooser.send(:center_toolbar_filename_classic)).to eq("miq_requests_center_tb")
       end
     end
 
     describe "generate explorer toolbar file names" do
-      context "#center_toolbar_filename_automate" do
+      context "#center_toolbar_filename_automate (private)" do
         before { @sb = {:active_tree => :ae_tree, :trees => {:ae_tree => {:tree => :ae_tree}}} }
 
         it "should return domains toolbar on root node" do
           x_node_set('root', :ae_tree)
-          expect(center_toolbar_filename_automate).to eq("miq_ae_domains_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domains_center_tb")
         end
 
         it "should return namespaces toolbar on domain node" do
           n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
           x_node_set("aen-#{n1.id}", :ae_tree)
-          expect(center_toolbar_filename_automate).to eq("miq_ae_domain_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domain_center_tb")
         end
 
         it "should return namespace toolbar on namespace node" do
           n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
           x_node_set("aen-#{n1.id}", :ae_tree)
-          expect(center_toolbar_filename_automate).to eq("miq_ae_namespace_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_namespace_center_tb")
         end
 
         it "should return tab specific toolbar on class node" do
@@ -55,16 +46,16 @@ describe ApplicationHelper do
           x_node_set("aec-#{c1.id}", :ae_tree)
 
           @sb[:active_tab] = "props"
-          expect(center_toolbar_filename_automate).to eq("miq_ae_class_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_class_center_tb")
 
           @sb[:active_tab] = "methods"
-          expect(center_toolbar_filename_automate).to eq("miq_ae_methods_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_methods_center_tb")
 
           @sb[:active_tab] = "schema"
-          expect(center_toolbar_filename_automate).to eq("miq_ae_fields_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_fields_center_tb")
 
           @sb[:active_tab] = ""
-          expect(center_toolbar_filename_automate).to eq("miq_ae_instances_center_tb")
+          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_instances_center_tb")
         end
       end
     end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -13,48 +13,40 @@ describe ApplicationHelper do
 
     context "#center_toolbar_filename_classic" do
       before do
-        @view = true
+        @view   = true
         @layout = "miq_request_vm"
       end
 
       it "miq_request summary screen" do
         @lastaction = "show"
-        toolbar_name = center_toolbar_filename_classic
-        toolbar_name.should == "miq_request_center_tb"
+        expect(center_toolbar_filename_classic).to eq("miq_request_center_tb")
       end
 
       it "miq_request list screen" do
         @lastaction = "show_list"
-        toolbar_name = center_toolbar_filename_classic
-        toolbar_name.should == "miq_requests_center_tb"
+        expect(center_toolbar_filename_classic).to eq("miq_requests_center_tb")
       end
     end
 
     describe "generate explorer toolbar file names" do
       context "#center_toolbar_filename_automate" do
-        before do
-          @sb = {:active_tree => :ae_tree,
-                 :trees       => {:ae_tree => {:tree => :ae_tree}}}
-        end
+        before { @sb = {:active_tree => :ae_tree, :trees => {:ae_tree => {:tree => :ae_tree}}} }
 
         it "should return domains toolbar on root node" do
           x_node_set('root', :ae_tree)
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_domains_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_domains_center_tb")
         end
 
         it "should return namespaces toolbar on domain node" do
           n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
           x_node_set("aen-#{n1.id}", :ae_tree)
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_domain_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_domain_center_tb")
         end
 
         it "should return namespace toolbar on namespace node" do
           n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
           x_node_set("aen-#{n1.id}", :ae_tree)
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_namespace_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_namespace_center_tb")
         end
 
         it "should return tab specific toolbar on class node" do
@@ -63,20 +55,16 @@ describe ApplicationHelper do
           x_node_set("aec-#{c1.id}", :ae_tree)
 
           @sb[:active_tab] = "props"
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_class_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_class_center_tb")
 
           @sb[:active_tab] = "methods"
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_methods_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_methods_center_tb")
 
           @sb[:active_tab] = "schema"
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_fields_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_fields_center_tb")
 
           @sb[:active_tab] = ""
-          toolbar_name = center_toolbar_filename_automate
-          toolbar_name.should eq("miq_ae_instances_center_tb")
+          expect(center_toolbar_filename_automate).to eq("miq_ae_instances_center_tb")
         end
       end
     end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe ApplicationHelper do
-  context "ToolbarChooser" do
+describe ApplicationHelper, "ToolbarChooser" do
+  describe "generate explorer toolbar file names" do
     context "#center_toolbar_filename_classic (private)" do
       before do
         @view   = true
@@ -19,44 +19,42 @@ describe ApplicationHelper do
       end
     end
 
-    describe "generate explorer toolbar file names" do
-      context "#center_toolbar_filename_automate (private)" do
-        before { @sb = {:active_tree => :ae_tree, :trees => {:ae_tree => {:tree => :ae_tree}}} }
+    context "#center_toolbar_filename_automate (private)" do
+      before { @sb = {:active_tree => :ae_tree, :trees => {:ae_tree => {:tree => :ae_tree}}} }
 
-        it "should return domains toolbar on root node" do
-          x_node_set('root', :ae_tree)
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domains_center_tb")
-        end
+      it "should return domains toolbar on root node" do
+        x_node_set('root', :ae_tree)
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domains_center_tb")
+      end
 
-        it "should return namespaces toolbar on domain node" do
-          n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
-          x_node_set("aen-#{n1.id}", :ae_tree)
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domain_center_tb")
-        end
+      it "should return namespaces toolbar on domain node" do
+        n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
+        x_node_set("aen-#{n1.id}", :ae_tree)
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domain_center_tb")
+      end
 
-        it "should return namespace toolbar on namespace node" do
-          n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
-          x_node_set("aen-#{n1.id}", :ae_tree)
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_namespace_center_tb")
-        end
+      it "should return namespace toolbar on namespace node" do
+        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+        x_node_set("aen-#{n1.id}", :ae_tree)
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_namespace_center_tb")
+      end
 
-        it "should return tab specific toolbar on class node" do
-          n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
-          c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
-          x_node_set("aec-#{c1.id}", :ae_tree)
+      it "should return tab specific toolbar on class node" do
+        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+        c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+        x_node_set("aec-#{c1.id}", :ae_tree)
 
-          @sb[:active_tab] = "props"
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_class_center_tb")
+        @sb[:active_tab] = "props"
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_class_center_tb")
 
-          @sb[:active_tab] = "methods"
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_methods_center_tb")
+        @sb[:active_tab] = "methods"
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_methods_center_tb")
 
-          @sb[:active_tab] = "schema"
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_fields_center_tb")
+        @sb[:active_tab] = "schema"
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_fields_center_tb")
 
-          @sb[:active_tab] = ""
-          expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_instances_center_tb")
-        end
+        @sb[:active_tab] = ""
+        expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_instances_center_tb")
       end
     end
   end


### PR DESCRIPTION
- Fix describes and contexts to improve readability
- Remove unnecessary includes and extends
- Remove method_missing hack
- Upgrade to expect syntax