### PR TITLE
[api] Use `#parse_id` for collection requests

### DIFF
--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -135,7 +135,10 @@ class ApiController
         next if r.blank?
 
         rid = parse_id(r, type)
-        r.except!(*ID_ATTRS) if rid && ! %w(create add).include?(action)
+        if rid && %w(create add).include?(action)
+          raise BadRequestError, "Resource id or href should not be specified for creating a new #{type}"
+        end
+        r.except!(*ID_ATTRS) if rid
         processed += 1
         update_one_collection(is_subcollection, target, type, rid, r)
       end

--- a/app/controllers/api_controller/manager.rb
+++ b/app/controllers/api_controller/manager.rb
@@ -118,11 +118,12 @@ class ApiController
     end
 
     def update_one_collection(is_subcollection, target, type, id, resource)
+      id = id.to_i unless id.blank?
       parent_resource = parent_resource_obj if is_subcollection
       if is_subcollection
-        send(target, parent_resource, type, id.to_i, resource)
+        send(target, parent_resource, type, id, resource)
       else
-        send(target, type, id.to_i, resource)
+        send(target, type, id, resource)
       end
     end
 
@@ -133,8 +134,8 @@ class ApiController
       results = resources.each.collect do |r|
         next if r.blank?
 
-        collection, rid = parse_href(r["href"])
-        r.except!(*ID_ATTRS) if collection == type && rid
+        rid = parse_id(r, type)
+        r.except!(*ID_ATTRS) if rid && ! %w(create add).include?(action)
         processed += 1
         update_one_collection(is_subcollection, target, type, rid, r)
       end

--- a/app/controllers/api_controller/tags.rb
+++ b/app/controllers/api_controller/tags.rb
@@ -34,11 +34,11 @@ class ApiController
       raise BadRequestError, "Could not create a new tag - #{err}"
     end
 
-    def tags_delete_resource(_parent, _type, _id, data)
-      tag_id = parse_id(data, :tags) || parse_by_attr(data, :tags, %w(name))
-      raise BadRequestError, "Tag id, href or name needs to be specified for deleting a tag resource" unless tag_id
-      destroy_tag_and_classification(tag_id)
-      action_result(true, "tags id: #{tag_id} deleting")
+    def tags_delete_resource(_parent, _type, id, data)
+      id ||= parse_by_attr(data, :tags, %w(name))
+      raise BadRequestError, "Tag id, href or name needs to be specified for deleting a tag resource" unless id
+      destroy_tag_and_classification(id)
+      action_result(true, "tags id: #{id} deleting")
     rescue => err
       action_result(false, err.to_s)
     end

--- a/app/controllers/api_controller/tags.rb
+++ b/app/controllers/api_controller/tags.rb
@@ -35,7 +35,7 @@ class ApiController
     end
 
     def tags_delete_resource(_parent, _type, id, data)
-      id ||= parse_by_attr(data, :tags, %w(name))
+      id ||= parse_id(data, :tags) || parse_by_attr(data, :tags, %w(name))
       raise BadRequestError, "Tag id, href or name needs to be specified for deleting a tag resource" unless id
       destroy_tag_and_classification(id)
       action_result(true, "tags id: #{id} deleting")

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -47,7 +47,7 @@ describe ApiController do
 
       run_post(groups_url, "description" => "sample group", "id" => 100)
 
-      expect_bad_request(/Invalid attribute/i)
+      expect_bad_request(/id or href should not be specified/i)
     end
 
     it "rejects group creation with invalid role specified" do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "users API" do
 
       run_post(users_url, "userid" => "userid1", "id" => 100)
 
-      expect_bad_request(/Invalid attribute/i)
+      expect_bad_request(/id or href should not be specified/i)
     end
 
     it "rejects user creation with invalid group specified" do


### PR DESCRIPTION
`#update_multiple_collection` would parse and delete any id
attrs (i.e. id, href) if it detected an href in the payload. This commit
updates it to do the same if an id is detected, instead.

Doing so caused a few other issues:

* the tags delete action was getting the id from the passed in data. The
  change causes that data to be deleted as it is parsed and is now being
  passed into the previously-unused id argument. It has been updated to
  work with that.
* `#update_one_collection` was calling `to_i` indiscriminately on any id
  passed in (which could be `nil`), so it was updated to only call
  `to_i` if the id was not blank.

***

@abellotti I decided to do this separately from https://github.com/ManageIQ/manageiq/pull/5669 as it started to get a bit complicated. Please review, thanks!
@miq-bot add-label api, core