### PR TITLE
Bump rspec/rspec-rails to ~> 2.99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ unless ENV['APPLIANCE']
   end
 
   group :development, :test do
-    gem "rspec-rails",      "~>2.14.0"
+    gem "rspec-rails",      "~>2.99.0"
   end
 end
 

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -85,7 +85,7 @@ unless ENV['APPLIANCE']
     gem "test-unit",                    :require => false
     gem "camcorder",                    :require => false
     gem "jasmine",                      :require => false, :git => "git://github.com/jasmine/jasmine-gem.git", :ref => "c726fe1"
-    gem "rspec",         "~>2.14.0",    :require => false
+    gem "rspec",         "~>2.99.0",    :require => false
     gem "rspec-fire",    "~>1.3.0",     :require => false
     gem "timecop",       "~>0.7.3",     :require => false
     gem "xml-simple",    "=1.0.12",     :require => false  # Used by test/xml/tc_xmlhash_methods.rb


### PR DESCRIPTION
Begins the road to RSpec 3. The test output now shows deprecations that need/should be fixed before the jump to 3; All tests should still _pass_, however.

Subsequent PRs forthcoming to convert specs to the `expect` syntax and fix breaking changes, nice and incrementally so as not to cause mass chaos with current work being done.

Everyone who _adds new spec_ from this point should try and avoid adding deprecations (best seen by running the individual specs you're adding)