### PR TITLE
Added Service Model for MiqAeDomain

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_ae_domain.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_ae_domain.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqAeDomain < MiqAeServiceMiqAeNamespace
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_ae_namespace.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqAeNamespace < MiqAeServiceModelBase
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -80,4 +80,18 @@ module MiqAeServiceModelSpec
       end
     end
   end
+
+  describe MiqAeMethodService::MiqAeServiceMiqAeDomain do
+    let(:tenant) { Tenant.seed }
+    let(:domain) { FactoryGirl.create(:miq_ae_domain, :tenant => tenant) }
+
+    it "#ae_domains" do
+      domain
+      t = MiqAeMethodService::MiqAeServiceTenant.new(tenant)
+      dom = t.ae_domains.first
+      [:name, :system, :priority, :id].each do |attr|
+        expect(dom.send(attr)).to eql(domain.send(attr))
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1287473

Starting in 5.5 each domain is owned by a tenant, tenants have a
relationship to domains. The Service Model for MiqAeDomain was not
being defined. Added Service Model for MiqAeDomain & MiqAeNamespace