### PR TITLE
Rename class of leaves for Template filter tree.

### DIFF
--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
   def tree_init_options(tree_name)
-    super.update(:leaf => 'MiqTemplate')
+    super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
   end
 
   def set_locals_for_render


### PR DESCRIPTION
Rename class of leaves for Template filter tree as earlier renamed
elsewhere in the big model rename.

https://bugzilla.redhat.com/show_bug.cgi?id=1283642