### PR TITLE
RSpec 'expect' syntax for automation specs

### DIFF
--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
@@ -31,7 +31,7 @@ describe "MultipleStateMachineSteps" do
                         :miq_group_id     => @user.current_group_id,
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
-    MiqServer.stub(:my_zone).and_return('default')
+    allow(MiqServer).to receive(:my_zone).and_return('default')
     clear_domain
     setup_model
   end
@@ -262,16 +262,16 @@ describe "MultipleStateMachineSteps" do
     expect(ws.root.attributes['step_on_entry']).to match_array(all_states + %w(SM1_2 SM2_2 SM3_1))
     (@max_retries).times do
       status, _message, ws = deliver_ae_request_from_queue
-      status.should_not eq(MiqQueue::STATUS_ERROR)
-      ws.should_not be_nil
+      expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+      expect(ws).not_to be_nil
       expect(ws.root.attributes['step_on_entry']).to match_array(%w(SM1_2 SM2_2 SM3_1))
     end
 
     status, _message, ws = deliver_ae_request_from_queue
-    status.should_not eq(MiqQueue::STATUS_ERROR)
-    ws.should_not be_nil
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
     expect(ws.root.attributes['step_on_entry']).to match_array(%w(SM1_2))
 
-    deliver_ae_request_from_queue.should be_nil
+    expect(deliver_ae_request_from_queue).to be_nil
   end
 end

--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -21,7 +21,7 @@ describe "MiqAeStateMachineRetry" do
                         :miq_group_id     => @user.current_group_id,
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
-    MiqServer.stub(:my_zone).and_return('default')
+    allow(MiqServer).to receive(:my_zone).and_return('default')
     clear_domain
   end
 
@@ -179,13 +179,13 @@ describe "MiqAeStateMachineRetry" do
     expected = {'three' => 3, 'one'  => 1, 'two'  => 2, 'gravy' => 'train'}
     send_ae_request_via_queue(@automate_args)
     status, _message, ws = deliver_ae_request_from_queue
-    status.should_not eq(MiqQueue::STATUS_ERROR)
-    ws.should_not be_nil
-    MiqQueue.count.should eq(2)
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
+    expect(MiqQueue.count).to eq(2)
     status, _message, ws = deliver_ae_request_from_queue
-    status.should_not eq(MiqQueue::STATUS_ERROR)
-    ws.persist_state_hash.should eq(expected)
-    ws.root.attributes['finished'].should be_true
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws.persist_state_hash).to eq(expected)
+    expect(ws.root.attributes['finished']).to be_truthy
   end
 
   it "check max retries" do
@@ -193,10 +193,10 @@ describe "MiqAeStateMachineRetry" do
     send_ae_request_via_queue(@automate_args)
     (@max_retries + 2).times do
       status, _message, ws = deliver_ae_request_from_queue
-      status.should_not eq(MiqQueue::STATUS_ERROR)
-      ws.should_not be_nil
+      expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+      expect(ws).not_to be_nil
     end
-    deliver_ae_request_from_queue.should be_nil
+    expect(deliver_ae_request_from_queue).to be_nil
   end
 
   it "check max_time" do
@@ -223,8 +223,8 @@ describe "MiqAeStateMachineRetry" do
     create_restart_model(simpleton_script, simpleton_script, perpetual_restart_script)
     send_ae_request_via_queue(@automate_args)
     status, _message, ws = deliver_ae_request_from_queue
-    status.should_not eq(MiqQueue::STATUS_ERROR)
-    ws.should_not be_nil
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
     q = MiqQueue.where(:state => 'ready').first
     expect(q.args[0][:state]).to eql('state1')
   end
@@ -233,8 +233,8 @@ describe "MiqAeStateMachineRetry" do
     create_restart_model(simpleton_script, simpleton_script, perpetual_restart_script_with_nextstate)
     send_ae_request_via_queue(@automate_args)
     status, _message, ws = deliver_ae_request_from_queue
-    status.should_not eq(MiqQueue::STATUS_ERROR)
-    ws.should_not be_nil
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
     q = MiqQueue.where(:state => 'ready').first
     expect(q.args[0][:state]).to eql('state2')
   end

--- a/spec/automation/unit/method_validation/amazon_auto_placement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_auto_placement_spec.rb
@@ -82,8 +82,8 @@ describe "AMAZON best fit" do
     def check_attributes_not_set
       miq_provision.reload
       keys = miq_provision.options.keys
-      expect(keys.include?(:cloud_network)).to be_false
-      expect(keys.include?(:cloud_subnet)).to be_false
+      expect(keys.include?(:cloud_network)).to be_falsey
+      expect(keys.include?(:cloud_subnet)).to be_falsey
     end
   end
 end

