### PR TITLE
apparent misspelling of local variable name 'actions' should be 'action'

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1047,7 +1047,7 @@ class MiqAction < ActiveRecord::Base
         action = create(rec)
       else
         action.attributes = rec
-        if action.changed? || action.options_was != actions.options
+        if action.changed? || action.options_was != action.options
           _log.info("Updating [#{rec[:name]}]")
           action.save
         end


### PR DESCRIPTION
evm.log contains: undefined local variable or method `actions'

this patch replaces 'actions' with 'action' following the example of similar code on line 1101.