### PR TITLE
Moved Timelines & Utilization buttons to summary screen from list view.

### DIFF
--- a/product/toolbars/container_center_tb.yaml
+++ b/product/toolbars/container_center_tb.yaml
@@ -34,3 +34,20 @@
       :url_parms: 'main_div'
       :text: 'Edit Tags'
       :title: 'Edit Tags for this #{ui_lookup(:table=>"container")}'
+- :name: container_monitoring
+  :items:
+  - :buttonSelect: container_monitoring_choice
+    :image: monitoring
+    :title: Monitoring
+    :text: Monitoring
+    :items:
+    - :button: container_timeline
+      :image: timeline
+      :text: "Timelines"
+      :title: "Show Timelines for this Container"
+      :url_parms: '?display=timeline'
+    - :button: container_perf
+      :image: capacity
+      :text: "Utilization"
+      :title: "Show Capacity & Utilization data for this Container"
+      :url_parms: '?display=performance'

--- a/product/toolbars/containers_center_tb.yaml
+++ b/product/toolbars/containers_center_tb.yaml
@@ -41,26 +41,8 @@
     - :button: container_tag
       :image: tag
       :text: 'Edit Tags'
-      :title: 'Edit Tags for this #{ui_lookup(:table=>"container")}'
+      :title: 'Edit Tags for selected #{ui_lookup(:tables=>"container")}'
       :url_parms: 'main_div'
       :enabled: 'false'
       :onwhen: '1+'
-- :name: container_monitoring
-  :items:
-  - :buttonSelect: container_monitoring_choice
-    :image: monitoring
-    :title: Monitoring
-    :text: Monitoring
-    :items:
-    - :button: container_timeline
-      :image: timeline
-      :text: "Timelines"
-      :title: "Show Timelines for this Container"
-      :url: '/explorer'
-      :url_parms: '?display=timeline'
-    - :button: container_perf
-      :image: capacity
-      :text: "Utilization"
-      :title: "Show Capacity & Utilization data for this Container"
-      :url: '/explorer'
-      :url_parms: '?display=performance'
+

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -70,4 +70,42 @@ describe ContainerController do
       expect(assigns(:edit)).to be_nil
     end
   end
+
+  context "#x_button" do
+    before(:each) do
+      ems = FactoryGirl.create(:ems_kubernetes)
+      container_project = ContainerProject.create(:ext_management_system => ems)
+      container_group = ContainerGroup.create(:ext_management_system => ems,
+                                              :container_project     => container_project)
+      @ct = FactoryGirl.create(:container,
+                               :name            => "container-01",
+                               :container_group => container_group
+                              )
+      controller.stub(:x_node).and_return("cnt_#{controller.to_cid(@ct.id)}")
+      controller.instance_variable_set(:@record, @ct)
+      FactoryGirl.create(:ems_event, :container_id => @ct.id)
+    end
+
+    after(:each) do
+      expect(response.status).to eq(200)
+    end
+
+    it "renders timeline views" do
+      post :x_button,
+           :pressed => "container_timeline",
+           :id      => @ct.id,
+           :display => 'timeline'
+      response.should render_template('layouts/_tl_show')
+      response.should render_template('layouts/_tl_detail')
+    end
+
+    it "renders utilization views" do
+      post :x_button,
+           :pressed => "container_perf",
+           :id      => @ct.id,
+           :display => 'performance'
+      response.should render_template('layouts/_perf_options')
+      response.should render_template('layouts/_perf_charts')
+    end
+  end
 end


### PR DESCRIPTION
Fixed Timelines & Utilization buttons to go thru x_button method similar to all other toolbar buttons and removed any code that is not needed in explorer & show method.

@dkorn please take a look, this PR addresses the issue where Timelines/Utilization buttons were going thru explorer method and were messing up the url, causing an error(that was fixed with a hack  https://github.com/ManageIQ/manageiq/blob/master/app/controllers/container_controller.rb#L138 in explorer method) when clicking on nodes in the tree while user is on timelines/C&U screen.