--- a/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
@@ -20,12 +20,12 @@ describe "amazon_pre_retirement Method Validation" do
   it "calls stop for ebs instances" do
     @vm.hardware = @ebs_hardware
     MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
-    MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations').should be_true
+    expect(MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations')).to be_truthy
   end
 
   it "should not call stop for instance store instances" do
     @vm.hardware = @is_hardware
     MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
-    MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations').should be_false
+    expect(MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations')).to be_falsey
   end
 end

--- a/spec/automation/unit/method_validation/available_flavors_spec.rb
+++ b/spec/automation/unit/method_validation/available_flavors_spec.rb
@@ -10,7 +10,7 @@ describe "Available_Flavors Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the flavor list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -20,7 +20,7 @@ describe "Available_Flavors Method Validation" do
 
     it "provides only default value to the flavor list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -52,7 +52,7 @@ describe "Available_Flavors Method Validation" do
 
     it "provides only default value to the flavor list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -78,7 +78,7 @@ describe "Available_Flavors Method Validation" do
 
     it "provides only default value to the flavor list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end

--- a/spec/automation/unit/method_validation/available_flavors_spec.rb
+++ b/spec/automation/unit/method_validation/available_flavors_spec.rb
@@ -10,8 +10,8 @@ describe "Available_Flavors Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the flavor list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -20,8 +20,8 @@ describe "Available_Flavors Method Validation" do
 
     it "provides only default value to the flavor list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -42,18 +42,18 @@ describe "Available_Flavors Method Validation" do
 
     it "finds all the flavors and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<Choose>",
         @flavor1.name => @flavor1.name,
         @flavor2.name => @flavor2.name
       )
-      ws.root["default_value"].should be_nil
+      expect(ws.root["default_value"]).to be_nil
     end
 
     it "provides only default value to the flavor list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -68,18 +68,18 @@ describe "Available_Flavors Method Validation" do
 
     it "finds all the flavors and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<Choose>",
         @flavor1.name => @flavor1.name,
         @flavor2.name => @flavor2.name
       )
-      ws.root["default_value"].should be_nil
+      expect(ws.root["default_value"]).to be_nil
     end
 
     it "provides only default value to the flavor list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_images_spec.rb
+++ b/spec/automation/unit/method_validation/available_images_spec.rb
@@ -10,7 +10,7 @@ describe "Available_Images Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the image list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -20,7 +20,7 @@ describe "Available_Images Method Validation" do
 
     it "provides only default value to the image list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -67,7 +67,7 @@ describe "Available_Images Method Validation" do
 
     it "provides only default value to the image list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end
@@ -114,7 +114,7 @@ describe "Available_Images Method Validation" do
 
     it "provides only default value to the image list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end
   end

--- a/spec/automation/unit/method_validation/available_images_spec.rb
+++ b/spec/automation/unit/method_validation/available_images_spec.rb
@@ -10,8 +10,8 @@ describe "Available_Images Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the image list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -20,8 +20,8 @@ describe "Available_Images Method Validation" do
 
     it "provides only default value to the image list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -49,26 +49,26 @@ describe "Available_Images Method Validation" do
 
     it "finds all the images and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<Choose>",
         @img1.uid_ems => "windows | #{@img1.name}",
         @img2.uid_ems => "linux | #{@img2.name}"
       )
-      ws.root["default_value"].should be_nil
+      expect(ws.root["default_value"]).to be_nil
     end
 
     it "finds the only image and set it as the only item in the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_one_img.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         @img1.uid_ems => "unknown | #{@img1.name}"
       )
-      ws.root["default_value"].should == @img1.uid_ems
+      expect(ws.root["default_value"]).to eq(@img1.uid_ems)
     end
 
     it "provides only default value to the image list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 
@@ -96,26 +96,26 @@ describe "Available_Images Method Validation" do
 
     it "finds all the images and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<Choose>",
         @img1.uid_ems => "windows | #{@img1.name}",
         @img2.uid_ems => "linux | #{@img2.name}"
       )
-      ws.root["default_value"].should be_nil
+      expect(ws.root["default_value"]).to be_nil
     end
 
     it "finds the only image and set it as the only item in the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_one_img.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         @img1.uid_ems => "unknown | #{@img1.name}"
       )
-      ws.root["default_value"].should == @img1.uid_ems
+      expect(ws.root["default_value"]).to eq(@img1.uid_ems)
     end
 
     it "provides only default value to the image list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
