### PR TITLE
Container dashboard views for container projects and container groups(pods)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,8 @@
 //= require controllers/ems_common/single_provider_dashboard_controller
 //= require controllers/container_dashboard/card/card-module
 //= require controllers/container_dashboard/card/heatmaps/heatmaps-card-directive
+//= require controllers/container_project/container_project_controller
+//= require controllers/container_group/container_group_controller
 //= require controllers/container_topology/container_topology_controller
 //= require d3/d3
 //= require c3/c3

--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -6,17 +6,7 @@ angular.module('containerDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.
         function($scope, containerDashboardUtils, chartsDataMixin, $http, $interval, $location) {
             document.getElementById("center_div").className += " miq-body";
 
-            $scope.objectStatus = {
-                providers:  containerDashboardUtils.createProvidersStatus(),
-                nodes:      containerDashboardUtils.createNodesStatus(),
-                containers: containerDashboardUtils.createContainersStatus(),
-                registries: containerDashboardUtils.createRegistriesStatus(),
-                projects:   containerDashboardUtils.createProjectsStatus(),
-                pods:       containerDashboardUtils.createPodsStatus(),
-                services:   containerDashboardUtils.createServicesStatus(),
-                images:     containerDashboardUtils.createImagesStatus(),
-                routes:     containerDashboardUtils.createRoutesStatus()
-            };
+            $scope.objectStatus = containerDashboardUtils.createAllStatuses();
 
             $scope.nodeCpuUsage = {
                 title: 'CPU',
@@ -68,20 +58,15 @@ angular.module('containerDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.
                         }
                     }
 
-                    containerDashboardUtils.updateStatus($scope.objectStatus.nodes,      data.status.nodes);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.containers, data.status.containers);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.registries, data.status.registries);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.projects,   data.status.projects);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.pods,       data.status.pods);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.services,   data.status.services);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.images,     data.status.images);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.routes,     data.status.routes);
+                    // Update entity counts
+                    containerDashboardUtils.updateAllStatuses($scope.objectStatus, data.status)
 
                     // Heatmaps
                     $scope.nodeCpuUsage.data = data.heatmaps.nodeCpuUsage.sort(containerDashboardUtils.heatmapSort);
                     $scope.nodeCpuUsage.loadingDone = true;
                     $scope.nodeMemoryUsage.data = data.heatmaps.nodeMemoryUsage.sort(containerDashboardUtils.heatmapSort);
                     $scope.nodeMemoryUsage.loadingDone = true;
+
                 });
         };
         $scope.refresh();

--- a/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils.js
@@ -70,6 +70,14 @@ angular.module('miq.util').factory('miq.util', [function dashboardUtilsFactory (
       notification: {}
     };
   };
+  var createReplicatorsStatus = function() {
+    return {
+        title: "Replicators",
+        iconClass: "pficon pficon-replicator",
+        count: 0,
+        notification: {}
+    };
+  };
   var updateStatus = function (statusObject, data) {
     statusObject.notification = {};
     if (data) {
@@ -94,7 +102,29 @@ angular.module('miq.util').factory('miq.util', [function dashboardUtilsFactory (
       statusObject.count = 0;
     }
   };
+
   var heatmapSort = function(a, b) {return b.value - a.value};
+
+  var createAllStatuses = function() {
+    return {
+      providers: createProvidersStatus(),
+      container_nodes: createNodesStatus(),
+      containers: createContainersStatus(),
+      container_image_registries: createRegistriesStatus(),
+      container_projects: createProjectsStatus(),
+      container_groups: createPodsStatus(),
+      container_services: createServicesStatus(),
+      container_images: createImagesStatus(),
+      container_routes: createRoutesStatus(),
+      container_replicators: createReplicatorsStatus()
+    }
+  };
+
+  var updateAllStatuses = function(objStatues, data) {
+      for (var key in data){
+          updateStatus(objStatues[key], data[key]);
+      }
+  };
 
   return {
     heatmapSort: heatmapSort,
@@ -107,6 +137,9 @@ angular.module('miq.util').factory('miq.util', [function dashboardUtilsFactory (
     createServicesStatus: createServicesStatus,
     createImagesStatus: createImagesStatus,
     createRoutesStatus: createRoutesStatus,
-    updateStatus: updateStatus
+    createReplicatorsStatus: createReplicatorsStatus,
+    createAllStatuses: createAllStatuses,
+    updateStatus: updateStatus,
+    updateAllStatuses: updateAllStatuses
   };
 }]);

--- a/app/assets/javascripts/controllers/container_group/container_group_controller.js
+++ b/app/assets/javascripts/controllers/container_group/container_group_controller.js
@@ -1,0 +1,27 @@
+angular.module('containerGroupDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts', 'miq.util'])
+  .config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.headers.common['X-CSRF-Token'] = jQuery('meta[name=csrf-token]').attr('content');
+  }])
+  .controller('containerGroupDashboardController', ['$scope','miq.util', '$http', '$interval', "$location",
+    function($scope, containerDashboardUtils, $http, $interval, $location) {
+      document.getElementById("center_div").className += " miq-body";
+
+      $scope.objectStatus = containerDashboardUtils.createAllStatuses();
+
+      $scope.refresh = function() {
+        var id = '/'+ (/container_group\/show\/(\d+)/.exec($location.absUrl())[1]);
+        var url = '/container_group/data'+id;
+
+        $http.get(url).success(function(response) {
+          'use strict';
+
+          var data = response.data;
+
+          containerDashboardUtils.updateAllStatuses($scope.objectStatus, data.status)
+        });
+      };
+      $scope.refresh();
+      var promise = $interval( $scope.refresh, 1000*60*3);
+
+      $scope.$on('$destroy', function() { $interval.cancel(promise); });
+    }]);

