### PR TITLE
Automate - Expose customization_specs in automate

### DIFF
--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -11,6 +11,7 @@ module MiqProvisionMixin
     "WindowsImage"                                   => [:windows_images,          :pxe_image_id],
     "CustomizationTemplate"                          => [:customization_templates, :customization_template_id],
     "IsoImage"                                       => [:iso_images,              :iso_image_id],
+    "CustomizationSpec"                              => [:customization_specs,     :sysprep_custom_spec],
 
     # Cloud
     "AvailabilityZone"                               => [:availability_zones,      :placement_availability_zone],
@@ -81,7 +82,10 @@ module MiqProvisionMixin
     klass = resource_type_to_class(rsc_type)
 
     allowed_method = "allowed_#{rsc_type}"
-    raise MiqException::MiqProvisionError, "Provision workflow does not contain the expected method <#{allowed_method}>" unless prov_wf.respond_to?(allowed_method)
+    unless prov_wf.respond_to?(allowed_method)
+      error_str = "Provision workflow does not contain the expected method <#{allowed_method}>"
+      raise MiqException::MiqProvisionError, error_str
+    end
 
     result = prov_wf.send(allowed_method)
     result = result.collect { |rsc| eligible_resource_lookup(klass, rsc) }
@@ -107,11 +111,16 @@ module MiqProvisionMixin
 
     rsc_class = resource_class(rsc)
     rsc_type, key = class_to_resource_type_and_key(rsc_class)
-    raise "Unsupported resource type <#{rsc.class.base_class.name}> passed to set_resource for provisioning." if rsc_type.nil?
+    if rsc_type.nil?
+      raise "Unsupported resource type <#{rsc.class.base_class.name}> passed to set_resource for provisioning."
+    end
 
     rsc_name = resource_display_name(rsc)
     result   = eligible_resources(rsc_type).any? { |r| r.id == rsc.id }
-    raise "Resource <#{rsc_class}> <#{rsc.id}:#{rsc_name}> is not an eligible resource for this provisioning instance." if result == false
+    if result == false
+      resource_str = "<#{rsc_class}> <#{rsc.id}:#{rsc_name}>"
+      raise "Resource #{resource_str} is not an eligible resource for this provisioning instance."
+    end
 
     value = construct_value(key, rsc_class, rsc.id, rsc_name)
     _log.info("option <#{key}> being set to <#{value.inspect}>")
@@ -127,7 +136,7 @@ module MiqProvisionMixin
   end
 
   def set_folder(folder)
-    return nil  if folder.blank?
+    return nil if folder.blank?
     return set_resource(folder) if folder.kind_of?(MiqAeMethodService::MiqAeServiceEmsFolder)
 
     result = nil
@@ -182,26 +191,25 @@ module MiqProvisionMixin
   end
 
   def set_customization_spec(custom_spec_name, override = false)
-    unless source.ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
-      _log.info "Specifying a Customization spec is not valid for provision type #{self.class.name}.  Spec name: <#{custom_spec_name.inspect}>"
-      return false
-    end
 
     if custom_spec_name.nil?
       disable_customization_spec
     else
+      custom_spec_name = custom_spec_name.name unless custom_spec_name.kind_of?(String)
       options = self.options.dup
       prov_wf = workflow
-      options[:sysprep_enabled]       = ['fields', 'Specification']
+      options[:sysprep_enabled] = %w(fields Specification)
       prov_wf.init_from_dialog(options)
       prov_wf.get_all_dialogs
       prov_wf.allowed_customization_specs
       prov_wf.get_timezones
       prov_wf.refresh_field_values(options)
       custom_spec = prov_wf.allowed_customization_specs.detect { |cs| cs.name == custom_spec_name }
-      raise MiqException::MiqProvisionError, "Customization Specification [#{custom_spec_name}] does not exist." if custom_spec.nil?
+      if custom_spec.nil?
+        raise MiqException::MiqProvisionError, "Customization Specification [#{custom_spec_name}] does not exist."
+      end
 