-      ws.root["default_value"].should be_nil
+      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["default_value"]).to be_nil
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_os_types_spec.rb
+++ b/spec/automation/unit/method_validation/available_os_types_spec.rb
@@ -20,13 +20,13 @@ describe "Available_Os_Types Method Validation" do
 
   it "provides all os types and default to unknown" do
     ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-    ws.root["values"].should include(os_list)
-    ws.root["default_value"].should == 'unknown'
+    expect(ws.root["values"]).to include(os_list)
+    expect(ws.root["default_value"]).to eq('unknown')
   end
 
   it "provides all os types and auto selects the type based on the user selection of an image" do
     ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}&dialog_param_userImageName=uid1", user)
-    ws.root["values"].should include(os_list)
-    ws.root["default_value"].should == 'windows'
+    expect(ws.root["values"]).to include(os_list)
+    expect(ws.root["default_value"]).to eq('windows')
   end
 end

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -10,7 +10,7 @@ describe "Available_Resource_Groups Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
     end
   end
 
@@ -19,7 +19,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
     end
   end
 
@@ -49,7 +49,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
     end
   end
 
@@ -73,7 +73,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => default_desc})
+      expect(ws.root["values"]).to eq(nil => default_desc)
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -10,7 +10,7 @@ describe "Available_Resource_Groups Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => default_desc}
+      expect(ws.root["values"]).to eq({nil => default_desc})
     end
   end
 
@@ -19,7 +19,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => default_desc}
+      expect(ws.root["values"]).to eq({nil => default_desc})
     end
   end
 
@@ -40,7 +40,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "finds all the resource groups and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => default_desc,
         @rgroup1.name => @rgroup1.name,
         @rgroup2.name => @rgroup2.name
@@ -49,7 +49,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
+      expect(ws.root["values"]).to eq({nil => default_desc})
     end
   end
 
@@ -64,7 +64,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "finds all the resource groups and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => default_desc,
         @rgroup1.name => @rgroup1.name,
         @rgroup2.name => @rgroup2.name
@@ -73,7 +73,7 @@ describe "Available_Resource_Groups Method Validation" do
 
     it "provides only default value to the resource group list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      ws.root["values"].should == {nil => default_desc}
+      expect(ws.root["values"]).to eq({nil => default_desc})
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_tenants_spec.rb
+++ b/spec/automation/unit/method_validation/available_tenants_spec.rb
@@ -9,7 +9,7 @@ describe "Available_Tenants Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the tenant list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      expect(ws.root["values"]).to eq({nil => "<default>"})
+      expect(ws.root["values"]).to eq(nil => "<default>")
     end
   end
 
@@ -18,7 +18,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      expect(ws.root["values"]).to eq({nil => "<default>"})
+      expect(ws.root["values"]).to eq(nil => "<default>")
     end
   end
 
@@ -48,7 +48,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => "<default>"})
+      expect(ws.root["values"]).to eq(nil => "<default>")
     end
   end
 
