### PR TITLE
Fix reset dashboards button

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -81,8 +81,8 @@ function miqOnResize() {
 
 // Initialize the widget pulldown on the dashboard
 function miqInitWidgetPulldown() {
-  $("#dashboard_dropdown #toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").off('click');
-  $("#dashboard_dropdown #toolbar button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").click(miqWidgetToolbarClick);
+  $("#dashboard_dropdown button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").off('click');
+  $("#dashboard_dropdown button:not(.dropdown-toggle), #toolbar ul.dropdown-menu > li > a").on('click', miqWidgetToolbarClick);
 }
 
 function miqCalendarDateConversion(server_offset) {

--- a/app/views/dashboard/_widgets_menu.html.haml
+++ b/app/views/dashboard/_widgets_menu.html.haml
@@ -28,5 +28,5 @@
                   = item[:text]
 
   - if @widgets_menu[:allow_reset]
-    %button.disabled.btn.btn-default.dropdown-toggle{'data-toggle' => 'dropdown', :title => _('Reset Dashboard Widgets to the defaults'), 'data-click' => 'reset'}
+    %button.btn.btn-default{:title => _('Reset Dashboard Widgets to the defaults'), 'data-click' => 'reset'}
       %img{:src => '/images/dashboard/reset_widgets.png'}


### PR DESCRIPTION
clicking on the dashboard reset button should be handled by miqWidgetToolbarClick
which was never called because of a wrong selector in miqInitWidgetPulldown

also un-disabled and removed dropdown-toggle from the button

https://bugzilla.redhat.com/show_bug.cgi?id=1285778