### PR TITLE
Fixing tenant accessibility for subclassed objects

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -277,7 +277,7 @@ module Rbac
   end
 
   def self.accessible_tenant_ids_strategy(klass)
-    TENANT_ACCESS_STRATEGY[klass.to_s]
+    TENANT_ACCESS_STRATEGY[klass.base_model.to_s]
   end
 
   def self.find_targets_with_rbac(klass, scope, rbac_filters, find_options = {}, user_or_group = nil)


### PR DESCRIPTION
- Accessibility strategy was nil for subclasses of classes listed in TENANT_ACCESS_STRATEGY hash keys
- Added call to base_model normalize class name before lookup to ensure it will match the appropriate base class in the hash

https://bugzilla.redhat.com/show_bug.cgi?id=1283309