### PR TITLE
vim_performance_daily extract time_profile options

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -288,9 +288,9 @@ class ConfigurationController < ApplicationController
   def show_timeprofiles
     build_tabs if params[:action] == "change_tab" || ["cancel", "add", "save"].include?(params[:button])
     if admin_user?
-      @timeprofiles = TimeProfile.in_my_region.all(:order => "lower(description) ASC")
+      @timeprofiles = TimeProfile.in_my_region.ordered_by_desc
     else
-      @timeprofiles = TimeProfile.in_my_region.all(:conditions => ["(profile_type = ? or (profile_type = ? and  profile_key = ?))", "global", "user", session[:userid]], :order => "lower(description) ASC")
+      @timeprofiles = TimeProfile.in_my_region.for_user(session[:userid]).ordered_by_desc
     end
     timeprofile_set_days_hours
     drop_breadcrumb(:name => "Time Profiles", :url => "/configuration/change_tab/?tab=4")

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -17,12 +17,12 @@ class TimeProfile < ActiveRecord::Base
   after_create :rebuild_daily_metrics_on_create
   after_save   :rebuild_daily_metrics_on_save
 
-  def self.find_all_with_entire_tz(*args)
-    all(*args).select(&:entire_tz?)
+  def self.find_all_with_entire_tz
+    all.select(&:entire_tz?)
   end
 
-  def self.all_timezones(*args)
-    all(*args).collect(&:tz).uniq
+  def self.all_timezones
+    select(%w(id profile)).collect(&:tz).uniq
   end
 
   def self.seed

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -143,12 +143,20 @@ class TimeProfile < ActiveRecord::Base
     @rebuild_daily_metrics_on_create = false
   end
 
+  # TODO: use AR "or" here
+  def self.for_user(user_id)
+    where("profile_type = ? or (profile_type = ? and profile_key = ?)", "global", "user", user_id)
+  end
+
+  def self.ordered_by_desc
+    order("lower(description) ASC")
+  end
+
   def self.profiles_for_user(user_id, region_id)
-    TimeProfile
-      .in_region(region_id)
-      .where("profile_type = ? or (profile_type = ? and profile_key = ?)", "global", "user", user_id)
-      .where(:rollup_daily_metrics => true)
-      .order("lower(description) ASC")
+    in_region(region_id)
+      .for_user(user_id)
+      .rollup_daily_metrics
+      .ordered_by_desc
   end
 
   def self.profile_for_user_tz(user_id, user_tz)

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -34,21 +34,13 @@ class VimPerformanceDaily < MetricRollup
       .to_a
   end
 
-  def self.default_time_profile(ext_options)
-    if (tz = Metric::Helper.get_time_zone(ext_options))
-      # Determine if this search falls into an existing valid TimeProfile
-      TimeProfile.rollup_daily_metrics.find_all_with_entire_tz.detect { |p| p.tz_or_default == tz }
-    end
-  end
-
+  # @param ext_options [Hash] search options
+  # @opts ext_options :klass [Class] class for metrics (default: MetricRollup)
+  # @opts ext_options :tp [TimeProfile]
+  # @opts ext_options :tz [Timezone] (default: DEFUULTf)
   def self.find_entries(ext_options)
     ext_options ||= {}
-    ext_options[:time_profile] ||= default_time_profile(ext_options)
-
-    find_by_time_profile(ext_options)
-  end
-
-  def self.find_by_time_profile(ext_options)
+    time_profile = ext_options[:time_profile] ||= TimeProfile.default_time_profile(ext_options[:tz])
     klass = ext_options[:class] || MetricRollup
 
     # Support for multi-region DB. We need to try to find a time profile in each


### PR DESCRIPTION
High level: Use scopes/relations and get away from `find`

vim_performance_daily extract time_profile options

Introduce a scope so it can be used as a traditional AR scope / model

/cc @matthewd rails5 love (and performance too)