### PR TITLE
Restrict the list of e-mails returned

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -749,10 +749,13 @@ class ApplicationController < ActionController::Base
   # Build the user_emails hash for edit screens needing the edit_email view
   def build_user_emails_for_edit
     @edit[:user_emails] = {}
+    group_id = User.find_by_userid(session[:userid])[:current_group_id]
     User.all.sort_by { |u| u.name.downcase }.each do |u|
       unless u.email.blank? ||
              (@edit[:new][:email][:to] && @edit[:new][:email][:to].include?(u.email))
-        @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
+        if u.current_group_id == group_id
+          @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
+        end
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -751,11 +751,10 @@ class ApplicationController < ActionController::Base
     @edit[:user_emails] = {}
     group_id = User.find_by_userid(session[:userid])[:current_group_id]
     User.all.sort_by { |u| u.name.downcase }.each do |u|
+      next unless u.current_group_id == group_id
       unless u.email.blank? ||
              (@edit[:new][:email][:to] && @edit[:new][:email][:to].include?(u.email))
-        if u.current_group_id == group_id
-          @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
-        end
+        @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
       end
     end
   end


### PR DESCRIPTION
build_user_emails_for_edit currently returns all valid users with e-mails on the system

This patch reduces that list to the members of the logged-in user's group

This is a very specific solution to the problem we are having (customers able to view all accounts on the system), but I wanted to get it out here for discussion. There is an open bugzilla for this issue at https://bugzilla.redhat.com/1287216