### PR TITLE
[api] Fix `expect_single_action_result`

### DIFF
--- a/app/controllers/api_controller/vms.rb
+++ b/app/controllers/api_controller/vms.rb
@@ -210,6 +210,7 @@ class ApiController
     def set_owner_vm(vm, owner)
       desc = "#{vm_ident(vm)} setting owner to '#{owner}'"
       user = User.lookup_by_identity(owner)
+      raise "Invalid user #{owner} specified" unless user
       vm.evm_owner = user
       vm.miq_group = user.current_group unless user.nil?
       vm.save!

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -347,7 +347,7 @@ module ApiSpecHelper
 
   def expect_single_action_result(options = {})
     expect_request_success
-    if options[:success]
+    if options.key?(:success)
       expect(@result).to have_key("success")
       expect(@result["success"]).to eq(options[:success])
     end


### PR DESCRIPTION
The method makes conditional expectations based on the presence of
certain options. Unfortunately, the `success` options will be a boolean,
so will never fail - the condition is essentially the return result of
`options[:success]`. The fix is to check whether `:success` has been
keyed instead.

The change also fixes a false positive that was obscured by the above.

@abellotti please review, thanks!