-      options[:sysprep_custom_spec]   = [custom_spec.id, custom_spec.name]
+      options[:sysprep_custom_spec] = [custom_spec.id, custom_spec.name]
       override_value = override == false ? [false, 0] : [true, 0]
       options[:sysprep_spec_override] = override_value
       # Call refresh_field_values a second time so it recognizes the config change
@@ -294,7 +302,7 @@ module MiqProvisionMixin
   def resource_display_name(rsc)
     return rsc.address if rsc.respond_to?(:address)
     return rsc.name    if rsc.respond_to?(:name)
-    ""
+    ''
   end
 
   def construct_value(key, rsc_class, rsc_id, rsc_name)
@@ -306,7 +314,9 @@ module MiqProvisionMixin
   end
 
   def resource_class(rsc)
-    return "ManageIQ::Providers::CloudManager::AuthKeyPair" if rsc.kind_of?(MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager_AuthKeyPair)
+    if rsc.kind_of?(MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager_AuthKeyPair)
+      return 'ManageIQ::Providers::CloudManager::AuthKeyPair'
+    end
     $1 if rsc.class.base_class.name =~ /::MiqAeService(.*)/
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_customization_spec.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_customization_spec.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceCustomizationSpec < MiqAeServiceModelBase
+    expose :ext_management_system, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-provision.rb
@@ -1,4 +1,15 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Provision < MiqAeServiceMiqProvision
+    def set_customization_spec(name = nil, override = false)
+      object_send(:set_customization_spec, name, override)
+    end
+
+    def eligible_customization_specs
+      sysprep = options[:sysprep_enabled]
+      options[:sysprep_enabled] = %w(fields Specification)
+      wrap_results(object_send(:eligible_resources, :customization_specs)).tap do
+        options[:sysprep_enabled] = sysprep
+      end
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -20,10 +20,6 @@ module MiqAeMethodService
     expose_eligible_resources :customization_templates
     expose_eligible_resources :iso_images
 
-    def set_customization_spec(name = nil, override = false)
-      object_send(:set_customization_spec, name, override)
-    end
-
     def get_network_scope
       object_send(:get_network_scope)
     end
@@ -46,7 +42,7 @@ module MiqAeMethodService
 
     def statemachine_task_status
       ar_method do
-        if ['finished', 'provisioned'].include?(@object.state)
+        if %w(finished provisioned).include?(@object.state)
           if @object.status.to_s.downcase == 'error' || @object.vm.nil?
             'error'
           else

--- a/spec/factories/customization_spec.rb
+++ b/spec/factories/customization_spec.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :customization_spec do
+    sequence(:name) { |n| "customization_spec_#{seq_padded_for_sorting(n)}" }
+    typ { 'Windows' }
+    sequence(:description) { |n| "Customization spec #{seq_padded_for_sorting(n)}" }
+    spec { {options => {}} }
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
@@ -13,7 +13,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       @options       = {}
       @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
       @options[:pass]      = 1
-      @user        = FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred')
+      @user = FactoryGirl.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred')
       @miq_provision = FactoryGirl.create(:miq_provision_vmware,
                                           :provision_type => 'template',
                                           :state => 'pending', :status => 'Ok',
@@ -42,7 +42,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#miq_request" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
         @ae_method.update_attributes(:data => method)
         ae_object = invoke_ae.root(@ae_result_key)
         expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
@@ -50,7 +50,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#miq_provision_request" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
         @ae_method.update_attributes(:data => method)
         ae_object = invoke_ae.root(@ae_result_key)
         ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
@@ -61,7 +61,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#vm" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
       ae_object.should be_nil
@@ -76,7 +76,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#vm_template" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
       ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
@@ -84,7 +84,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#execute" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
       @ae_method.update_attributes(:data => method)
 
       MiqProvision.any_instance.should_receive(:execute_queue).once
@@ -92,7 +92,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#request_type" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].request_type"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].request_type"
       @ae_method.update_attributes(:data => method)
 
       %w( template clone_to_vm clone_to_template ).each do |provision_type|
@@ -102,7 +102,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#register_automate_callback - no previous callbacks" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
       method += ".register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
       invoke_ae.root(@ae_result_key).should be_true
@@ -114,7 +114,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
     end
 
     it "#register_automate_callback - with previous callbacks" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
       method += ".register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
       @miq_provision[:options][:callbacks].should be_nil
@@ -124,13 +124,13 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       invoke_ae.root(@ae_result_key).should be_true
       @miq_provision.reload
       callback_hash = @miq_provision[:options][:callbacks]
-      callback_hash.count.should  eq(2)
+      callback_hash.count.should eq(2)
       callback_hash[:first_time_out].should eq('do_something_great')
       callback_hash[:next_time_around].should == 'do_something_better_yet'
     end
 
     it "#target_type" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].target_type"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].target_type"
       @ae_method.update_attributes(:data => method)
 
       %w( clone_to_template ).each do |provision_type|
