### PR TITLE
Move duplicate hostname check out of sub-context

### DIFF
--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -274,11 +274,15 @@ describe Host do
   end
 
   context ".lookUpHost" do
-    let(:host_3_part_hostname) { FactoryGirl.create(:host_vmware, :hostname => "test1.example.com",       :ipaddress => "192.168.1.1") }
-    let(:host_4_part_hostname) { FactoryGirl.create(:host_vmware, :hostname => "test2.dummy.example.com", :ipaddress => "192.168.1.2") }
+    let(:host_3_part_hostname)    { FactoryGirl.create(:host_vmware, :hostname => "test1.example.com",       :ipaddress => "192.168.1.1") }
+    let(:host_4_part_hostname)    { FactoryGirl.create(:host_vmware, :hostname => "test2.dummy.example.com", :ipaddress => "192.168.1.2") }
+    let(:host_duplicate_hostname) { FactoryGirl.create(:host_vmware, :hostname => "test1.example.com",       :ipaddress => "192.168.1.3", :ems_ref => "host-1", :ems_id => 1) }
+    let(:host_no_ems_id)          { FactoryGirl.create(:host_vmware, :hostname => "test2.example.com",       :ipaddress => "192.168.1.4", :ems_ref => "host-2") }
     before do
       host_3_part_hostname
       host_4_part_hostname
+      host_duplicate_hostname
+      host_no_ems_id
     end
 
     it "with exact hostname and IP" do
@@ -321,36 +325,28 @@ describe Host do
       expect(Host.lookUpHost("test2.dummy", nil)).to eq(host_4_part_hostname)
     end
 
-    context "when hosts have duplicate hostnames" do
-      before do
-        # when an EMS is removed, the host is left behind with a nil ems_id
-        @host_no_ems_id = FactoryGirl.create(:host_vmware, :hostname => "test1.example.com", :ipaddress => "192.168.1.2", :ems_ref => "host-2")
-        @host           = FactoryGirl.create(:host_vmware, :hostname => "test1.example.com", :ipaddress => "192.168.1.1", :ems_ref => "host-1", :ems_id => 1)
-      end
+    it "with duplicate hostname and ipaddress" do
+      expect(Host.lookUpHost(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress)).to eq(host_duplicate_hostname)
+    end
 
-      it "with only fqdn and ipaddress" do
-        expect(Host.lookUpHost(@host.hostname, @host.ipaddress)).to eq(@host)
-      end
+    it "with fqdn, ipaddress, and ems_ref finds right host" do
+      expect(Host.lookUpHost(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress, :ems_ref => host_duplicate_hostname.ems_ref)).to eq(host_duplicate_hostname)
+    end
 
-      it "with fqdn, ipaddress, and ems_ref finds right host" do
-        expect(Host.lookUpHost(@host.hostname, @host.ipaddress, :ems_ref => @host.ems_ref)).to eq(@host)
-      end
+    it "with fqdn, ipaddress, and ems_ref finds right host without an ems_id (reconnect orphaned host)" do
+      expect(Host.lookUpHost(host_no_ems_id.hostname, host_no_ems_id.ipaddress, :ems_ref => host_no_ems_id.ems_ref)).to eq(host_no_ems_id)
+    end
 
-      it "with fqdn, ipaddress, and ems_ref finds right host without an ems_id (reconnect orphaned host)" do
-        expect(Host.lookUpHost(@host_no_ems_id.hostname, @host_no_ems_id.ipaddress, :ems_ref => @host_no_ems_id.ems_ref)).to eq(@host_no_ems_id)
-      end
+    it "with fqdn, ipaddress, and different ems_ref returns nil" do
+      expect(Host.lookUpHost(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress, :ems_ref => "dummy_ref")).to be_nil
+    end
 
-      it "with fqdn, ipaddress, and different ems_ref returns nil" do
-        expect(Host.lookUpHost(@host.hostname, @host.ipaddress, :ems_ref => "dummy_ref")).to be_nil
-      end
+    it "with ems_ref and ems_id" do
+      expect(Host.lookUpHost(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress, :ems_ref => host_duplicate_hostname.ems_ref, :ems_id => 1)).to eq(host_duplicate_hostname)
+    end
 
-      it "with ems_ref and ems_id" do
-        expect(Host.lookUpHost(@host.hostname, @host.ipaddress, :ems_ref => @host.ems_ref, :ems_id => 1)).to eq(@host)
-      end
-
-      it "with ems_ref and other ems_id" do
-        expect(Host.lookUpHost(@host.hostname, @host.ipaddress, :ems_ref => @host.ems_ref, :ems_id => 0)).to be_nil
-      end
+    it "with ems_ref and other ems_id" do
+      expect(Host.lookUpHost(host_duplicate_hostname.hostname, host_duplicate_hostname.ipaddress, :ems_ref => host_duplicate_hostname.ems_ref, :ems_id => 0)).to be_nil
     end
   end
 


### PR DESCRIPTION
Move the duplicate hostname checks out of a sub-context so there
aren't conflicting hosts in the test

cc @bdunne 