### PR TITLE
Make OpsController::Diagnostics#delete_server more simple

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,8 +697,7 @@ module OpsController::Diagnostics
 
   # Common Server button handler routines
   def process_server(server, task)
-    servers = [server]
-    MiqServer.where(:id => servers).order("lower(name)").each do |svr|
+    MiqServer.where(:id => [server]).order("lower(name)").each do |svr|
       id = svr.id
       svr_name = svr.name
       if task == "destroy"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,7 +697,7 @@ module OpsController::Diagnostics
 
   # Common Server button handler routines
   def process_server(server_id, task)
-    MiqServer.where(:id => [server_id]).order("lower(name)").each do |svr|
+    MiqServer.where(:id => server_id).order("lower(name)").each do |svr|
       id = svr.id
       svr_name = svr.name
       if task == "destroy"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,8 +689,7 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      servers = [@sb[:diag_selected_id]]
-      process_servers(servers, "destroy")
+      process_servers([@sb[:diag_selected_id]], "destroy")
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -701,7 +701,7 @@ module OpsController::Diagnostics
     return unless svr
 
     begin
-      svr.destroy if svr.respond_to?(:destroy)    # Run the task
+      svr.destroy
     rescue StandardError => bang
       add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr.name, :task => "destroy"} << bang.message,
                 :error)

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,14 +689,14 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      process_servers(@sb[:diag_selected_id], "destroy")
+      process_server(@sb[:diag_selected_id], "destroy")
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
   # Common Server button handler routines
-  def process_servers(server, task)
+  def process_server(server, task)
     servers = [server]
     MiqServer.where(:id => servers).order("lower(name)").each do |svr|
       id = svr.id

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -696,8 +696,8 @@ module OpsController::Diagnostics
   end
 
   # Common Server button handler routines
-  def process_server(server, task)
-    MiqServer.where(:id => [server]).order("lower(name)").each do |svr|
+  def process_server(server_id, task)
+    MiqServer.where(:id => [server_id]).order("lower(name)").each do |svr|
       id = svr.id
       svr_name = svr.name
       if task == "destroy"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -702,7 +702,13 @@ module OpsController::Diagnostics
 
     id = svr.id
     svr_name = svr.name
-    audit = {:event => "svr_record_delete", :message => "[#{svr_name}] Record deleted", :target_id => id, :target_class => "MiqServer", :userid => session[:userid]}
+    audit = {
+      :event => "svr_record_delete",
+      :message => "[#{svr_name}] Record deleted",
+      :target_id => id,
+      :target_class => "MiqServer",
+      :userid => session[:userid]
+    }
     begin
       svr.send("destroy".to_sym) if svr.respond_to?("destroy")    # Run the task
     rescue StandardError => bang

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,16 +689,14 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      process_server_deletion(@sb[:diag_selected_id])
+      svr = MiqServer.find_by(:id => @sb[:diag_selected_id])
+      process_server_deletion(svr) if svr
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
-  def process_server_deletion(server_id)
-    svr = MiqServer.find_by(:id => server_id)
-    return unless svr
-
+  def process_server_deletion(svr)
     begin
       svr.destroy
     rescue StandardError => bang

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -710,7 +710,7 @@ module OpsController::Diagnostics
       :userid => session[:userid]
     }
     begin
-      svr.send("destroy".to_sym) if svr.respond_to?("destroy")    # Run the task
+      svr.destroy if svr.respond_to?(:destroy)    # Run the task
     rescue StandardError => bang
       add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => "destroy"} << bang.message,
                 :error)

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -700,21 +700,20 @@ module OpsController::Diagnostics
     svr = MiqServer.find_by(:id => server_id)
     return unless svr
 
-    svr_name = svr.name
     begin
       svr.destroy if svr.respond_to?(:destroy)    # Run the task
     rescue StandardError => bang
-      add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => "destroy"} << bang.message,
+      add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr.name, :task => "destroy"} << bang.message,
                 :error)
     else
       AuditEvent.success(
         :event        => "svr_record_delete",
-        :message      => "[#{svr_name}] Record deleted",
+        :message      => "[#{svr.name}] Record deleted",
         :target_id    => svr.id,
         :target_class => "MiqServer",
         :userid       => session[:userid]
       )
