### PR TITLE
Find eradication

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1723,7 +1723,7 @@ module ApplicationController::Filter
     temp = MiqSearch.new
     temp.description = "ALL"
     temp.id = 0
-    @def_searches = MiqSearch.where(:db => db).where("search_type=? or (search_type=? and (search_key is null or search_key<>?))", "global", "default", "_hidden_").sort_by { |s| s.description.downcase }
+    @def_searches = MiqSearch.where(:db => db).visible_to_all.sort_by { |s| s.description.downcase }
     @def_searches = @def_searches.unshift(temp) unless @def_searches.empty?
     @my_searches = MiqSearch.where(:search_type => "user", :search_key => session[:userid], :db => db).sort_by { |s| s.description.downcase }
   end

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -46,7 +46,7 @@ module ApplicationController::TreeSupport
   # Build a compliance history tree
   def compliance_history_tree(rec, count)
     t_kids = []                          # Array to hold node children
-    rec.compliances.all(:limit => count, :order => "timestamp DESC").each do |c|
+    rec.compliances.order("timestamp DESC").limit(count).each do |c|
       c_node = TreeNodeBuilder.generic_tree_node(
         "c_#{c.id}",
         format_timezone(c.timestamp, Time.zone, 'gtl'),
@@ -59,7 +59,7 @@ module ApplicationController::TreeSupport
       temp_pol_id = nil
       p_node = {}
       p_kids = []
-      c.compliance_details.all(:order => "miq_policy_desc, condition_desc").each do |d|
+      c.compliance_details.order("miq_policy_desc, condition_desc").each do |d|
         if d.miq_policy_id != temp_pol_id
           unless p_node.empty?
             p_node[:children] = p_kids unless p_kids.empty?

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -496,7 +496,7 @@ class ChargebackController < ApplicationController
   def cb_rpt_build_folder_nodes
     @parent_reports = {}
 
-    MiqReportResult.auto_generated.select("miq_report_id, name").group("miq_report_id, name").where(
+    MiqReportResult.auto_generated.select(:miq_report_id, :name).distinct.where(
       :db     => "Chargeback",
       :userid => session[:userid]
     ).sort_by { |sr| sr.name.downcase }.each_with_index do |sr, sr_idx|
@@ -507,7 +507,8 @@ class ChargebackController < ApplicationController
   def cb_rpts_get_all_reps(nodeid)
     @sb[:miq_report_id] = from_cid(nodeid)
     miq_report = MiqReport.find(@sb[:miq_report_id])
-    saved_reports = MiqReportResult.all(:conditions => ["miq_report_id = ? and userid = ?", @sb[:miq_report_id], session[:userid]], :order => "created_on DESC", :select => "id, miq_report_id, name,last_run_on,report_source")
+    saved_reports = miq_report.miq_report_results.where(:userid => session[:userid])
+                    .select("id, miq_report_id, name,last_run_on,report_source").order("created_on DESC")
     @sb[:last_run_on] = {}
     @sb[:timezone_abbr] = @timezone_abbr if @timezone_abbr  # Saving converted time to be displayed on saved reports list view
     saved_reports.each do |s|

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -68,7 +68,7 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def import_service_dialogs
-    import_file_upload = ImportFileUpload.first(:conditions => {:id => params[:import_file_upload_id]})
+    import_file_upload = ImportFileUpload.find_by(:id => params[:import_file_upload_id])
 
     if import_file_upload
       dialog_import_service.import_service_dialogs(import_file_upload, params[:dialogs_to_import])

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -245,7 +245,7 @@ module MiqPolicyController::AlertProfiles
     alerts.each { |a| @edit[:new][:alerts][a.description] = a.id } # Build a hash for the members list box
 
     @edit[:choices] = {}
-    MiqAlert.all(:conditions => ["db = ?", @edit[:new][:mode]]).each do |a|
+    MiqAlert.where(:db => @edit[:new][:mode]).select(:id, :description).each do |a|
       @edit[:choices][a.description] = a.id           # Build a hash for the alerts to choose from
     end
 

--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -32,8 +32,8 @@ module OpsController::Db
       )
     elsif model == VmdbDatabaseConnection
       @zones = Zone.all.sort_by(&:name).collect { |z| [z.name, z.name] }
-      # for now we dont need this pulldown, need ot get a method that could give us a list of workers for filter pulldown
-      # @workers = MiqWorker.all(:order=>"type ASC").uniq.sort_by(&:type).collect { |w| [w.friendly_name, w.id] }
+      # for now we dont need this pulldown, need to get a method that gives us a list of workers for filter pulldown
+      # @workers = MiqWorker.all.sort_by(&:type).collect { |w| [w.friendly_name, w.id] }
     end
 
     @view, @pages = get_view(model, :filter => exp ? exp : nil) # Get the records (into a view) and the paginator

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -195,7 +195,8 @@ module OpsController::Settings::CapAndU
 
     @edit[:current][:storages] = []
     @st_recs = {}
-    Storage.in_my_region.all(:include => [:taggings, :tags, :hosts], :select => "id, name, store_type, location").sort_by { |s| s.name.downcase }.each do |s|
+    Storage.in_my_region.includes(:taggings, :tags, :hosts).select(:id, :name, :store_type, :location)
+      .sort_by { |s| s.name.downcase }.each do |s|
       @st_recs[s.id] = s
       @edit[:current][:storages].push(:name       => s.name,
                                       :id         => s.id,

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1167,12 +1167,9 @@ module OpsController::Settings::Common
       @scan_items = ScanItemSet.all
       @zones = Zone.in_my_region
       @ldap_regions = LdapRegion.in_my_region
-      @miq_schedules = []
-      MiqSchedule.all(:conditions => "prod_default != 'system' or prod_default is null").sort_by { |s| s.name.downcase }.each do |s|
-        if s.adhoc.nil? && (s.towhat != "DatabaseBackup" || (s.towhat == "DatabaseBackup" && DatabaseBackup.backup_supported?))
-          @miq_schedules.push(s) unless @miq_schedules.include?(s)
-        end
-      end
+      @miq_schedules = MiqSchedule.where("(prod_default != 'system' or prod_default is null) and adhoc IS NULL")
+                       .select { |s| s.towhat != "DatabaseBackup" || DatabaseBackup.backup_supported? }
+                       .sort_by { |s| s.name.downcase }
     end
   end
 

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -183,17 +183,9 @@ module ReportController::Reports
     end
 
     if @sb[:active_tab] == "report_info"
-      if super_admin_user? # Super admins see all report schedules
-        schedules = MiqSchedule.all(:conditions => ["towhat=?", "MiqReport"])
-      else
-        schedules = MiqSchedule.all(:conditions => ["towhat=? AND userid=?", "MiqReport", session[:userid]])
-      end
-      @schedules = []
-      schedules.sort_by(&:name).each do |s|
-        if s.filter.exp["="]["value"].to_i == @miq_report.id.to_i
-          @schedules.push(s)
-        end
-      end
+      schedules = MiqSchedule.where(:towhat => "MiqReport")
+      schedules = schedules.where(:userid => current_userid) unless super_admin_user?
+      @schedules = schedules.select { |s| s.filter.exp["="]["value"].to_i == @miq_report.id.to_i }.sort_by(&:name)
 
       @widget_nodes = @miq_report.widgets.to_a
     end

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -81,8 +81,8 @@ module ReportController::Reports
   def miq_report_delete
     assert_privileges("miq_report_delete")
     rpt = MiqReport.find(params[:id])
-    report_widgets = MiqWidget.all(:conditions => {:resource_id => rpt.id})
-    if report_widgets.length > 0
+
+    if rpt.widgets.exist?
       add_flash(_("Report cannot be deleted if it's being used by one or more Widgets"), :error)
       render :update do |page|
         page.replace("flash_msg_div_report_list", :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"})
@@ -195,7 +195,7 @@ module ReportController::Reports
         end
       end
 
-      @widget_nodes = MiqWidget.all(:conditions => ["resource_id = ?", @miq_report.id.to_i])
+      @widget_nodes = @miq_report.widgets.to_a
     end
 
     @sb[:tree_typ]   = "reports"

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -237,8 +237,7 @@ module ReportController::Widgets
         @view, @pages = get_view(MiqWidget, :where_clause => ["content_type=?", nodeid])
       else
         # get all widgets for passed in report id
-        # @view, @pages = get_view(MiqWidget, :where_clause=>["content_type=? AND resource_id=?",nodeid, rep_id])
-        @widget_nodes = MiqWidget.all(:conditions => ["content_type = ? AND resource_id = ?", "report", rep_id])
+        @widget_nodes = MiqWidget.where(:content_type => "report", :resource_id => rep_id)
       end
     end
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -928,8 +928,8 @@ class ApplicationHelper::ToolbarBuilder
     return true if ["button_add", "button_save", "button_reset"].include?(id) && !@changed
 
     # need to add this here, since this button is on list view screen
-    if @layout == "pxe" && id == "iso_datastore_new"
-      return "No #{ui_lookup(:tables => "ext_management_system")} are available to create an ISO Datastore on" if ManageIQ::Providers::Redhat::InfraManager.find(:all).delete_if { |e| !e.iso_datastore.nil? }.count <= 0
+    if @layout == "pxe" && id == "iso_datastore_new" && ManageIQ::Providers::Redhat::InfraManager.datastore?
+      return "No #{ui_lookup(:tables => "ext_management_system")} are available to create an ISO Datastore on"
     end
 
     case get_record_cls(@record)

--- a/app/helpers/vm_helper.rb
+++ b/app/helpers/vm_helper.rb
@@ -9,9 +9,7 @@ module VmHelper
   end
 
   def last_date_processes
-    return nil if @record.operating_system.nil?
-    p = @record.operating_system.processes.first(:select => "updated_on", :order => "updated_on DESC")
-    p.nil? ? nil : p.updated_on
+    @record.operating_system && @record.operating_system.processes.max(:updated_on)
   end
 
   def set_controller_action

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -240,11 +240,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.default_rates
-    rates = []
-    ChargebackRate.find(:all, :conditions => {:default => true}).each do |rate|
-      rates += rate.chargeback_rate_details
-    end
-    rates
+    ChargebackRate.where(:default => true).flat_map(&:chargeback_rate_details)
   end
 
   def self.get_report_time_range(options, interval, tz)

--- a/app/models/cim_base_storage_extent.rb
+++ b/app/models/cim_base_storage_extent.rb
@@ -9,11 +9,8 @@ class CimBaseStorageExtent < ActsAsArModel
     CimStorageExtent._virtual_reflections
   end
 
-  def self.find(*args)
-    options = args.extract_options!
-    options[:conditions] = CimStorageExtent.merge_conditions(options[:conditions], :id => base_storage_extent_ids)
-    args << options
-    CimStorageExtent.find(*args)
+  def self.aar_scope
+    CimStorageExtent.where(:id => base_storage_extent_ids)
   end
 
   def self.base_storage_extent_ids

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -310,10 +310,8 @@ class EmsCluster < ActiveRecord::Base
   end
 
   def self.get_perf_collection_object_list
-    # cl_hash = self.in_my_region.all(:include => [:tags, :taggings, :ext_management_system], :select => "name, id, ems_id").inject({}) do |h,c|
-    cl_hash = in_my_region.all(:include => [:tags, :taggings], :select => "name, id").inject({}) do |h, c|
+    cl_hash = in_my_region.includes(:tags, :taggings).select(:id, :name).each_with_object({}) do |c, h|
       h[c.id] = {:cl_rec => c, :ho_ids => c.host_ids}
-      h
     end
 
     hids = cl_hash.values.flat_map { |v| v[:ho_ids] }.compact.uniq

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -317,7 +317,7 @@ class EmsCluster < ActiveRecord::Base
     end
 
     hids = cl_hash.values.flat_map { |v| v[:ho_ids] }.compact.uniq
-    hosts_by_id = Host.find_all_by_id(hids, :include => [:tags, :taggings], :select => "name, id").inject({}) { |h, host| h[host.id] = host; h }
+    hosts_by_id = Host.where(:id => hids).includes(:tags, :taggings).select(:id, :name).index_by(&:id)
 
     cl_hash.each do |_k, v|
       hosts = hosts_by_id.values_at(*v[:ho_ids]).compact

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -506,4 +506,9 @@ class ExtManagementSystem < ActiveRecord::Base
   def self.blacklisted_events
     BlacklistedEvent.where(:provider_model => name, :ems_id => nil)
   end
+
+  # @return [Boolean] true if a datastore exists for this type of ems
+  def self.datastore?
+    IsoDatastore.where(:ems_id => all).exists?
+  end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1107,7 +1107,7 @@ class Host < ActiveRecord::Base
   end
 
   def refresh_patches(ssu)
-    return unless vmm_buildnumber && vmm_buildnumber != Patch.highest_patch_level(self)
+    return unless vmm_buildnumber && vmm_buildnumber != patches.highest_patch_level
 
     patches = []
     begin

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1831,13 +1831,12 @@ class Host < ActiveRecord::Base
             else VmPerformance
             end
 
-    vm_perfs = klass.all(:conditions => [
+    vm_perfs = klass.where(
       "parent_host_id = ? AND capture_interval_name = ? AND timestamp >= ? AND timestamp <= ?",
       id,
       capture_interval.to_s,
       time_range[0],
-      time_range[1]
-    ])
+      time_range[1])
 
     perf_hash = {}
     vm_perfs.each do |p|

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -209,7 +209,7 @@ class Job < ActiveRecord::Base
     jobs = Marshal.load(jobs)
     job_guids = jobs.collect { |j| j[:taskid] }
     unless job_guids.empty?
-      Job.find(:all, :conditions => ["state != 'finished' and guid in (?)", job_guids]).each do |job|
+      Job.where(:guid => job_guids).where.not(:state => 'finished').each do |job|
         _log.debug("Job: guid: [#{job.guid}], job timeout extended due to work pending.")
         job.updated_on = Time.now.utc
         job.save

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -115,7 +115,7 @@ module Metric::Processing
     end
 
     last_perf = {}
-    obj.send(meth).all(:conditions => cond, :order => "timestamp, capture_interval_name").each do |perf|
+    obj.send(meth).where(cond).order("timestamp, capture_interval_name").each do |perf|
       interval = interval_name_to_interval(perf.capture_interval_name)
       last_perf[interval] = perf if last_perf[interval].nil?
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -728,7 +728,7 @@ class MiqAction < ActiveRecord::Base
 
     has_ch = false
     snap   = nil
-    rec.snapshots.all(:order => "create_time DESC").each do |s|
+    rec.snapshots.order("create_time DESC").each do |s|
       if s.is_a_type?(:consolidate_helper)
         has_ch = true
         next

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -38,12 +38,11 @@ module MiqFilter
       if reflection.macro == :has_one
         result = [obj.send(reflection.name)]
       else
-        result = obj.send(reflection.name).find(:all,
-                                                :order      => options[:order],
-                                                :offset     => options[:offset],
-                                                :limit      => options[:limit],
-                                                :conditions => options[:conditions]
-                                               )
+        result = obj.send(reflection.name)
+                 .where(options[:conditions])
+                 .order(options[:order])
+                 .offset(options[:offset])
+                 .limit(options[:limit])
       end
       total_count = result.length
     end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -226,7 +226,7 @@ class MiqRegion < ActiveRecord::Base
     total_hosts   = 0
     total_sockets = 0
 
-    ExtManagementSystem.all(:order => :id).each do |e|
+    ExtManagementSystem.all.each do |e|
       vms     = e.all_vms_and_templates.count
       hosts   = e.all_hosts.count
       sockets = e.aggregate_physical_cpus

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -40,6 +40,7 @@ class MiqReport < ActiveRecord::Base
   belongs_to                :time_profile
   belongs_to                :miq_group
   belongs_to                :user
+  has_many                  :widgets, :as => :resource
 
   attr_accessor_that_yamls :table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -35,11 +35,8 @@ module MiqReport::Generator::Trend
       trend_klass = db_options[:trend_db].kind_of?(Class) ? db_options[:trend_db] : Object.const_get(db_options[:trend_db])
 
       time_range_cond = ["timestamp BETWEEN ? AND ?", start_time, end_time]
-      recs = VimPerformanceDaily.find(:all,
-                                      :conditions  => VimPerformanceDaily.merge_conditions(where_clause, time_range_cond),
-                                      :include     => includes,
-                                      :ext_options => {:class => trend_klass, :only_cols => only_cols, :reflections => associations, :tz => tz, :time_profile => time_profile}
-                                     )
+      recs = VimPerformanceDaily.find_entries(:class => trend_klass, :tz => tz, :time_profile => time_profile)
+             .where(where_clause).where(time_range_cond).includes(includes)
       results = Rbac.filtered(recs, :class        => db_options[:trend_db],
                                     :filter       => db_options[:trend_filter],
                                     :userid       => options[:userid],

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -24,15 +24,14 @@ module MiqReport::Seeding
       if typ == "report"
         dir = REPORT_DIR
         pattern = "*/*.yaml"
-        cond = ["rpt_type = 'Default' and (template_type = ? or template_type is null)", typ]
+        cond = {:rpt_type => 'Default', :template_type => [typ, nil]}
       else
         dir = COMPARE_DIR
         pattern = "*.yaml"
-        cond = ["rpt_type = 'Default' and template_type = ?", typ]
+        cond = {:rpt_type => 'Default', :template_type => typ}
       end
 
-      where(cond).each do |f|
-        next unless f.filename
+      where(cond).where.not(:filename => nil).each do |f|
         unless File.exist?(File.join(dir, f.filename))
           $log.info("#{typ.titleize}: file [#{f.filename}] has been deleted from disk, deleting from model")
           f.destroy

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -26,6 +26,10 @@ class MiqSearch < ActiveRecord::Base
     Rbac.filtered(targets, options.merge(:class => db, :filter => filter).merge(opts))
   end
 
+  def self.visible_to_all
+    where("search_type=? or (search_type=? and (search_key is null or search_key<>?))", "global", "default", "_hidden_")
+  end
+
   def self.get_expressions_by_model(db)
     get_expressions(:db => db.to_s)
   end

--- a/app/models/miq_smis_agent.rb
+++ b/app/models/miq_smis_agent.rb
@@ -150,7 +150,7 @@ class MiqSmisAgent < StorageManager
   end
 
   def self.update_stats
-    find(:all, :conditions => {:agent_type => 'SMIS'}).each do |agent|
+    where(:agent_type => 'SMIS').each do |agent|
       # TODO: Log hostname, not ipaddress
       _log.info "Agent: #{agent.ipaddress}"
 
@@ -197,7 +197,7 @@ class MiqSmisAgent < StorageManager
   end
 
   def self.update_status
-    find(:all, :conditions => {:agent_type => 'SMIS'}).each do |agent|
+    where(:agent_type => 'SMIS').each do |agent|
       # TODO: Log hostname, not ipaddress
       _log.info "Agent: #{agent.ipaddress}"
 

--- a/app/models/miq_smis_agent.rb
+++ b/app/models/miq_smis_agent.rb
@@ -46,9 +46,8 @@ class MiqSmisAgent < StorageManager
       agent.save
     end
 
-    MiqCimInstance.find(:all, :conditions => {:source => 'SMIS', :zone_id => zoneId}).each do |inst|
-      inst.last_update_status = STORAGE_UPDATE_NO_AGENT
-      inst.save
+    MiqCimInstance.where(:source => 'SMIS', :zone_id => zoneId).each do |inst|
+      inst.update_attributes(:last_update_status => STORAGE_UPDATE_NO_AGENT)
     end
 
     pendingAgents = []
@@ -252,10 +251,10 @@ class MiqSmisAgent < StorageManager
   def self.cleanup
     zoneId = MiqServer.my_server.zone.id
 
-    MiqCimInstance.find(:all, :conditions => [
-      "zone_id = ? and source = ? and (last_update_status = ? or last_update_status = ?)",
-      zoneId, "SMIS", STORAGE_UPDATE_NO_AGENT, STORAGE_UPDATE_AGENT_OK_NO_INSTANCE
-    ]).each do |inst|
+    MiqCimInstance.where(
+      :zone_id            => zoneId,
+      :source             => "SMIS",
+      :last_update_status => [STORAGE_UPDATE_NO_AGENT, STORAGE_UPDATE_AGENT_OK_NO_INSTANCE]).each do |inst|
       if inst.last_update_status == STORAGE_UPDATE_AGENT_OK_NO_INSTANCE
         alus = inst.agent.last_update_status
         next if alus == STORAGE_UPDATE_FAILED || alus == STORAGE_UPDATE_IN_PROGRESS

--- a/app/models/netapp_remote_service.rb
+++ b/app/models/netapp_remote_service.rb
@@ -329,27 +329,21 @@ class NetappRemoteService < StorageManager
   end
 
   def self.aggregate_names(oss)
-    ocea = MiqCimInstance.find(:all,  :conditions => {
-                                 :class_name             => "ONTAP_ConcreteExtent",
-                                 :top_managed_element_id => oss.id
-                               })
-    ocea.collect { |oce| oce.property('name') }
+    MiqCimInstance.select(:id, :properites)
+      .where(:class_name => "ONTAP_ConcreteExtent", :top_managed_element_id => oss.id)
+      .collect { |oce| oce.property('name') }
   end
 
   def self.volume_names(oss)
-    olda = MiqCimInstance.find(:all,  :conditions => {
-                                 :class_name             => "ONTAP_LogicalDisk",
-                                 :top_managed_element_id => oss.id
-                               })
-    olda.collect { |old| old.property('name') }
+    MiqCimInstance.select(:id, :properites)
+      .where(:class_name => "ONTAP_LogicalDisk", :top_managed_element_id => oss.id)
+      .collect { |old| old.property('name') }
   end
 
   def self.remote_service_ips(oss)
-    rsapa = MiqCimInstance.find(:all,  :conditions => {
-                                  :class_name             => "ONTAP_RemoteServiceAccessPoint",
-                                  :top_managed_element_id => oss.id
-                                })
-    rsapa.collect { |rsap| rsap.property('name').split(':').first }
+    MiqCimInstance.select(:id, :properites)
+      .where(:class_name => "ONTAP_RemoteServiceAccessPoint", :top_managed_element_id => oss.id)
+      .collect { |rsap| rsap.property('name').split(':').first }
   end
 
   def self.find_controller_by_ip(ip)

--- a/app/models/netapp_remote_service.rb
+++ b/app/models/netapp_remote_service.rb
@@ -172,8 +172,8 @@ class NetappRemoteService < StorageManager
   end
 
   def self.agent_query(nrsIds)
-    return where(:conditions => {:agent_type => DEFAULT_AGENT_TYPE, :zone_id => MiqServer.my_server.zone.id}) if nrsIds.empty?
-    where(:id => nrsIds)
+    return where(:id => nrsIds) if nrsIds.present?
+    where(:agent_type => DEFAULT_AGENT_TYPE, :zone_id => MiqServer.my_server.zone.id)
   end
 
   def self.update_ontap(nrsIds = [])

--- a/app/models/patch.rb
+++ b/app/models/patch.rb
@@ -23,13 +23,9 @@ class Patch < ActiveRecord::Base
     EmsRefresh.save_patches_inventory(parent, hashes) unless hashes.blank?
   end
 
-  def self.highest_patch_level(target)
-    ret_val = 0
-    target.patches.find(:all, :select => "id, name").collect do |rec|
-      level  = rec[:name].split("-")[-1].to_i
-      ret_val = level if level > ret_val
-    end
-    ret_val.to_s
+  def self.highest_patch_level
+    levels = all.pluck(:name).collect { |name| name.split("-").last.to_i }
+    (levels.max || 0).to_s
   end
 
   def self.xml_to_hashes(xmlNode, findPath)

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -526,7 +526,7 @@ module Rbac
     if ar_scope == VmdbDatabaseConnection || ar_scope == VmdbDatabaseSetting
       ar_scope.all
     elsif ar_scope < ActsAsArModel || (ar_scope.respond_to?(:instances_are_derived?) && ar_scope.instances_are_derived?)
-      ar_scope.find(:all, options)
+      ar_scope.all(options)
     else
       ar_scope.apply_legacy_finder_options(options)
     end

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -13,7 +13,7 @@ class ScanItem < ActiveRecord::Base
   DEFAULT_HOST_PROFILE = {:name => "host default", :description => "Host Default", :mode => 'Host'}.freeze
 
   def self.sync_from_dir
-    find(:all, :conditions => "prod_default = 'Default'").each do|f|
+    where(:prod_default => 'Default').where.not(:filename => nil).each do|f|
       next unless f.filename
       unless File.exist?(File.join(YAML_DIR, f.filename))
         $log.info("Scan Item: file [#{f.filename}] has been deleted from disk, deleting from model")
@@ -68,7 +68,7 @@ class ScanItem < ActiveRecord::Base
     load_host_default = host_default.new_record?
     host_default.update_attributes(DEFAULT_HOST_PROFILE)
 
-    find(:all, :conditions => {:prod_default => 'Default'}).each do |s|
+    where(:prod_default => 'Default').each do |s|
       case s.mode
       when "Host"
         host_profile.add_member(s) unless host_profile.members.include?(s)

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -140,7 +140,7 @@ class TimeProfile < ActiveRecord::Base
     end
   end
 
-  def for_user_tz?(user_id, user_tz)
+  def match_user_tz?(user_id, user_tz)
     user_id = user_id.to_s
     tz == user_tz &&
       (profile_type == "global" ||
@@ -180,7 +180,7 @@ class TimeProfile < ActiveRecord::Base
   end
 
   def self.profile_for_user_tz(user_id, user_tz)
-    TimeProfile.rollup_daily_metrics.detect { |tp| tp.for_user_tz?(user_id, user_tz) }
+    TimeProfile.rollup_daily_metrics.detect { |tp| tp.match_user_tz?(user_id, user_tz) }
   end
 
   def self.default_time_profile(tz = DEFAULT_TZ)

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -527,7 +527,7 @@ module VimPerformanceAnalysis
     # puts "find_child_perf_for_time_period: cond: #{cond.inspect}"
 
     if interval_name == "daily"
-      VimPerformanceDaily.find(:all, :conditions => cond, :ext_options => options[:ext_options], :select => options[:select])
+      VimPerformanceDaily.find_entries(options[:ext_options]).where(cond).select(options[:select])
     else
       klass.where(cond).select(options[:select]).to_a
     end
@@ -645,7 +645,7 @@ module VimPerformanceAnalysis
 
   def self.get_daily_perf(obj, start_time, end_time, options)
     cond = ["resource_type = ? and resource_id = ? and (timestamp > ? and timestamp <= ?)", obj.class.base_class.name, obj.id, start_time.utc, end_time.utc]
-    results = VimPerformanceDaily.find(:all, :conditions => cond, :order => "timestamp", :ext_options => options)
+    results = VimPerformanceDaily.find_entries(options).where(cond).order("timestamp")
 
     # apply time profile to returned records if one was specified
     results.each { |rec| rec.apply_time_profile(options[:time_profile]) if rec.respond_to?(:apply_time_profile) } unless options[:time_profile].nil?

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -37,7 +37,7 @@ class VimPerformanceDaily < MetricRollup
   # @param ext_options [Hash] search options
   # @opts ext_options :klass [Class] class for metrics (default: MetricRollup)
   # @opts ext_options :tp [TimeProfile]
-  # @opts ext_options :tz [Timezone] (default: DEFUULTf)
+  # @opts ext_options :tz [Timezone] (default: DEFAULT_TIMEZONE)
   def self.find_entries(ext_options)
     ext_options ||= {}
     time_profile = ext_options[:time_profile] ||= TimeProfile.default_time_profile(ext_options[:tz])

--- a/app/models/vim_performance_tag_daily.rb
+++ b/app/models/vim_performance_tag_daily.rb
@@ -5,6 +5,6 @@ class VimPerformanceTagDaily < VimPerformanceTag
 
   def self.find_and_group_by_tags(options)
     raise "no catagory provided" if options[:category].blank?
-    group_by_tags(VimPerformanceDaily.find(:all, :conditions => options[:where_clause], :ext_options => options[:ext_options]), options)
+    group_by_tags(VimPerformanceDaily.find_entries(options[:ext_options]).where(options[:where_clause]), options)
   end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -549,11 +549,7 @@ class VmOrTemplate < ActiveRecord::Base
 
   # Generates the contents of the RSS feed that lists VMs that fail policy
   def self.rss_fails_policy(_name, options)
-    result = []
-    vms = find(:all,
-               :order => options[:orderby],
-               :limit => options[:limit_to_count]
-              ).each do|vm|
+    order(options[:orderby]).limit(options[:limit_to_count]).each_with_object([]) do |vm, result|
       rec = OpenStruct.new(vm.attributes)
       if vm.host.nil?
         rec.host_name = "unknown"
@@ -573,7 +569,6 @@ class VmOrTemplate < ActiveRecord::Base
         end
       end
     end
-    result
   end
 
   def vendor

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -14,15 +14,13 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   end
 
   def x_get_tree_stc_kids(object, count_only)
-    return count_only_or_objects(count_only,
-                                 rbac_filtered_objects(object.service_templates),
-                                 'name') unless object.id.nil?
-    objects = []
-    items = rbac_filtered_objects(ServiceTemplate.find(:all))
-    items.sort_by { |o| o.name.downcase }.each do |item|
-      objects.push(item) if item.service_template_catalog_id.nil?
-    end
-    count_only_or_objects(count_only, objects, 'name')
+    # TODO: may want to order in rbac and not in sql
+    templates = if object.id.nil?
+                  ServiceTemplate.where(:service_template_catalog_id => nil).order("lower(name)")
+                else
+                  object.service_templates
+                end
+    count_only_or_objects(count_only, rbac_filtered_objects(templates), 'name')
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_containers_filter.rb
+++ b/app/presenters/tree_builder_containers_filter.rb
@@ -28,12 +28,8 @@ class TreeBuilderContainersFilter < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    case object[:id]
-    when "global" # Global filters
-      objects = MiqSearch.all(:conditions => ["(search_type=? or (search_type=? and (search_key is null
-                                                or search_key<>?))) and db=?", "global", "default", "_hidden_",
-                                              options[:leaf]]).sort_by { |a| a.description.downcase }
-    end
-    count_only ? objects.length : objects
+    return count_only ? 0 : [] if object[:id] != "global"
+    objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
+    count_only ? objects.length : objects.sort_by { |a| a.description.downcase }
   end
 end

--- a/app/presenters/tree_builder_foreman_configured_systems.rb
+++ b/app/presenters/tree_builder_foreman_configured_systems.rb
@@ -48,16 +48,11 @@ class TreeBuilderForemanConfiguredSystems < TreeBuilder
   end
 
   def x_get_global_filter_search_results(leaf)
-    MiqSearch
-      .where(:db => leaf)
-      .where("search_type=? or (search_type=? and (search_key is null or search_key<>?))", "global", "default", "_hidden_")
-      .sort_by { |a| a.description.downcase }
+    MiqSearch.where(:db => leaf).visible_to_all.sort_by { |a| a.description.downcase }
   end
 
   def x_get_my_filter_search_results(leaf)
-    MiqSearch
-      .where(:db => leaf)
-      .where(:search_type => "user", :search_key => User.current_user.userid)
+    MiqSearch.where(:db => leaf, :search_type => "user", :search_key => User.current_user.userid)
       .sort_by { |a| a.description.downcase }
   end
 end

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -20,9 +20,9 @@ class TreeBuilderReportSchedules < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
       # Super admins see all report schedules
-      objects = MiqSchedule.all(:conditions => %w(towhat=? MiqReport))
+      objects = MiqSchedule.where(:towhat => 'MiqReport')
     else
-      objects = MiqSchedule.all(:conditions => ['towhat=? AND userid=?', 'MiqReport', User.current_user.userid])
+      objects = MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
     end
     count_only_or_objects(count_only, objects.sort_by { |o| o.name.downcase }, 'name')
   end

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -28,7 +28,7 @@ class TreeBuilderVmsFilter < TreeBuilder
     objects = MiqSearch.where(:db => options[:leaf])
     objects = case object[:id]
               when "global" # Global filters
-                objects.where("search_type=? or (search_type=? and (search_key is null or search_key<>?))", "global", "default", "_hidden_")
+                objects.visible_to_all
               when "my"     # My filters
                 objects.where(:search_type => "user", :search_key => User.current_user.userid)
               end

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -149,32 +149,51 @@ class ActsAsArModel
   # Find routines
   #
 
+  def self.where(*args)
+    return aar_scope.where(*args) if self.respond_to?(:aar_scope)
+    raise NotImplementedError
+  end
+
+  def self.find(*args)
+    return aar_scope.find(*args) if self.respond_to?(:aar_scope)
+    raise NotImplementedError
+  end
+
   def self.all(*args)
-    raise NotImplementedError unless self.respond_to?(:find)
-    find(:all, *args)
+    if !self.respond_to?(:aar_scope)
+      find(:all, *args)
+    elsif args.empty? || args.size == 1 && args.first.respond_to?(:empty?) && args.first.empty?
+      # avoid warnings
+      aar_scope
+    else
+      aar_scope.all(*args)
+    end
   end
 
   def self.first(*args)
-    raise NotImplementedError unless self.respond_to?(:find)
+    return aar_scope.first(*args) if self.respond_to?(:aar_scope)
     find(:first, *args)
   end
 
   def self.last(*args)
-    raise NotImplementedError unless self.respond_to?(:find)
+    return aar_scope.last(*args) if self.respond_to?(:aar_scope)
     find(:last, *args)
   end
 
   def self.count(*args)
+    return aar_scope.count(*args) if self.respond_to?(:aar_scope)
     all(*args).size
   end
 
   def self.find_by_id(*id)
+    return aar_scope.find_by_id(*id) if self.respond_to?(:aar_scope)
     options = id.extract_options!
     options.merge!(:conditions => {:id => id.first})
     first(options)
   end
 
   def self.find_all_by_id(*ids)
+    return aar_scope.find_all_by_id(*args) if self.respond_to?(:aar_scope)
     options = ids.extract_options!
     options.merge!(:conditions => {:id => ids.flatten})
     all(options)

--- a/lib/vmdb_storage_bridge.rb
+++ b/lib/vmdb_storage_bridge.rb
@@ -16,7 +16,7 @@ class VmdbStorageBridge
 
   def initialize
     @zone = MiqServer.my_server.zone.id
-    @agent  = CimVmdbAgent.find(:all, :conditions => {:agent_type => 'VMDB', :zone_id => @zone}).first
+    @agent  = CimVmdbAgent.find_by(:agent_type => 'VMDB', :zone_id => @zone)
     @agent  = CimVmdbAgent.add(nil, nil, nil, 'VMDB', @zone, "VMDB-#{@zone}") unless @agent
   end
 

--- a/product/script/export_policies.rb
+++ b/product/script/export_policies.rb
@@ -4,7 +4,7 @@ dir = Dir.pwd
 # ext = "xml"
 ext = "yaml"
 
-Policy.find(:all).each do |p|
+Policy.all.each do |p|
   fname = File.join(dir, "policy#{p.id}.#{ext}")
   puts "Creating #{fname}"
   f = File.new(fname, "w")

--- a/product/script/export_policy_profiles.rb
+++ b/product/script/export_policy_profiles.rb
@@ -12,7 +12,7 @@ ext = "yaml"
 
 dir = Dir.pwd
 
-MiqPolicySet.find(:all).each do |ps|
+MiqPolicySet.all.each do |ps|
   begin
     contents = ps.export_to_yaml if ext == "yaml"
     contents = ps.export_to_xml  if ext == "xml"

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -349,7 +349,7 @@ describe MiqAeCustomizationController do
 
     before do
       bypass_rescue
-      allow(ImportFileUpload).to receive(:first).with(:conditions => {:id => "123"}).and_return(import_file_upload)
+      allow(ImportFileUpload).to receive(:find_by).with(:id => "123").and_return(import_file_upload)
       allow(DialogImportService).to receive(:new).and_return(dialog_import_service)
     end
 

--- a/spec/lib/acts_as_ar_model_spec.rb
+++ b/spec/lib/acts_as_ar_model_spec.rb
@@ -1,8 +1,14 @@
 require "spec_helper"
 
 describe ActsAsArModel do
-  before(:each) do
-    class TestClass1 < ActsAsArModel
+  before { base_class }
+
+  # id is a default column included regardless if it's in the set_columns_hash
+  let(:col_names_syms) { [:str, :id, :int, :flt, :dt, :str_with_options] }
+  let(:col_names_strs) { %w(str id int flt dt str_with_options) }
+
+  let(:base_class) do
+    Class.new(ActsAsArModel) do
       set_columns_hash(
         :str              => :string,
         :int              => :integer,
@@ -11,47 +17,39 @@ describe ActsAsArModel do
         :str_with_options => {:type => :string, :some_opt => 'opt_value'}
       )
     end
-
-    # id is a default column included regardless if it's in the set_columns_hash
-    @col_names_syms = [:str, :id, :int, :flt, :dt, :str_with_options]
-    @col_names_strs = ["str", "id", "int", "flt", "dt", "str_with_options"]
   end
 
-  after(:each) do
-    Object.send(:remove_const, :TestClass1)
-  end
+  describe "subclass, base_class," do
+    it(".base_class") { base_class.base_class.should == base_class }
+    it(".base_model") { base_class.base_model.should == base_class }
 
-  describe "subclass, TestClass1," do
-    it(".base_class") { TestClass1.base_class.should == TestClass1 }
-    it(".base_model") { TestClass1.base_model.should == TestClass1 }
+    it { base_class.should respond_to(:columns_hash) }
+    it { base_class.should respond_to(:columns) }
+    it { base_class.should respond_to(:column_names) }
+    it { base_class.should respond_to(:column_names_symbols) }
 
-    it { TestClass1.should respond_to(:columns_hash) }
-    it { TestClass1.should respond_to(:columns) }
-    it { TestClass1.should respond_to(:column_names) }
-    it { TestClass1.should respond_to(:column_names_symbols) }
+    it { base_class.should respond_to(:virtual_columns) }
 
-    it { TestClass1.should respond_to(:virtual_columns) }
+    it { base_class.should respond_to(:aar_columns) }
 
-    it { TestClass1.should respond_to(:aar_columns) }
+    it { base_class.columns_hash.values[0].should be_kind_of(ActsAsArModelColumn) }
+    it { base_class.columns_hash.keys.should      match_array(col_names_strs) }
+    it { base_class.column_names.should           match_array(col_names_strs) }
+    it { base_class.column_names_symbols.should   match_array(col_names_syms) }
 
-    it { TestClass1.columns_hash.values[0].should be_kind_of(ActsAsArModelColumn) }
-    it { TestClass1.columns_hash.keys.should      match_array(@col_names_strs) }
-    it { TestClass1.column_names.should           match_array(@col_names_strs) }
-    it { TestClass1.column_names_symbols.should   match_array(@col_names_syms) }
-
-    it { TestClass1.columns_hash["str_with_options"].options[:some_opt].should == 'opt_value' }
+    it { base_class.columns_hash["str_with_options"].options[:some_opt].should == 'opt_value' }
 
     describe "instance" do
-      it { TestClass1.new.should respond_to(:attributes) }
-      it { TestClass1.new.should respond_to(:str) }
+      it { base_class.new.should respond_to(:attributes) }
+      it { base_class.new.should respond_to(:str) }
 
       it "should allow attribute initialization" do
-        t = TestClass1.new(:str => "test_value")
+        t = base_class.new(:str => "test_value")
         t.str.should == "test_value"
       end
 
       it "should allow attribute access" do
-        t = TestClass1.new
+        t = base_class.new
         t.str.should be_nil
 
         t.str = "test_value"
@@ -60,21 +58,54 @@ describe ActsAsArModel do
     end
 
     describe "subclass, TestSubClass1," do
-      before(:each) { class TestSubClass1 < TestClass1; end }
-      after(:each)  { Object.send(:remove_const, :TestSubClass1) }
+      let(:sub_class) { Class.new(base_class) }
 
-      it(".base_class") { TestSubClass1.base_class.should == TestClass1 }
-      it(".base_model") { TestSubClass1.base_model.should == TestClass1 }
+      it(".base_class") { sub_class.base_class.should == base_class }
+      it(".base_model") { sub_class.base_model.should == base_class }
     end
   end
 
   describe "subclass, TestClass2," do
-    before(:each) { class TestClass2 < ActsAsArModel; end }
-    after(:each)  { Object.send(:remove_const, :TestClass2) }
+    let(:sub_class) { Class.new(ActsAsArModel) }
 
-    it(".base_class") { TestClass2.base_class.should == TestClass2 }
-    it(".base_model") { TestClass2.base_model.should == TestClass2 }
+    it(".base_class") { sub_class.base_class.should == sub_class }
+    it(".base_model") { sub_class.base_model.should == sub_class }
 
-    it { TestClass2.columns_hash.should be_empty }
+    it { sub_class.columns_hash.should be_empty }
+  end
+
+  context "AR backed model" do
+    # model contains ids of important vms - acts like ar model
+    let(:important_vm_model) do
+      Class.new(ActsAsArModel) do
+        def self.vm_ids
+          @vm_ids ||= []
+        end
+
+        def self.vm_ids=(new_ids)
+          @vm_ids = new_ids
+        end
+
+        def self.aar_scope
+          Vm.where(:id => vm_ids)
+        end
+      end
+    end
+
+    it ".all" do
+      good = FactoryGirl.create_list(:vm, 3)
+      bad = FactoryGirl.create_list(:vm, 1)
+
+      important_vm_model.vm_ids += good.map(&:id)
+
+      expect(important_vm_model.all.order(:id)).to eq(good)
+      expect(important_vm_model.all.order('id desc').first).to eq(good.last)
+      expect(important_vm_model.first).to eq(good.first)
+      expect(important_vm_model.last).to eq(good.last)
+      expect(important_vm_model.all.count).to eq(3)
+      expect(important_vm_model.all.order('id desc').first).to eq(good.last)
+      expect(important_vm_model.where(:id => good.last.id).count).to eq(1)
+      expect(important_vm_model.where(:id => bad.last.id).count).to eq(0)
+    end
   end
 end

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -332,4 +332,23 @@ describe Chargeback do
       end
     end
   end
+
+  describe ".default_rates" do
+    it "works" do
+      expect(Chargeback.default_rates.map(&:description)).to match_array([
+        "Used CPU",
+        "Allocated CPU Count",
+        "Used Memory",
+        "Allocated Memory",
+        "Used Network I/O",
+        "Used Disk I/O",
+        "Fixed Compute Cost 1",
+        "Fixed Compute Cost 2",
+        "Allocated Disk Storage",
+        "Used Disk Storage",
+        "Fixed Storage Cost 1",
+        "Fixed Storage Cost 2",
+      ])
+    end
+  end
 end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -291,50 +291,42 @@ EOF
       context "last" do
         it "without conditions" do
           t = VmdbTable.vmdb_table_names.last
-          VmdbTable.find(:last).name.should == t
           VmdbTable.last.name.should == t
         end
 
         it "with conditions" do
           t = VmdbTable.vmdb_table_names.third
-          VmdbTable.find(:last, :conditions => {:id => [2, 3]}).name.should == t
-          VmdbTable.last(:conditions => {:id => [2, 3]}).name.should == t
+          VmdbTable.where(:id => [2, 3]).last.name.should == t
         end
       end
 
       context "all" do
         it "without conditions" do
           t = VmdbTable.vmdb_table_names
-          VmdbTable.find(:all).collect(&:name).should == t
           VmdbTable.all.collect(&:name).should == t
         end
 
         context "with conditions" do
           it "of an array of ids" do
             t = VmdbTable.vmdb_table_names[0, 2]
-            VmdbTable.find(:all, :conditions => {:id => [1, 2]}).collect(&:name).should == t
             VmdbTable.all(:conditions => {:id => [1, 2]}).collect(&:name).should == t
           end
 
           it "of a single id" do
             t = [VmdbTable.vmdb_table_names.second]
-            VmdbTable.find(:all, :conditions => {:id => 2}).collect(&:name).should == t
             VmdbTable.all(:conditions => {:id => 2}).collect(&:name).should == t
           end
 
           it "of an array of invalid ids" do
-            VmdbTable.find(:all, :conditions => {:id => [650, 651]}).collect(&:name).should be_empty
             VmdbTable.all(:conditions => {:id => [650, 651]}).collect(&:name).should        be_empty
           end
 
           it "of an array of both invalid and valid ids" do
             t = [VmdbTable.vmdb_table_names.first]
-            VmdbTable.find(:all, :conditions => {:id => [650, 1]}).collect(&:name).should == t
             VmdbTable.all(:conditions => {:id => [650, 1]}).collect(&:name).should == t
           end
 
           it "of a single invalid id" do
-            VmdbTable.find(:all, :conditions => {:id => 650}).should be_empty
             VmdbTable.all(:conditions => {:id => 650}).should        be_empty
           end
         end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -303,31 +303,38 @@ EOF
       context "all" do
         it "without conditions" do
           t = VmdbTable.vmdb_table_names
-          VmdbTable.all.collect(&:name).should == t
+          expect(VmdbTable.all.collect(&:name)).to eq(t)
+        end
+      end
+
+      context ".where" do
+        it "without conditions" do
+          t = VmdbTable.vmdb_table_names
+          expect(VmdbTable.where({}).collect(&:name)).to eq(t)
         end
 
         context "with conditions" do
           it "of an array of ids" do
             t = VmdbTable.vmdb_table_names[0, 2]
-            VmdbTable.all(:conditions => {:id => [1, 2]}).collect(&:name).should == t
+            expect(VmdbTable.where(:id => [1, 2]).collect(&:name)).to eq(t)
           end
 
           it "of a single id" do
             t = [VmdbTable.vmdb_table_names.second]
-            VmdbTable.all(:conditions => {:id => 2}).collect(&:name).should == t
+            expect(VmdbTable.where(:id => 1).collect(&:name)).to eq(t)
           end
 
           it "of an array of invalid ids" do
-            VmdbTable.all(:conditions => {:id => [650, 651]}).collect(&:name).should        be_empty
+            expect(VmdbTable.where(:id => [650, 651])).to be_empty
           end
 
           it "of an array of both invalid and valid ids" do
             t = [VmdbTable.vmdb_table_names.first]
-            VmdbTable.all(:conditions => {:id => [650, 1]}).collect(&:name).should == t
+            expect(VmdbTable.where(:id => [650, 1]).collect(&:name)).to eq(t)
           end
 
           it "of a single invalid id" do
-            VmdbTable.all(:conditions => {:id => 650}).should        be_empty
+            expect(VmdbTable.where(:id => 650)).to be_empty
           end
         end
       end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -246,7 +246,7 @@ EOF
         task_id = VmdbTable.export_queue(@ids.first, :userid => "admin", :action => "Export Tables")
         task_id.should be_kind_of(Integer)
 
-        q = MiqQueue.first(:conditions => {:class_name  => "VmdbTable", :method_name => "export_all_by_id"})
+        q = MiqQueue.find_by(:class_name => "VmdbTable", :method_name => "export_all_by_id")
         q.should_not be_nil
 
         q.delivered(*q.deliver)
@@ -261,7 +261,7 @@ EOF
         taskid = VmdbTable.export_queue(@ids, :userid => "admin", :action => "Export Tables")
         taskid.should be_kind_of(Integer)
 
-        q = MiqQueue.first(:conditions => {:class_name  => "VmdbTable", :method_name => "export_all_by_id"})
+        q = MiqQueue.find_by(:class_name => "VmdbTable", :method_name => "export_all_by_id")
         q.should_not be_nil
 
         q.delivered(*q.deliver)

--- a/tools/classify_vms_by_folder
+++ b/tools/classify_vms_by_folder
@@ -1,1 +1,1 @@
-Vm.find(:all).each { |vm| vm.classify_with_parent_folder_path }
+Vm.all.each { |vm| vm.classify_with_parent_folder_path }

--- a/tools/db_printers/print_network.rb
+++ b/tools/db_printers/print_network.rb
@@ -1,13 +1,13 @@
 def print_switch(indent, switch)
   puts "#{indent}Switch: #{switch.name}"
-  switch.lans.find(:all, :order => "lower(name)").each do |lan|
+  switch.lans.order("lower(name)").each do |lan|
     puts "#{indent}  Lan: #{lan.name}"
     vms = lan.guest_devices.collect { |gd| [gd.hardware.vm, gd.device_name] if gd.hardware && gd.hardware.vm }.compact
     vms.sort_by { |vm| vm[0].name.downcase }.each { |vm| puts "#{indent}    #{vm[0].class}: #{vm[0].name} (vNIC: #{vm[1]})" }
   end
 end
 
-Host.find(:all).each do |host|
+Host.all.each do |host|
   puts "Host: #{host.name} [#{host.ipaddress}] (id: #{host.id})"
 
   found_switches = []
@@ -37,7 +37,7 @@ Host.find(:all).each do |host|
 
   unless host.switches.length == found_switches.length
     puts "  pNIC: (None)"
-    host.switches.find(:all, :order => "lower(name)").each do |switch|
+    host.switches.order("lower(name)").each do |switch|
       next if found_switches.include?(switch.name)
       print_switch("    ", switch)
     end

--- a/tools/db_printers/print_scsi.rb
+++ b/tools/db_printers/print_scsi.rb
@@ -1,12 +1,12 @@
-Host.find(:all).each do |host|
+Host.all.each do |host|
   puts "Host: #{host.name} (id: #{host.id})"
 
   host.hardware.guest_devices.find_all_by_device_type('storage', :order => "lower(device_name)").each do |adapter|
     sub_name = adapter.iscsi_name.nil? ? "" : " (#{adapter.iscsi_name})"
     puts "  SCSI Adapter: #{adapter.device_name}#{sub_name}"
-    adapter.miq_scsi_targets.find(:all, :order => "lower(target)").each do |target|
+    adapter.miq_scsi_targets.order("lower(target)").each do |target|
       puts "    Target: #{target.iscsi_name} (#{target.target})"
-      target.miq_scsi_luns.find(:all, :order => "lower(lun)").each do |lun|
+      target.miq_scsi_luns.order("lower(lun)").each do |lun|
         puts "      Lun: #{lun.canonical_name} (#{lun.lun})"
       end
     end

--- a/tools/evm_dump.rb
+++ b/tools/evm_dump.rb
@@ -47,7 +47,7 @@ MODELS += ARGV.collect { |model| Object.const_get(model) }
 
 MODELS.each do |klass|
   log :info, "Getting #{klass} objects"
-  items = klass.find(:all)
+  items = klass.all.to_a
   if items.length > 0
     fname = yml_fname(klass)
     yml_fnames << fname

--- a/tools/fix_vm_relationships.rb
+++ b/tools/fix_vm_relationships.rb
@@ -5,7 +5,7 @@
 fixed_vms = []
 rels_to_delete = []
 
-Vm.all(:include => :all_relationships).each do |v|
+Vm.includes(:all_relationships).each do |v|
   begin
     v.parent_resource_pool
   rescue ActiveRecord::RecordNotFound => err

--- a/tools/kill_provision.rb
+++ b/tools/kill_provision.rb
@@ -16,10 +16,10 @@ provisions = args.collect { |a| a =~ /miq_provision_(\d*)/ ? $1.to_i : a.to_i }
 
 puts "Checking for provisions IDs:<#{provisions.inspect}>"
 provisions.each do |prov_id|
-  MiqQueue.find(:all, :conditions => {:method_name => 'do_post_provision', :class_name => 'MiqProvision', :instance_id => prov_id, :state => 'ready'}).each do |queue|
+  MiqQueue.where(:method_name => 'do_post_provision', :class_name => 'MiqProvision', :instance_id => prov_id, :state => 'ready').each do |queue|
     kill_provision_task(prov_id, queue)
   end
-  MiqQueue.find(:all, :conditions => {:task_id => "miq_provision_#{prov_id}", :state => 'ready'}).each do |queue|
+  MiqQueue.where(:task_id => "miq_provision_#{prov_id}", :state => 'ready').each do |queue|
     kill_provision_task(prov_id, queue)
   end
 end

--- a/tools/metrics_populate_retro_tags.rb
+++ b/tools/metrics_populate_retro_tags.rb
@@ -10,7 +10,7 @@ if klass == Vm
 else
   vm_ids = []
   meth = klass.instance_methods.collect(&:to_s).include?("all_vms") ? :all_vms : :vms
-  klass.find_all_by_id(ids).each do |obj|
+  klass.where(:id => ids).each do |obj|
     vm_ids += obj.send(meth).collect(&:id)
   end
 end
@@ -19,11 +19,9 @@ vm_ids.uniq!
 time_cond = {:timestamp => (start_ts.to_time.utc.beginning_of_day..end_ts.to_time.utc.end_of_day)}
 puts "Processing VM IDs: #{vm_ids.sort.inspect} for time range: #{time_cond.inspect}"
 
-vm_perf_recs = MetricRollup.all(
-  :conditions => time_cond.merge(:capture_interval_name => 'hourly', :resource_id => vm_ids),
-  :include    => {:vm => {:taggings => :tag}},
-  :select     => "id, resource_type, resource_id, resource_name, parent_host_id"
-)
+vm_perf_recs = MetricRollup.where(time_cond).where(:capture_interval_name => 'hourly', :resource_id => vm_ids)
+               .includes(:vm => {:taggings => :tag})
+               .select(:id, :resource_type, :resource_id, :resource_name, :parent_host_id)
 
 vm_perf_recs.group_by(&:resource_id).sort.each do |resource_id, perfs|
   puts "Updating tags in performance data for VM: ID: #{resource_id} => #{perfs.first.resource_name}"
@@ -34,12 +32,12 @@ vm_perf_recs.group_by(&:resource_id).sort.each do |resource_id, perfs|
 end
 
 host_ids = vm_perf_recs.collect(&:parent_host_id).compact.uniq
-Host.find_all_by_id(host_ids, :order => :id).each do |host|
+Host.where(:id => host_ids).order(:id).each do |host|
   puts "Updating performance breakdown by tags for VMs under Host: ID: #{host.id} => #{host.name}"
 
   host.preload_vim_performance_state_for_ts(time_cond)
-  perf_recs = host.metric_rollups.all(:conditions => time_cond.merge(:capture_interval_name => 'hourly'))
-  VimPerformanceTagValue.delete_all(:metric_type => "Host", :metric_id => perf_recs.collect(&:id))
+  perf_recs = host.metric_rollups.where(time_cond).where(:capture_interval_name => 'hourly')
+  VimPerformanceTagValue.where(:metric_type => "Host", :metric_id => perf_recs.collect(&:id)).delete_all
   perf_recs.each do |perf|
     perf.resource.target = host
     VimPerformanceTagValue.build_from_performance_record(perf)

--- a/tools/migrate_policies
+++ b/tools/migrate_policies
@@ -32,12 +32,12 @@ puts
 
 puts "[#{Time.now}] Removing previously migrated conditions..."
 guid_re = /^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/
-Condition.find(:all).each {|c| c.destroy unless (c.name =~ guid_re).nil?}
+Condition.all.each {|c| c.destroy unless (c.name =~ guid_re).nil?}
 puts "[#{Time.now}] Removing previously migrated conditions... Complete"
 puts
 
 puts "[#{Time.now}] Migrating policies..."
-Policy.find(:all).each do |p|
+Policy.all.each do |p|
   puts "[#{Time.now}] Create: MiqPolicy: [#{p.description}]"
   npolicy = MiqPolicy.create(clean_attrs(p.attributes))
   
@@ -80,7 +80,7 @@ puts "[#{Time.now}] Migrating policies... Complete"
 
 puts
 puts "[#{Time.now}] Migrating policy profiles and assignments..."
-PolicySet.find(:all).each do |ps|
+PolicySet.all.each do |ps|
   ps_attrs = ps.attributes
   ps_attrs.delete("name")
   puts "[#{Time.now}] Create: Profile:   [#{ps.description}]"

--- a/tools/purge_orphaned_tag_values.rb
+++ b/tools/purge_orphaned_tag_values.rb
@@ -22,8 +22,9 @@ log "Purging orphaned tag values..."
 # Determine all of the known metric ids in the tag values table
 log "Finding known metric ids..."
 perf_ids = Hash.new { |h, k| h[k] = [] }
+# TODO: there is probably a way to do this without bringing the ids back
 t = Benchmark.realtime do
-  VimPerformanceTagValue.all(:select => "DISTINCT metric_type, metric_id").each { |v| perf_ids[v.metric_type] << v.metric_id }
+  VimPerformanceTagValue.select("metric_type, metric_id").distinct.order(nil).each { |v| perf_ids[v.metric_type] << v.metric_id }
 end
 perf_ids_count = perf_ids.inject(0) { |sum, (_type, ids)| sum + ids.length }
 log "Finding known metric ids...Complete - #{formatter.number_with_delimiter(perf_ids_count)} records (#{t}s)"
@@ -36,7 +37,7 @@ if perf_ids_count > 0
   perf_ids.each do |type, ids|
     klass = type.constantize
     ids.each_slice(opts[:search_window]) do |ids_window|
-      found_ids = klass.all(:select => "id", :conditions => {:id => ids_window}).collect(&:id)
+      found_ids = klass.where(:id => ids_window).pluck(:id)
       deleted_ids[type] += (ids_window - found_ids)
       pbar.progress += ids_window.length
     end


### PR DESCRIPTION
The goal is to convert our legacy finders over to using associations

- introduce `aar_scope` to `ActAsActiveRecord`, so a model can implement that method instead of `find`.
- convert string arguments to just use hashes.
- use relation methods instead of `:conditions`

/cc @matthewd Yay (we need a rails 5 tag)
/cc @gtanzillo @jrafanie @Fryguy FYI