### PR TITLE
Fix dynamic dropdown scripts for service reconfiguration

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
@@ -2,9 +2,9 @@
 # Description: provide the dynamic list content from available flavors
 #
 flavor_list = {}
-service_template = $evm.root.attributes["service_template"]
-if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
-  service_template.orchestration_manager.flavors.each { |f| flavor_list[f.name] = f.name }
+service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
+if service.respond_to?(:orchestration_manager) && service.orchestration_manager
+  service.orchestration_manager.flavors.each { |f| flavor_list[f.name] = f.name }
 end
 flavor_list[nil] = flavor_list.empty? ? "<None>" : "<Choose>"
 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
@@ -2,9 +2,9 @@
 # Description: provide the dynamic list content from available images
 #
 image_list = {}
-service_template = $evm.root.attributes["service_template"]
-if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
-  service_template.orchestration_manager.miq_templates.each do |img|
+service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
+if service.respond_to?(:orchestration_manager) && service.orchestration_manager
+  service.orchestration_manager.miq_templates.each do |img|
     os = img.hardware.try(:guest_os) || "unknown"
     image_list[img.uid_ems] = "#{os} | #{img.name}"
   end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
@@ -2,9 +2,9 @@
 # Description: provide the dynamic list content from available resource groups
 #
 rg_list = {nil => "<New resource group>"}
-service_template = $evm.root.attributes["service_template"]
-if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
-  service_template.orchestration_manager.resource_groups.each { |t| rg_list[t.name] = t.name }
+service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
+if service.respond_to?(:orchestration_manager) && service.orchestration_manager
+  service.orchestration_manager.resource_groups.each { |t| rg_list[t.name] = t.name }
 end
 
 dialog_field = $evm.object

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
@@ -2,9 +2,9 @@
 # Description: provide the dynamic list content from available tenants
 #
 tenant_list = {nil => "<default>"}
-service_template = $evm.root.attributes["service_template"]
-if service_template.respond_to?(:orchestration_manager) && service_template.orchestration_manager
-  service_template.orchestration_manager.cloud_tenants.each { |t| tenant_list[t.name] = t.name }
+service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
+if service.respond_to?(:orchestration_manager) && service.orchestration_manager
+  service.orchestration_manager.cloud_tenants.each { |t| tenant_list[t.name] = t.name }
 end
 
 dialog_field = $evm.object

--- a/spec/automation/unit/method_validation/available_flavors_spec.rb
+++ b/spec/automation/unit/method_validation/available_flavors_spec.rb
@@ -25,13 +25,13 @@ describe "Available_Flavors Method Validation" do
     end
   end
 
-  context "workspace has orchestration service template" do
-    let(:ems) do
-      @flavor1 = FactoryGirl.create(:flavor, :name => 'flavor1')
-      @flavor2 = FactoryGirl.create(:flavor, :name => 'flavor2')
-      FactoryGirl.create(:ems_openstack, :flavors => [@flavor1, @flavor2])
-    end
+  let(:ems) do
+    @flavor1 = FactoryGirl.create(:flavor, :name => 'flavor1')
+    @flavor2 = FactoryGirl.create(:flavor, :name => 'flavor2')
+    FactoryGirl.create(:ems_openstack, :flavors => [@flavor1, @flavor2])
+  end
 
+  context "workspace has orchestration service template" do
     let(:service_template) do
       FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
     end
@@ -52,6 +52,32 @@ describe "Available_Flavors Method Validation" do
 
     it "provides only default value to the flavor list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
+
+  context "workspace has orchestration service" do
+    let(:service) do
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_no_ems) do
+      FactoryGirl.create(:service_orchestration)
+    end
+
+    it "finds all the flavors and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
+      ws.root["values"].should include(
+        nil           => "<Choose>",
+        @flavor1.name => @flavor1.name,
+        @flavor2.name => @flavor2.name
+      )
+      ws.root["default_value"].should be_nil
+    end
+
+    it "provides only default value to the flavor list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
       ws.root["values"].should == {nil => default_desc}
       ws.root["default_value"].should be_nil
     end

--- a/spec/automation/unit/method_validation/available_images_spec.rb
+++ b/spec/automation/unit/method_validation/available_images_spec.rb
@@ -71,4 +71,51 @@ describe "Available_Images Method Validation" do
       ws.root["default_value"].should be_nil
     end
   end
