### PR TITLE
Refine test tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,8 @@ begin
   load 'jasmine/tasks/jasmine.rake'
 rescue LoadError
 end
+
+# Clear noisy and unusable tasks added by rspec-rails
+if defined?(RSpec)
+  Rake::Task.tasks.select { |t| t.name =~ /^spec(:)?/ }.each(&:clear)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,12 @@
 require File.expand_path('../boot', __FILE__)
 require File.expand_path('../preinitializer', __FILE__)
-require 'rails/all'
+require 'rails'
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+require 'sprockets/railtie'
 
 if defined?(Bundler)
   Bundler.require *Rails.groups(:assets => %w(development test))

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -27,4 +27,7 @@ namespace :test do
 end
 
 task :default => 'test:vmdb'
+
+desc "Run vmdb specs"
+task :test => 'test:vmdb' # TODO: Run all test suites?
 end # ifdef

--- a/lib/tasks/test_self_service.rake
+++ b/lib/tasks/test_self_service.rake
@@ -1,6 +1,5 @@
 namespace :test do
   namespace :self_service do
-    desc "Setup environment for self_service tests"
     task :setup # NOOP - Stub for consistent CI testing
   end
 

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -7,7 +7,7 @@ namespace :test do
     task :setup => [:verify_no_db_access_loading_rails_environment, :setup_db]
   end
 
-  desc "Run all specs except migrations, replication, and automation"
+  desc "Run all core specs (excludes automation, migrations, replication, etc)"
   RSpec::Core::RakeTask.new(:vmdb => [:initialize, "evm:compile_sti_loader"]) do |t|
     EvmTestHelper.init_rspec_task(t)
     t.pattern = EvmTestHelper::VMDB_SPECS


### PR DESCRIPTION
Cleans up Rake tasks related to testing - Removes unused test_unit railtie, tasks loaded by rspec-rails, and our own NOOP tasks. This may seem minor (and it is), but extremely helpful for new developers to avoid confusion and see what tasks are the ones that actually matter.

Before:

![](http://screenshots.chrisarcand.com/5abm5.jpg)

After:

![](http://screenshots.chrisarcand.com/1kntn.jpg)