### PR TITLE
containers dashboard shows only providers types that are allowed 

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/single_provider_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/single_provider_dashboard_controller.js
@@ -26,7 +26,7 @@ angular.module('containerDashboard')
                     'use strict';
 
                     var data = response.data;
-                    $scope.providerTypeIconClass = data.providers.iconClass;
+                    $scope.providerTypeIconClass = data.providers[0].iconClass;
 
                     containerDashboardUtils.updateStatus($scope.objectStatus.nodes,      data.status.nodes);
                     containerDashboardUtils.updateStatus($scope.objectStatus.containers, data.status.containers);

--- a/app/assets/stylesheets/container_providers_dashboard.css
+++ b/app/assets/stylesheets/container_providers_dashboard.css
@@ -45,7 +45,7 @@
 }
 
 /* Remove after next pf release */
-.icon-atomic:before {
+.pficon-atomic:before {
     max-height: 20px;
     display: inline-block;
     content: url(/images/icons/new/vendor-atomic_dashboard.png);

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe ContainerDashboardService do
+  context "providers" do
+    it "filters containers providers with zero entity count and sorts providers by type correctly" do
+      FactoryGirl.create(:ems_openshift, :hostname => "test2.com")
+      FactoryGirl.create(:ems_openshift_enterprise, :hostname => "test3.com")
+      FactoryGirl.create(:ems_atomic, :hostname => "test4.com")
+      FactoryGirl.create(:ems_atomic_enterprise, :hostname => "test5.com")
+
+      providers_data = ContainerDashboardService.new(nil, nil).providers
+
+      # Kubernetes should not appear
+      expect(providers_data).to eq([{
+                                      :iconClass    => "pficon pficon-openshift",
+                                      :count        => 2,
+                                      :id           => :openshift,
+                                      :providerType => :Openshift
+                                    },
+                                    {
+                                      :iconClass    => "pficon pficon-atomic",
+                                      :count        => 2,
+                                      :id           => :atomic,
+                                      :providerType => :Atomic
+                                    }])
+    end
+  end
+end


### PR DESCRIPTION
Containers dashboard now shows providers types count if they are allowed in the system and if theres at least one of that type.

Before:
![before_allowed_providers](https://cloud.githubusercontent.com/assets/11256940/11713500/7e2d9ed4-9f3c-11e5-8e82-6668d2fab11f.png)

After:
![after_allowed_provider](https://cloud.githubusercontent.com/assets/11256940/11713513/8f9a2e9e-9f3c-11e5-8272-2baa14da24f6.png)

In the screenshots Kubernetes was ommited since it was not allowed in the system or because its entity count was zero.

@simon3z @abonas Please review
fyi @jeff-phillips-18 @serenamarie125