### PR TITLE
Add migration to fix host_storages replication issue

### DIFF
--- a/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
+++ b/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
@@ -1,0 +1,49 @@
+class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration
+  include MigrationHelper
+  include MigrationHelper::SharedStubs
+
+  class MiqRegion < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class HostsStorage < ActiveRecord::Base
+    self.table_name = "host_storages"
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    if on_replication_target?
+      run_for_replication_target
+    else
+      run_for_replication_source
+    end
+  end
+
+  def on_replication_target?
+    MiqRegion.select(:region).distinct.count > 1
+  end
+
+  def run_for_replication_target
+    HostsStorage.delete_all
+  end
+
+  def run_for_replication_source
+    return unless RrSyncState.table_exists?
+
+    prefix = "rr#{ActiveRecord::Base.my_region_number}"
+    old_name = "hosts_storages"
+    new_name = "host_storages"
+
+    drop_trigger(new_name, "#{prefix}_#{old_name}")
+
+    say_with_time("Deleting pending changes for #{old_name}") do
+      RrPendingChange.where(:change_table => old_name).delete_all
+    end
+
+    say_with_time("Deleting sync state for #{old_name}") do
+      RrSyncState.where(:table_name => old_name).delete_all
+    end
+
+    Rake::Task['evm:dbsync:prepare_replication_without_sync'].invoke
+  end
+end

--- a/spec/migrations/20151208150956_fix_host_storage_replication_on_upgrade_spec.rb
+++ b/spec/migrations/20151208150956_fix_host_storage_replication_on_upgrade_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+require_migration
+
+describe FixHostStorageReplicationOnUpgrade do
+  let(:pending_change_stub) { migration_stub(:RrPendingChange) }
+  let(:sync_state_stub)     { migration_stub(:RrSyncState) }
+  let(:region_stub)         { migration_stub(:MiqRegion) }
+  let(:host_storage_stub)   { migration_stub(:HostsStorage) }
+
+  migration_context :up do
+    before do
+      region_stub.create!(:id => 1_000_000_000_001, :region => 1)
+    end
+
+    context "on a replication target" do
+      it "removes all the host_storages records" do
+        region_stub.create!(:id => 99_000_000_000_001, :region => 99)
+        host_storage_stub.create!(:id => 1_000_000_000_001, :storage_id => 1, :host_id => 1)
+        host_storage_stub.create!(:id => 2_000_000_000_001, :storage_id => 1, :host_id => 2)
+
+        migrate
+
+        expect(host_storage_stub.count).to eq 0
+      end
+    end
+
+    context "on a replication source" do
+      before do
+        pending_change_stub.create_table
+        sync_state_stub.create_table
+      end
+
+      it "reinstalls replication for the new table name" do
+        pending_change_stub.create!(:change_table => "hosts_storages")
+        sync_state_stub.create!(:table_name => "hosts_storages")
+        task = double
+        expect(Rake::Task).to receive(:[]).with("evm:dbsync:prepare_replication_without_sync").and_return(task)
+        expect(task).to receive(:invoke)
+
+        migrate
+
+        expect(pending_change_stub.where(:change_table => "hosts_storages").count).to eq 0
+        expect(sync_state_stub.where(:table_name => "hosts_storages").count).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
After we run the migration added in commit 04f2fa211b8ebeb0557ca3712af846c9b556869f
the table host_storages will be assigned a primary key column and existing
rows will be given a value within the current region's range.

This causes an issue when run on a replication target as the id should
match the one on the replication source region not the target one.

This fix removes the entries in the host_storages table on the target
region and resets the replication triggers on the source regions.

https://bugzilla.redhat.com/show_bug.cgi?id=1289156

@gtanzillo @agrare @jrafanie 