### PR TITLE
core: fix start_event_monitor logic

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -149,13 +149,14 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
 
   def do_work
     if @tid.nil? || !@tid.alive?
-      _log.info("#{log_prefix} Event Monitor Thread gone. Restarting...")
-      @tid ||= start_event_monitor
-
-      if @tid.status.nil?
+      if !@tid.nil? && @tid.status.nil?
         dead_tid, @tid = @tid, nil
+        _log.info("#{log_prefix} Waiting for the Monitor Thread to exit...")
         dead_tid.join # raise the exception the dead thread failed with
       end
+
+      _log.info("#{log_prefix} Event Monitor Thread gone. Restarting...")
+      @tid = start_event_monitor
     end
 
     process_events(@queue.deq) while @queue.length > 0


### PR DESCRIPTION
In some cases `@tid` could be dead (not `alive?`) but still have a `status`, which would lead to an infinite loop.

In fact:

    @tid ||= start_event_monitor

would never `start` a new `event_monitor` (since `@tid` already has value), and:

    if @tid.status.nil?
      dead_tid, @tid = @tid, nil
      ...

would never take place as `@tid.status` is not `nil` resulting in an infinite loop.

This issue was introduced in #4939

cc @jvlcek @Fryguy @chessbyte @blomquisg 