### PR TITLE
Container Timelines/Utilization - reset UI variables

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -127,6 +127,10 @@ class ContainerController < ApplicationController
     if @display == "timeline"
       show_timeline
     elsif @display != "performance"
+      if @record.nil?
+        self.x_node = "root"
+        @showtype = ""
+      end
       get_node_info(x_node)
     end
 


### PR DESCRIPTION
Moving to another entity tab after displaying container
Timelines/Utilization will result an error when returning
to containers explorer, due to UI variables that needs resetting.