### PR TITLE
Compress output for SCVMM inventory collection for speed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "color"
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-7"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "winrm",                          "=1.1.3",    :require => false, :git => "git://github.com/ManageIQ/WinRM.git", :tag => "v1.1.3-1"
+gem "winrm",                          "~>1.4.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required


### PR DESCRIPTION
This PR modifies the get_inventory.ps1 script so that it returns compressed output instead of raw output. By compressing the XML before sending it over the wire we can significantly reduce the overall processing time for inventory collection. In testing, the compressed file was less than 1/10th the original size.

This required modification of the powershell.rb file so that it handled compressed data before processing it. Note that it will still work if the output is not compressed, too, so there's backwards compatibility if needed.

Internally I updated the winrm gem to 1.4.0, which gives us some handy methods in the form of a WinRM::Output object that we can use instead of unrolling chunks of stdout manually ourselves. This did require some modification of the spec to match the library. I also explicitly compress the data within the spec so that it matches the actual behavior.