### PR TITLE
Fix label of column 'disable run levels'

### DIFF
--- a/product/views/SystemService-linux_initprocesses.yaml
+++ b/product/views/SystemService-linux_initprocesses.yaml
@@ -52,8 +52,8 @@ headers:
 - Image Path
 - Display Name
 - Description
-- Enable Run Levels
-- Disble Run Levels
+- Enabled Run Levels
+- Disabled Run Levels
 
 # Condition(s) string for the SQL query
 conditions: 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1289597

I am using form "Disabled run levels" instead of "Disable run levels" as was proposed in BZ, so I changed it also for column "Enable run levels"(to "Enabled run levels")

before
![before](https://cloud.githubusercontent.com/assets/14937244/11720344/0e4a8c26-9f5f-11e5-9307-74c7138ecc9f.png)

after
![after](https://cloud.githubusercontent.com/assets/14937244/11720340/0ba7bf52-9f5f-11e5-869a-cf4cf5cd3b1b.png)