### PR TITLE
Automate > Customization > Buttons - fix "Description is required" flash for form with no "Description"

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -513,4 +513,14 @@ class MiqAeCustomizationController < ApplicationController
   def dialog_import_export_build_tree
     TreeBuilderAeCustomization.new("dialog_import_export_tree", "dialog_import_export", @sb)
   end
+
+  def group_button_add_save(typ)
+    # override for AE Customization Buttons - the label doesn't say Description
+    if @edit[:new][:description].blank?
+      render_flash(_("%s is required") % "Button Group Hover Text", :error)
+      return
+    end
+
+    super(typ)
+  end
 end


### PR DESCRIPTION
1. Go to Automate > Customization > Buttons
1. Add a new buttons group
1. Don't fill out the hover text
1. Click Add

A "Description is required" flash is shown .. but the input it's referring to is called "Button Group Hover Text".

This fixes the flash message to say "Button Group Hover Text is required".

Before...
![bg_bad](https://cloud.githubusercontent.com/assets/289743/11507970/685a35c6-984e-11e5-8489-04fe8b224340.png)

After...
![bg_ok](https://cloud.githubusercontent.com/assets/289743/11507976/6d93e37a-984e-11e5-99a5-edac24cb672f.png)
