### PR TITLE
[WIP] Automate Method Dialog Parser testing outside engine

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -1,133 +1,137 @@
-
-def vmdb_object_from_array_entry(entry)
-  model, id = entry.split("::")
-  $evm.vmdb(model, id.to_i) if model && id
-end
-
-def parent_task(task)
-  return task if task.miq_request_task.nil?
-  parent_task(task.miq_request_task)
-end
-
-def add_hash_value(sequence_id, option_key, value, hash)
-  $evm.log("info", "Adding seq_id: #{sequence_id} key: #{option_key} value: #{value} ")
-  hash[sequence_id][option_key] = value
-end
-
-def process_comma_separated_object_array(sequence_id, option_key, value, hash)
-  return if value.nil?
-  options_value_array = []
-  value.split(",").each do |entry|
-    vmdb_obj = vmdb_object_from_array_entry(entry)
-    next if vmdb_obj.nil?
-    options_value_array << (vmdb_obj.respond_to?(:name) ? vmdb_obj.name : "#{vmdb_obj.class.name}::#{vmdb_obj.id}")
-  end
-  hash[sequence_id][option_key] = options_value_array
-end
-
-def option_password_value(dialog_key, dialog_value, options_hash)
-  return false unless /^password::dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
-  add_password_value(sequence.to_i, option_key, dialog_value, options_hash)
-  true
-end
-
-def generic_password_value(dialog_key, dialog_value, options_hash)
-  return false unless /^password::dialog_(?<option_key>.*)/i =~ dialog_key
-  add_password_value(0, option_key, dialog_value, options_hash)
-  true
-end
-
-def add_password_value(sequence, option_key, value, options_hash)
-  stripped_option_key = 'password::' + option_key
-  prefixed_option_key = 'password::dialog_' + option_key
-  add_hash_value(sequence, stripped_option_key.to_sym, value, options_hash)
-  add_hash_value(sequence, prefixed_option_key.to_sym, value, options_hash)
-end
-
-def option_hash_value(dialog_key, dialog_value, options_hash)
-  return false unless /^dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
-  add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, options_hash)
-  true
-end
-
-def option_array_value(dialog_key, dialog_value, options_hash)
-  return false unless /^array::dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
-  process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, options_hash)
-  true
-end
-
-def tag_hash_value(dialog_key, dialog_value, tags_hash)
-  return false unless /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
-  add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
-  true
-end
-
-def tag_array_value(dialog_key, dialog_value, tags_hash)
-  return false unless /^array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
-  process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
-  true
-end
-
-def generic_dialog_value(dialog_key, dialog_value, options_hash)
-  return false unless /^dialog_(?<option_key>.*)/i =~ dialog_key
-  add_hash_value(0, option_key.to_sym, dialog_value, options_hash)
-  add_hash_value(0, dialog_key.to_sym, dialog_value, options_hash)
-  true
-end
-
-def set_dialog_value(key, value, options_hash, tags_hash)
-  option_hash_value(key, value, options_hash) ||
-    option_array_value(key, value, options_hash) ||
-    option_password_value(key, value, options_hash) ||
-    tag_hash_value(key, value, tags_hash) ||
-    tag_array_value(key, value, tags_hash) ||
-    generic_dialog_value(key, value, options_hash) ||
-    generic_password_value(key, value, options_hash)
-end
-
-def parse_dialog_entries(dialog_options)
-  options_hash        = Hash.new { |h, k| h[k] = {} }
-  tags_hash           = Hash.new { |h, k| h[k] = {} }
-
-  dialog_options.each do |key, value|
-    next if value.blank?
-    set_dialog_value(key, value, options_hash, tags_hash)
-  end
-  return options_hash, tags_hash
-end
-
-def parent_task_dialog_information(task)
-  bundle_task = parent_task(task)
-  if bundle_task.nil?
-    $evm.log('error', "Unable to locate Dialog information")
-    exit MIQ_ABORT
+class DialogParser
+  def initialize(handle)
+    @handle = handle
+    @options_hash  = Hash.new { |h, k| h[k] = {} }
+    @tags_hash     = Hash.new { |h, k| h[k] = {} }
   end
 
