### PR TITLE
Remove container dashboard from default view settings

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -36,7 +36,7 @@
                     #{view_name}
                   .col-md-8
                     %ul#toolbars= render_view_buttons(resource, @edit[:new][:views][resource])
-        - if has_any_role?(%w(ems_container_show_list container_group_show_list container_node_show_list container_route_show_list container_project_show_list container_replicator_show_list container_image_show_list container_image_registry_show_list container_service_accord containers_filter_accord containers_accord container_dashboard))
+        - if has_any_role?(%w(ems_container_show_list container_group_show_list container_node_show_list container_route_show_list container_project_show_list container_replicator_show_list container_image_show_list container_image_registry_show_list container_service_accord containers_filter_accord containers_accord))
           %fieldset
             %h3
               = _('Containers')
@@ -49,8 +49,7 @@
                       :containerreplicator    => "container_replicator",
                       :containerimage         => "container_image",
                       :containerimageregistry => "container_image_registry",
-                      :container              => "container",
-                      :containerdashboard     => "container_dashboard"}
+                      :container              => "container"}
             - keys.each do |resource, table_view_name|
               .form-group
                 %label.col-md-3.control-label


### PR DESCRIPTION
Same as #5632 - containers dashboard no longer appears
![boring](https://cloud.githubusercontent.com/assets/11256940/11479244/a57125e2-9799-11e5-9506-256f0bedad8d.png)
