### PR TITLE
Add 'a' char to "Add New Containers" header.

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -259,7 +259,7 @@ module EmsCommon
     set_form_vars
     @in_a_form = true
     session[:changed] = nil
-    drop_breadcrumb({:name => "Add New #{ui_lookup(:table => @table_name)}", :url => "/#{@table_name}/new"})
+    drop_breadcrumb({:name => "Add a New #{ui_lookup(:table => @table_name)}", :url => "/#{@table_name}/new"})
   end
 
   def create


### PR DESCRIPTION
Mentioned in https://github.com/ManageIQ/manageiq/issues/5747

The 'a' is currently being displayed in the drop down menu, so I will look into silencing it. If anyone has any pointers, I'm all ears. : )

![screenshot 2015-12-10 12 21 51](https://cloud.githubusercontent.com/assets/2935006/11727425/9d4736e4-9f38-11e5-8fa2-70e3b15b5577.png)
