### PR TITLE
[api] Update host password

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -61,6 +61,7 @@ class ApiController < ApplicationController
   include_concern 'Providers'
   include_concern 'Events'
   include_concern 'Features'
+  include_concern 'Hosts'
   include_concern 'ProvisionRequests'
   include_concern "Rates"
   include_concern "Reports"

--- a/app/controllers/api_controller/hosts.rb
+++ b/app/controllers/api_controller/hosts.rb
@@ -1,0 +1,19 @@
+class ApiController
+  module Hosts
+    CREDENTIALS_ATTR = "credentials"
+    AUTH_TYPE_ATTR = "type"
+    DEFAULT_AUTH_TYPE = "default"
+
+    def edit_resource_hosts(type, id, data = {})
+      host = resource_search(id, type, collection_class(:hosts))
+      credentials = data[CREDENTIALS_ATTR]
+      all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
+        auth_type = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
+        creds.reverse_merge!(:userid => host.authentication_userid(auth_type))
+        hash[auth_type.to_sym] = creds.symbolize_keys!
+      end
+      host.update_authentication(all_credentials) if all_credentials.present?
+      host
+    end
+  end
+end

--- a/app/controllers/api_controller/hosts.rb
+++ b/app/controllers/api_controller/hosts.rb
@@ -1,7 +1,7 @@
 class ApiController
   module Hosts
     CREDENTIALS_ATTR = "credentials"
-    AUTH_TYPE_ATTR = "type"
+    AUTH_TYPE_ATTR = "auth_type"
     DEFAULT_AUTH_TYPE = "default"
 
     def edit_resource_hosts(type, id, data = {})

--- a/app/controllers/api_controller/hosts.rb
+++ b/app/controllers/api_controller/hosts.rb
@@ -5,15 +5,16 @@ class ApiController
     DEFAULT_AUTH_TYPE = "default"
 
     def edit_resource_hosts(type, id, data = {})
-      host = resource_search(id, type, collection_class(:hosts))
-      credentials = data[CREDENTIALS_ATTR]
-      all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
-        auth_type = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
-        creds.reverse_merge!(:userid => host.authentication_userid(auth_type))
-        hash[auth_type.to_sym] = creds.symbolize_keys!
+      credentials = data.delete(CREDENTIALS_ATTR)
+      raise BadRequestError, "Cannot update non-credentials attributes of host resource" if data.any?
+      resource_search(id, type, collection_class(:hosts)).tap do |host|
+        all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
+          auth_type = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
+          creds.reverse_merge!(:userid => host.authentication_userid(auth_type))
+          hash[auth_type.to_sym] = creds.symbolize_keys!
+        end
+        host.update_authentication(all_credentials) if all_credentials.present?
       end
-      host.update_authentication(all_credentials) if all_credentials.present?
-      host
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -270,7 +270,7 @@
       :post:
       - :name: edit
         :identifier: host_edit
-        :disabled: true
+        :disabled: false
       - :name: refresh
         :identifier: host_refresh
         :disabled: true

--- a/config/api.yml
+++ b/config/api.yml
@@ -270,7 +270,6 @@
       :post:
       - :name: edit
         :identifier: host_edit
-        :disabled: false
       - :name: refresh
         :identifier: host_refresh
         :disabled: true

--- a/config/api.yml
+++ b/config/api.yml
@@ -241,7 +241,6 @@
         :disabled: true
       - :name: edit
         :identifier: host_edit
-        :disabled: true
       - :name: refresh
         :identifier: host_refresh
         :disabled: true

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe "hosts API" do
+  include Rack::Test::Methods
+
+  before { init_api_spec_env }
+
+  def app
+    Vmdb::Application
+  end
+
+  describe "editing a host's password" do
+    context "with an appropriate role" do
+      it "can edit the password on a host" do
+        host = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = {:credentials => {:authtype => "default", :password => "abc123"}}
+
+        expect do
+          run_post hosts_url(host.id), gen_request(:edit, options)
+        end.to change { host.reload.authentication_password(:default) }.to("abc123")
+        expect_request_success
+      end
+
+      it "will update the default authentication if no type is given" do
+        host = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = {:credentials => {:password => "abc123"}}
+
+        expect do
+          run_post hosts_url(host.id), gen_request(:edit, options)
+        end.to change { host.reload.authentication_password(:default) }.to("abc123")
+        expect_request_success
+      end
+    end
+
+    context "without an appropriate role" do
+      it "cannot edit the password on a host" do
+        host = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize
+        options = {:credentials => {:authtype => "default", :password => "abc123"}}
+
+        expect do
+          run_post hosts_url(host.id), gen_request(:edit, options)
+        end.not_to change { host.reload.authentication_password(:default) }
+        expect_request_forbidden
+      end
+    end
+  end
+end

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -43,6 +43,36 @@ RSpec.describe "hosts API" do
         end.not_to change { host.reload.name }
         expect_bad_request
       end
+
+      it "can update passwords on multiple hosts by href" do
+        host1 = FactoryGirl.create(:host_with_authentication)
+        host2 = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = [
+          {:href => hosts_url(host1.id), :credentials => {:password => "abc123"}},
+          {:href => hosts_url(host2.id), :credentials => {:password => "def456"}}
+        ]
+
+        run_post hosts_url, gen_request(:edit, options)
+        expect_request_success
+        expect(host1.reload.authentication_password(:default)).to eq("abc123")
+        expect(host2.reload.authentication_password(:default)).to eq("def456")
+      end
+
+      it "can update passwords on multiple hosts by id" do
+        host1 = FactoryGirl.create(:host_with_authentication)
+        host2 = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = [
+          {:id => host1.id, :credentials => {:password => "abc123"}},
+          {:id => host2.id, :credentials => {:password => "def456"}}
+        ]
+
+        run_post hosts_url, gen_request(:edit, options)
+        expect_request_success
+        expect(host1.reload.authentication_password(:default)).to eq("abc123")
+        expect(host2.reload.authentication_password(:default)).to eq("def456")
+      end
     end
 
     context "without an appropriate role" do

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe "hosts API" do
         end.to change { host.reload.authentication_password(:default) }.to("abc123")
         expect_request_success
       end
+
+      it "sending non-credentials attributes will result in a bad request error" do
+        host = FactoryGirl.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = {:name => "new name"}
+
+        expect do
+          run_post hosts_url(host.id), gen_request(:edit, options)
+        end.not_to change { host.reload.name }
+        expect_bad_request
+      end
     end
 
     context "without an appropriate role" do


### PR DESCRIPTION
Allow an authorized user to update the password on a host.

Resolves https://trello.com/c/aRAnctCh

***

Example (with some details in response omitted):

```
tim@tim-thinkpad:~/src/manageiq/gems/cfme_client$ be bin/rest_api.rb post hosts/1
Enter data to send with request:
Terminate with "" or "."
{"action": "edit", "resource": {"credentials": {"password": "abc123"}}}

{
  "href": "http://localhost:3000/api/hosts/1",
  "id": 1,
  [...]
  "power_state": "on",
  "smart": 1,
  [...]
  "connection_state": "connected",
  [...]
  "type": "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
  [...]
  "hyperthreading": true,
  "ems_cluster_id": 1
}
```
***

@abellotti please review
@miq-bot add-label api, core, enhancement