### PR TITLE
Merge MiqSearch.filtered and Rbac.filtered

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -847,16 +847,10 @@ class MiqRequestWorkflow
   def process_filter(filter_prop, ci_klass, targets)
     rails_logger("process_filter - [#{ci_klass}]", 0)
     filter_id = get_value(@values[filter_prop]).to_i
-    if filter_id.zero?
-      Rbac.filtered(targets,
-                    :class     => ci_klass,
-                    :user      => @requester,
-                    :miq_group => @requester.current_group)
-    else
-      MiqSearch.find(filter_id).filtered(targets,
-                                         :user      => @requester,
-                                         :miq_group => @requester.current_group)
-    end.tap { rails_logger("process_filter - [#{ci_klass}]", 1) }
+    MiqSearch.filtered(filter_id, ci_klass, targets,
+                       :user      => @requester,
+                       :miq_group => @requester.current_group,
+                      ).tap { rails_logger("process_filter - [#{ci_klass}]", 1) }
   end
 
   def find_all_ems_of_type(klass, src = nil)

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -16,14 +16,30 @@ class MiqSearch < ActiveRecord::Base
     read_attribute(:search_type) || "default"
   end
 
-  def search(targets = [], opts = {})
+  def search(opts = {})
     self.options ||= {}
-    Rbac.search(options.merge(:targets => targets, :class => db, :filter => filter).merge(opts))
+    Rbac.search(options.merge(:class => db, :filter => filter).merge(opts))
   end
 
   def filtered(targets, opts = {})
     self.options ||= {}
     Rbac.filtered(targets, options.merge(:class => db, :filter => filter).merge(opts))
+  end
+
+  def self.search(filter_id, klass, opts = {})
+    if filter_id.nil? || filter_id.zero?
+      Rbac.search(opts.merge(:class => klass))
+    else
+      find(filter_id).search(opts)
+    end
+  end
+
+  def self.filtered(filter_id, klass, targets, opts = {})
+    if filter_id.nil? || filter_id.zero?
+      Rbac.filtered(targets, opts.merge(:class => klass))
+    else
+      find(filter_id).filtered(targets, opts)
+    end
   end
 
   def self.visible_to_all

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -27,4 +27,87 @@ describe MiqSearch do
         srchs[1].id.to_s => srchs[1].description)
     end
   end
+
+  let(:vm_location_search) do
+    FactoryGirl.create(:miq_search,
+                       :db     => "Vm",
+                       :filter => MiqExpression.new("=" => {"field" => "Vm-location", "value" => "good"})
+                      )
+  end
+
+  let(:matched_vms) { FactoryGirl.create_list(:vm_vmware, 2, :location => "good") }
+  let(:other_vms)   { FactoryGirl.create_list(:vm_vmware, 1, :location => "other") }
+  let(:all_vms)     { matched_vms + other_vms }
+  let(:partial_matched_vms) { [matched_vms.first] }
+  let(:partial_vms) { partial_matched_vms + other_vms }
+
+  # general use cases around rbac
+  describe "#search" do
+    it "brings back filtered targets" do
+      all_vms
+      expect(vm_location_search.search.first).to match_array(matched_vms.map(&:id))
+    end
+
+    it "resects search options" do
+      all_vms
+      expect(vm_location_search.search(:results_format => :objects).first).to match_array(matched_vms)
+    end
+  end
+
+  describe "#filtered" do
+    # TODO: return matched_vms
+    it "works with models" do
+      all_vms
+      expect { vm_location_search.filtered(Vm).first }.to raise_error
+    end
+
+    it "works with scopes" do
+      all_vms
+      expect(vm_location_search.filtered(Vm.all)).to match_array(matched_vms)
+    end
+
+    it "finds elements only in the array" do
+      all_vms
+      expect(vm_location_search.filtered(partial_vms)).to match_array(partial_matched_vms)
+    end
+
+    # TODO: return matched_vms
+    it "brings back all for no target" do
+      all_vms
+      expect(vm_location_search.filtered(nil)).to eq(nil)
+    end
+
+    it "brings back empty array for empty arrays" do
+      all_vms
+      expect(vm_location_search.filtered([])).to match_array([])
+    end
+  end
+
+  describe ".search" do
+    it "uses an existing search" do
+      all_vms
+      results = MiqSearch.search(vm_location_search.id, "Vm", :results_format => :objects).first
+      expect(results).to match_array(matched_vms)
+    end
+
+    it "calls Rbac directly if there is no search" do
+      all_vms
+      results = MiqSearch.search(0, "Vm", :results_format => :objects).first
+      expect(results).to match_array(all_vms)
+    end
+  end
+
+  describe ".filtered" do
+    it "uses an existing search" do
+      all_vms
+      results = MiqSearch.filtered(vm_location_search.id, "Vm", partial_vms)
+      expect(results).to match_array(partial_matched_vms)
+    end
+
+    it "calls Rbac directly for no search" do
+      all_vms
+      results = MiqSearch.filtered(0, "Vm", partial_vms)
+      expect(results).to match_array(partial_vms)
+    end
+  end
 end


### PR DESCRIPTION
Big picture: Want to remove all of our `presence?` / `empty?` calls - in many cases it is not an optimization but rather hitting the database.

This PR simplifies calling into `Rbac` via `MiqSearch` - setting us up for possibly removing `empty?`

https://bugzilla.redhat.com/show_bug.cgi?id=1281999

/cc @Fryguy @jrafanie @matthewd @gtanzillo Here are the issues I found.
/cc @dmetzger57 FYI
