### PR TITLE
Fix event title in container providers timelines

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -106,12 +106,22 @@ module ReportFormatter
             ems = ExtManagementSystem.find(rec[:ems_id])
             ems_cloud =  true if ems.kind_of?(EmsCloud)
           end
-          if rec[:vm_name] && !ems_cloud             # Create the title using VM name
-            e_title = rec[:vm_name]
-          elsif rec[:host_name] && !ems_cloud                 #   or Host Name
-            e_title = rec[:host_name]
-          elsif rec[:ems_cluster_name] && !ems_cloud          #   or Cluster Name
-            e_title = rec[:ems_cluster_name]
+          if !ems_cloud
+            e_title = if rec[:vm_name] # Create the title using VM name
+                        rec[:vm_name]
+                      elsif rec[:host_name] # or Host Name
+                        rec[:host_name]
+                      elsif rec[:ems_cluster_name] # or Cluster Name
+                        rec[:ems_cluster_name]
+                      elsif rec[:container_name]
+                        rec[:container_name]
+                      elsif rec[:container_group_name]
+                        rec[:container_group_name]
+                      elsif rec[:container_replicator_name]
+                        rec[:container_replicator_name]
+                      elsif rec[:container_node_name]
+                        rec[:container_node_name]
+                      end
           elsif ems                             #   or EMS name
             e_title = ems.name
           else


### PR DESCRIPTION
Event titles in container provider entities timeline currently display the provider name, instead of the entity name they relate to, like in other providers.

before:
![event_title_before](https://cloud.githubusercontent.com/assets/6347577/11631501/f7acea0a-9d0a-11e5-8da5-67677532aa33.png)

after (pod event):
![event_title_pod](https://cloud.githubusercontent.com/assets/6347577/11631522/0bc86ad2-9d0b-11e5-950e-b22246ef2749.png)

after (container event in pod):
![event_title_container](https://cloud.githubusercontent.com/assets/6347577/11631535/1a5ac20c-9d0b-11e5-9338-fbf2524712d8.png)