@@ -72,7 +72,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      expect(ws.root["values"]).to eq({nil => "<default>"})
+      expect(ws.root["values"]).to eq(nil => "<default>")
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_tenants_spec.rb
+++ b/spec/automation/unit/method_validation/available_tenants_spec.rb
@@ -9,7 +9,7 @@ describe "Available_Tenants Method Validation" do
   context "workspace has no service template" do
     it "provides only default value to the tenant list" do
       ws = MiqAeEngine.instantiate("#{@ins}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      expect(ws.root["values"]).to eq({nil => "<default>"})
     end
   end
 
@@ -18,7 +18,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      expect(ws.root["values"]).to eq({nil => "<default>"})
     end
   end
 
@@ -39,7 +39,7 @@ describe "Available_Tenants Method Validation" do
 
     it "finds all the tenants and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<default>",
         @tenant1.name => @tenant1.name,
         @tenant2.name => @tenant2.name
@@ -48,7 +48,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      expect(ws.root["values"]).to eq({nil => "<default>"})
     end
   end
 
@@ -63,7 +63,7 @@ describe "Available_Tenants Method Validation" do
 
     it "finds all the tenants and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
-      ws.root["values"].should include(
+      expect(ws.root["values"]).to include(
         nil           => "<default>",
         @tenant1.name => @tenant1.name,
         @tenant2.name => @tenant2.name
@@ -72,7 +72,7 @@ describe "Available_Tenants Method Validation" do
 
     it "provides only default value to the tenant list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      ws.root["values"].should == {nil => "<default>"}
+      expect(ws.root["values"]).to eq({nil => "<default>"})
     end
   end
 end

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -70,9 +70,9 @@ describe "CatalogBundleInitialization Automate Method" do
     def check_svc_attrs
       @stp.reload
       service = @stp.destination
-      service.description.should eql(@service_description)
-      service.name.should eql(@service_name)
-      service.tags[0].name.should eql('/managed/tracker/gps')
+      expect(service.description).to eql(@service_description)
+      expect(service.name).to eql(@service_name)
+      expect(service.tags[0].name).to eql('/managed/tracker/gps')
     end
 
     def process_stp(options)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -90,16 +90,16 @@ describe "CatalogItemInitialization Automate Method" do
 
     def check_options(request_task, required_options)
       options = request_task.options
-      required_options.each { |k, v| options[k].should eql(v) }
+      required_options.each { |k, v| expect(options[k]).to eql(v) }
     end
 
     def check_tags(request_task, required_tags)
       tags = request_task.get_tags
-      required_tags.each { |k, v| tags[k].should eql(v) }
+      required_tags.each { |k, v| expect(tags[k]).to eql(v) }
     end
 
     def check_destination_options(service, required_options)
-      required_options.each { |k, v| service.options[:dialog]["dialog_#{k}"].should eql(v) }
+      required_options.each { |k, v| expect(service.options[:dialog]["dialog_#{k}"]).to eql(v) }
     end
   end
 end

--- a/spec/automation/unit/method_validation/check_amazon_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/check_amazon_pre_retirement_spec.rb
@@ -20,22 +20,22 @@ describe "amazon_check_pre_retirement Method Validation" do
   it "returns 'ok' for instance store instances even with power on" do
     @vm.hardware = @is_hardware
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
-    ws.root['ae_result'].should be == 'ok'
-    ws.root['vm'].power_state.should be == 'on'
+    expect(ws.root['ae_result']).to eq('ok')
+    expect(ws.root['vm'].power_state).to eq('on')
   end
 
   it "returns 'retry' for running ebs instances" do
     @vm.hardware = @ebs_hardware
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
-    ws.root['ae_result'].should be == 'retry'
-    ws.root['vm'].power_state.should be == 'on'
+    expect(ws.root['ae_result']).to eq('retry')
+    expect(ws.root['vm'].power_state).to eq('on')
   end
 
   it "returns 'ok' for stopped ebs instances" do
     @vm.hardware = @ebs_hardware
     @vm.update_attributes(:raw_power_state => "off")
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
-    ws.root['ae_result'].should be == 'ok'
-    ws.root['vm'].power_state.should be == 'off'
+    expect(ws.root['ae_result']).to eq('ok')
+    expect(ws.root['vm'].power_state).to eq('off')
   end
 end

--- a/spec/automation/unit/method_validation/check_openstack_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/check_openstack_pre_retirement_spec.rb
@@ -13,14 +13,14 @@ describe "openstack_check_pre_retirement Method Validation" do
 
   it "returns 'retry' for running instances" do
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#openstack", @user)
-    ws.root['ae_result'].should be == 'retry'
-    ws.root['vm'].power_state.should be == 'on'
+    expect(ws.root['ae_result']).to eq('retry')
+    expect(ws.root['vm'].power_state).to eq('on')
   end
 
   it "returns 'ok' for stopped instances" do
     @vm.update_attributes(:raw_power_state => "SHUTOFF")
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#openstack", @user)
-    ws.root['ae_result'].should be == 'ok'
-    ws.root['vm'].power_state.should be == 'off'
+    expect(ws.root['ae_result']).to eq('ok')
+    expect(ws.root['vm'].power_state).to eq('off')
   end
 end

--- a/spec/automation/unit/method_validation/check_powered_off_spec.rb
+++ b/spec/automation/unit/method_validation/check_powered_off_spec.rb
@@ -10,21 +10,21 @@ describe "check_powered_off Method Validation" do
   it "returns 'ok' for a vm in powered_off state" do
     @vm.update_attribute(:raw_power_state, "poweredOff")
 
-    ws.root['vm'].power_state.should be == "off"
-    ws.root['ae_result'].should be == "ok"
+    expect(ws.root['vm'].power_state).to eq("off")
+    expect(ws.root['ae_result']).to eq("ok")
   end
 
   it "errors for a template" do
     @vm.update_attribute(:template, true)
-    @vm.state.should be == "never"
+    expect(@vm.state).to eq("never")
 
-    -> { ws }.should raise_error(MiqAeException::ServiceNotFound)
+    expect { ws }.to raise_error(MiqAeException::ServiceNotFound)
   end
 
   it "retries for a vm in powered_on state" do
     @vm.update_attribute(:raw_power_state, "poweredOn")
 
-    ws.root['ae_result'].should be == "retry"
-    ws.root['vm'].power_state.should be == "on"
+    expect(ws.root['ae_result']).to eq("retry")
+    expect(ws.root['vm'].power_state).to eq("on")
   end
 end

--- a/spec/automation/unit/method_validation/check_removed_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/check_removed_from_provider_spec.rb
@@ -16,15 +16,15 @@ describe "check_removed_from_provider Method Validation" do
   let(:ws) { MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}&ae_state_data=#{URI.escape(YAML.dump(@ae_state))}", @user) }
 
   it "returns 'ok' if the vm is not connected to a ems" do
-    ws.root['vm']['registered'].should  eql(false)
-    ws.root['ae_result'].should         eql("ok")
+    expect(ws.root['vm']['registered']).to  eql(false)
+    expect(ws.root['ae_result']).to         eql("ok")
   end
 
   it "returns 'retry' if the vm is still connected to ems" do
     @vm.update_attributes(:host => @host, :ems_id => @ems.id,
                           :registered => true)
-    Vm.any_instance.stub(:refresh_ems)
-    ws.root['ae_result'].should         eql("retry")
-    ws.root['vm']['registered'].should == true
+    allow_any_instance_of(Vm).to receive(:refresh_ems)
+    expect(ws.root['ae_result']).to         eql("retry")
+    expect(ws.root['vm']['registered']).to eq(true)
   end
 end

--- a/spec/automation/unit/method_validation/check_removed_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/check_removed_from_provider_spec.rb
@@ -24,7 +24,7 @@ describe "check_removed_from_provider Method Validation" do
     @vm.update_attributes(:host => @host, :ems_id => @ems.id,
                           :registered => true)
     allow_any_instance_of(Vm).to receive(:refresh_ems)
-    expect(ws.root['ae_result']).to         eql("retry")
+    expect(ws.root['ae_result']).to eql("retry")
     expect(ws.root['vm']['registered']).to eq(true)
   end
 end

--- a/spec/automation/unit/method_validation/check_unregistered_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/check_unregistered_from_provider_spec.rb
@@ -16,15 +16,15 @@ describe "check_unregistered_from_provider Method Validation" do
   let(:ws) { MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}&ae_state_data=#{URI.escape(YAML.dump(@ae_state))}", @user) }
 
   it "returns 'ok' if the vm is not connected to a ems" do
-    ws.root['vm']['registered'].should  eql(false)
-    ws.root['ae_result'].should         eql("ok")
+    expect(ws.root['vm']['registered']).to  eql(false)
+    expect(ws.root['ae_result']).to         eql("ok")
   end
 
   it "returns 'retry' if the vm is still connected to ems" do
     @vm.update_attributes(:host => @host, :ems_id => @ems.id,
                           :registered => true)
-    Vm.any_instance.stub(:refresh_ems)
-    ws.root['ae_result'].should         eql("retry")
-    ws.root['vm']['registered'].should == true
+    allow_any_instance_of(Vm).to receive(:refresh_ems)
+    expect(ws.root['ae_result']).to         eql("retry")
+    expect(ws.root['vm']['registered']).to eq(true)
   end
 end

--- a/spec/automation/unit/method_validation/check_unregistered_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/check_unregistered_from_provider_spec.rb
@@ -24,7 +24,7 @@ describe "check_unregistered_from_provider Method Validation" do
     @vm.update_attributes(:host => @host, :ems_id => @ems.id,
                           :registered => true)
     allow_any_instance_of(Vm).to receive(:refresh_ems)
-    expect(ws.root['ae_result']).to         eql("retry")
+    expect(ws.root['ae_result']).to eql("retry")
     expect(ws.root['vm']['registered']).to eq(true)
   end
 end

--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -49,7 +49,7 @@ describe "FilterByDialogParameters Automate Method" do
       ws = run_automate_method(ServiceTemplate.find_by_name("top"),
                                root_service_template_task,
                                FactoryGirl.create(:service))
-      expect(ws.root['include_service']).to be_true
+      expect(ws.root['include_service']).to be_truthy
     end
 
     it "with vm_serice" do
@@ -57,7 +57,7 @@ describe "FilterByDialogParameters Automate Method" do
       ws = run_automate_method(ServiceTemplate.find_by_name("vm_service"),
                                root_service_template_task,
                                FactoryGirl.create(:service))
-      expect(ws.root['include_service']).to be_true
+      expect(ws.root['include_service']).to be_truthy
     end
 
     it "with missing dialog_environment" do
@@ -73,7 +73,7 @@ describe "FilterByDialogParameters Automate Method" do
       ws = run_automate_method(ServiceTemplate.find_by_name("vm_service"),
                                root_service_template_task,
                                FactoryGirl.create(:service))
-      expect(ws.root['include_service']).to be_false
+      expect(ws.root['include_service']).to be_falsey
     end
   end
 end

--- a/spec/automation/unit/method_validation/openstack_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/openstack_pre_retirement_spec.rb
@@ -13,12 +13,12 @@ describe "openstack_pre_retirement Method Validation" do
 
   it "call suspend for running instances" do
     MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#Openstack", @user)
-    MiqQueue.exists?(:method_name => 'suspend', :instance_id => @vm.id, :role => 'ems_operations').should be_true
+    expect(MiqQueue.exists?(:method_name => 'suspend', :instance_id => @vm.id, :role => 'ems_operations')).to be_truthy
   end
 
   it "does not call suspend for powered off instances" do
     @vm.update_attributes(:raw_power_state => 'SHUTOFF')
     MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#Openstack", @user)
-    MiqQueue.exists?(:method_name => 'suspend', :instance_id => @vm.id, :role => 'ems_operations').should be_false
+    expect(MiqQueue.exists?(:method_name => 'suspend', :instance_id => @vm.id, :role => 'ems_operations')).to be_falsey
   end
 end

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -19,7 +19,8 @@ describe "Orchestration check_provisioned Method Validation" do
   end
 
   it "catches the error during stack deployment" do
-    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack_status) { ['CREATE_FAILED', failure_msg] }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['CREATE_FAILED', failure_msg] }
     expect(ws.root['ae_result']).to eq('error')
     expect(ws.root['ae_reason']).to eq(failure_msg)
     expect(request.reload.message).to eq(failure_msg)
@@ -27,21 +28,25 @@ describe "Orchestration check_provisioned Method Validation" do
 
   it "truncates the error message that exceeds 255 characters" do
     long_error = 't' * 300
-    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack_status) { ['CREATE_FAILED', long_error] }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['CREATE_FAILED', long_error] }
     expect(ws.root['ae_result']).to eq('error')
     expect(ws.root['ae_reason']).to eq(long_error)
     expect(request.reload.message).to eq('t' * 252 + '...')
   end
 
   it "considers rollback as provision error" do
