### PR TITLE
containers: link image registries with their openshift services

### DIFF
--- a/app/helpers/container_image_registry_helper/textual_summary.rb
+++ b/app/helpers/container_image_registry_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module ContainerImageRegistryHelper
     end
 
     def textual_group_relationships
-      %i(ems container_images containers)
+      %i(ems container_services container_groups container_images containers)
     end
 
     def textual_group_smart_management

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -30,7 +30,7 @@ module ContainerServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(ems container_project container_routes container_groups container_nodes)
+    %i(ems container_project container_routes container_groups container_nodes container_image_registry)
   end
 
   def textual_group_smart_management

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -94,8 +94,7 @@ module ContainerSummaryHelper
 
   def textual_container_image_registry
     object = @record.container_image_registry
-
-    if object.nil?
+    if object.nil? && @record.respond_to?(:display_registry)
       {
         :label => ui_lookup(:model => ContainerImageRegistry.name),
         :image => "container_image_registry_unknown",

--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -4,6 +4,8 @@ class ContainerImageRegistry < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_images, :dependent => :destroy # What about deleted registry but containers are still running
   has_many :containers, :through => :container_images
+  has_many :container_services
+  has_many :container_groups, :through => :container_services
 
   acts_as_miq_taggable
   virtual_column :full_name, :type => :string

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -12,6 +12,7 @@ class ContainerService < ApplicationRecord
   has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_many :container_nodes, -> { distinct }, :through => :container_groups
+  belongs_to :container_image_registry
 
   # Needed for metrics
   has_many :metrics,                :as => :resource

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -183,11 +183,12 @@ module EmsRefresh::SaveInventoryContainer
     hashes.each do |h|
       h[:container_group_ids] = h[:container_groups].map { |x| x[:id] }
       h[:container_project_id] = h.fetch_path(:project, :id)
+      h[:container_image_registry_id] = h.fetch_path(:container_image_registry, :id)
     end
 
     save_inventory_multi(ems.container_services, hashes, deletes, [:ems_ref],
                          [:labels, :selector_parts, :container_service_port_configs],
-                         [:container_groups, :project, :namespace])
+                         [:container_groups, :project, :container_image_registry, :namespace])
 
     store_ids_for_new_records(ems.container_services, hashes, :ems_ref)
   end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -212,7 +212,11 @@ module ManageIQ::Providers::Kubernetes
 
       ports = service.spec.ports
       new_result[:container_service_port_configs] = Array(ports).collect do |port_entry|
-        parse_service_port_config(port_entry, new_result[:ems_ref])
+        pc = parse_service_port_config(port_entry, new_result[:ems_ref])
+        new_result[:container_image_registry] = @data_index.fetch_path(
+          :container_image_registry, :by_host_and_port, "#{new_result[:portal_ip]}:#{pc[:port]}"
+        )
+        pc
       end
 
       new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,

--- a/app/views/container_image_registry/show.html.haml
+++ b/app/views/container_image_registry/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(container_images containers).include?(@display)
+- if %w(container_images container_services container_groups containers).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
   = render :partial => @showtype

--- a/app/views/layouts/listnav/_container_image_registry.html.haml
+++ b/app/views/layouts/listnav/_container_image_registry.html.haml
@@ -15,5 +15,5 @@
     = miq_accordion_panel(_("Relationships"), false, "container_image_registry_rel") do
       %ul.nav.nav-pills.nav-stacked
         = single_relationship_link(@record, :ems_container, "ext_management_system")
-        - %i(container_image container).each do |ent|
+        - %i(container_service container_group container_image container).each do |ent|
           = multiple_relationship_link(@record, ent)

--- a/app/views/layouts/listnav/_container_service.html.haml
+++ b/app/views/layouts/listnav/_container_service.html.haml
@@ -27,3 +27,4 @@
         = single_relationship_link(@record, :container_project)
         - %i(container_route container_group container_node).each do |ent|
           = multiple_relationship_link(@record, ent)
+        = single_relationship_link(@record, :container_image_registry)

--- a/db/migrate/20151210154747_add_container_image_registry_to_container_service.rb
+++ b/db/migrate/20151210154747_add_container_image_registry_to_container_service.rb
@@ -1,0 +1,5 @@
+class AddContainerImageRegistryToContainerService < ActiveRecord::Migration
+  def change
+    add_column :container_services, :container_image_registry_id, :bigint
+  end
+end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -22,7 +22,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       assert_specific_container
       assert_specific_container_group
       assert_specific_container_node
-      assert_specific_container_service
+      assert_specific_container_services
+      assert_specific_container_image_registry
       assert_specific_container_project
       assert_specific_container_route
       assert_specific_container_build
@@ -98,7 +99,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(@containernode.ext_management_system).to eq(@ems)
   end
 
-  def assert_specific_container_service
+  def assert_specific_container_services
     @containersrv = ContainerService.find_by_name("frontend")
     expect(@containersrv).to have_attributes(
       :name             => "frontend",
@@ -108,6 +109,19 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
 
     expect(@containersrv.container_project).to eq(ContainerProject.find_by(:name => "test"))
     expect(@containersrv.ext_management_system).to eq(@ems)
+    expect(@containersrv.container_image_registry).to be_nil
+
+    expect(ContainerService.find_by_name("docker-registry").container_image_registry.name). to eq("172.30.44.14")
+  end
+
+  def assert_specific_container_image_registry
+    @registry = ContainerImageRegistry.find_by_name("172.30.44.14")
+    expect(@registry).to have_attributes(
+      :name => "172.30.44.14",
+      :host => "172.30.44.14",
+      :port => "5000"
+    )
+    expect(@registry.container_services.first.name).to eq("docker-registry")
   end
 
   def assert_specific_container_project


### PR DESCRIPTION
container service view: added registry

![manageiq services](https://cloud.githubusercontent.com/assets/3010449/11868942/4109b1ae-a4c4-11e5-9bfb-fdadab6a6546.png)

container image registry view: added service and pods

![manageiq image registries](https://cloud.githubusercontent.com/assets/3010449/11955355/09afcc26-a8ba-11e5-813b-bee4f6d19291.png)

container image registry view: list of services

![manageiq image registries s list](https://cloud.githubusercontent.com/assets/3010449/11955373/29f6a298-a8ba-11e5-8435-d8b4803a7d5e.png)


container image registry view: list of pods

![screenshot from 2015-12-10 21-55-40](https://cloud.githubusercontent.com/assets/3010449/11726842/4ec19202-9f89-11e5-9c50-0f16564e7ebb.png)