### PR TITLE
RSpec 3 - Migration specs conversion

### DIFF
--- a/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
+++ b/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
@@ -52,9 +52,9 @@ describe ExpandDialogFieldDefaultValueSize do
 
       reserve1 = reserve_stub.where(:resource_id   => field1.id,
                                     :resource_type => 'DialogField').first!
-      expect(reserve1.reserved).to eq({:default_value => val1})
+      expect(reserve1.reserved).to eq(:default_value => val1)
       expect(reserve_stub.where(:resource_id   => field2.id,
-                         :resource_type => 'DialogField')).not_to exist
+                                :resource_type => 'DialogField')).not_to exist
     end
   end
 end

--- a/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
+++ b/spec/migrations/20131107000917_expand_dialog_field_default_value_size_spec.rb
@@ -7,9 +7,9 @@ describe ExpandDialogFieldDefaultValueSize do
 
   migration_context :up do
     it "should convert default_value to text type" do
-      dialog_field_stub.columns_hash['default_value'].type.should == :string
+      expect(dialog_field_stub.columns_hash['default_value'].type).to eq(:string)
       migrate
-      dialog_field_stub.columns_hash['default_value'].type.should == :text
+      expect(dialog_field_stub.columns_hash['default_value'].type).to eq(:text)
     end
 
     it "should migrate default_value from the reserved table" do