-  $evm.log('info', "Current task has empty dialogs, getting dialog information from parent task")
-  options_hash = YAML.load(bundle_task.get_option(:parsed_dialog_options))
-  tags_hash = YAML.load(bundle_task.get_option(:parsed_dialog_tags))
-  return options_hash, tags_hash
+  def main
+    stp_request = @handle.root['service_template_provision_request']
+
+    dialog_entries = stp_request.options[:dialog]
+
+    @handle.log('info', "dialog_options: #{dialog_entries.inspect}")
+
+    parse_dialog_entries(dialog_entries)
+
+    save_parsed_dialog_information(stp_request)
+  end
+
+  private
+
+  def parse_dialog_entries(dialog_options)
+    dialog_options.each do |key, value|
+      next if value.blank?
+      set_dialog_value(key, value)
+    end
+  end
+
+  def save_parsed_dialog_information(miq_request)
+    miq_request.set_option(:parsed_dialog_options, YAML.dump(merge_hash(@options_hash)))
+    miq_request.set_option(:parsed_dialog_tags, YAML.dump(merge_hash(@tags_hash)))
+    @handle.log('info', "parsed_dialog_options: #{miq_request.get_option(:parsed_dialog_options).inspect}")
+    @handle.log('info', "parsed_dialog_tags: #{miq_request.get_option(:parsed_dialog_tags).inspect}")
+  end
+
+  def vmdb_object_from_array_entry(entry)
+    model, id = entry.split("::")
+    @handle.vmdb(model, id.to_i) if model && id
+  end
+
+  def add_hash_value(sequence_id, option_key, value, hash)
+    @handle.log("info", "Adding seq_id: #{sequence_id} key: #{option_key} value: #{value} ")
+    hash[sequence_id][option_key] = value
+  end
+
+  def process_comma_separated_object_array(sequence_id, option_key, value, hash)
+    return if value.nil?
+    options_value_array = []
+    value.split(",").each do |entry|
+      vmdb_obj = vmdb_object_from_array_entry(entry)
+      next if vmdb_obj.nil?
+      options_value_array << (vmdb_obj.respond_to?(:name) ? vmdb_obj.name : "#{vmdb_obj.class.name}::#{vmdb_obj.id}")
+    end
+    hash[sequence_id][option_key] = options_value_array
+  end
+
+  def option_password_value(dialog_key, dialog_value)
+    return false unless /^password::dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+    add_password_value(sequence.to_i, option_key, dialog_value)
+    true
+  end
+
+  def generic_password_value(dialog_key, dialog_value)
+    return false unless /^password::dialog_(?<option_key>.*)/i =~ dialog_key
+    add_password_value(0, option_key, dialog_value)
+    true
+  end
+
+  def add_password_value(sequence, option_key, value)
+    stripped_option_key = 'password::' + option_key
+    prefixed_option_key = 'password::dialog_' + option_key
+    add_hash_value(sequence, stripped_option_key.to_sym, value, @options_hash)
+    add_hash_value(sequence, prefixed_option_key.to_sym, value, @options_hash)
+  end
+
+  def option_hash_value(dialog_key, dialog_value)
+    return false unless /^dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+    add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, @options_hash)
+    true
+  end
+
+  def option_array_value(dialog_key, dialog_value)
+    return false unless /^array::dialog_option_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+    process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, @options_hash)
+    true
+  end
+
+  def tag_hash_value(dialog_key, dialog_value)
+    return false unless /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+    add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, @tags_hash)
+    true
+  end
+
+  def tag_array_value(dialog_key, dialog_value)
+    return false unless /^array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+    process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, @tags_hash)
+    true
+  end
+
+  def generic_dialog_value(dialog_key, dialog_value)
+    return false unless /^dialog_(?<option_key>.*)/i =~ dialog_key
+    add_hash_value(0, option_key.to_sym, dialog_value, @options_hash)
+    add_hash_value(0, dialog_key.to_sym, dialog_value, @options_hash)
+    true
+  end
+
+  def set_dialog_value(key, value)
+    option_value(key, value) || tag_value(key, value) || generic_value(key, value)
+  end
+
+  def option_value(key, value)
+    option_hash_value(key, value) ||
+      option_array_value(key, value) ||
+      option_password_value(key, value)
+  end
+
+  def tag_value(key, value)
+    tag_hash_value(key, value) || tag_array_value(key, value)
+  end
+
+  def generic_value(key, value)
+    generic_dialog_value(key, value) || generic_password_value(key, value)
+  end
+
+  def merge_hash(hash)
+    return hash unless hash.key?(0)
+    hash0 = hash[0]
+    mergeable_keys = hash.keys.select { |n| n.kind_of?(Integer) && n > 0 }
+    # The merge is needed because quota and other methods dont have to reparse
+    mergeable_keys.each { |key| hash[key] = hash0.reverse_merge(hash[key]) }
+    hash
+  end
 end
 
