### PR TITLE
Fixed wording of Domain version message

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -203,7 +203,7 @@ class MiqAeClassController < ApplicationController
     version = domain.version
     available_version = domain.available_version
     return if version.nil? || available_version.nil?
-    _("%s domain: Currently version - %s, Available version - %s") % [domain.name, version, available_version] if version != available_version
+    _("%s domain: Current version - %s, Available version - %s") % [domain.name, version, available_version] if version != available_version
   end
 
   def add_all_domains_version_message(domains)


### PR DESCRIPTION
Changed from "xx domain: Currently version - xx, Available version - xx" to "xx domain: Current version - xx, Available version - xx"

https://bugzilla.redhat.com/show_bug.cgi?id=1289703
https://bugzilla.redhat.com/show_bug.cgi?id=1289706

before:
![before](https://cloud.githubusercontent.com/assets/3450808/11688410/77051aac-9e5a-11e5-97d7-42506d2503bb.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/11688416/7e4f965c-9e5a-11e5-958a-c5542f8dd235.png)

@dclarizio please review/merge