@@ -30,17 +30,17 @@ describe ExpandDialogFieldDefaultValueSize do
 
       expect { reserved1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { reserved2.reload }.to_not raise_error
-      field1.reload.default_value.should == val1
-      field2.reload.default_value.should == val2
-      field3.reload.default_value.should == val3
+      expect(field1.reload.default_value).to eq(val1)
+      expect(field2.reload.default_value).to eq(val2)
+      expect(field3.reload.default_value).to eq(val3)
     end
   end
 
   migration_context :down do
     it "should convert default_value to string type" do
-      dialog_field_stub.columns_hash['default_value'].type.should == :text
+      expect(dialog_field_stub.columns_hash['default_value'].type).to eq(:text)
       migrate
-      dialog_field_stub.columns_hash['default_value'].type.should == :string
+      expect(dialog_field_stub.columns_hash['default_value'].type).to eq(:string)
     end
 
     it "should migrate default_value to the reserved table" do
@@ -52,9 +52,9 @@ describe ExpandDialogFieldDefaultValueSize do
 
       reserve1 = reserve_stub.where(:resource_id   => field1.id,
                                     :resource_type => 'DialogField').first!
-      reserve1.reserved.should == {:default_value => val1}
-      reserve_stub.where(:resource_id   => field2.id,
-                         :resource_type => 'DialogField').should_not exist
+      expect(reserve1.reserved).to eq({:default_value => val1})
+      expect(reserve_stub.where(:resource_id   => field2.id,
+                         :resource_type => 'DialogField')).not_to exist
     end
   end
 end

--- a/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
+++ b/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
@@ -12,7 +12,7 @@ describe ChangeOptionsInMiqAlert do
       migrate
 
       alert.reload
-      alert.options.should == {:notifications => {:email => {:to => ''}}}
+      expect(alert.options).to eq({:notifications => {:email => {:to => ''}}})
     end
 
     it 'non-default miq_alert email is ignored' do
@@ -22,7 +22,7 @@ describe ChangeOptionsInMiqAlert do
       migrate
 
       alert.reload
-      alert.options.should == options
+      expect(alert.options).to eq(options)
     end
   end
 end

--- a/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
+++ b/spec/migrations/20131121211455_change_options_in_miq_alert_spec.rb
@@ -12,7 +12,7 @@ describe ChangeOptionsInMiqAlert do
       migrate
 
       alert.reload
-      expect(alert.options).to eq({:notifications => {:email => {:to => ''}}})
+      expect(alert.options).to eq(:notifications => {:email => {:to => ''}})
     end
 
     it 'non-default miq_alert email is ignored' do

--- a/spec/migrations/20131125153220_import_provision_dialogs_spec.rb
+++ b/spec/migrations/20131125153220_import_provision_dialogs_spec.rb
@@ -7,26 +7,26 @@ describe ImportProvisionDialogs do
   migration_context :up do
     before do
       dialog_file = File.join(File.dirname(__FILE__), "data/20131125153220_import_provision_dialogs_spec/miq_provision_dialogs.rb")
-      Dir.stub(:glob).and_yield(dialog_file)
+      allow(Dir).to receive(:glob).and_yield(dialog_file)
     end
 
     it "import dialog file into database" do
       migrate
 
-      miq_dialog_stub.count.should == 1
+      expect(miq_dialog_stub.count).to eq(1)
 
       dialog = miq_dialog_stub.first
-      dialog.name.should == "miq_provision_dialogs"
-      dialog.dialog_type.should == "MiqProvisionWorkflow"
-      dialog.default.should           be_false
-      dialog.content.should           be_kind_of(Hash)
-      dialog.content.should           include(:dialog_order, :buttons, :dialogs)
-      dialog.content[:buttons].should include(:submit, :cancel)
+      expect(dialog.name).to eq("miq_provision_dialogs")
+      expect(dialog.dialog_type).to eq("MiqProvisionWorkflow")
+      expect(dialog.default).to           be_falsey
+      expect(dialog.content).to           be_kind_of(Hash)
+      expect(dialog.content).to           include(:dialog_order, :buttons, :dialogs)
+      expect(dialog.content[:buttons]).to include(:submit, :cancel)
     end
 
     it "skip dialog file if already in database" do
       miq_dialog_stub.create!(:name => "miq_provision_dialogs")
-      miq_dialog_stub.should_receive(:create).never
+      expect(miq_dialog_stub).to receive(:create).never
 
       migrate
     end

--- a/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
+++ b/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
@@ -35,8 +35,8 @@ describe UpdateLogCollectionPathInConfigurationsSettings do
       migrate
 
       settings = configuration_stub.first.settings
-      settings.fetch_path("log", "collection", :current, :pattern, 4).should eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf")
-      settings.fetch_path("log", "collection", :current, :pattern, 5).should eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/*")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 4)).to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 5)).to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/*")
     end
 
     it "ignores changes when expected path doesn't exist" do
@@ -54,7 +54,7 @@ describe UpdateLogCollectionPathInConfigurationsSettings do
       migrate
 
       settings = configuration_stub.first.settings
-      settings.fetch_path("log", "collection", :current, :pattern).should be_empty
+      expect(settings.fetch_path("log", "collection", :current, :pattern)).to be_empty
     end
   end
 
@@ -89,8 +89,8 @@ describe UpdateLogCollectionPathInConfigurationsSettings do
       migrate
 
       settings = configuration_stub.first.settings
-      settings.fetch_path("log", "collection", :current, :pattern, 4).should eq("/var/lib/pgsql/data/*.conf")
-      settings.fetch_path("log", "collection", :current, :pattern, 5).should eq("/var/lib/pgsql/data/serverlog*")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 4)).to eq("/var/lib/pgsql/data/*.conf")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 5)).to eq("/var/lib/pgsql/data/serverlog*")
     end
 
     it "ignores changes when expected path doesn't exist" do
@@ -108,7 +108,7 @@ describe UpdateLogCollectionPathInConfigurationsSettings do
       migrate
 
       settings = configuration_stub.first.settings
-      settings.fetch_path("log", "collection", :current, :pattern).should be_empty
+      expect(settings.fetch_path("log", "collection", :current, :pattern)).to be_empty
     end
   end
 end

--- a/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
+++ b/spec/migrations/20131210202928_update_log_collection_path_in_configurations_settings_spec.rb
@@ -35,8 +35,10 @@ describe UpdateLogCollectionPathInConfigurationsSettings do
       migrate
 
       settings = configuration_stub.first.settings
-      expect(settings.fetch_path("log", "collection", :current, :pattern, 4)).to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf")
-      expect(settings.fetch_path("log", "collection", :current, :pattern, 5)).to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/*")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 4))
+        .to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/*.conf")
+      expect(settings.fetch_path("log", "collection", :current, :pattern, 5))
+        .to eq("/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/*")
     end
 
     it "ignores changes when expected path doesn't exist" do

--- a/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -29,8 +29,10 @@ describe FixReplicationOnUpgradeFromVersionFour do
       migrate
 
       settings = configuration_stub.first.settings
-      expect(settings.key_path?("workers", "worker_base", :replication_worker, :replication, :include_tables)).to be_falsey
-      expect(settings.fetch_path("workers", "worker_base", :replication_worker, :replication, :exclude_tables)).to eq(described_class::V5_DEFAULT_EXCLUDE_TABLES)
+      expect(settings.key_path?("workers", "worker_base", :replication_worker, :replication, :include_tables))
+        .to be_falsey
+      expect(settings.fetch_path("workers", "worker_base", :replication_worker, :replication, :exclude_tables))
+        .to eq(described_class::V5_DEFAULT_EXCLUDE_TABLES)
     end
 
     context "handles replication" do
@@ -44,8 +46,12 @@ describe FixReplicationOnUpgradeFromVersionFour do
         # them unless we have replication set up, which is not yet possible in a
         # migration spec.
         require 'awesome_spawn'
-        expect(AwesomeSpawn).to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
-        expect(AwesomeSpawn).to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
+        expect(AwesomeSpawn)
+          .to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
+        expect(AwesomeSpawn)
+          .to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall" \
+                                  " drift_states miq_cim_derived_metrics miq_request_tasks" \
+                                  " miq_storage_metrics storages_vms_and_templates")
       end
 
       it "for renamed tables in rr_pending_changes" do

--- a/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
+++ b/spec/migrations/20131216214850_fix_replication_on_upgrade_from_version_four_spec.rb
@@ -29,8 +29,8 @@ describe FixReplicationOnUpgradeFromVersionFour do
       migrate
 
       settings = configuration_stub.first.settings
-      settings.key_path?("workers", "worker_base", :replication_worker, :replication, :include_tables).should be_false
-      settings.fetch_path("workers", "worker_base", :replication_worker, :replication, :exclude_tables).should eq(described_class::V5_DEFAULT_EXCLUDE_TABLES)
+      expect(settings.key_path?("workers", "worker_base", :replication_worker, :replication, :include_tables)).to be_falsey
+      expect(settings.fetch_path("workers", "worker_base", :replication_worker, :replication, :exclude_tables)).to eq(described_class::V5_DEFAULT_EXCLUDE_TABLES)
     end
 
     context "handles replication" do
@@ -44,8 +44,8 @@ describe FixReplicationOnUpgradeFromVersionFour do
         # them unless we have replication set up, which is not yet possible in a
         # migration spec.
         require 'awesome_spawn'
-        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
-        AwesomeSpawn.should_receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
+        expect(AwesomeSpawn).to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:prepare_replication_without_sync")
+        expect(AwesomeSpawn).to receive(:run!).with("bin/rake evm:db:environmentlegacykey evm:dbsync:uninstall drift_states miq_cim_derived_metrics miq_request_tasks miq_storage_metrics storages_vms_and_templates")
       end
 
       it "for renamed tables in rr_pending_changes" do
@@ -62,14 +62,14 @@ describe FixReplicationOnUpgradeFromVersionFour do
 
         migrate
 
-        changed.collect { |c| c.reload.change_table }.should == %w(
+        expect(changed.collect { |c| c.reload.change_table }).to eq(%w(
           drift_states
           miq_cim_derived_metrics
           miq_request_tasks
           miq_storage_metrics
           storages_vms_and_templates
-        )
-        ignored.reload.change_table.should == "accounts"
+        ))
+        expect(ignored.reload.change_table).to eq("accounts")
       end
 
       it "for renamed tables in rr_sync_states" do
@@ -86,14 +86,14 @@ describe FixReplicationOnUpgradeFromVersionFour do
 
         migrate
 
-        changed.collect { |c| c.reload.table_name }.should == %w(
+        expect(changed.collect { |c| c.reload.table_name }).to eq(%w(
           drift_states
           miq_cim_derived_metrics
           miq_request_tasks
           miq_storage_metrics
           storages_vms_and_templates
-        )
-        ignored.reload.table_name.should == "accounts"
+        ))
+        expect(ignored.reload.table_name).to eq("accounts")
       end
 
       it "for removed tables in rr_sync_states" do
@@ -110,7 +110,7 @@ describe FixReplicationOnUpgradeFromVersionFour do
         migrate
 
         deleted.each { |c| expect { c.reload }.to raise_error(ActiveRecord::RecordNotFound) }
-        ignored.reload.table_name.should == "accounts"
+        expect(ignored.reload.table_name).to eq("accounts")
       end
     end
   end

--- a/spec/migrations/20140402134329_change_utc_time_profile_type_to_global_spec.rb
+++ b/spec/migrations/20140402134329_change_utc_time_profile_type_to_global_spec.rb
@@ -11,7 +11,7 @@ describe ChangeUtcTimeProfileTypeToGlobal do
       migrate
 
       tp.reload
-      tp.profile_type.should == 'global'
+      expect(tp.profile_type).to eq('global')
     end
   end
 end

--- a/spec/migrations/20140421150958_create_miq_groups_users_join_table_spec.rb
+++ b/spec/migrations/20140421150958_create_miq_groups_users_join_table_spec.rb
@@ -13,7 +13,7 @@ describe CreateMiqGroupsUsersJoinTable do
                            :resource_id   => user.id,
                            :reserved      => {:eligible_miq_group_ids => [101, 108, 111]}
                           )
-      reserve_stub.count.should eq(1)
+      expect(reserve_stub.count).to eq(1)
 
       migrate
 
@@ -26,7 +26,7 @@ describe CreateMiqGroupsUsersJoinTable do
 
       migrate
 
-      join_table_stub.where(:user_id => user.id).count.should == 0
+      expect(join_table_stub.where(:user_id => user.id).count).to eq(0)
     end
   end
 end

--- a/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
+++ b/spec/migrations/20140424173120_migrate_automate_to_customer_domain_spec.rb
@@ -18,10 +18,10 @@ describe MigrateAutomateToCustomerDomain do
 
         test_ns.reload
 
-        miq_ae_namespace_stub.where(:name => '$').first.should_not be_nil
+        expect(miq_ae_namespace_stub.where(:name => '$').first).not_to be_nil
 
         domain = miq_ae_namespace_stub.where(:name => 'Customer').first
-        test_ns.parent_id.should eq(domain.id)
+        expect(test_ns.parent_id).to eq(domain.id)
       end
 
       it 'with existing Customer namespace' do
@@ -35,8 +35,8 @@ describe MigrateAutomateToCustomerDomain do
         test_ns.reload
         customer_ns.reload
 
-        test_ns.parent_id.should     eq(domain.id)
-        customer_ns.parent_id.should eq(domain.id)
+        expect(test_ns.parent_id).to     eq(domain.id)
+        expect(customer_ns.parent_id).to eq(domain.id)
       end
 
       it 'with existing domain' do
@@ -49,7 +49,7 @@ describe MigrateAutomateToCustomerDomain do
 
         test_ns.reload
 
-        test_ns.parent_id.should eq(domain.id)
+        expect(test_ns.parent_id).to eq(domain.id)
       end
 
       it 'with inherited class' do
@@ -59,7 +59,7 @@ describe MigrateAutomateToCustomerDomain do
         migrate
 
         ae_class.reload
-        ae_class.inherits.should eq('Customer/ns_test/class1')
+        expect(ae_class.inherits).to eq('Customer/ns_test/class1')
       end
 
       it 'with inherited class from another domain' do
@@ -70,7 +70,7 @@ describe MigrateAutomateToCustomerDomain do
         migrate
 
         ae_class.reload
-        ae_class.inherits.should eq('domain2/ns_test/class1')
+        expect(ae_class.inherits).to eq('domain2/ns_test/class1')
       end
     end
   end
@@ -87,11 +87,11 @@ describe MigrateAutomateToCustomerDomain do
 
         migrate
 
-        miq_ae_namespace_stub.where(:name => '$').first.should_not    be_nil
-        miq_ae_namespace_stub.where(:name => 'Customer').first.should be_nil
+        expect(miq_ae_namespace_stub.where(:name => '$').first).not_to    be_nil
+        expect(miq_ae_namespace_stub.where(:name => 'Customer').first).to be_nil
 
         test_ns.reload
-        test_ns.parent_id.should be_nil
+        expect(test_ns.parent_id).to be_nil
       end
 
       it 'with existing Customer namespace' do
@@ -101,14 +101,14 @@ describe MigrateAutomateToCustomerDomain do
 
         migrate
 
-        miq_ae_namespace_stub.where(:name => 'Customer').first.should_not             be_nil
-        miq_ae_namespace_stub.where(:name => 'Customer', :priority => 1).first.should be_nil
+        expect(miq_ae_namespace_stub.where(:name => 'Customer').first).not_to             be_nil
+        expect(miq_ae_namespace_stub.where(:name => 'Customer', :priority => 1).first).to be_nil
 
         test_ns.reload
         customer_ns.reload
 
-        test_ns.parent_id.should     be_nil
-        customer_ns.parent_id.should be_nil
+        expect(test_ns.parent_id).to     be_nil
+        expect(customer_ns.parent_id).to be_nil
       end
 
       it 'with existing domain' do
@@ -118,11 +118,11 @@ describe MigrateAutomateToCustomerDomain do
 
         migrate
 
-        miq_ae_namespace_stub.where(:name => 'Customer').first.should     be_nil
-        miq_ae_namespace_stub.where(:name => 'ManageIQ').first.should_not be_nil
+        expect(miq_ae_namespace_stub.where(:name => 'Customer').first).to     be_nil
+        expect(miq_ae_namespace_stub.where(:name => 'ManageIQ').first).not_to be_nil
 
         test_ns.reload
-        test_ns.parent_id.should be_nil
+        expect(test_ns.parent_id).to be_nil
       end
 
       it 'with inherited class' do
@@ -133,7 +133,7 @@ describe MigrateAutomateToCustomerDomain do
         migrate
 
         ae_class.reload
-        ae_class.inherits.should eq('ns_test/class1')
+        expect(ae_class.inherits).to eq('ns_test/class1')
       end
 
       it 'with inherited class from another domain' do
@@ -144,7 +144,7 @@ describe MigrateAutomateToCustomerDomain do
         migrate
 
         ae_class.reload
-        ae_class.inherits.should eq('domain2/ns_test/class1')
+        expect(ae_class.inherits).to eq('domain2/ns_test/class1')
       end
     end
   end

--- a/spec/migrations/20140428162159_rename_miq_group_id_column_in_users_spec.rb
+++ b/spec/migrations/20140428162159_rename_miq_group_id_column_in_users_spec.rb
@@ -13,7 +13,7 @@ describe RenameMiqGroupIdColumnInUsers do
 
       migrate
 
-      user_stub.find(user_id).current_group_id.should eq miq_group.id
+      expect(user_stub.find(user_id).current_group_id).to eq miq_group.id
     end
   end
 end

--- a/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
+++ b/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
@@ -12,7 +12,7 @@ describe ChangeOptionsInMiqAlertForEmailTo do
       migrate
 
       alert.reload
-      expect(alert.options).to eq({:notifications => {:email => {:to => []}}})
+      expect(alert.options).to eq(:notifications => {:email => {:to => []}})
     end
 
     it 'existing string type miq_alert emails are converted to an array' do
@@ -22,7 +22,7 @@ describe ChangeOptionsInMiqAlertForEmailTo do
       migrate
 
       alert.reload
-      expect(alert.options).to eq({:notifications => {:email => {:to => %w(mail1 mail2)}}})
+      expect(alert.options).to eq(:notifications => {:email => {:to => %w(mail1 mail2)}})
     end
 
     it 'existing array type miq_alert emails remain unchanged' do

--- a/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
+++ b/spec/migrations/20140611194007_change_options_in_miq_alert_for_email_to_spec.rb
@@ -12,7 +12,7 @@ describe ChangeOptionsInMiqAlertForEmailTo do
       migrate
 
       alert.reload
-      alert.options.should == {:notifications => {:email => {:to => []}}}
+      expect(alert.options).to eq({:notifications => {:email => {:to => []}}})
     end
 
     it 'existing string type miq_alert emails are converted to an array' do
@@ -22,7 +22,7 @@ describe ChangeOptionsInMiqAlertForEmailTo do
       migrate
 
       alert.reload
-      alert.options.should == {:notifications => {:email => {:to => %w(mail1 mail2)}}}
+      expect(alert.options).to eq({:notifications => {:email => {:to => %w(mail1 mail2)}}})
     end
 
     it 'existing array type miq_alert emails remain unchanged' do
@@ -32,7 +32,7 @@ describe ChangeOptionsInMiqAlertForEmailTo do
       migrate
 
       alert.reload
-      alert.options.should == options
+      expect(alert.options).to eq(options)
     end
   end
 end

--- a/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
+++ b/spec/migrations/20140918140859_add_cloud_tenant_sti_column_spec.rb
@@ -11,7 +11,7 @@ describe AddCloudTenantStiColumn do
 
       migrate
 
-      cloud_tenant_stub.all.each { |tenant| tenant.type.should be == "CloudTenantOpenstack" }
+      cloud_tenant_stub.all.each { |tenant| expect(tenant.type).to eq("CloudTenantOpenstack") }
     end
   end
 end

--- a/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
+++ b/spec/migrations/20150224164512_add_loopback_to_memcache_server_opts_in_configuration_spec.rb
@@ -12,7 +12,7 @@ describe AddLoopbackToMemcacheServerOptsInConfiguration do
 
       migrate
 
-      config.reload.settings.fetch_path("session", "memcache_server_opts").should == custom_binding
+      expect(config.reload.settings.fetch_path("session", "memcache_server_opts")).to eq(custom_binding)
     end
 
     it "adds listen on localhost binding to memcache_server_opts" do
@@ -22,7 +22,7 @@ describe AddLoopbackToMemcacheServerOptsInConfiguration do
 
       migrate
 
-      config.reload.settings.fetch_path("session", "memcache_server_opts").should == default_binding
+      expect(config.reload.settings.fetch_path("session", "memcache_server_opts")).to eq(default_binding)
     end
   end
 
@@ -34,7 +34,7 @@ describe AddLoopbackToMemcacheServerOptsInConfiguration do
 
       migrate
 
-      config.reload.settings.fetch_path("session", "memcache_server_opts").should == custom_binding
+      expect(config.reload.settings.fetch_path("session", "memcache_server_opts")).to eq(custom_binding)
     end
 
     it "reverts listen on localhost binding to blank option" do
@@ -44,7 +44,7 @@ describe AddLoopbackToMemcacheServerOptsInConfiguration do
 
       migrate
 
-      config.reload.settings.fetch_path("session", "memcache_server_opts").should == ""
+      expect(config.reload.settings.fetch_path("session", "memcache_server_opts")).to eq("")
     end
   end
 end

--- a/spec/migrations/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag_spec.rb
+++ b/spec/migrations/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag_spec.rb
@@ -12,7 +12,7 @@ describe ChangeDialogFieldDynamicListsToDialogFieldDropDownListWithDynamicFlag d
 
       dialog_field.reload
       expect(dialog_field.type).to eq("DialogFieldDropDownList")
-      expect(dialog_field.dynamic).to be_true
+      expect(dialog_field.dynamic).to be_truthy
     end
   end
 
@@ -26,9 +26,9 @@ describe ChangeDialogFieldDynamicListsToDialogFieldDropDownListWithDynamicFlag d
       dialog_field.reload
       dialog_field_2.reload
       expect(dialog_field.type).to eq("DialogFieldDropDownList")
-      expect(dialog_field.dynamic).to be_false
+      expect(dialog_field.dynamic).to be_falsey
       expect(dialog_field_2.type).to eq("DialogFieldDynamicList")
-      expect(dialog_field_2.dynamic).to be_false
+      expect(dialog_field_2.dynamic).to be_falsey
     end
   end
 end

--- a/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
+++ b/spec/migrations/20150405141637_remove_port_config_from_container_service_spec.rb
@@ -14,9 +14,9 @@ describe RemovePortConfigFromContainerService do
                                                :container_port => 2222)
       migrate
       pconfig = container_service_port_config_stub.where(:container_service_id => service.id).first
-      pconfig.protocol.should == "TCP"
-      pconfig.port.should == 1111
-      pconfig.target_port.should == "2222" # container_port:integer turns into target_port:string
+      expect(pconfig.protocol).to eq("TCP")
+      expect(pconfig.port).to eq(1111)
+      expect(pconfig.target_port).to eq("2222") # container_port:integer turns into target_port:string
     end
   end
 
@@ -30,9 +30,9 @@ describe RemovePortConfigFromContainerService do
                                                  :target_port          => "2222")
       migrate
       service.reload
-      service.protocol.should == "TCP"
-      service.port.should == 1111
-      service.container_port.should == 2222
+      expect(service.protocol).to eq("TCP")
+      expect(service.port).to eq(1111)
+      expect(service.container_port).to eq(2222)
     end
   end
 end

--- a/spec/migrations/20150522161336_add_container_entities_type_spec.rb
+++ b/spec/migrations/20150522161336_add_container_entities_type_spec.rb
@@ -28,9 +28,9 @@ describe AddContainerEntitiesType do
 
       migrate
 
-      ContainerNode.find(container_node.id).should_not respond_to(:type)
-      Container.find(container.id).should_not respond_to(:type)
-      ContainerGroup.find(container_group.id).should_not respond_to(:type)
+      expect(ContainerNode.find(container_node.id)).not_to respond_to(:type)
+      expect(Container.find(container.id)).not_to respond_to(:type)
+      expect(ContainerGroup.find(container_group.id)).not_to respond_to(:type)
     end
   end
 end

--- a/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
+++ b/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
@@ -12,7 +12,7 @@ describe FixSerializedReportsForRailsFour do
       @raw_blob     = File.read(File.join(data_dir, 'binary_blob_obj.yaml'))
       @raw_blob_csv = File.read(File.join(data_dir, 'binary_blob_csv.yaml'))
 
-      FixSerializedReportsForRailsFour::BinaryBlob.any_instance.stub(:resource).and_return(true)
+      allow_any_instance_of(FixSerializedReportsForRailsFour::BinaryBlob).to receive(:resource).and_return(true)
     end
 
     it "migrates existing reports serialized as MiqReport objects to Hashes" do
@@ -73,7 +73,7 @@ describe FixSerializedReportsForRailsFour do
       @raw_blob     = File.read(File.join(data_dir, 'binary_blob_hash.yaml'))
       @raw_blob_csv = File.read(File.join(data_dir, 'binary_blob_csv.yaml'))
 
-      FixSerializedReportsForRailsFour::BinaryBlob.any_instance.stub(:resource).and_return(true)
+      allow_any_instance_of(FixSerializedReportsForRailsFour::BinaryBlob).to receive(:resource).and_return(true)
     end
 
     it "migrates existing reports serialized as Hashes objects to MiqReports" do

--- a/spec/migrations/20150818181427_update_tenant_divisible_on_existing_rows_spec.rb
+++ b/spec/migrations/20150818181427_update_tenant_divisible_on_existing_rows_spec.rb
@@ -7,28 +7,28 @@ describe UpdateTenantDivisibleOnExistingRows do
   migration_context :up do
     it "updates nil values to true" do
       t_nil = tenant_stub.create!(:divisible => nil)
-      t_nil.divisible.should be_nil
+      expect(t_nil.divisible).to be_nil
 
       migrate
 
       t_nil.reload
-      t_nil.divisible.should be_true
+      expect(t_nil.divisible).to be_truthy
     end
 
     it "leaves true and false values alone" do
       t_true  = tenant_stub.create!(:divisible => true)
       t_false = tenant_stub.create!(:divisible => false)
 
-      t_true.divisible.should  be_true
-      t_false.divisible.should be_false
+      expect(t_true.divisible).to  be_truthy
+      expect(t_false.divisible).to be_falsey
 
       migrate
 
       t_true.reload
       t_false.reload
 
-      t_true.divisible.should  be_true
-      t_false.divisible.should be_false
+      expect(t_true.divisible).to  be_truthy
+      expect(t_false.divisible).to be_falsey
     end
   end
 end

--- a/spec/migrations/20150903162623_assign_tenant_spec.rb
+++ b/spec/migrations/20150903162623_assign_tenant_spec.rb
@@ -51,7 +51,7 @@ describe AssignTenant do
 
       expect(tenant_stub.count).to eq(1)
       stubs.each do |stub|
-        expect(stub.where(:tenant_id => nil).exists?).to be_false
+        expect(stub.where(:tenant_id => nil).exists?).to be_falsey
       end
     end
   end

--- a/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
+++ b/spec/migrations/20150915001329_assign_tenant_to_miq_request_spec.rb
@@ -61,7 +61,7 @@ describe AssignTenantToMiqRequest do
 
       expect(tenant_stub.count).to eq(1)
       stubs.each do |stub|
-        expect(stub.where(:tenant_id => nil).exists?).to be_false
+        expect(stub.where(:tenant_id => nil).exists?).to be_falsey
       end
     end
   end

--- a/spec/migrations/20151019194111_tenant_cfg_not_nil_spec.rb
+++ b/spec/migrations/20151019194111_tenant_cfg_not_nil_spec.rb
@@ -9,21 +9,21 @@ describe TenantCfgNotNil do
       tenant = tenant_stub.create(:use_config_for_attributes => false)
       migrate
 
-      expect(tenant.reload.use_config_for_attributes).to be_false
+      expect(tenant.reload.use_config_for_attributes).to be_falsey
     end
 
     it "doesnt change false" do
       tenant = tenant_stub.create(:use_config_for_attributes => true)
       migrate
 
-      expect(tenant.reload.use_config_for_attributes).to be_true
+      expect(tenant.reload.use_config_for_attributes).to be_truthy
     end
 
     it "doesnt changes nil" do
       tenant = tenant_stub.create(:use_config_for_attributes => nil)
       migrate
 
-      expect(tenant.reload.use_config_for_attributes).to be_false
+      expect(tenant.reload.use_config_for_attributes).to be_falsey
     end
   end
 end

--- a/spec/migrations/20151021104529_add_persistent_volumes_to_container_volumes_spec.rb
+++ b/spec/migrations/20151021104529_add_persistent_volumes_to_container_volumes_spec.rb
@@ -21,8 +21,8 @@ describe AddPersistentVolumesToContainerVolumes do
 
       migrate
 
-      ContainerVolume.find(container_volume.id).should_not respond_to(:parent_type)
-      ContainerVolume.exists?(persistent_volume.id).should be false
+      expect(ContainerVolume.find(container_volume.id)).not_to respond_to(:parent_type)
+      expect(ContainerVolume.exists?(persistent_volume.id)).to be false
     end
   end
 end


### PR DESCRIPTION
Converts all migration specs to RSpec 3 `expect` syntax.

No troubles at all with this one.