--- a/app/assets/javascripts/controllers/container_project/container_project_controller.js
+++ b/app/assets/javascripts/controllers/container_project/container_project_controller.js
@@ -1,0 +1,28 @@
+angular.module('containerProjectDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts', 'miq.util'])
+  .config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.headers.common['X-CSRF-Token'] = jQuery('meta[name=csrf-token]').attr('content');
+  }])
+  .controller('containerProjectDashboardController', ['$scope','miq.util', '$http', '$interval', "$location",
+    function($scope, containerDashboardUtils, $http, $interval, $location) {
+      document.getElementById("center_div").className += " miq-body";
+
+      $scope.objectStatus = containerDashboardUtils.createAllStatuses();
+
+      $scope.refresh = function() {
+        var id = '/'+ (/container_project\/show\/(\d+)/.exec($location.absUrl())[1]);
+        var url = '/container_project/data'+id;
+
+        $http.get(url).success(function(response) {
+            'use strict';
+
+            var data = response.data;
+
+            containerDashboardUtils.updateAllStatuses($scope.objectStatus, data.status)
+          });
+      };
+
+      $scope.refresh();
+      var promise = $interval( $scope.refresh, 1000*60*3);
+
+      $scope.$on('$destroy', function() { $interval.cancel(promise); });
+    }]);

--- a/app/assets/javascripts/controllers/ems_common/single_provider_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/single_provider_dashboard_controller.js
@@ -6,17 +6,7 @@ angular.module('containerDashboard')
         function($scope, containerDashboardUtils, $http, $interval, $location) {
             document.getElementById("center_div").className += " miq-body";
 
-            $scope.objectStatus = {
-                providers:  containerDashboardUtils.createProvidersStatus(),
-                nodes:      containerDashboardUtils.createNodesStatus(),
-                containers: containerDashboardUtils.createContainersStatus(),
-                registries: containerDashboardUtils.createRegistriesStatus(),
-                projects:   containerDashboardUtils.createProjectsStatus(),
-                pods:       containerDashboardUtils.createPodsStatus(),
-                services:   containerDashboardUtils.createServicesStatus(),
-                images:     containerDashboardUtils.createImagesStatus(),
-                routes:     containerDashboardUtils.createRoutesStatus()
-            };
+            $scope.objectStatus = containerDashboardUtils.createAllStatuses();
 
             $scope.refresh = function() {
                 var id = '/'+ (/ems_container\/show\/(\d+)/.exec($location.absUrl())[1]);
@@ -28,14 +18,7 @@ angular.module('containerDashboard')
                     var data = response.data;
                     $scope.providerTypeIconClass = data.providers.iconClass;
 
-                    containerDashboardUtils.updateStatus($scope.objectStatus.nodes,      data.status.nodes);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.containers, data.status.containers);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.registries, data.status.registries);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.projects,   data.status.projects);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.pods,       data.status.pods);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.services,   data.status.services);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.images,     data.status.images);
-                    containerDashboardUtils.updateStatus($scope.objectStatus.routes,     data.status.routes);
+                    containerDashboardUtils.updateAllStatuses($scope.objectStatus, data.status)
                 });
             };
             $scope.refresh();

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -10,7 +10,15 @@ class ContainerGroupController < ApplicationController
     process_show_list
   end
 
