### PR TITLE
Toolbars: introduce classes for buttons.

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -1,0 +1,24 @@
+class ApplicationHelper::Button::Basic < Hash
+  def initialize(view_context, view_binding, instance_data, props)
+    @view_context  = view_context
+    @view_binding  = view_binding
+
+    props.each { |k, v| self[k] = v }
+
+    instance_data.each do |name, value|
+      instance_variable_set(:"@#{name}", value)
+    end
+  end
+
+  def calculate_properties
+    self["enabled"] = "false" if disabled?
+  end
+
+  def skip?
+    false
+  end
+
+  def disabled?
+    false
+  end
+end

--- a/app/helpers/application_helper/button/chargeback_download_choice.rb
+++ b/app/helpers/application_helper/button/chargeback_download_choice.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::ChargebackDownloadChoice < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @view_context.x_active_tree == :cb_reports_tree &&
+       @report && !@report.contains_records?
+      props["enabled"] = "false"
+      props["title"] = _("No records found for this report")
+    end
+  end
+end

--- a/app/helpers/application_helper/button/chargeback_download_choice.rb
+++ b/app/helpers/application_helper/button/chargeback_download_choice.rb
@@ -3,8 +3,8 @@ class ApplicationHelper::Button::ChargebackDownloadChoice < ApplicationHelper::B
     super
     if @view_context.x_active_tree == :cb_reports_tree &&
        @report && !@report.contains_records?
-      props["enabled"] = "false"
-      props["title"] = _("No records found for this report")
+      self["enabled"] = "false"
+      self["title"] = _("No records found for this report")
     end
   end
 end

--- a/app/helpers/application_helper/button/chargeback_report_only.rb
+++ b/app/helpers/application_helper/button/chargeback_report_only.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::ChargebackReportOnly < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @view_context.x_active_tree == :cb_reports_tree &&
+       @report && !@report.contains_records?
+      self["enabled"] = "false"
+      self["title"] = _("No records found for this report")
+    end
+  end
+end

--- a/app/helpers/application_helper/button/collect_logs.rb
+++ b/app/helpers/application_helper/button/collect_logs.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::CollectLogs < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @record.try(:log_file_depot).try(:requires_support_case?)
+      self[:prompt] = true
+    end
+  end
+end

--- a/app/helpers/application_helper/button/history_choice.rb
+++ b/app/helpers/application_helper/button/history_choice.rb
@@ -7,4 +7,3 @@ class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::Basi
     end
   end
 end
-

--- a/app/helpers/application_helper/button/history_choice.rb
+++ b/app/helpers/application_helper/button/history_choice.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    # Show disabled history button if no history
+    if @view_context.x_tree_history.length < 2
+      self["enabled"] = false
+    end
+  end
+end
+

--- a/app/helpers/application_helper/button/history_item.rb
+++ b/app/helpers/application_helper/button/history_item.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @view_context.x_tree_history.length > 1
+      self["text"] = @view_context.x_tree_history[self['id'].split("_").last.to_i][:text]
+    end
+  end
+end

--- a/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
+++ b/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::OrchestrationOldDialogsEditDelete < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @view_context.x_active_tree == :old_dialogs_tree && @record && @record[:default]
+      self['enabled'] = 'false'
+      self['title'] = if self['id'] =~ /_edit/
+                        _('Default dialogs cannot be edited')
+                      else
+                        _('Default dialogs cannot be removed from the VMDB')
+                      end
+    end
+  end
+end

--- a/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
+++ b/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::OrchestrationTemplateEditRemove < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if @view_context.x_active_tree == :ot_tree && @record
+      self['enabled'] = @record.in_use? ? 'false' : 'true'
+      self['title'] = if self['id'] =~ /_edit$/
+                        _('Orchestration Templates that are in use cannot be edited')
+                      else
+                        _('Orchestration Templates that are in use cannot be removed')
+                      end
+    end
+  end
+end

--- a/app/helpers/application_helper/button/pdf.rb
+++ b/app/helpers/application_helper/button/pdf.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::Pdf < ApplicationHelper::Button::Basic
+  def skip?
+    !PdfGenerator.available?
+  end
+end

--- a/app/helpers/application_helper/button/separator.rb
+++ b/app/helpers/application_helper/button/separator.rb
@@ -1,0 +1,6 @@
+class ApplicationHelper::Button::Separator < ApplicationHelper::Button::Basic
+  def initialize(props)
+    super(nil, nil, {}, props)
+    self['type'] = 'separator'
+  end
+end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -47,7 +47,8 @@ class ApplicationHelper::ToolbarBuilder
 
   def build_select_button(bgi, index)
     bs_children = false