-def save_parsed_dialog_information(options_hash, tags_hash, task)
-  task.set_option(:parsed_dialog_options, YAML.dump(options_hash))
-  task.set_option(:parsed_dialog_tags, YAML.dump(tags_hash))
-  $evm.log('info', "parsed_dialog_options: #{task.get_option(:parsed_dialog_options).inspect}")
-  $evm.log('info', "parsed_dialog_tags: #{task.get_option(:parsed_dialog_tags).inspect}")
+if __FILE__ == $PROGRAM_NAME
+  DialogParser.new($evm).main
 end
-
-task = $evm.root['service_template_provision_task']
-
-dialog_entries = task.dialog_options
-
-$evm.log('info', "dialog_options: #{dialog_entries.inspect}")
-
-options_hash, tags_hash = parse_dialog_entries(dialog_entries)
-
-if options_hash.blank? && tags_hash.blank?
-  options_hash, tags_hash = parent_task_dialog_information(task)
-else
-  $evm.log('info', "Current task has dialog information")
-end
-
-save_parsed_dialog_information(options_hash, tags_hash, task)

--- a/spec/lib/miq_automation_engine/methods/dialog_parser_spec.rb
+++ b/spec/lib/miq_automation_engine/methods/dialog_parser_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser')
+require Rails.root.join('spec/support/miq_ae_mock_service')
+
+describe DialogParser do
+  let(:user)  { FactoryGirl.create(:user_with_group) }
+  let(:stp_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+  let(:stpr) {  MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest.find(stp_request.id) }
+  let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspace", :root => options, :persist_state_hash => {}) }
+
+  let(:options) { {'service_template_provision_request' => stpr} }
+
+  def create_tags
+    FactoryGirl.create(:classification_department_with_tags)
+    @array_name = "Array::dialog_tag_0_department"
+    @dept_ids = Classification.find_by_description('Department').children.collect do |x|
+      "Classification::#{x.id}"
+    end.join(',')
+
+    @dept_array = Classification.find_by_description('Department').children.collect(&:name)
+  end
+
+  def run_automate_method
+    service = MiqAeMockService.new(options)
+    DialogParser.new(service).main
+  end
+
+  def setup_and_run_method(dialog_hash)
+    stp_request.options = stp_request.options.merge(:dialog => dialog_hash)
+    stp_request.save
+    run_automate_method
+    stp_request.reload
+  end
+
+  def load_options
+    YAML.load(stp_request.get_option(:parsed_dialog_options))
+  end
+
+  def load_tags
+    YAML.load(stp_request.get_option(:parsed_dialog_tags))
+  end
+
+  context "parser" do
+    it "with options tags and arrays" do
+      create_tags
+      dialog_hash = {'dialog_option_1_numero' => 'one', 'dialog_option_2_numero' => 'two',
+                     'dialog_option_3_numero' => 'three', 'dialog_option_0_numero' => 'zero',
+                     'dialog_tag_0_location' => 'NYC', 'dialog_tag_1_location' => 'BOM',
+                     'dialog_tag_2_location' => 'EWR', @array_name => @dept_ids}
+
+      parsed_dialog_options_hash = {1 => {:numero => "zero"},
+                                    2 => {:numero => "zero"},
+                                    3 => {:numero => "zero"},
+                                    0 => {:numero => "zero"}}
+      parsed_dialog_tags_hash = {0 => {:location => "NYC", :department => @dept_array},
+                                 1 => {:location => "NYC", :department => @dept_array},
+                                 2 => {:location => "NYC", :department => @dept_array}}
+
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+      pdt = load_tags
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+      expect(pdt).to eql(parsed_dialog_tags_hash)
+    end
+
+    it "with password option" do
+      dialog_hash = {'password::dialog_option_1_passwordtest' => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}
+      parsed_dialog_options_hash = {1 => {:"password::dialog_passwordtest" => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :"password::passwordtest"        => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}}
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+    end
+
+    it "with generic password" do
+      dialog_hash = {'password::dialog_passwordtest' => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}
+      parsed_dialog_options_hash = {0 => {:"password::dialog_passwordtest" => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :"password::passwordtest"        => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}}
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+    end
+
+    it "with no dialogs set" do
+      stp_request.options = stp_request.options.merge(:dialog => {})
+      stp_request.save
+      expect { run_automate_method }.not_to raise_exception
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/methods/new_dialog_parser_spec.rb
+++ b/spec/lib/miq_automation_engine/methods/new_dialog_parser_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser')
+require Rails.root.join('spec/support/miq_ae_mock_service')
+
+describe DialogParser do
+  let(:user)  { FactoryGirl.create(:user_with_group) }
+  let(:stp_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+  let(:stpr) {  MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest.find(stp_request.id) }
+  let(:workspace) { instance_double("MiqAeEngine::MiqAeWorkspace", :root => options, :persist_state_hash => {}) }
+
+  let(:options) { {'service_template_provision_request' => stpr} }
+
+  def create_tags
+    FactoryGirl.create(:classification_department_with_tags)
+    @array_name = "Array::dialog_tag_0_department"
+    @dept_ids = Classification.find_by_description('Department').children.collect do |x|
+      "Classification::#{x.id}"
+    end.join(',')
+
+    @dept_array = Classification.find_by_description('Department').children.collect(&:name)
+  end
+
+  def run_automate_method
+    service = MiqAeMockService.new(options)
+    DialogParser.new(service).main
+  end
+
+  def setup_and_run_method(dialog_hash)
+    stp_request.options = stp_request.options.merge(:dialog => dialog_hash)
+    stp_request.save
+    run_automate_method
+    stp_request.reload
+  end
+
+  def load_options
+    YAML.load(stp_request.get_option(:parsed_dialog_options))
+  end
+
+  def load_tags
+    YAML.load(stp_request.get_option(:parsed_dialog_tags))
+  end
+
+  context "parser" do
+    it "with options tags and arrays" do
+      create_tags
+      dialog_hash = {'dialog_option_1_numero' => 'one', 'dialog_option_2_numero' => 'two',
+                     'dialog_option_3_numero' => 'three', 'dialog_option_0_numero' => 'zero',
+                     'dialog_tag_0_location' => 'NYC', 'dialog_tag_1_location' => 'BOM',
+                     'dialog_tag_2_location' => 'EWR', @array_name => @dept_ids}
+
+      parsed_dialog_options_hash = {1 => {:numero => "zero"},
+                                    2 => {:numero => "zero"},
+                                    3 => {:numero => "zero"},
+                                    0 => {:numero => "zero"}}
+      parsed_dialog_tags_hash = {0 => {:location => "NYC", :department => @dept_array},
+                                 1 => {:location => "NYC", :department => @dept_array},
+                                 2 => {:location => "NYC", :department => @dept_array}}
+
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+      pdt = load_tags
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+      expect(pdt).to eql(parsed_dialog_tags_hash)
+    end
+
+    it "with password option" do
+      dialog_hash = {'password::dialog_option_1_passwordtest' => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}
+      parsed_dialog_options_hash = {1 => {:"password::dialog_passwordtest" => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :"password::passwordtest"        => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}}
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+    end
+
+    it "with generic password" do
+      dialog_hash = {'password::dialog_passwordtest' => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}
+      parsed_dialog_options_hash = {0 => {:"password::dialog_passwordtest" => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :"password::passwordtest"        => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}}
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+    end
+
+    it "with no dialogs set" do
+      stp_request.options = stp_request.options.merge(:dialog => {})
+      stp_request.save
+      expect { run_automate_method }.not_to raise_exception
+    end
+  end
+end

--- a/spec/support/miq_ae_mock_service.rb
+++ b/spec/support/miq_ae_mock_service.rb
@@ -1,0 +1,27 @@
+class MiqAeMockService
+  include MiqAeMethodService::MiqAeServiceObjectCommon
+  include MiqAeMethodService::MiqAeServiceModelLegacy
+
+  def initialize(hash = {})
+    @root_hash = hash
+  end
+
+  def root
+    @root_hash
+  end
+
+  def log(level, msg)
+    $miq_ae_logger.send(level, "<AEMethod> #{msg}")
+  end
+
+  def vmdb(model_name, *args)
+    service = service_model(model_name)
+    args.empty? ? service : service.find(*args)
+  end
+
+  def service_model(model_name)
+    "MiqAeMethodService::MiqAeService#{model_name}".constantize
+  rescue NameError
+    service_model_lookup(model_name)
+  end
+end


### PR DESCRIPTION
The Automate Method Dialog Parser can be tested outside the
Automate Engine. It uses a Mock Service to replace the Drb calls
and allows for testing the methods outside of the engine.