-    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack_status) { ['ROLLBACK_COMPLETE', 'Stack was rolled back'] }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['ROLLBACK_COMPLETE', 'Stack was rolled back'] }
     expect(ws.root['ae_result']).to eq('error')
     expect(ws.root['ae_reason']).to eq('Stack was rolled back')
   end
 
   it "refreshes the provider and waits for it to complete" do
-    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack_status) { ['CREATE_COMPLETE', nil] }
-    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon) }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['CREATE_COMPLETE', nil] }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon) }
     expect_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:refresh_ems)
     expect(ws.root['ae_result']).to eq('retry')
   end

--- a/spec/automation/unit/method_validation/orchestration_provision_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_provision_spec.rb
@@ -8,22 +8,22 @@ describe "Orchestration provision Method Validation" do
   let(:ws)                    { MiqAeEngine.instantiate("/Cloud/Orchestration/Provisioning/StateMachines/Methods/Provision?MiqRequestTask::service_template_provision_task=#{miq_request_task.id}", user) }
 
   it "provisions a stack through the service" do
-    ServiceOrchestration.any_instance.should_receive(:deploy_orchestration_stack)
+    expect_any_instance_of(ServiceOrchestration).to receive(:deploy_orchestration_stack)
     ws
   end
 
   it "catches the error at stack provisioning" do