-    props = ApplicationHelper::ToolbarButtons.button(@view_context, @view_binding, @instance_data,
+    props = ApplicationHelper::ToolbarButtons.button(
+      @view_context, @view_binding, @instance_data,
       "id"     => bgi[:buttonSelect],
       "type"   => "buttonSelect",
       "img"    => img = "#{bgi[:image] ? bgi[:image] : bgi[:buttonSelect]}.png",
@@ -64,9 +65,10 @@ class ApplicationHelper::ToolbarBuilder
       if bsi.key?(:separator)
         props = ApplicationHelper::Button::Separator.new("id" => "sep_#{index}_#{bsi_idx}", :hidden => !any_visible)
       else
-        next if build_toolbar_hide_button(bsi[:pressed] || bsi[:button])  # Use pressed, else button name
+        next if build_toolbar_hide_button(bsi[:pressed] || bsi[:button]) # Use pressed, else button name
         bs_children = true
-        props = ApplicationHelper::ToolbarButtons.button(@view_context, @view_binding, @instance_data,
+        props = ApplicationHelper::ToolbarButtons.button(
+          @view_context, @view_binding, @instance_data,
           "child_id" => bsi[:button],
           "id"       => bgi[:buttonSelect] + "__" + bsi[:button],
           "type"     => "button",
@@ -112,7 +114,7 @@ class ApplicationHelper::ToolbarBuilder
     dis_title = build_toolbar_disable_button(button['id'])
     if dis_title
       button["enabled"] = "false"
-      button["title"]    = dis_title
+      button["title"]   = dis_title
     end
     button
   end
@@ -126,7 +128,8 @@ class ApplicationHelper::ToolbarBuilder
     end
 
     @sep_needed = true unless button_hide
-    props = ApplicationHelper::ToolbarButtons.button(@view_context, @view_binding, @instance_data,
+    props = ApplicationHelper::ToolbarButtons.button(
+      @view_context, @view_binding, @instance_data,
       "id"     => bgi[:button],
       "type"   => "button",
       "img"    => "#{get_image(bgi[:image], bgi[:button]) ? get_image(bgi[:image], bgi[:button]) : bgi[:button]}.png",
@@ -150,13 +153,14 @@ class ApplicationHelper::ToolbarBuilder
         @sep_added = true
       end
     end
-    @sep_needed = true                                         # Button was added, need separators from now on
+    @sep_needed = true # Button was added, need separators from now on
   end
 
   def build_twostate_button(bgi, index)
     return nil if build_toolbar_hide_button(bgi[:buttonTwoState])
 
-    props = ApplicationHelper::ToolbarButtons.button(@view_context, @view_binding, @instance_data,
+    props = ApplicationHelper::ToolbarButtons.button(
+      @view_context, @view_binding, @instance_data,
       "id"     => bgi[:buttonTwoState],
       "type"   => "buttonTwoState",
       "img"    => img = "#{bgi[:image] ? bgi[:image] : bgi[:buttonTwoState]}.png",

--- a/app/helpers/application_helper/toolbar_buttons.rb
+++ b/app/helpers/application_helper/toolbar_buttons.rb
@@ -30,4 +30,3 @@ class ApplicationHelper::ToolbarButtons
     button
   end
 end
-

--- a/app/helpers/application_helper/toolbar_buttons.rb
+++ b/app/helpers/application_helper/toolbar_buttons.rb
@@ -1,0 +1,33 @@
+class ApplicationHelper::ToolbarButtons
+  def self.button_class(button_id)
+    case button_id
+    when 'chargeback_download_pdf', 'download_pdf', 'download_view',
+         'drift_pdf', 'miq_capacity_download_pdf', 'render_report_pdf',
+         'timeline_pdf', 'vm_download_pdf'
+      ApplicationHelper::Button::Pdf
+    when 'chargeback_report_only'
+      ApplicationHelper::Button::ChargebackReportOnly
+    when /^orchestration_template_(edit|remove)$/
+      ApplicationHelper::Button::OrchestrationTemplateEditRemove
+    when 'history_choice'
+      ApplicationHelper::Button::HistoryChoice
+    when /^history_(\d+)$/
+      ApplicationHelper::Button::HistoryItem
+    when 'chargeback_download_choice'
+      ApplicationHelper::Button::ChargebackDownloadChoice
+    when /^old_dialogs_(edit|delete)$/
+      ApplicationHelper::Button::OldDialogsEditDelete
+    when 'collect_logs', 'collect_current_logs', 'zone_collect_logs', 'zone_collect_current_logs'
+      ApplicationHelper::Button::CollectLogs
+    else
+      ApplicationHelper::Button::Basic
+    end
+  end
+
+  def self.button(view_context, view_binding, instance_data, props)
+    button_class = button_class(props['child_id'] || props['id'])
+    button = button_class.new(view_context, view_binding, instance_data, props)
+    button
+  end
+end
+


### PR DESCRIPTION
The idea is to move the logic specific to particular buttons to classes representing the individual buttons.

Then in `ApplicationHelper::ToolbarBuilder` only generic logic would remain and the task of adding buttons and toolbars in the future would not include changes to this class.