### PR TITLE
Miq expression merge

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -911,11 +911,17 @@ class MiqExpression
   end
 
   def self.merge_where_clauses(*list)
-    l = list.compact.collect do |s|
+    list = list.compact.collect do |s|
       s = ActiveSupport::Deprecation.silence { MiqReport.send(:sanitize_sql_for_conditions, s) }
-      "(#{s})"
+    end.compact
+
+    if list.size == 0
+      nil
+    elsif list.size == 1
+      list.first
+    else
+      "(#{list.join(") AND (")})"
     end
-    l.empty? ? nil : l.join(" AND ")
   end
 
   def self.merge_includes(*incl_list)

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -865,4 +865,43 @@ describe MiqExpression do
       MiqExpression.new(complex_qs_exp).quick_search?.should be_true
     end
   end
+
+  describe ".merge_where_clauses" do
+    it "returns nil for nil" do
+      expect(MiqExpression.merge_where_clauses(nil)).to be_nil
+    end
+
+    it "returns nil for blank" do
+      expect(MiqExpression.merge_where_clauses("")).to be_nil
+    end
+
+    it "returns nil for multiple empty arrays" do
+      expect(MiqExpression.merge_where_clauses([],[])).to be_nil
+    end
+
+    it "returns same string single results" do
+      expect(MiqExpression.merge_where_clauses("a=5")).to eq("a=5")
+    end
+
+    it "returns same string when concatinating blank results" do
+      expect(MiqExpression.merge_where_clauses("a=5", [])).to eq("a=5")
+    end
+
+    # would be nice if we returned a hash
+    it "returns a string if the only argument is a hash" do
+      expect(MiqExpression.merge_where_clauses({"vms.id" => 5})).to eq("\"vms\".\"id\" = 5")
+    end
+
+    it "concatinates 2 arrays" do
+      expect(MiqExpression.merge_where_clauses(["a=?",5], ["b=?",5])).to eq("(a=5) AND (b=5)")
+    end
+
+    it "concatinates 2 string" do
+      expect(MiqExpression.merge_where_clauses("a=5", "b=5")).to eq("(a=5) AND (b=5)")
+    end
+
+    it "concatinates a string and a hash" do
+      expect(MiqExpression.merge_where_clauses("a=5", {"vms.id" => 5})).to eq("(a=5) AND (\"vms\".\"id\" = 5)")
+    end
+  end
 end

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe MiqExpression do
-  before(:each) do
-    # Create a single host and vm for searching
-    @host = FactoryGirl.create(:host)
-    @host.filesystems << FactoryGirl.create(:filesystem)
-    @host.save
-
-    @vm   = FactoryGirl.create(:vm_vmware)
-  end
-
   # Based on FogBugz 6181: something INCLUDES []
   it "should test bracket characters" do
     exp    = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "/[]/"})


### PR DESCRIPTION
If we can have the same conditions generate the same sql, then we have a better chance of hitting sql query cache

This modifies `MiqExpression#merge_where_clauses` so it does not add extra parens where not necessary. (last commit)

This also cleans up some of the specs.

/cc @gtanzillo this is minor
/cc @Fryguy @dmetzger57 @jrafanie FYI