### PR TITLE
Rescue the error raised when the user provides an invalid hostname

### DIFF
--- a/gems/pending/appliance_console/key_configuration.rb
+++ b/gems/pending/appliance_console/key_configuration.rb
@@ -83,8 +83,8 @@ module ApplianceConsole
         scp.download!(key_path, KEY_FILE)
       end
       File.exist?(KEY_FILE)
-    rescue Net::SSH::AuthenticationFailed => e
-      say(e.message)
+    rescue Net::SSH::AuthenticationFailed, SocketError => e
+      say("Failed to fetch key: #{e.message}")
       false
     end
 


### PR DESCRIPTION
A SocketError was being raised when the hostname provided was not
resolvable. This change allows the user to see the error message
(Name or service not known) and also retry the key fetch.

https://bugzilla.redhat.com/show_bug.cgi?id=1290391