### PR TITLE
Fix rendering of edit and remove buttons for orchestration templates

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -95,13 +95,13 @@ class ApplicationHelper::ToolbarBuilder
               end
             end
           end
-          if bgi[:buttonSelect] == "orchestration_template_vmdb_choice" && x_active_tree == :ot_tree && @record && @record.in_use?
+          if bgi[:buttonSelect] == "orchestration_template_vmdb_choice" && x_active_tree == :ot_tree && @record
             bgi[:items].each do |bgsi|
               if bgsi[:button] == "orchestration_template_edit"
-                bgsi[:enabled] = 'false'
+                bgsi[:enabled] = @record.in_use? ? 'false' : 'true'
                 bgsi[:title] = _('Orchestration Templates that are in use cannot be edited')
               elsif bgsi[:button] == "orchestration_template_remove"
-                bgsi[:enabled] = 'false'
+                bgsi[:enabled] = @record.in_use? ? 'false' : 'true'
                 bgsi[:title] = _('Orchestration Templates that are in use cannot be removed')
               end
             end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2935,6 +2935,9 @@ describe ApplicationHelper do
                      :onwhen    => nil,
                      :url       => "/download_data",
                      :url_parms => "?download_type=pdf"}
+      @layout = "catalogs"
+      helper.stub(:role_allows).and_return(true)
+      helper.stub(:x_active_tree).and_return(:ot_tree)
     end
 
     it "Hides PDF button when PdfGenerator is not available" do
@@ -2947,6 +2950,24 @@ describe ApplicationHelper do
       PdfGenerator.stub(:available? => true)
       buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button['id'] == "download_choice" }.compact.flatten
       buttons.should include(@pdf_button)
+    end
+
+    it "Enables edit and remove buttons for read-write orchestration templates" do
+      @record = FactoryGirl.create(:orchestration_template)
+      buttons = helper.build_toolbar('orchestration_template_center_tb').first[:items]
+      edit_btn = buttons.select {|b| b['id'].end_with?("_edit")}.first
+      remove_btn = buttons.select {|b| b['id'].end_with?("_remove")}.first
+      expect(edit_btn["enabled"]).to eq("true")
+      expect(remove_btn["enabled"]).to eq("true")
+    end
+
+    it "Disables edit and remove buttons for read-only orchestration templates" do
+      @record = FactoryGirl.create(:orchestration_template_with_stacks)
+      buttons = helper.build_toolbar('orchestration_template_center_tb').first[:items]
+      edit_btn = buttons.select {|b| b['id'].end_with?("_edit")}.first
+      remove_btn = buttons.select {|b| b['id'].end_with?("_remove")}.first
+      expect(edit_btn["enabled"]).to eq("false")
+      expect(remove_btn["enabled"]).to eq("false")
     end
   end
 end


### PR DESCRIPTION
Previously, when selecting a read-write OT, then selecting a read-only
OT and then selecting back the read-write OT would incorrectly disable
edit and removal buttons for the read-write OT.

https://bugzilla.redhat.com/show_bug.cgi?id=1286690