### PR TITLE
Use String#freeze to allocate a single string

### DIFF
--- a/gems/pending/util/extensions/miq-yaml.rb
+++ b/gems/pending/util/extensions/miq-yaml.rb
@@ -6,13 +6,11 @@ require 'yaml'
 module Psych
   module Visitors
     class ToRuby
-      SHOVEL      = '<<'
-      IVAR_MARKER = '__iv__'
       def revive_hash(hash, o)
         o.children.each_slice(2) do |k, v|
           key = accept(k)
 
-          if key == SHOVEL
+          if key == '<<'.freeze
             case v
             when Nodes::Alias
               hash.merge! accept(v)
@@ -26,7 +24,7 @@ module Psych
 
           # We need to migrate all old YAML before we can remove this
           #### Reapply the instance variables, see https://github.com/tenderlove/psych/issues/43
-          elsif key.to_s.start_with?(IVAR_MARKER)
+          elsif key.to_s.start_with?('__iv__'.freeze)
             hash.instance_variable_set(key.to_s[6..-1], accept(v))
 
           else


### PR DESCRIPTION
Upstream psych uses a constant to avoid creating so many strings.
We can use freeze in our codebase since we use ruby 2.2+

Fixes: Already initialized constant Psych::Visitors::ToRuby::SHOVEL
Fixes #5772 

Before / after
```
$ bundle exec rails r ''

/Users/joerafaniello/Code/manageiq/gems/pending/util/extensions/miq-yaml.rb:11: warning: already initialized constant Psych::Visitors::ToRuby::SHOVEL
/Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.16/lib/psych/visitors/to_ruby.rb:333: warning: previous definition of SHOVEL was here

$ bundle exec rails r ''
```