### PR TITLE
Add number of pods to Services explore table

### DIFF
--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -14,4 +14,10 @@ class ContainerService < ActiveRecord::Base
   has_many :container_nodes, -> { distinct }, :through => :container_groups
 
   acts_as_miq_taggable
+
+  virtual_column :container_groups_count, :type => :integer
+
+  def container_groups_count
+    number_of(:container_groups)
+  end
 end

--- a/product/views/ContainerService.yaml
+++ b/product/views/ContainerService.yaml
@@ -23,6 +23,7 @@ cols:
 - service_type
 - portal_ip
 - session_affinity
+- container_groups_count
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -44,6 +45,7 @@ col_order:
 - service_type
 - portal_ip
 - session_affinity
+- container_groups_count
 
 # Column titles, in order
 headers:
@@ -53,6 +55,7 @@ headers:
 - Type
 - Portal IP
 - Session Affinity
+- Pods
 
 # Condition(s) string for the SQL query
 conditions: 
@@ -65,6 +68,7 @@ sortby:
 - name
 - portal_ip
 - session_affinity
+- container_groups_count
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION
Display number of Pods that a Service is related-to in the Services explore table: 

![services_pods](https://cloud.githubusercontent.com/assets/11769555/11457186/09f7f88c-96ab-11e5-82e6-1a1d0f7e666c.png)
