### PR TITLE
Editing a catalog item no longer fails in a bad way

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1184,7 +1184,7 @@ class MiqRequestWorkflow
   end
 
   def folder_to_respool(src)
-    return nil if src[:folder_id].nil?
+    return nil if src[:folder].nil?
     datacenter = find_datacenter_for_ci(src[:folder])
     targets = find_respools_under_ci(datacenter)
     res_pool_with_path = get_ems_respool(get_ems_metadata_tree(src))
@@ -1248,7 +1248,7 @@ class MiqRequestWorkflow
   end
 
   def respool_to_folder(src)
-    return nil if src[:respool_id].nil?
+    return nil if src[:respool].nil?
     sources = [src[:respool]]
     datacenters = sources.collect { |h| find_datacenter_for_ci(h) }.compact
     folders = {}

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -2,6 +2,9 @@ require "spec_helper"
 
 describe MiqRequestWorkflow do
   let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
+  let(:ems) { FactoryGirl.create(:ext_management_system) }
+  let(:resource_pool) { FactoryGirl.create(:resource_pool) }
+  let(:ems_folder) { FactoryGirl.create(:ems_folder) }
 
   context "#validate" do
     let(:dialog) { workflow.instance_variable_get(:@dialogs) }
@@ -9,7 +12,7 @@ describe MiqRequestWorkflow do
     context "validation_method" do
       it "skips validation if no validation_method is defined" do
         expect(workflow.get_all_dialogs[:customize][:fields][:root_password][:validation_method]).to eq(nil)
-        expect(workflow.validate({})).to be_true
+        expect(workflow.validate({})).to be true
       end
 
       it "calls the validation_method if defined" do
@@ -17,7 +20,7 @@ describe MiqRequestWorkflow do
 
         expect(workflow).to receive(:respond_to?).with(:some_validation_method).and_return(true)
         expect(workflow).to receive(:some_validation_method).once
-        expect(workflow.validate({})).to be_true
+        expect(workflow.validate({})).to be true
       end
 
       it "returns false when validation fails" do
@@ -25,7 +28,7 @@ describe MiqRequestWorkflow do
 
         expect(workflow).to receive(:respond_to?).with(:some_validation_method).and_return(true)
         expect(workflow).to receive(:some_validation_method).and_return("Some Error")
-        expect(workflow.validate({})).to be_false
+        expect(workflow.validate({})).to be false
       end
     end
 
@@ -36,7 +39,7 @@ describe MiqRequestWorkflow do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :display, :hide)
 
         expect(workflow).to_not receive(:some_required_method)
-        expect(workflow.validate({})).to be_true
+        expect(workflow.validate({})).to be true
       end
 
       it "field visible" do
@@ -44,7 +47,7 @@ describe MiqRequestWorkflow do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
 
         expect(workflow).to receive(:some_required_method).and_return("Some Error")
-        expect(workflow.validate({})).to be_false
+        expect(workflow.validate({})).to be false
       end
     end
 
@@ -55,7 +58,7 @@ describe MiqRequestWorkflow do
 
         expect(workflow).to receive(:some_validation_method).and_return("Some Error")
         expect(workflow).to receive(:other_validation_method)
-        expect(workflow.validate({})).to be_false
+        expect(workflow.validate({})).to be false
       end
     end
   end
@@ -297,6 +300,48 @@ describe MiqRequestWorkflow do
       request = workflow.create_request(values)
       expect(request.options[:owner_email]).to eq(owner.email)
       expect(request.options[:owner_group]).to eq(owner.current_group.description)
+    end
+  end
+
+  context "#respool_to_folder" do
+    before do
+      resource_pool.ext_management_system = ems
+      ems_folder.ext_management_system = ems
+      attrs = ems_folder.attributes.merge(:object => ems_folder)
+      xml_hash = XmlHash::Element.new('EmsFolder', attrs)
+      hash = {"ResourcePool_#{resource_pool.id}" => xml_hash}
+      workflow.instance_variable_set("@ems_xml_nodes", hash)
+    end
+
+    it "returns nil if :respool is nil" do
+      src = {:respool => nil}
+      expect(workflow.respool_to_folder(src)).to eq nil
+    end
+
+    it "returns an empty hash if no folders are found" do
+      src = {:respool => resource_pool}
+      expect(workflow.respool_to_folder(src)).to be_empty
+    end
+  end
+
+  context "#folder_to_respool" do
+    before do
+      resource_pool.ext_management_system = ems
+      ems_folder.ext_management_system = ems
+      attrs = resource_pool.attributes.merge(:object => resource_pool, :ems => ems)
+      xml_hash = XmlHash::Element.new('ResourcePool', attrs)
+      hash = {"EmsFolder_#{ems_folder.id}" => xml_hash}
+      workflow.instance_variable_set("@ems_xml_nodes", hash)
+    end
+
+    it "returns nil if :folder is nil" do
+      src = {:folder => nil}
+      expect(workflow.folder_to_respool(src)).to eq nil
+    end
+
+    it "returns an empty hash if no resource pools are found" do
+      src = {:ems =>  ems, :folder => ems_folder}
+      expect(workflow.folder_to_respool(src)).to be_empty
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1236966

Editing a catalog item will no longer fail with an error
If a resource pool or ems folder is removed from an
existing catalog item.