### PR TITLE
Openstack remove fallback to non ssl

### DIFF
--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -36,16 +36,6 @@ module OpenstackHandle
       else
         yield "http", {}
       end
-    rescue Excon::Errors::SocketError => err
-      # TODO(lsmola) keeping this for backwards compatibility, but it should go away, fallback to non ssl can be be
-      # unsafe. We should never send plain text credentials over wire, when SSL selected
-      # TODO: recognizing something in exception message is not very reliable. But somebody would need to go to excon gem
-      # and do proper exceptions like Excon::Errors::SocketError::UnknownProtocolSSL,
-      # Excon::Errors::SocketError::BadCertificate, etc. all of them inheriting from Excon::Errors::SocketError
-      raise unless err.message.include?("end of file reached (EOFError)") ||
-                   err.message.include?("unknown protocol (OpenSSL::SSL::SSLError)")
-      # attempt the same connection without SSL
-      yield "http", {}
     end
 
     def self.raw_connect_try_ssl(username, password, address, port, service = "Compute", opts = nil, api_version = nil,

--- a/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
+++ b/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
@@ -54,22 +54,11 @@ describe OpenstackHandle::Handle do
 
     it "handles ssl connections just fine, too" do
       fog            = double('fog')
-      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address")
-      auth_url_nossl = OpenstackHandle::Handle.auth_url("address")
+      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl')
       auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
-
-      # setup the socket error for the initial ssl failure
-      socket_error = double('socket_error')
-      allow(socket_error).to receive(:message).and_return("unknown protocol (OpenSSL::SSL::SSLError)")
-      expect(socket_error).to receive(:class).and_return(Object)
-      expect(socket_error).to receive(:backtrace)
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
-        raise Excon::Errors::SocketError.new(socket_error)
-      end
-      expect(OpenstackHandle::Handle).to receive(:raw_connect) do |_, _, address|
-        expect(address).to eq(auth_url_nossl)
         fog
       end
 


### PR DESCRIPTION
Remove fallback to https
    
    When ssl is chosen, data should be always send in encrypted form,
    fallback to non ssl when ssl is not available breaks it. Also
    validation will always return valid, while silenty failing
    and switching to non ssl.
    
    Only downside is that it's not backwards compatible. New default
    will be SSl without validation, so provider needs to be edited to
    what is really supported, otherwise validation and refresh will
    fail.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1286629
