### PR TITLE
Altered the console to set the canonical hostname rather than an alias

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -25,7 +25,7 @@ gem "fog-core",                "!=1.31.1",          :require => false
 gem "httpclient",              "~>2.5.3",           :require => false
 gem "kubeclient",              "=0.8.0",            :require => false
 gem "hawkular-client",         "~>0.1.2",           :require => false
-gem "linux_admin",             "~>0.12.1",          :require => false
+gem "linux_admin",             "~>0.13.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.11.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -244,7 +244,7 @@ Static Network Configuration
           system_hosts.parsed_file.each { |line| line[:hosts].to_a.delete(host) } unless host =~ /^localhost.*/
 
           system_hosts.hostname = new_host
-          system_hosts.update_entry("127.0.0.1", new_host)
+          system_hosts.set_canonical_hostname("127.0.0.1", new_host)
           system_hosts.save
           LinuxAdmin::Service.new("network").restart
           press_any_key

--- a/spec/models/miq_server/rhn_mirror_spec.rb
+++ b/spec/models/miq_server/rhn_mirror_spec.rb
@@ -15,7 +15,7 @@ describe "MiqServer" do
 
         FileUtils.should_not_receive(:rm_f)
         File.should_receive(:read).with("/etc/hosts").and_return("\n #Some Comment\n127.0.0.1\tlocalhost")
-        File.should_receive(:write).with("/etc/hosts", "\n#Some Comment\n127.0.0.1        localhost\n#{@server1.ipaddress}          #{@server1.guid}\n#{@server2.ipaddress}          #{@server2.guid}")
+        File.should_receive(:write).with("/etc/hosts", "\n#Some Comment\n127.0.0.1        localhost\n#{@server1.ipaddress}          #{@server1.guid}\n#{@server2.ipaddress}          #{@server2.guid}\n")
         MiqServer.any_instance.should_receive(:write_yum_repo_file).with([@server2])
 
         @server1.configure_rhn_mirror_client


### PR DESCRIPTION
The /etc/hosts man page describes a difference between the "canonical_hostname"
(fqdn) and the aliases for that hostname.

This difference is reflected in the behaviour of some external tools such
as cloud-init and freeipa.
These tools will retrieve the hostname (typically via the hostname
command or from /etc/hostname) then consult /etc/hosts to find the
fqdn by taking the name in the "canonical_hostname" place in the line
where the found hostname is an alias.

This can cause problems when the application acts differently based on
whether the fqdn is "localhost" or not.

https://bugzilla.redhat.com/show_bug.cgi?id=1286830