-    ServiceOrchestration.any_instance.stub(:deploy_orchestration_stack) { raise "test failure" }
-    ws.root['ae_result'].should == "error"
-    ws.root['ae_reason'].should == "test failure"
-    request.reload.message.should == "test failure"
+    allow_any_instance_of(ServiceOrchestration).to receive(:deploy_orchestration_stack) { raise "test failure" }
+    expect(ws.root['ae_result']).to eq("error")
+    expect(ws.root['ae_reason']).to eq("test failure")
+    expect(request.reload.message).to eq("test failure")
   end
 
   it "truncates the error message exceeding 255 character limits" do
     long_error = 't' * 300
-    ServiceOrchestration.any_instance.stub(:deploy_orchestration_stack) { raise long_error }
-    ws.root['ae_result'].should == "error"
-    ws.root['ae_reason'].should == long_error
-    request.reload.message.should == 't' * 252 + '...'
+    allow_any_instance_of(ServiceOrchestration).to receive(:deploy_orchestration_stack) { raise long_error }
+    expect(ws.root['ae_result']).to eq("error")
+    expect(ws.root['ae_reason']).to eq(long_error)
+    expect(request.reload.message).to eq('t' * 252 + '...')
   end
 end

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -60,7 +60,8 @@ describe "Orchestration retirement state machine Methods Validation" do
     end
 
     it "completes the step when stack no longer exists" do
