### PR TITLE
Allow users to see reports in their groups

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -157,10 +157,10 @@ module ReportController::SavedReports
 
     # Admin users can see all saved reports
     unless admin_user?
-      cond[0] << " AND miq_group_id=?"
-      cond.push(current_group_id)
+      cond[0] << " AND miq_group_id IN (?)"
+      cond.push(current_user.miq_groups.collect(&:id))
     end
 
-    cond.flatten
+    cond
   end
 end

--- a/app/presenters/tree_builder_report_reports_class.rb
+++ b/app/presenters/tree_builder_report_reports_class.rb
@@ -2,7 +2,7 @@ class TreeBuilderReportReportsClass < TreeBuilder
   private
 
   def x_get_tree_r_kids(object, count_only)
-    objects = MiqReportResult.where(set_saved_reports_condition(object.id)).all
+    objects = MiqReportResult.where(set_saved_reports_condition(object.id)).to_a
     count_only_or_objects(count_only, objects, nil)
   end
 

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -20,8 +20,8 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   def x_get_tree_roots(count_only, _options)
     folder_ids = {}
     u = User.current_user
-    g = u.admin_user? ? nil : u.miq_group
-    MiqReport.having_report_results(:miq_group => g, :select => [:id, :name]).each do |r|
+    user_groups = u.admin_user? ? nil : u.miq_groups
+    MiqReport.having_report_results(:miq_groups => user_groups, :select => [:id, :name]).each do |r|
       folder_ids[r.name] = to_cid(r.id.to_i)
     end
     objects = []

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -32,7 +32,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    objects = MiqReportResult.where(set_saved_reports_condition(from_cid(object[:id].split('-').last))).all
+    objects = MiqReportResult.where(set_saved_reports_condition(from_cid(object[:id].split('-').last))).to_a
     count_only_or_objects(count_only, objects, nil)
   end
 end

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,5 +1,19 @@
 require "spec_helper"
 
+def create_user_with_group(user_id, group_name, role)
+  group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => group_name)
+  FactoryGirl.create(:user, :userid => user_id, :miq_groups => [group])
+end
+
+def create_and_generate_report_for_user(report_name, user_id)
+  MiqReport.seed_report(report_name)
+  @rpt = MiqReport.where(:name => report_name).last
+  @rpt.generate_table(:userid => user_id)
+  report_result = @rpt.build_create_results(:userid => user_id)
+  report_result.reload
+  @rpt
+end
+
 describe ReportHelper do
   context '#chart_fields_options' do
     it 'should return fields with models and aggregate functions from summary when "Show Sort Breaks" is not "No"' do

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require "helpers/report_helper_spec"
+
+describe TreeBuilderReportSavedReports do
+  include CompressedIds
+
+  describe "#x_get_tree_roots" do
+    context "User1 has Group1(current group: Group1), User2 has Group1, Group2(current group: Group2)" do
+      before :each do
+        EvmSpecHelper.local_miq_server
+
+        MiqUserRole.seed
+        role = MiqUserRole.find_by_name("EvmRole-operator")
+
+        # User1 with 2 groups(Group1,Group2), current group for User2 is Group2
+        create_user_with_group('User2', "Group1", role)
+
+        @user1 = create_user_with_group('User1', "Group2", role)
+        @user1.miq_groups << MiqGroup.where(:description => "Group1")
+        login_as @user1
+      end
+
+      context "User2 generates report under Group1" do
+        before :each do
+          @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
+        end
+
+        it "is allowed to see report created under Group1 for User 1(with current group Group2)" do
+          # there is calling of x_get_tree_roots
+          tree = TreeBuilderReportSavedReports.new('savedreports_tree', 'savedreports', {})
+
+          saved_reports_in_tree = JSON.parse(tree.tree_nodes).first['children']
+
+          displayed_report_ids = saved_reports_in_tree.map do |saved_report|
+            from_cid(saved_report["key"].gsub("xx-", ""))
+          end
+
+          # logged User1 can see report with Group1
+          expect(displayed_report_ids).to include(@rpt.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/B7jTan2r
https://bugzilla.redhat.com/show_bug.cgi?id=1285865

User1 belongs to groups Group1 and Group2. Group2 is current group for User1.
User2 belongs to Group1(current group for User2).
User2 generate Report1(Vendor and Guest OS).
Expected behaviour:
User1 can see saved Report1 in Cloud Inteligence->Reports->Saved Reports
