### PR TITLE
refactor Azure cloud manager VM operations

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -59,22 +59,26 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   # Operations
 
   def vm_start(vm, _options = {})
-    vm.provider_service.start(vm.name, vm.resource_group)
-    vm.update_attributes!(:raw_power_state => "VM starting")
+    vm.start
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
   def vm_stop(vm, _options = {})
-    vm.provider_service.stop(vm.name, vm.resource_group)
-    vm.update_attributes!(:raw_power_state => "VM stopping")
+    vm.stop
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  def vm_destroy(vm, _options = {})
+    vm.vm_destroy
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
   def vm_restart(vm, _options = {})
-    vm.provider_service.restart(vm.name, vm.resource_group)
-    vm.update_attributes!(:raw_power_state => "VM starting")
+    # TODO switch to vm.restart
+    vm.raw_restart
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -1,3 +1,9 @@
 module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
   include_concern 'Power'
+
+  def raw_destroy
+    raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
+    provider_service.delete(name, resource_group)
+    update_attributes!(:raw_power_state => "Deleting")
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -6,4 +6,19 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
   def validate_pause
     validate_unsupported("Pause Operation")
   end
+
+  def raw_start
+    provider_service.start(name, resource_group)
+    update_attributes!(:raw_power_state => "VM starting")
+  end
+
+  def raw_stop
+    provider_service.stop(name, resource_group)
+    update_attributes!(:raw_power_state => "VM stopping")
+  end
+
+  def raw_restart
+    provider_service.restart(name, resource_group)
+    update_attributes!(:raw_power_state => "VM starting")
+  end
 end


### PR DESCRIPTION
This refactoring follows the same pattern as the implementation in Amazon and Openstack CloudManager. 

The VM start, stop, and destroy commands need to go through policy check and delegate to raw operations through events.

Currently the restart operation is only implemented in Azure. The base `VmOrTemplate` class does not have restart method. We need to decide whether to add this method so that the restart operation can go through the same procedure as other operations.