### PR TITLE
AMQP validation always returned true

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -107,7 +107,6 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   def verify_amqp_credentials(_options = {})
     require 'openstack/openstack_event_monitor'
     OpenstackEventMonitor.test_amqp_connection(event_monitor_options)
-    true
   rescue => err
     miq_exception = translate_exception(err)
     raise unless miq_exception

--- a/gems/pending/openstack/openstack_event_monitor.rb
+++ b/gems/pending/openstack/openstack_event_monitor.rb
@@ -14,7 +14,7 @@ class OpenstackEventMonitor
   end
 
   def self.available?(options)
-    !event_monitor_class(options).kind_of? OpenstackNullEventMonitor
+    event_monitor_class(options) != OpenstackNullEventMonitor
   end
 
   DEFAULT_PLUGIN_PRIORITY = 0


### PR DESCRIPTION
AMQP validation always returned true.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1265638