### PR TITLE
Automate | Services | Fixed blank dialog issue.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -102,11 +102,9 @@ def parent_task_dialog_information(task)
     $evm.log('error', "Unable to locate Dialog information")
     exit MIQ_ABORT
   end
-
   $evm.log('info', "Current task has empty dialogs, getting dialog information from parent task")
-  options_hash = YAML.load(bundle_task.get_option(:parsed_dialog_options))
-  tags_hash = YAML.load(bundle_task.get_option(:parsed_dialog_tags))
-  return options_hash, tags_hash
+  return YAML.load(bundle_task.get_option(:parsed_dialog_options) || "{}"),
+         YAML.load(bundle_task.get_option(:parsed_dialog_tags) || "{}")
 end
 
 def save_parsed_dialog_information(options_hash, tags_hash, task)

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -94,5 +94,9 @@ describe "CatalogBundleInitialization Automate Method" do
       process_stp(:dialog => @dialog_hash)
       check_svc_attrs
     end
+
+    it "allows blank dialogs" do
+      expect { process_stp(:dialog => {'dialog_option_1_service_name' => ''}) }.not_to raise_exception
+    end
   end
 end

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -73,6 +73,11 @@ describe "CatalogItemInitialization Automate Method" do
       process_stp(stp2, parsed_options, required_options, required_tags)
     end
 
+    it "allows blank dialogs" do
+      create_request_and_tasks
+      process_stp(root_service_template_task, {0 => {:location => ""}}, {}, {})
+    end
+
     def process_stp(stp, parsed_options, required_options, required_tags)
       stp.options = stp.options.merge(parsed_options)
       stp.save

--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -91,7 +91,13 @@ describe "DialogParser Automate Method" do
     it "with no dialogs set" do
       @root_stp.options = @root_stp.options.merge(:dialog => {})
       @root_stp.save
-      expect { run_automate_method }.to raise_exception
+      expect { run_automate_method }.not_to raise_exception
+    end
+
+    it "with blank dialog set" do
+      @root_stp.options = @root_stp.options.merge(:dialog => {:dialog_text_box => ""})
+      @root_stp.save
+      expect { run_automate_method }.not_to raise_exception
     end
   end
 end


### PR DESCRIPTION
Dialog parser and catalog*initialization methods raised errors when no dialog values were supplied. Changed methods to allow this and created tests.  

https://bugzilla.redhat.com/show_bug.cgi?id=1233605