### PR TITLE
trim down ActiveRecordQueryParts part 1

### DIFF
--- a/lib/active_record_query_parts.rb
+++ b/lib/active_record_query_parts.rb
@@ -31,8 +31,7 @@ module ActiveRecordQueryParts
   end
 
   def self.glob_to_sql_like(text)
-    text.tr!('*', '%')
-    text.tr!('?', '_')
+    text.tr!('*?', '%_')
     text
   end
 end

--- a/lib/active_record_query_parts.rb
+++ b/lib/active_record_query_parts.rb
@@ -18,27 +18,6 @@ module ActiveRecordQueryParts
     " FOR SHARE"
   end
 
-  # Links for the various string length functions:
-  #   http://www.postgresql.org/docs/9.1/static/functions-binarystring.html
-  #   http://www.postgresql.org/docs/9.1/static/functions-string.html
-  #   http://blog.sqlauthority.com/2007/06/20/sql-server-find-length-of-text-field/
-
-  def self.string_length
-    "LENGTH"
-  end
-
-  def self.text_length
-    "LENGTH"
-  end
-
-  def self.binary_length
-    "LENGTH"
-  end
-
-  def self.concat(*args)
-    args.join('||')
-  end
-
   def self.regexp(field, regex, qualifier = nil)
     operator = "SIMILAR TO"
 

--- a/spec/lib/active_record_query_parts_spec.rb
+++ b/spec/lib/active_record_query_parts_spec.rb
@@ -15,4 +15,19 @@ describe ActiveRecordQueryParts do
       expect(result).to eq "#{field} NOT SIMILAR TO '#{regex}'"
     end
   end
+
+  context "glob to sql" do
+    it "replaces '*'" do
+      expect(described_class.glob_to_sql_like("a*b*c")).to eq("a%b%c")
+    end
+    it "replaces '?'" do
+      expect(described_class.glob_to_sql_like("a?b?c")).to eq("a_b_c")
+    end
+    it "replaces mixed '?' and '*'" do
+      expect(described_class.glob_to_sql_like("a?b*c")).to eq("a_b%c")
+    end
+    it "works with replacing nothing" do
+      expect(described_class.glob_to_sql_like("axbxc")).to eq("axbxc")
+    end
+  end
 end

--- a/tools/fix_binary_blobs_and_parts_size_column.rb
+++ b/tools/fix_binary_blobs_and_parts_size_column.rb
@@ -1,6 +1,6 @@
 puts "Fixing BinaryBlob and BinaryBlobPart sizes"
 
-blob_ids = BinaryBlobPart.select(:binary_blob_id).where("size != #{ActiveRecordQueryParts.binary_length}(data)")
+blob_ids = BinaryBlobPart.select(:binary_blob_id).where("size != LENGTH(data)")
 BinaryBlob.where(:id => blob_ids).find_each do |bb|
   bb_size = bb.binary_blob_parts.inject(0) do |total_size, part|
     data = part.read_attribute(:data) # avoid error due to size mismatch


### PR DESCRIPTION
1. No reason to have 3 functions that all do length. `LENGTH` is self explanatory.
2. We don't use the concat methd. `||` is ANSI SQL92 and supported by [most databases](https://en.wikibooks.org/wiki/SQL_Dialects_Reference/Functions_and_expressions/String_functions).

I Pulled out thes 2 simple cases from #5472

@chessbyte hope this moves the PR forward

--Keenan