### PR TITLE
[api] API Put and Patch should honor type specific methods

### DIFF
--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -29,7 +29,7 @@ class ApiController
     end
 
     def put_resource(type, id)
-      edit_resource(type, id, json_body)
+      send(target_resource_method(false, type, "edit"), type, id, json_body)
     end
 
     #
@@ -62,7 +62,7 @@ class ApiController
           patched_attrs[attr] = nil if action == "remove"
         end
       end
-      edit_resource(type, id, patched_attrs)
+      send(target_resource_method(false, type, "edit"), type, id, patched_attrs)
     end
 
     def delete_subcollection_resource(type, id = nil)

--- a/app/controllers/api_controller/users.rb
+++ b/app/controllers/api_controller/users.rb
@@ -1,5 +1,5 @@
 class ApiController
-  INVALID_USER_ATTRS = %w(id href)
+  INVALID_USER_ATTRS = %w(id href current_group_id)
 
   module Users
     def update_users


### PR DESCRIPTION
- With Put/Patch directly calling edit_resource, any processing
done for type specific resources are not honored.

This solves issue #5686