-      add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]"})
+      add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr.name} [#{svr.id}]"})
     end
   end
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,7 +697,8 @@ module OpsController::Diagnostics
 
   # Common Server button handler routines
   def process_server(server_id, task)
-    MiqServer.where(:id => server_id).each do |svr|
+    svr = MiqServer.find_by(:id => server_id)
+    if svr
       id = svr.id
       svr_name = svr.name
       if task == "destroy"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,11 +689,12 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       servers = []
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
+      process_servers(servers, "destroy") unless servers.empty?
     else
       servers = []
       servers.push(@sb[:diag_selected_id])
+      process_servers(servers, "destroy") unless servers.empty?
     end
-    process_servers(servers, "destroy") unless servers.empty?
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,14 +689,15 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      process_server(@sb[:diag_selected_id], "destroy")
+      process_server(@sb[:diag_selected_id])
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
   # Common Server button handler routines
-  def process_server(server_id, task)
+  def process_server(server_id)
+    task = "destroy"
     svr = MiqServer.find_by(:id => server_id)
     return unless svr
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,14 +689,14 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      process_server(@sb[:diag_selected_id])
+      process_server_deletion(@sb[:diag_selected_id])
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
   # Common Server button handler routines
-  def process_server(server_id)
+  def process_server_deletion(server_id)
     svr = MiqServer.find_by(:id => server_id)
     return unless svr
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -683,7 +683,7 @@ module OpsController::Diagnostics
     refresh_screen
   end
 
-  # Delete all selected server
+  # Delete selected server
   def delete_server
     assert_privileges("delete_server")
     if @sb[:diag_selected_id].nil?

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -695,7 +695,6 @@ module OpsController::Diagnostics
     refresh_screen
   end
 
-  # Common Server button handler routines
   def process_server_deletion(server_id)
     svr = MiqServer.find_by(:id => server_id)
     return unless svr

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,26 +697,25 @@ module OpsController::Diagnostics
 
   # Common Server button handler routines
   def process_server(server_id)
-    task = "destroy"
     svr = MiqServer.find_by(:id => server_id)
     return unless svr
 
     id = svr.id
     svr_name = svr.name
-    if task == "destroy"
+    if "destroy" == "destroy"
       audit = {:event => "svr_record_delete", :message => "[#{svr_name}] Record deleted", :target_id => id, :target_class => "MiqServer", :userid => session[:userid]}
     end
     begin
-      svr.send(task.to_sym) if svr.respond_to?(task)    # Run the task
+      svr.send("destroy".to_sym) if svr.respond_to?("destroy")    # Run the task
     rescue StandardError => bang
-      add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => task} << bang.message,
+      add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => "destroy"} << bang.message,
                 :error)
     else
-      if task == "destroy"
+      if "destroy" == "destroy"
         AuditEvent.success(audit)
         add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]"})
       else
-        add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]", :task => task})
+        add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]", :task => "destroy"})
       end
     end
   end

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -700,7 +700,6 @@ module OpsController::Diagnostics
     svr = MiqServer.find_by(:id => server_id)
     return unless svr
 
-    id = svr.id
     svr_name = svr.name
     begin
       svr.destroy if svr.respond_to?(:destroy)    # Run the task
@@ -711,7 +710,7 @@ module OpsController::Diagnostics
       AuditEvent.success(
         :event        => "svr_record_delete",
         :message      => "[#{svr_name}] Record deleted",
-        :target_id    => id,
+        :target_id    => svr.id,
         :target_class => "MiqServer",
         :userid       => session[:userid]
       )

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,14 +689,15 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      process_servers([@sb[:diag_selected_id]], "destroy")
+      process_servers(@sb[:diag_selected_id], "destroy")
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
   # Common Server button handler routines
-  def process_servers(servers, task)
+  def process_servers(server, task)
+    servers = [server]
     MiqServer.where(:id => servers).order("lower(name)").each do |svr|
       id = svr.id
       svr_name = svr.name

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,8 +689,7 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      servers = []
-      servers.push(@sb[:diag_selected_id])
+      servers = [@sb[:diag_selected_id]]
       process_servers(servers, "destroy") unless servers.empty?
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,7 +689,6 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       servers = []
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
-      process_servers(servers, "destroy") unless servers.empty?
     else
       servers = []
       servers.push(@sb[:diag_selected_id])

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -702,9 +702,7 @@ module OpsController::Diagnostics
 
     id = svr.id
     svr_name = svr.name
-    if "destroy" == "destroy"
-      audit = {:event => "svr_record_delete", :message => "[#{svr_name}] Record deleted", :target_id => id, :target_class => "MiqServer", :userid => session[:userid]}
-    end
+    audit = {:event => "svr_record_delete", :message => "[#{svr_name}] Record deleted", :target_id => id, :target_class => "MiqServer", :userid => session[:userid]}
     begin
       svr.send("destroy".to_sym) if svr.respond_to?("destroy")    # Run the task
     rescue StandardError => bang

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,21 +697,19 @@ module OpsController::Diagnostics
   end
 
   def process_server_deletion(svr)