-      allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'stack not exist' }
+      allow_any_instance_of(OrchestrationStack)
+        .to receive(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'stack not exist' }
       expect(ws.root['ae_result']).to eq("ok")
     end
 

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -20,7 +20,7 @@ describe "Orchestration retirement state machine Methods Validation" do
 
     it "starts a retirement request" do
       ws
-      OrchestrationStack.where(:id => stack.id).first.retirement_state.should == 'retiring'
+      expect(OrchestrationStack.where(:id => stack.id).first.retirement_state).to eq('retiring')
     end
 
     it "aborts if stack is already retired" do
@@ -38,14 +38,14 @@ describe "Orchestration retirement state machine Methods Validation" do
     let(:method_name) { "RemoveFromProvider" }
 
     it "requests stack to be deleted from provider if stack exists in provider" do
-      OrchestrationStack.any_instance.stub(:raw_exists?) { true }
-      OrchestrationStack.any_instance.should_receive(:raw_delete_stack)
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_exists?) { true }
+      expect_any_instance_of(OrchestrationStack).to receive(:raw_delete_stack)
       ws
     end
 
     it "does nothing if stack no longer exists in provider" do
-      OrchestrationStack.any_instance.stub(:raw_exists?) { false }
-      OrchestrationStack.any_instance.should_not_receive(:raw_delete_stack)
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_exists?) { false }
+      expect_any_instance_of(OrchestrationStack).not_to receive(:raw_delete_stack)
       ws
     end
   end
@@ -55,24 +55,24 @@ describe "Orchestration retirement state machine Methods Validation" do
 
     it "completes the step when stack is removed from provider" do
       status = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status.new('DELETE_COMPLETE', nil)
-      OrchestrationStack.any_instance.stub(:raw_status) { status }
-      ws.root['ae_result'].should == 'ok'
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { status }
+      expect(ws.root['ae_result']).to eq('ok')
     end
 
     it "completes the step when stack no longer exists" do
-      OrchestrationStack.any_instance.stub(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'stack not exist' }
-      ws.root['ae_result'].should == "ok"
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'stack not exist' }
+      expect(ws.root['ae_result']).to eq("ok")
     end
 
     it "retries if stack has not been removed from provider" do
       status = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status.new('DELETING', nil)
-      OrchestrationStack.any_instance.stub(:raw_status) { status }
-      ws.root['ae_result'].should == 'retry'
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { status }
+      expect(ws.root['ae_result']).to eq('retry')
     end
 
     it "reports error if cannot get stack status" do
-      OrchestrationStack.any_instance.stub(:raw_status) { raise "an error" }
-      ws.root['ae_result'].should == 'error'
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { raise "an error" }
+      expect(ws.root['ae_result']).to eq('error')
     end
   end
 
@@ -82,7 +82,7 @@ describe "Orchestration retirement state machine Methods Validation" do
 
     it "deletes stack from vmdb" do
       ws
-      OrchestrationStack.where(:id => stack.id).first.should be_nil
+      expect(OrchestrationStack.where(:id => stack.id).first).to be_nil
     end
   end
 end

--- a/spec/automation/unit/method_validation/power_off_spec.rb
+++ b/spec/automation/unit/method_validation/power_off_spec.rb
@@ -16,8 +16,8 @@ describe "power_off Method Validation" do
   it "powers off a vm in a 'powered on' state" do
     ws
 
-    MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id,
-    :role => 'ems_operations').should be_true
+    expect(MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id,
+    :role => 'ems_operations')).to be_truthy
   end
 
   it "does not queue any operation for a vm in 'powered_off' state" do
@@ -25,6 +25,6 @@ describe "power_off Method Validation" do
 
     ws
 
-    MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations').should be_false
+    expect(MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations')).to be_falsey
   end
 end

--- a/spec/automation/unit/method_validation/remove_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/remove_from_provider_spec.rb
@@ -19,11 +19,11 @@ describe "remove_from_provider Method Validation" do
     @vm_id = @vm.id
 
     ws
-    MiqQueue.exists?(:method_name => 'vm_destroy', :instance_id => @vm.id, :role => 'ems_operations').should be_true
+    expect(MiqQueue.exists?(:method_name => 'vm_destroy', :instance_id => @vm.id, :role => 'ems_operations')).to be_truthy
   end
 
   it "errors for a vm equal to nil" do
     @vm_id = nil
-    -> { ws }.should raise_error
+    expect { ws }.to raise_error
   end
 end

--- a/spec/automation/unit/method_validation/remove_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/remove_from_provider_spec.rb
@@ -19,7 +19,11 @@ describe "remove_from_provider Method Validation" do
     @vm_id = @vm.id
 
     ws
-    expect(MiqQueue.exists?(:method_name => 'vm_destroy', :instance_id => @vm.id, :role => 'ems_operations')).to be_truthy
+    expect(
+      MiqQueue.exists?(:method_name => 'vm_destroy',
+                       :instance_id => @vm.id,
+                       :role        => 'ems_operations')
+    ).to be_truthy
   end
 
   it "errors for a vm equal to nil" do

--- a/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
+++ b/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
@@ -38,7 +38,7 @@ describe "SCVMM microsoft_best_fit_least_utilized" do
       before do
         host_struct = MiqHashStruct.new(:id               => host.id,
                                         :evm_object_class => host.class.base_class.name.to_sym)
-        ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.any_instance.stub(:allowed_hosts).and_return([host_struct])
+        allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow).to receive(:allowed_hosts).and_return([host_struct])
       end
 
       it "without storage will not set placement values" do
