### PR TITLE
Fix refreshing page after deleting miq server

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -751,7 +751,7 @@ module OpsController::Diagnostics
   # Reload the selected node and redraw the screen via ajax
   def refresh_screen
     @explorer = true
-    if params[:pressed] == "delete_server"
+    if params[:pressed] == "delete_server" || params[:pressed] == "zone_delete_server"
       @sb[:diag_selected_id] = nil
       settings_build_tree
       diagnostics_build_tree


### PR DESCRIPTION
Configure->Configuration->Diagnostics->lead to any zone in tree
then in Roles by Servers tab click any server and click on Configured button and delete server and it caused error

![screen shot 2015-12-11 at 15 41 44](https://cloud.githubusercontent.com/assets/14937244/11746318/e01a130c-a01d-11e5-8bf8-947ab3814d0b.png)

