### PR TITLE
Fix Pod - Services relationship

### DIFF
--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(containers).include?(@display)
+- if %w(containers container_services).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
     - case @showtype


### PR DESCRIPTION
When clicking the services in a pod's relationships table the UI crashes, as a result of missing partial.
The fix adds the services table list partial.