-  private ############################
+  def data
+    render :json => {:data => collect_data(params[:id])}
+  end
+
+  private
+
+  def collect_data(project_id)
+    ContainerGroupDashboardService.new(project_id, self).all_data
+  end
 
   def display_name
     "Pods"

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -10,7 +10,15 @@ class ContainerProjectController < ApplicationController
     process_show_list
   end
 
-  private ############################
+  def data
+    render :json => {:data => collect_data(params[:id])}
+  end
+
+  private
+
+  def collect_data(project_id)
+    ContainerProjectDashboardService.new(project_id, self).all_data
+  end
 
   def display_name
     "Container Projects"

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -66,6 +66,12 @@ module ContainersCommonMixin
                       :url  => "/#{controller_name}/show/#{record.id}" \
                                "?display=#{@display}&refresh=n")
       perf_gen_init_options # Intialize options, charts are generated async
+    elsif @display == "dashboard"
+      @showtype = "dashboard"
+      @lastaction = "show_dashboard"
+      drop_breadcrumb(:name => "#{record.name} (Dashboard)",
+                      :url  => "/#{controller_name}/show/#{record.id}" \
+                               "?display=#{@display}&refresh=n")
     elsif @display == "container_groups" || session[:display] == "container_groups" && params[:display].nil?
       show_container_display(record, "container_groups", ContainerGroup)
     elsif @display == "containers"

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -7,10 +7,10 @@ class ContainerDashboardService
 
   def all_data
     {
-      :providers_link => get_url_to_entity(:ems_container),
-      :status    => status,
-      :providers => providers,
-      :heatmaps  => heatmaps
+      :providers_link => url_to_entity(:ems_container),
+      :status         => status,
+      :providers      => providers,
+      :heatmaps       => heatmaps
     }
   end
 