-    begin
-      svr.destroy
-    rescue StandardError => bang
-      add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr.name, :task => "destroy"} << bang.message,
-                :error)
-    else
-      AuditEvent.success(
-        :event        => "svr_record_delete",
-        :message      => "[#{svr.name}] Record deleted",
-        :target_id    => svr.id,
-        :target_class => "MiqServer",
-        :userid       => session[:userid]
-      )
-      add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr.name} [#{svr.id}]"})
-    end
+    svr.destroy
+  rescue StandardError => bang
+    add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr.name, :task => "destroy"} << bang.message,
+              :error)
+  else
+    AuditEvent.success(
+      :event        => "svr_record_delete",
+      :message      => "[#{svr.name}] Record deleted",
+      :target_id    => svr.id,
+      :target_class => "MiqServer",
+      :userid       => session[:userid]
+    )
+    add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr.name} [#{svr.id}]"})
   end
 
   def promote_server

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -686,10 +686,11 @@ module OpsController::Diagnostics
   # Delete all selected server
   def delete_server
     assert_privileges("delete_server")
-    servers = []
     if @sb[:diag_selected_id].nil?
+      servers = []
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
+      servers = []
       servers.push(@sb[:diag_selected_id])
     end
     process_servers(servers, "destroy") unless servers.empty?

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -689,27 +689,27 @@ module OpsController::Diagnostics
     if @sb[:diag_selected_id].nil?
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
-      svr = MiqServer.find_by(:id => @sb[:diag_selected_id])
-      process_server_deletion(svr) if svr
+      server = MiqServer.find_by(:id => @sb[:diag_selected_id])
+      process_server_deletion(server) if server
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen
   end
 
-  def process_server_deletion(svr)
-    svr.destroy
+  def process_server_deletion(server)
+    server.destroy
   rescue StandardError => bang
-    add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr.name, :task => "destroy"} << bang.message,
+    add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => server.name, :task => "destroy"} << bang.message,
               :error)
   else
     AuditEvent.success(
       :event        => "svr_record_delete",
-      :message      => "[#{svr.name}] Record deleted",
-      :target_id    => svr.id,
+      :message      => "[#{server.name}] Record deleted",
+      :target_id    => server.id,
       :target_class => "MiqServer",
       :userid       => session[:userid]
     )
-    add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr.name} [#{svr.id}]"})
+    add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{server.name} [#{svr.id}]"})
   end
 
   def promote_server

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -687,7 +687,6 @@ module OpsController::Diagnostics
   def delete_server
     assert_privileges("delete_server")
     if @sb[:diag_selected_id].nil?
-      servers = []
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
       servers = []

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -690,7 +690,7 @@ module OpsController::Diagnostics
       add_flash(_("%s no longer exists") % ui_lookup(:table => "evm_server"), :error)
     else
       servers = [@sb[:diag_selected_id]]
-      process_servers(servers, "destroy") unless servers.empty?
+      process_servers(servers, "destroy")
     end
     add_flash(_("The selected %s was deleted") % ui_lookup(:table => "evm_server")) if @flash_array.nil?
     refresh_screen

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -702,20 +702,19 @@ module OpsController::Diagnostics
 
     id = svr.id
     svr_name = svr.name
-    audit = {
-      :event => "svr_record_delete",
-      :message => "[#{svr_name}] Record deleted",
-      :target_id => id,
-      :target_class => "MiqServer",
-      :userid => session[:userid]
-    }
     begin
       svr.destroy if svr.respond_to?(:destroy)    # Run the task
     rescue StandardError => bang
       add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => "destroy"} << bang.message,
                 :error)
     else
-      AuditEvent.success(audit)
+      AuditEvent.success(
+        :event        => "svr_record_delete",
+        :message      => "[#{svr_name}] Record deleted",
+        :target_id    => id,
+        :target_class => "MiqServer",
+        :userid       => session[:userid]
+      )
       add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]"})
     end
   end

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -697,7 +697,7 @@ module OpsController::Diagnostics
 
   # Common Server button handler routines
   def process_server(server_id, task)
-    MiqServer.where(:id => server_id).order("lower(name)").each do |svr|
+    MiqServer.where(:id => server_id).each do |svr|
       id = svr.id
       svr_name = svr.name
       if task == "destroy"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -715,12 +715,8 @@ module OpsController::Diagnostics
       add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => svr_name, :task => "destroy"} << bang.message,
                 :error)
     else
-      if "destroy" == "destroy"
-        AuditEvent.success(audit)
-        add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]"})
-      else
-        add_flash(_("%{model} \"%{name}\": %{task} successfully initiated") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]", :task => "destroy"})
-      end
+      AuditEvent.success(audit)
+      add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{svr_name} [#{svr.id}]"})
     end
   end
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -709,7 +709,7 @@ module OpsController::Diagnostics
       :target_class => "MiqServer",
       :userid       => session[:userid]
     )
-    add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{server.name} [#{svr.id}]"})
+    add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => ui_lookup(:model => "MiqServer"), :name => "#{server.name} [#{server.id}]"})
   end
 
   def promote_server


### PR DESCRIPTION
This PR does not change the observable behavior of the app, this is pure refactoring.

It means that 

1. If `@sb[:diag_selected_id]` is `nil`, the app will show _server no longer exist_.
2. otherwise, if there is no server with id = `@sb[:diag_selected_id]`, the app will show _the server was deleted_.
3. otherwise, if there is a server with such id, and its deletion is successful, the app will show _Delete successful_
4. otherwise, if deletion of a server was unsuccessful, the error message will be _Error during 'destroy'_.

I know, it is inconsistent (see points 1 and 2), but that's how it works.

Also, previous code had some dead code. `process_server` was never called with any command other than `"destroy"`, so I deleted the dead branches and renamed the method to `process_server_deletion`.

For full story, please read individual comments.