@@ -156,7 +156,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "eligible_iso_images" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
         result.should be_kind_of(Array)
@@ -176,7 +176,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
 
     context "#source_type" do
       before(:each) do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].source_type"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].source_type"
         @ae_method.update_attributes(:data => method)
       end
 
@@ -195,7 +195,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
 
     context "subclassing" do
       before do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
         @ae_method.update_attributes(:data => method)
       end
 
@@ -225,7 +225,8 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#statemachine_task_status finished state, status of error returns error " do
-        @miq_provision.update_attributes(:status => "Error", :state => "finished", :vm => FactoryGirl.create(:vm_vmware))
+        @miq_provision.update_attributes(:status => "Error", :state => "finished",
+                                         :vm => FactoryGirl.create(:vm_vmware))
         ae_svc_prov.status.should eq('error')
       end
 
@@ -235,7 +236,8 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#statemachine_task_status finished state, status of ok returns ok " do
-        @miq_provision.update_attributes(:status => "Ok", :state => "finished", :vm => FactoryGirl.create(:vm_vmware))
+        @miq_provision.update_attributes(:status => "Ok", :state => "finished",
+                                         :vm => FactoryGirl.create(:vm_vmware))
         ae_svc_prov.status.should eq('ok')
       end
     end
@@ -249,7 +251,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#eligible_customization_templates" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
         result.should be_kind_of(Array)
@@ -268,6 +270,38 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
     end
 
+    context "customization_specs" do
+      before(:each) do
+        @cs = FactoryGirl.create(:customization_spec, :name => "Test Specs", :spec => {"script_text" => "blah"})
+        cs_struct = [MiqHashStruct.new(:id => @cs.id, :name => @cs.name,
+                                       :evm_object_class => @cs.class.base_class.name.to_sym)]
+        MiqProvisionVirtWorkflow.any_instance.stub(:allowed_customization_specs).and_return(cs_struct)
+
+        MiqProvisionVirtWorkflow.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        MiqRequestWorkflow.any_instance.stub(:normalize_numeric_fields)
+        ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
+      end
+
+      it "#eligible_customization_specs" do
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_specs"
+        @ae_method.update_attributes(:data => method)
+        result = invoke_ae.root(@ae_result_key)
+        result.should be_kind_of(Array)
+        result.first.class.should == MiqAeMethodService::MiqAeServiceCustomizationSpec
+      end
+
+      it "#set_customization_spec" do
+        method = <<-AUTOMATE_SCRIPT
+          prov = $evm.root['miq_provision']
+          prov.eligible_customization_specs.each {|cs| prov.set_customization_spec(cs)}
+        AUTOMATE_SCRIPT
+        @ae_method.update_attributes(:data => method)
+        invoke_ae.root(@ae_result_key)
+        @miq_provision.reload.options[:sysprep_custom_spec].should == [@cs.id, @cs.name]
+        @miq_provision.reload.options[:sysprep_enabled].should == %w(fields Specification)
+      end
+    end
+
     context "resource_pools" do
       before(:each) do
         @rsc = FactoryGirl.create(:resource_pool)
@@ -276,7 +310,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       end
 
       it "#eligible_resource_pools" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
         result.should be_kind_of(Array)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=942471

Exposed customization_specs in automate via
the vmware infra manager provision subclass.

Moved set_customization_specs from the
automate miq_provision class into the vmware
infra manager provision subclass.