### PR TITLE
path_to_my_worker_settings

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -67,7 +67,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     keys    = [keys] unless keys.kind_of?(Array)
     value   = worker_settings.fetch_path(keys)
     value ||= begin
-      fq_keys = [:workers] + @worker.class.path_to_my_worker_settings + keys
+      fq_keys = @worker.class.config_settings_path + keys
       v = VMDB::Config.new("vmdb").template_configuration.fetch_path(fq_keys)
       v = v.to_i_with_method if v.number_with_method?
       v

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -251,9 +251,7 @@ module VMDB
       klass = Object.const_get(klass) unless klass.class == Class
 
       # find the key for the class and set the value
-      keys = klass.path_to_my_worker_settings.dup
-      keys.unshift(:workers)
-      keys += setting.to_miq_a
+      keys = klass.config_settings_path + settings.to_miq_a
       config.store_path(keys, value)
     end
 


### PR DESCRIPTION
[this](https://github.com/ManageIq/manageiq/blob/master/app/models/miq_worker.rb#L459-L461) is already defined, lets just use it.

```ruby
def config_settings_path
  [:workers] + path_to_my_worker_settings
end
```