@@ -54,7 +54,7 @@ describe "SCVMM microsoft_best_fit_least_utilized" do
           host.storages << storage
           storage_struct = MiqHashStruct.new(:id               => storage.id,
                                              :evm_object_class => storage.class.base_class.name.to_sym)
-          ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow.any_instance.stub(:allowed_storages).and_return([storage_struct])
+          allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow).to receive(:allowed_storages).and_return([storage_struct])
         end
 
         it "will set placement values" do

--- a/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
+++ b/spec/automation/unit/method_validation/scvmm_microsoft_best_fit_least_utilized_spec.rb
@@ -38,7 +38,8 @@ describe "SCVMM microsoft_best_fit_least_utilized" do
       before do
         host_struct = MiqHashStruct.new(:id               => host.id,
                                         :evm_object_class => host.class.base_class.name.to_sym)
-        allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow).to receive(:allowed_hosts).and_return([host_struct])
+        allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow)
+          .to receive(:allowed_hosts).and_return([host_struct])
       end
 
       it "without storage will not set placement values" do
@@ -54,7 +55,8 @@ describe "SCVMM microsoft_best_fit_least_utilized" do
           host.storages << storage
           storage_struct = MiqHashStruct.new(:id               => storage.id,
                                              :evm_object_class => storage.class.base_class.name.to_sym)
-          allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow).to receive(:allowed_storages).and_return([storage_struct])
+          allow_any_instance_of(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow)
+            .to receive(:allowed_storages).and_return([storage_struct])
         end
 
         it "will set placement values" do

--- a/spec/automation/unit/method_validation/unregister_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/unregister_from_provider_spec.rb
@@ -19,13 +19,13 @@ describe "unregister_from_provider Method Validation" do
 
     ws
 
-    MiqQueue.exists?(:method_name => 'unregister', :instance_id => @vm.id,
-    :role => 'ems_operations').should be_true
+    expect(MiqQueue.exists?(:method_name => 'unregister', :instance_id => @vm.id,
+    :role => 'ems_operations')).to be_truthy
   end
 
   it "errors for a vm equal to nil" do
     @vm_id = nil
 
-    lambda { ws }.should raise_error
+    expect { ws }.to raise_error
   end
 end

--- a/spec/automation/unit/method_validation/validate_quota_spec.rb
+++ b/spec/automation/unit/method_validation/validate_quota_spec.rb
@@ -26,7 +26,7 @@ describe "Quota Validation" do
       @quota_limit_max  = YAML.dump(:storage => 0, :vms => 0, :cpu => 0, :memory => 0)
       @quota_limit_warn = YAML.dump(:storage => 0, :vms => 0, :cpu => 0, :memory => 0)
       ws = run_automate_method(@miq_provision_request)
-      ws.root['ae_result'].should == 'ok'
+      expect(ws.root['ae_result']).to eq('ok')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false
 
+  # From rspec-rails, infer what helpers to mix in, such as `get` and
+  # `post` methods in spec/controllers, without specifying type
+  config.infer_spec_type_from_file_location!
+
   # config.before(:all) do
   #   EvmSpecHelper.log_ruby_object_usage
   # end


### PR DESCRIPTION
* Converts all automation specs to the new (Not really new anymore, is it?) `expect` syntax
* Enables the inferring of test type by rspec-rails (no need to specify `type => :controller` for instance) (keeps currently functionality we use in RSpec2)
* Also removes all Rubocop violations from automation specs

**Note**: There are still two deprecations present when running automation specs. These specs are tied to our use of rspec-fire, which is obsolete with RSpec 3 doubles. rspec-fire allows for NOOP functionality in RSpec3, so I'm waiting to remove it until we actually move to RSpec 3 and can do it cleanly. 

cc/ @jrafanie @Fryguy 