### PR TITLE
Automate | Fixed issue with group as quota source.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/limits.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/limits.rb
@@ -77,6 +77,8 @@ def set_root_limit_values(quota_max, quota_warn)
 end
 
 def model_and_tag_quota_values
+  quota_max = {}
+  quota_warn = {}
   QUOTA_ATTRIBUTES.each do |name|
     quota_max[name.to_sym] = quota_values("max_#{name}", "quota_max_#{name}".to_sym)
     quota_warn[name.to_sym] = quota_values("warn_#{name}", "quota_warn_#{name}".to_sym)

--- a/spec/automation/unit/method_validation/calculate_limits_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_limits_spec.rb
@@ -2,11 +2,17 @@ require "spec_helper"
 include QuotaHelper
 
 describe "Quota Validation" do
-  def run_automate_method(provision_request)
+  def run_automate_method(provision_request, quota_source)
+    source = case quota_source
+             when 'tenant'
+               "Tenant::quota_source=#{@tenant.id}&quota_source_type=tenant"
+             when 'group'
+               "MiqGroup::quota_source=#{@miq_group.id}&quota_source_type=group"
+             end
+
     attrs = []
     attrs << "MiqProvisionRequest::miq_provision_request=#{provision_request.id}&" \
-             "MiqRequest::miq_request=#{provision_request.id}&" \
-             "Tenant::quota_source=#{@tenant.id}&max_cpu=3&max_vms=2&quota_source_type=tenant" if provision_request
+             "MiqRequest::miq_request=#{provision_request.id}&max_cpu=3&max_vms=2&#{source}" if provision_request
     MiqAeEngine.instantiate("/ManageIQ/system/request/Call_instance?namespace=System/CommonMethods&" \
                             "class=QuotaMethods&instance=limits&#{attrs.join('&')}", @user)
   end
@@ -16,12 +22,22 @@ describe "Quota Validation" do
     setup_tags
   end
 
-  it "limits" do
-    ws = run_automate_method(@miq_provision_request)
+  it "limits, using tenant as quota source" do
+    ws = run_automate_method(@miq_provision_request, 'tenant')
     root = ws.root
     expect(root['quota_source']).to be_kind_of(MiqAeMethodService::MiqAeServiceTenant)
     expect(root['quota_limit_max'][:storage]).to eq(4096)
     expect(root['quota_limit_max'][:cpu]).to eq(2)
+    expect(root['quota_limit_max'][:vms]).to eq(4)
+    expect(root['quota_limit_max'][:memory]).to eq(2048)
+  end
+
+  it "limits, using group as quota source" do
+    ws = run_automate_method(@miq_provision_request, 'group')
+    root = ws.root
+    expect(root['quota_source']).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqGroup)
+    expect(root['quota_limit_max'][:storage]).to eq(2048)
+    expect(root['quota_limit_max'][:cpu]).to eq(4)
     expect(root['quota_limit_max'][:vms]).to eq(4)
     expect(root['quota_limit_max'][:memory]).to eq(2048)
   end


### PR DESCRIPTION
Fix quota error when using group as quota source.

automation.log
ERROR -- : Q- <AEMethod limits>   NameError: undefined local variable or method `quota_max' for main:Object

https://bugzilla.redhat.com/show_bug.cgi?id=1286999