### PR TITLE
Report menu editor tree styling fix

### DIFF
--- a/app/assets/stylesheets/miq_dynatree.scss
+++ b/app/assets/stylesheets/miq_dynatree.scss
@@ -31,6 +31,15 @@ ul.dynatree-container
   padding-right: 0 !important; /*needed so that dynatree hover effect goes to edges*/
 }
 
+
+// Report menu editor styling (report names not clickable)
+#menu_roles_treebox ul ul ul ul span.dynatree-node a {
+  cursor: default !important;
+}
+#menu_roles_treebox ul ul ul ul span.dynatree-node:hover {
+  background-color: transparent !important;
+}
+
 #accordion a.btn {
   margin-right: 10px;
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1283900

Old
<img width="313" alt="screen shot 2015-12-03 at 11 21 34 am" src="https://cloud.githubusercontent.com/assets/1287144/11566285/acf15fcc-99af-11e5-8426-60f20b94273b.png">

New
<img width="436" alt="screen shot 2015-12-03 at 11 13 24 am" src="https://cloud.githubusercontent.com/assets/1287144/11566170/4333b238-99af-11e5-935e-02a71bbee067.png">