@@ -22,53 +22,53 @@ class ContainerDashboardService
     end
 
     {
-      :nodes      => {
+      :container_nodes            => {
         :count        => @ems.present? ? @ems.container_nodes.count : ContainerNode.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_node)
+        :href         => url_to_entity(:container_node)
       },
-      :containers => {
+      :containers                 => {
         :count        => @ems.present? ? @ems.containers.count : Container.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container)
+        :href         => url_to_entity(:container)
       },
-      :registries => {
+      :container_image_registries => {
         :count        => @ems.present? ? @ems.container_image_registries.count : ContainerImageRegistry.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_image_registry)
+        :href         => url_to_entity(:container_image_registry)
       },
-      :projects   => {
+      :container_projects         => {
         :count        => @ems.present? ? @ems.container_projects.count : ContainerProject.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_project)
+        :href         => url_to_entity(:container_project)
       },
-      :pods       => {
+      :container_groups           => {
         :count        => @ems.present? ? @ems.container_groups.count : ContainerGroup.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_group)
+        :href         => url_to_entity(:container_group)
       },
-      :services   => {
+      :container_services         => {
         :count        => @ems.present? ? @ems.container_services.count : ContainerService.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_service)
+        :href         => url_to_entity(:container_service)
       },
-      :images     => {
+      :container_images           => {
         :count        => @ems.present? ? @ems.container_images.count : ContainerImage.count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_image)
+        :href         => url_to_entity(:container_image)
       },
-      :routes     => {
+      :container_routes           => {
         :count        => routes_count,
         :errorCount   => 0,
         :warningCount => 0,
-        :href         => get_url_to_entity(:container_route)
+        :href         => url_to_entity(:container_route)
       }
     }
   end
@@ -124,7 +124,7 @@ class ContainerDashboardService
 
   private
 
-  def get_url_to_entity(entity)
+  def url_to_entity(entity)
     if @ems.present?
       @controller.url_for(:action     => 'show',
                           :id         => @provider_id,

--- a/app/services/container_group_dashboard_service.rb
+++ b/app/services/container_group_dashboard_service.rb
@@ -1,0 +1,15 @@
+class ContainerGroupDashboardService
+  include DashboardServicesCommonMixin
+
+  def initialize(id, controller)
+    @id = id
+    @controller = controller
+    @record = ContainerGroup.find(@id)
+  end
+
+  def all_data
+    {
+      :status => obj_statuses([:container_services, :containers])
+    }
+  end
+end

--- a/app/services/container_project_dashboard_service.rb
+++ b/app/services/container_project_dashboard_service.rb
@@ -1,0 +1,15 @@
+class ContainerProjectDashboardService
+  include DashboardServicesCommonMixin
+
+  def initialize(id, controller)
+    @id = id
+    @controller = controller
+    @record = ContainerProject.find(@id)
+  end
+
+  def all_data
+    {
+      :status => obj_statuses([:container_groups, :container_nodes, :container_routes, :container_services])
+    }
+  end
+end

--- a/app/services/dashboard_services_common_mixin.rb
+++ b/app/services/dashboard_services_common_mixin.rb
@@ -1,0 +1,27 @@
+module DashboardServicesCommonMixin
+  def status_obj_for(entity)
+    {
+      :count        => @record.try(entity).count,
+      :errorCount   => 0,
+      :warningCount => 0,
+      :href         => url_to_entity(entity)
+    }
+  end
+
+  def obj_statuses(entities)
+    obj_statuses = {}
+
+    entities.each do |entity|
+      obj_statuses[entity] = status_obj_for(entity)
+    end
+
+    obj_statuses
+  end
+
+  def url_to_entity(entity)
+    @controller.url_for(:action     => 'show',
+                        :id         => @id,
+                        :display    => entity.to_s.pluralize,
+                        :controller => @record.class.base_class.name.underscore.to_sym)
+  end
+end

--- a/app/views/container_dashboard/show.html
+++ b/app/views/container_dashboard/show.html
@@ -6,28 +6,28 @@
         <div class="col-xs-12 col-sm-12 col-md-10">
             <div class="row">
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.nodes" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_nodes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
                     <div  pf-aggregate-status-card status="objectStatus.containers" url="navigation" show-top-border="true" layout="mini"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.registries" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_image_registries" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.projects" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_projects" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash" ></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.pods" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_groups" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.services" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_services" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.images" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_images" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.routes" url="navigation" show-top-border="true" layout="mini"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_routes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
             </div><!-- /row -->
         </div>

--- a/app/views/container_group/_show_dashboard.html
+++ b/app/views/container_group/_show_dashboard.html
@@ -1,0 +1,15 @@
+<div ng-app="containerGroupDashboard" ng-controller="containerGroupDashboardController as dashboard" class="container-fluid container-tiles-pf containers-dashboard miq-dashboard-view single-provider-containers-dashboard">
+    <div class="row row-tile-pf" >
+        <div class="col-xs-7 col-sm-7 col-md-7 project-objects-status">
+            <div class="row">
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_services" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                </div>
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.containers" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                </div>
+            </div><!-- /row -->
+        </div>
+    </div><!-- /row -->
+</div>
+

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -10,5 +10,7 @@
         = render(:partial => "layouts/performance")
         :javascript
             var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    - when 'dashboard'
+        = render :partial => 'show_dashboard'
     - else
         = render :partial => @showtype

--- a/app/views/container_project/_show_dashboard.html
+++ b/app/views/container_project/_show_dashboard.html
@@ -1,0 +1,24 @@
+<div ng-app="containerProjectDashboard" ng-controller="containerProjectDashboardController as dashboard" class="container-fluid container-tiles-pf containers-dashboard miq-dashboard-view single-provider-containers-dashboard">
+    <div class="row row-tile-pf" >
+        <div class="col-xs-7 col-sm-7 col-md-7 project-objects-status">
+            <div class="row">
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_groups" url="navigation" show-top-border="true" layout="mini"></div>
+                </div>
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_routes" url="navigation" show-top-border="true" layout="mini"></div>
+                </div>
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_services" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                </div>
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_nodes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                </div>
+                <div class="col-xs-6 col-sm-6 col-md-4">
+                    <div  pf-aggregate-status-card status="objectStatus.container_replicators" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                </div>
+            </div><!-- /row -->
+        </div>
+    </div><!-- /row -->
+</div>
+

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -4,5 +4,7 @@
   = render(:partial => "layouts/tl_show")
   :javascript
     var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+- elsif @showtype == 'dashboard'
+  = render :partial => 'show_dashboard'
 - else
   = render :partial => @showtype

--- a/app/views/ems_container/_show_dashboard.html
+++ b/app/views/ems_container/_show_dashboard.html
@@ -8,28 +8,28 @@
         <div class="col-xs-12 col-sm-12 col-md-10">
             <div class="row">
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.nodes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_nodes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
                     <div  pf-aggregate-status-card status="objectStatus.containers" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.registries" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_image_registries" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.projects" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash" ></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_projects" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash" ></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.pods" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_groups" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.services" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_services" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.images" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_images" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
                 <div class="col-xs-6 col-sm-6 col-md-3">
-                    <div  pf-aggregate-status-card status="objectStatus.routes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
+                    <div  pf-aggregate-status-card status="objectStatus.container_routes" url="navigation" show-top-border="true" layout="mini" class="card-pf-title-container-dash"></div>
                 </div>
             </div><!-- /row -->
         </div>

--- a/app/views/layouts/_view_buttons.html.haml
+++ b/app/views/layouts/_view_buttons.html.haml
@@ -4,7 +4,7 @@
   - defered_toolbar_render('view_tb', 'compare_view_tb')
 - elsif @lastaction == "drift"
   - defered_toolbar_render('view_tb', 'drift_view_tb')
-- elsif %w(ems_container).include?(@layout)
+- elsif %w(ems_container container_project container_group).include?(@layout)
   - defered_toolbar_render('view_tb', 'dashboard_summary_toggle_view_tb')
 - elsif !%w(all_tasks all_ui_tasks timeline diagnostics my_tasks my_ui_tasks miq_server usage).include?(@layout) |
   && (!@layout.starts_with?("miq_request")) && !@treesize_buttons |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,7 @@ Vmdb::Application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
+        data
       ),
       :post => %w(
         button
@@ -528,6 +529,7 @@ Vmdb::Application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
+        data
       ),
       :post => %w(
         button

--- a/spec/javascripts/controllers/container_dashboard/container_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_dashboard/container_dashboard_controller_spec.js
@@ -3,7 +3,7 @@ describe('containerDashboardController', function() {
     var mock_data = {
         data: {
             status: {
-                services: {
+                container_services: {
                     errorCount: 0,
                     count: 9,
                     warningCount: 0
@@ -13,32 +13,37 @@ describe('containerDashboardController', function() {
                     errorCount: 0,
                     warningCount: 0
                 },
-                projects: {
+                container_projects: {
                     count: 11,
                     errorCount: 0,
                     warningCount: 0
                 },
-                pods: {
+                container_groups: {
                     warningCount: 0,
                     errorCount: 0,
                     count: 11
                 },
-                routes: {
+                container_routes: {
                     count: 2,
                     errorCount: 0,
                     warningCount: 0
                 },
-                images: {
+                container_images: {
                     errorCount: 0,
                     count: 8,
                     warningCount: 0
                 },
-                nodes: {
+                container_nodes: {
                     errorCount: 0,
                     count: 9,
                     warningCount: 0
                 },
-                registries: {
+                container_image_registries: {
+                    count: 3,
+                    errorCount: 0,
+                    warningCount: 0
+                },
+                container_replicators: {
                     count: 3,
                     errorCount: 0,
                     warningCount: 0


### PR DESCRIPTION
~~Depends on #5142~~(merged)
This patch will add dashboard views for all container entities.
![project_dashboard](https://cloud.githubusercontent.com/assets/11256940/11504455/2d47f144-984e-11e5-9ce4-d75ca095c231.png)
![pod_dashboard](https://cloud.githubusercontent.com/assets/11256940/11658473/87eb8f66-9dcb-11e5-9525-6e793a083c30.png)

@abonas