### PR TITLE
convert to_miq_a to Array.wrap [step 1 of many]

### DIFF
--- a/gems/pending/spec/util/extensions/miq-array_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-array_spec.rb
@@ -4,35 +4,42 @@ require 'util/extensions/miq-array'
 
 describe NilClass do
   it '#to_miq_a' do
-    nil.to_miq_a.should == []
+    expect(nil.to_miq_a).to eq([])
+    expect(nil.to_miq_a).to eq(Array.wrap(nil))
   end
 end
 
 describe Hash do
   it '#to_miq_a' do
-    {}.to_miq_a.should == [{}]
+    expect({}.to_miq_a).to eq([{}])
+    expect({}.to_miq_a).to eq(Array.wrap({}))
   end
 end
 
 describe String do
   context "#to_miq_a" do
     it 'normal' do
-      "onetwo".to_miq_a.should == ["onetwo"]
+      # NOTE: this differs from Array.wrap
+      expect("onetwo".to_miq_a).to eq(["onetwo"])
     end
 
     it 'with an empty string' do
-      "".to_miq_a.should == []
+      # NOTE: this differs from Array.wrap
+      expect("".to_miq_a).to eq([])
     end
 
     it 'with newlines' do
-      "one\ntwo".to_miq_a.should == ["one\n", "two"]
+      # NOTE: this differs from Array.wrap
+      expect("one\ntwo".to_miq_a).to eq(["one\n", "two"])
     end
   end
 end
 
 describe Array do
   it "#to_miq_a" do
-    [].to_miq_a.should == []
-    [[]].to_miq_a.should == [[]]
+    expect([].to_miq_a).to eq([])
+    expect([[]].to_miq_a).to eq([[]])
+    expect([].to_miq_a).to eq(Array.wrap([]))
+    expect([[]].to_miq_a).to eq(Array.wrap([[]]))
   end
 end

--- a/gems/pending/util/extensions/miq-array.rb
+++ b/gems/pending/util/extensions/miq-array.rb
@@ -1,32 +1,15 @@
 require 'more_core_extensions/core_ext/array'
+require 'active_support/core_ext/array/wrap'
 
 class Object #:nodoc:
   def to_miq_a
-    [*self]
+    Array.wrap(self)
   end
 end
 
 class String
   def to_miq_a
     lines.to_a
-  end
-end
-
-class Array
-  def to_miq_a
-    to_a
-  end
-end
-
-class Hash
-  def to_miq_a
-    [self]
-  end
-end
-
-class NilClass
-  def to_miq_a
-    []
   end
 end
 


### PR DESCRIPTION
Curious if we can just remove `to_miq_a` and replace with `Array.wrap`

 source|to_a    |to_miq_a    |Array.wrap|same
  -----|----    |--------    |----------|---
nil    |[]      |[]          |[]        |:grinning:
{}     |[]      |[{}]        |[{}]      |:grinning:
{a:5}  |[[:a,5]]|[{}]        |[{}]      |:grinning:
"ab"   | :dizzy_face:       |["ab"]      |["ab"]    |:grinning:
""     | :dizzy_face:      |[]          |[""]      |:-1:
"a\nb" | :dizzy_face:      |["a\n", "b"]|["a\nb"]  |:-1:
[]     | []     |[]          |[]        |:grinning:
[[]]   | [[]]   |[[]]        |[[]]      |:grinning:

/cc @Fryguy @matthewd thoughts?