### PR TITLE
ReportController - cache @grid_folders, same as @folders

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -995,6 +995,7 @@ class ReportController < ApplicationController
     @report_groups    = session[:report_groups]
     @edit             = session[:edit] unless session[:edit].nil?
     @catinfo          = session[:vm_catinfo]
+    @grid_folders     = session[:report_grid_folders]
   end
 
   def set_session_data
@@ -1009,6 +1010,7 @@ class ReportController < ApplicationController
     session[:report_result_id]  = @report_result_id
     session[:report_menu]       = @menu
     session[:report_folders]    = @folders
+    session[:report_grid_folders] = @grid_folders
   end
 
   def widget_import_service


### PR DESCRIPTION
menu_field_changed calls get_tree_data and then renders right div, which needs `@grid_folders`

get_tree_data calls edit_reports in that case, which does not regenerate `@grid_folders`
(edit_folder does, but also changes `@folders` and depends on params and session stuff which *may* have changed)

updated ReportController to cache the computed `@grid_folders`

https://bugzilla.redhat.com/show_bug.cgi?id=1283885