### PR TITLE
Don't render empty toolbar buttons

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1404,7 +1404,7 @@ class ApplicationHelper::ToolbarBuilder
 
     props.update(
       :name    => button,
-      :hidden  => !!item[:hidden],
+      :hidden  => props[:hidden] || !!item[:hidden],
       :pressed => item[:pressed],
       :onwhen  => item[:onwhen]
     )

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2683,6 +2683,18 @@ describe ApplicationHelper do
         b.send(:build_toolbar_save_button, @item, @item_out)
       end
     end
+
+    context "button visibility" do
+      it "defaults to hidden false" do
+        props = build_toolbar_save_button(@item, @item_out)
+        expect(props[:hidden]).to be(false)
+      end
+
+      it "honors explicit item's hidden properties" do
+        props = build_toolbar_save_button(@item, {:hidden => true})
+        expect(props[:hidden]).to be(true)
+      end
+    end
   end
 
   describe "url_for_save_button" do


### PR DESCRIPTION
`build_toolbar_save_button()` needs to honor button visibility property as passed in via the props hash.

Before:
![toolbar-before](https://cloud.githubusercontent.com/assets/6648365/11633573/54c94692-9d0c-11e5-83cc-991295a503af.jpg)

After:
![toolbar-after](https://cloud.githubusercontent.com/assets/6648365/11633574/54ce2770-9d0c-11e5-9527-22c355546920.jpg)
