### PR TITLE
Networking use network subnets for VM relations

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -7,6 +7,8 @@ class CloudSubnet < ActiveRecord::Base
   belongs_to :availability_zone
   has_many   :network_ports
   has_many   :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many   :network_routers, :through => :network_ports, :source => :device, :source_type => 'NetworkRouter'
+  has_many   :public_networks, :through => :network_routers, :source => :cloud_network
 
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -5,8 +5,8 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   has_many :cloud_networks, :through => :network_ports
   alias_method :private_networks, :cloud_networks
   has_many :cloud_subnets, :through => :network_ports
-  has_many :network_routers, :through => :cloud_networks
-  has_many :public_networks, :through => :cloud_networks
+  has_many :network_routers, :through => :cloud_subnets
+  has_many :public_networks, :through => :cloud_subnets
   belongs_to :orchestration_stack
 
   # TODO(lsmola) need to go away, but relation needs to be fixed in AWS and Azure first, then we can delete the

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -10,8 +10,9 @@ class NetworkRouter < ActiveRecord::Base
   has_many :floating_ips
   has_many :network_ports, :as => :device
   has_many :cloud_networks, :through => :network_ports
+  has_many :cloud_subnets, :through => :network_ports
   alias_method :private_networks, :cloud_networks
-  has_many :vms_network_ports, :through => :cloud_networks, :source => :network_ports
+  has_many :vms_network_ports, :through => :cloud_subnets, :source => :network_ports
   has_many :vms, :through => :vms_network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API


### PR DESCRIPTION
E.g relation of vm has many routers. The private network can be
connected to many routers (each subnet to another). So the query
would not be precise. Going through subnets, we will get the exact
wiring to routers and public network of the VM.