### PR TITLE
enable normal word wrapping in list view

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -144,7 +144,13 @@ li.brand-white-label.whitelabeled {
 
 table.table td {
   word-break: break-all
- }
+}
+
+//Enable normal word wrapping in List View
+
+#gtl_div table.table td {
+  word-break: normal !important;
+}
 
 table.table tbody td img {
   height: 20px;


### PR DESCRIPTION
Issue: #5617 

Old
<img width="1090" alt="screen shot 2015-12-09 at 9 17 36 am" src="https://cloud.githubusercontent.com/assets/1287144/11687536/3b76201c-9e55-11e5-9bc8-69d0bcd774fc.png">
New
<img width="1094" alt="screen shot 2015-12-09 at 9 17 14 am" src="https://cloud.githubusercontent.com/assets/1287144/11687539/3c8449a2-9e55-11e5-9a43-f5afd3ec8677.png">