+
+  context "workspace has orchestration service" do
+    let(:service) do
+      hw1 = FactoryGirl.create(:hardware, :guest_os => 'windows')
+      @img1 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid1', :hardware => hw1)
+
+      hw2 = FactoryGirl.create(:hardware, :guest_os => 'linux')
+      @img2 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid2', :hardware => hw2)
+
+      ems = FactoryGirl.create(:ems_openstack, :miq_templates => [@img1, @img2])
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_one_img) do
+      @img1 = FactoryGirl.create(:template_openstack, :uid_ems => 'uid1')
+      ems = FactoryGirl.create(:ems_openstack, :miq_templates => [@img1])
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_no_ems) do
+      FactoryGirl.create(:service_orchestration)
+    end
+
+    it "finds all the images and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
+      ws.root["values"].should include(
+        nil           => "<Choose>",
+        @img1.uid_ems => "windows | #{@img1.name}",
+        @img2.uid_ems => "linux | #{@img2.name}"
+      )
+      ws.root["default_value"].should be_nil
+    end
+
+    it "finds the only image and set it as the only item in the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_one_img.id}", user)
+      ws.root["values"].should include(
+        @img1.uid_ems => "unknown | #{@img1.name}"
+      )
+      ws.root["default_value"].should == @img1.uid_ems
+    end
+
+    it "provides only default value to the image list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+      ws.root["default_value"].should be_nil
+    end
+  end
 end

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -23,13 +23,13 @@ describe "Available_Resource_Groups Method Validation" do
     end
   end
 
-  context "workspace has orchestration service template" do
-    let(:ems) do
-      @rgroup1 = FactoryGirl.create(:resource_group)
-      @rgroup2 = FactoryGirl.create(:resource_group)
-      FactoryGirl.create(:ems_azure, :resource_groups => [@rgroup1, @rgroup2])
-    end
+  let(:ems) do
+    @rgroup1 = FactoryGirl.create(:resource_group)
+    @rgroup2 = FactoryGirl.create(:resource_group)
+    FactoryGirl.create(:ems_azure, :resource_groups => [@rgroup1, @rgroup2])
+  end
 
+  context "workspace has orchestration service template" do
     let(:service_template) do
       FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
     end
@@ -49,6 +49,30 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      ws.root["values"].should == {nil => default_desc}
+    end
+  end
+
+  context "workspace has orchestration service" do
+    let(:service) do
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_no_ems) do
+      FactoryGirl.create(:service_orchestration)
+    end
+
+    it "finds all the resource groups and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
+      ws.root["values"].should include(
+        nil           => default_desc,
+        @rgroup1.name => @rgroup1.name,
+        @rgroup2.name => @rgroup2.name
+      )
+    end
+
+    it "provides only default value to the resource group list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
       ws.root["values"].should == {nil => default_desc}
     end
   end

--- a/spec/automation/unit/method_validation/available_tenants_spec.rb
+++ b/spec/automation/unit/method_validation/available_tenants_spec.rb
@@ -22,13 +22,13 @@ describe "Available_Tenants Method Validation" do
     end
   end
 
-  context "workspace has orchestration service template" do
-    let(:ems) do
-      @tenant1 = FactoryGirl.create(:cloud_tenant)
-      @tenant2 = FactoryGirl.create(:cloud_tenant)
-      FactoryGirl.create(:ems_openstack, :cloud_tenants => [@tenant1, @tenant2])
-    end
+  let(:ems) do
+    @tenant1 = FactoryGirl.create(:cloud_tenant)
+    @tenant2 = FactoryGirl.create(:cloud_tenant)
+    FactoryGirl.create(:ems_openstack, :cloud_tenants => [@tenant1, @tenant2])
+  end
 
+  context "workspace has orchestration service template" do
     let(:service_template) do
       FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
     end
@@ -48,6 +48,30 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      ws.root["values"].should == {nil => "<default>"}
+    end
+  end
+
+  context "workspace has orchestration service" do
+    let(:service) do
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_no_ems) do
+      FactoryGirl.create(:service_orchestration)
+    end
+
+    it "finds all the tenants and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
+      ws.root["values"].should include(
+        nil           => "<default>",
+        @tenant1.name => @tenant1.name,
+        @tenant2.name => @tenant2.name
+      )
+    end
+
+    it "provides only default value to the tenant list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
       ws.root["values"].should == {nil => "<default>"}
     end
   end


### PR DESCRIPTION
Previously scripts to feed entries for dynamic dropdown lists including `AvailableFlavors`,  `AvailableImages`, `AvailableResourceGroups` and `AvailableTenants`  do not work correctly in service reconfigure dialog.

This fix finds `orchestration_manager` through `service_template` in the case of orchestration service provisioning, or through `service` in the case of service reconfiguration.