### PR TITLE
RSpec 3 - Misc spec conversion

### DIFF
--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -17,12 +17,16 @@ describe GenericMailer do
     expect(BinaryBlob.count).to eq(0)
     GenericMailer.deliver_queue(:generic_notification, @args)
     expect(BinaryBlob.count).to eq(1)
-    expect(MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier')).to be_truthy
+    expect(MiqQueue.exists?(:method_name => 'deliver',
+                            :class_name  => described_class,
+                            :role        => 'notifier')).to be_truthy
   end
 
   it "call deliver_queue for automation_notification" do
     GenericMailer.deliver_queue(:automation_notification, @args)
-    expect(MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier')).to be_truthy
+    expect(MiqQueue.exists?(:method_name => 'deliver',
+                            :class_name  => described_class,
+                            :role        => 'notifier')).to be_truthy
   end
 
   context "delivery error" do
@@ -188,7 +192,7 @@ describe GenericMailer do
     expect(mail.parts[0].mime_type).to eq("text/plain")
     expect(mail.parts[0].body).to match(/Do something on vm start policy/)
     expect(mail.parts[1].mime_type).to eq("text/html")
-    expect(mail.parts[1].body).to match(/<h3>[\s]*Alert Triggered[\s]*<\/h3>/)
+    expect(mail.parts[1].body).to match(%r{<h3>[\s]*Alert Triggered[\s]*</h3>})
   end
 
   describe "#test_mail" do

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -14,15 +14,15 @@ describe GenericMailer do
 
   it "call deliver_queue for generic_notification" do
     @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     GenericMailer.deliver_queue(:generic_notification, @args)
-    BinaryBlob.count.should == 1
-    MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier').should be_true
+    expect(BinaryBlob.count).to eq(1)
+    expect(MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier')).to be_truthy
   end
 
   it "call deliver_queue for automation_notification" do
     GenericMailer.deliver_queue(:automation_notification, @args)
-    MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier').should be_true
+    expect(MiqQueue.exists?(:method_name => 'deliver', :class_name => described_class, :role => 'notifier')).to be_truthy
   end
 
   context "delivery error" do
@@ -31,16 +31,16 @@ describe GenericMailer do
       # raises error when delivered
       msg = @args.merge(:to => 'me@bedrock.gov, you@bedrock.gov')
       notification = GenericMailer.generic_notification(msg)
-      notification.stub(:deliver_now).and_raise(Net::SMTPFatalError)
+      allow(notification).to receive(:deliver_now).and_raise(Net::SMTPFatalError)
 
       # send error msg first...
-      GenericMailer
-        .should_receive(:generic_notification)
+      expect(GenericMailer)
+        .to receive(:generic_notification)
         .and_return(notification)
 
       # ...after delegate to normal behaviour
-      GenericMailer
-        .should_receive(:generic_notification)
+      expect(GenericMailer)
+        .to receive(:generic_notification)
         .twice
         .and_call_original
 
@@ -48,9 +48,9 @@ describe GenericMailer do
       GenericMailer.deliver(:generic_notification)
 
       # ensure individual messages were sent
-      ActionMailer::Base.deliveries.size.should == 2
-      ActionMailer::Base.deliveries.first.to.should == ['me@bedrock.gov']
-      ActionMailer::Base.deliveries.last.to.should == ['you@bedrock.gov']
+      expect(ActionMailer::Base.deliveries.size).to eq(2)
+      expect(ActionMailer::Base.deliveries.first.to).to eq(['me@bedrock.gov'])
+      expect(ActionMailer::Base.deliveries.last.to).to eq(['you@bedrock.gov'])
     end
   end
 
@@ -58,23 +58,23 @@ describe GenericMailer do
     it "returns gracefully" do
       # generate message that will raise connection error when delivered
       notification = GenericMailer.generic_notification(@args)
-      notification.stub(:deliver_now).and_raise(Errno::ECONNREFUSED)
+      allow(notification).to receive(:deliver_now).and_raise(Errno::ECONNREFUSED)
 
       # generate error message on request
-      GenericMailer
-        .should_receive(:generic_notification)
+      expect(GenericMailer)
+        .to receive(:generic_notification)
         .and_return(notification)
 
       # send message
-      lambda do
+      expect do
         GenericMailer.deliver(:generic_notification)
-      end.should_not raise_error
+      end.not_to raise_error
     end
   end
 
   it "call deliver for generic_notification" do
     msg = GenericMailer.deliver(:generic_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
+    expect(ActionMailer::Base.deliveries).to eq([msg])
   end
 
   it "call deliver for generic_notification without a 'from' address" do
@@ -82,96 +82,96 @@ describe GenericMailer do
     new_args = @args.dup
     new_args.delete(:from)
     msg = GenericMailer.deliver(:generic_notification, new_args)
-    msg.from.should == ["test@123.com"]
+    expect(msg.from).to eq(["test@123.com"])
   end
 
   it "call deliver for automation_notification" do
     msg = GenericMailer.deliver(:automation_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
+    expect(ActionMailer::Base.deliveries).to eq([msg])
   end
 
   it "call deliver for automation_notification with attachment as BinaryBlob" do
     @args[:attachment] = [{:content_type => "application/txt", :filename => "generic_mailer_test.txt", :body => "automation_notification with attachment" * 2}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     @args[:attachment] = GenericMailer.attachment_to_blob(@args[:attachment])
-    BinaryBlob.count.should == 1
+    expect(BinaryBlob.count).to eq(1)
     msg = GenericMailer.deliver(:automation_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
-    BinaryBlob.count.should == 0
+    expect(ActionMailer::Base.deliveries).to eq([msg])
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call deliver for automation_notification, with attachment as BinaryBlob, and generate filenames" do
     @args[:attachment] = [{:content_type => "application/txt", :filename => nil, :body => "automation_notification with attachment" * 2}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     @args[:attachment] = GenericMailer.attachment_to_blob(@args[:attachment])
-    BinaryBlob.count.should == 1
+    expect(BinaryBlob.count).to eq(1)
     msg = GenericMailer.deliver(:automation_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
-    BinaryBlob.count.should == 0
+    expect(ActionMailer::Base.deliveries).to eq([msg])
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call blob_to_attachment and attachment_to_blob" do
     @args[:attachment] = [{:content_type => "application/txt", :filename => "generic_mailer_test.txt", :body => "maryhadalittlelamb" * 10}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     atob_attachment = GenericMailer.attachment_to_blob(@args[:attachment])
-    BinaryBlob.count.should == 1
+    expect(BinaryBlob.count).to eq(1)
     btoa_attachment = GenericMailer.blob_to_attachment(@args[:attachment])
-    btoa_attachment[0][:filename].should == "generic_mailer_test.txt"
-    @args[:attachment][0][:body].length.should == btoa_attachment[0][:body].length
-    BinaryBlob.count.should == 0
+    expect(btoa_attachment[0][:filename]).to eq("generic_mailer_test.txt")
+    expect(@args[:attachment][0][:body].length).to eq(btoa_attachment[0][:body].length)
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call blob_to_attachment and attachment_to_blob and generate attachment filenames" do
     @args[:attachment] = [{:content_type => "application/txt", :filename => nil, :body => "maryhadalittlelamb" * 10},
                           {:content_type => "application/txt", :filename => nil, :body => "itsfleecewaswhiteassnow" * 10}]
-    @args[:attachment][0][:filename].should be_nil
-    BinaryBlob.count.should == 0
+    expect(@args[:attachment][0][:filename]).to be_nil
+    expect(BinaryBlob.count).to eq(0)
     atob_attachment = GenericMailer.attachment_to_blob(@args[:attachment])
-    BinaryBlob.count.should == 2
+    expect(BinaryBlob.count).to eq(2)
     btoa_attachment = GenericMailer.blob_to_attachment(@args[:attachment])
-    btoa_attachment[0][:filename].should == "evm_attachment_1"
-    btoa_attachment[1][:filename].should == "evm_attachment_2"
-    @args[:attachment][0][:body].length.should == btoa_attachment[0][:body].length
-    BinaryBlob.count.should == 0
+    expect(btoa_attachment[0][:filename]).to eq("evm_attachment_1")
+    expect(btoa_attachment[1][:filename]).to eq("evm_attachment_2")
+    expect(@args[:attachment][0][:body].length).to eq(btoa_attachment[0][:body].length)
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call blob_to_attachment and attachment_to_blob and do not generate attachment filenames" do
     @args[:attachment] = [{:content_type => "application/txt", :filename => "maryhadalittlelamb.txt", :body => "maryhadalittlelamb" * 10},
                           {:content_type => "application/txt", :filename => "itsfleecewaswhiteassnow.txt", :body => "itsfleecewaswhiteassnow" * 10}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     atob_attachment = GenericMailer.attachment_to_blob(@args[:attachment])
-    BinaryBlob.count.should == 2
+    expect(BinaryBlob.count).to eq(2)
     btoa_attachment = GenericMailer.blob_to_attachment(@args[:attachment])
-    btoa_attachment[0][:filename].should == "maryhadalittlelamb.txt"
-    btoa_attachment[1][:filename].should == "itsfleecewaswhiteassnow.txt"
-    @args[:attachment][0][:body].length.should == btoa_attachment[0][:body].length
-    BinaryBlob.count.should == 0
+    expect(btoa_attachment[0][:filename]).to eq("maryhadalittlelamb.txt")
+    expect(btoa_attachment[1][:filename]).to eq("itsfleecewaswhiteassnow.txt")
+    expect(@args[:attachment][0][:body].length).to eq(btoa_attachment[0][:body].length)
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call deliver for generic_notification with text/plain attachment" do
     @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
-    BinaryBlob.count.should == 0
+    expect(BinaryBlob.count).to eq(0)
     msg = GenericMailer.deliver(:generic_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
-    BinaryBlob.count.should == 0
+    expect(ActionMailer::Base.deliveries).to eq([msg])
+    expect(BinaryBlob.count).to eq(0)
   end
 
   it "call deliver for generic_notification with text/html attachment" do
     @args[:attachment] = [{:content_type => "text/html", :filename => "generic_mailer_test.txt", :body => "generic_notification" * 10}]
     msg = GenericMailer.deliver(:generic_notification, @args)
-    ActionMailer::Base.deliveries.should == [msg]
+    expect(ActionMailer::Base.deliveries).to eq([msg])
   end
 
   it "call automation_notification directly" do
     @args[:attachment] = [{:content_type => "text/plain", :filename => "automation_filename.txt", :body => "automation_notification" * 10}]
-    GenericMailer.automation_notification(@args).message.should be_kind_of(Mail::Message)
-    ActionMailer::Base.deliveries.should be_empty
+    expect(GenericMailer.automation_notification(@args).message).to be_kind_of(Mail::Message)
+    expect(ActionMailer::Base.deliveries).to be_empty
   end
 
   it "call generic_notification directly" do
     @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_filename.txt", :body => "generic_notification" * 10}]
-    GenericMailer.generic_notification(@args).message.should be_kind_of(Mail::Message)
-    ActionMailer::Base.deliveries.should be_empty
+    expect(GenericMailer.generic_notification(@args).message).to be_kind_of(Mail::Message)
+    expect(ActionMailer::Base.deliveries).to be_empty
   end
 
   it "policy_action_email" do
@@ -183,24 +183,24 @@ describe GenericMailer do
       :entity_name       => "My Vm"
     }
     mail = GenericMailer.policy_action_email(@args)
-    mail.parts.length.should == 2
-    mail.mime_type.should == "multipart/alternative"
-    mail.parts[0].mime_type.should == "text/plain"
-    mail.parts[0].body.should =~ /Do something on vm start policy/
-    mail.parts[1].mime_type.should == "text/html"
-    mail.parts[1].body.should =~ /<h3>[\s]*Alert Triggered[\s]*<\/h3>/
+    expect(mail.parts.length).to eq(2)
+    expect(mail.mime_type).to eq("multipart/alternative")
+    expect(mail.parts[0].mime_type).to eq("text/plain")
+    expect(mail.parts[0].body).to match(/Do something on vm start policy/)
+    expect(mail.parts[1].mime_type).to eq("text/html")
+    expect(mail.parts[1].body).to match(/<h3>[\s]*Alert Triggered[\s]*<\/h3>/)
   end
 
   describe "#test_mail" do
     it "should be called directly" do
       mail = GenericMailer.test_email(@args[:to], settings = {})
-      mail.subject.should start_with I18n.t("product.name")
+      expect(mail.subject).to start_with I18n.t("product.name")
     end
 
     it "should not change the input parameters" do
       settings = {:host => "localhost"}
       GenericMailer.test_email(@args[:to], settings)
-      settings[:host].should == "localhost"
+      expect(settings[:host]).to eq("localhost")
     end
   end
 end

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -11,28 +11,28 @@ describe ExplorerPresenter do
     context "#replace_partial" do
       it 'returns proper JS' do
         js_str = @presenter.replace_partial(@el, @content)
-        js_str.should == "$('##{@el}').replaceWith('#{escape_javascript(@content)}');"
+        expect(js_str).to eq("$('##{@el}').replaceWith('#{escape_javascript(@content)}');")
       end
     end
 
     context "#update_partial" do
       it 'returns proper JS' do
         js_str = @presenter.update_partial(@el, @content)
-        js_str.should == "$('##{@el}').html('#{escape_javascript(@content)}');"
+        expect(js_str).to eq("$('##{@el}').html('#{escape_javascript(@content)}');")
       end
     end
 
     context "#set_or_undef" do
       it 'return proper JS for nil' do
         js_str = @presenter.set_or_undef("var1")
-        js_str.should == 'ManageIQ.record.var1 = null;'
+        expect(js_str).to eq('ManageIQ.record.var1 = null;')
       end
 
       it 'return proper JS for a random value' do
         random_value = 'xxx' + rand(10).to_s
         @presenter['var2'] = random_value
         js_str = @presenter.set_or_undef("var2")
-        js_str.should == "ManageIQ.record.var2 = '#{random_value}';"
+        expect(js_str).to eq("ManageIQ.record.var2 = '#{random_value}';")
       end
     end
 
@@ -43,7 +43,7 @@ describe ExplorerPresenter do
           :action     => 'bar',
           :record_id  => 42,
         )
-        js_str.should == "miqAsyncAjax('/foo/bar/42');"
+        expect(js_str).to eq("miqAsyncAjax('/foo/bar/42');")
       end
     end
 

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -15,13 +15,13 @@ describe TreeBuilderAeClass do
       @sb[:cached_waypoint_ids] =  MiqAeClass.waypoint_ids_for_state_machines
       tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
       domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
-      domains.should match_array ['LUIGI']
+      expect(domains).to match_array ['LUIGI']
     end
 
     it "a tree without filter" do
       tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
       domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
-      domains.should match_array %w(LUIGI MARIO)
+      expect(domains).to match_array %w(LUIGI MARIO)
     end
   end
 
@@ -38,8 +38,8 @@ describe TreeBuilderAeClass do
     it "should only return domains in a user's current tenant" do
       tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
       domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
-      domains.should match_array %w(test1)
-      domains.should_not include %w(test2)
+      expect(domains).to match_array %w(test1)
+      expect(domains).not_to include %w(test2)
     end
   end
 
@@ -55,7 +55,7 @@ describe TreeBuilderAeClass do
     it "should return domains in correct order" do
       tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
       domains = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
-      domains.should eq(%w(test2 test1))
+      expect(domains).to eq(%w(test2 test1))
     end
   end
 end

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -22,7 +22,7 @@ describe TreeBuilderAeCustomization  do
     end
 
     it "stores values into the sandbox" do
-      sandbox[:trees][:dialog_import_export_tree].should == expected_sandbox_values
+      expect(sandbox[:trees][:dialog_import_export_tree]).to eq(expected_sandbox_values)
     end
   end
 end

--- a/spec/presenters/tree_builder_chargeback_assignments.rb
+++ b/spec/presenters/tree_builder_chargeback_assignments.rb
@@ -8,9 +8,9 @@ describe TreeBuilderChargebackAssignments do
       titles = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['title'] }
       rates = ChargebackRate.all
 
-      rates.should be_empty
-      keys.should match_array %w(xx-Compute xx-Storage)
-      titles.should match_array %w(Compute Storage)
+      expect(rates).to be_empty
+      expect(keys).to match_array %w(xx-Compute xx-Storage)
+      expect(titles).to match_array %w(Compute Storage)
     end
   end
 end

--- a/spec/presenters/tree_builder_chargeback_rates_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_rates_spec.rb
@@ -8,9 +8,9 @@ describe TreeBuilderChargebackRates do
       titles = JSON.parse(tree.tree_nodes).first['children'].collect { |x| x['title'] }
       rates = ChargebackRate.all
 
-      rates.should be_empty
-      keys.should match_array %w(xx-Compute xx-Storage)
-      titles.should match_array %w(Compute Storage)
+      expect(rates).to be_empty
+      expect(keys).to match_array %w(xx-Compute xx-Storage)
+      expect(titles).to match_array %w(Compute Storage)
     end
   end
 end

--- a/spec/presenters/tree_builder_report_roles_spec.rb
+++ b/spec/presenters/tree_builder_report_roles_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderReportRoles do
     it "gets roles/group for the specified user" do
       tree = TreeBuilderReportRoles.new("roles_tree", "roles", {})
       roles = JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
-      roles.should eq([@group.description])
+      expect(roles).to eq([@group.description])
     end
   end
 end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -4,15 +4,15 @@ describe TreeBuilder do
   context "initialize" do
     it "initializes a tree" do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
-      tree.should be_a_kind_of(TreeBuilder)
-      tree.name.should == :cb_rates_tree
+      expect(tree).to be_a_kind_of(TreeBuilder)
+      expect(tree.name).to eq(:cb_rates_tree)
     end
 
     it "sets sandbox hash that can be accessed by other methods in the class" do
       sb = {}
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", sb)
-      tree.should be_a_kind_of(TreeBuilder)
-      tree.name.should == :cb_rates_tree
+      expect(tree).to be_a_kind_of(TreeBuilder)
+      expect(tree.name).to eq(:cb_rates_tree)
       sb.key?(:trees)
       sb[:trees].key?(:cb_rates_tree)
     end
@@ -22,9 +22,9 @@ describe TreeBuilder do
     it "sets title and tooltip for the passed in root node" do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
       title, tooltip, icon = tree.root_options
-      title.should == "Rates"
-      tooltip.should == "Rates"
-      icon.should be_nil
+      expect(title).to eq("Rates")
+      expect(tooltip).to eq("Rates")
+      expect(icon).to be_nil
     end
   end
 
@@ -48,7 +48,7 @@ describe TreeBuilder do
                 :icon     => "folder.png"
               }]
       tree.locals_for_render.key?(:json_tree)
-      tree.locals_for_render[:json_tree].should == nodes.to_json
+      expect(tree.locals_for_render[:json_tree]).to eq(nodes.to_json)
     end
   end
 
@@ -57,7 +57,7 @@ describe TreeBuilder do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
 
       active_node = 'foobar'
-      TreeState.any_instance.stub(:x_node).and_return(active_node)
+      allow_any_instance_of(TreeState).to receive(:x_node).and_return(active_node)
 
       expect(tree.locals_for_render[:select_node]).to eq(active_node)
     end

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -5,19 +5,19 @@ describe TreeNodeBuilder do
     it 'ExtManagementSystem node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       node = TreeNodeBuilder.build(mgmt_system, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'AvailabilityZone node' do
       zone = FactoryGirl.build(:availability_zone_amazon)
       node = TreeNodeBuilder.build(zone, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'ChargebackRate node' do
       rate = FactoryGirl.create(:chargeback_rate)
       node = TreeNodeBuilder.build(rate, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'CustomButton node' do
@@ -26,108 +26,108 @@ describe TreeNodeBuilder do
                                  :applies_to_id    => nil,
                                 )
       node = TreeNodeBuilder.build(button, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'CustomButtonSet node' do
       button_set = FactoryGirl.build(:custom_button_set)
       node = TreeNodeBuilder.build(button_set, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'CustomizationTemplate node' do
       template = FactoryGirl.build(:customization_template)
       node = TreeNodeBuilder.build(template, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'Dialog node' do
       dialog = FactoryGirl.build(:dialog, :label => 'How much wood would a woodchuck chuck if a woodchuck would chuck wood?')
       node = TreeNodeBuilder.build(dialog, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'DialogTab node' do
       tab = FactoryGirl.create(:dialog_tab, :label => '<script>alert("Hacked!");</script>')
       node = TreeNodeBuilder.build(tab, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'DialogGroup node' do
       group = FactoryGirl.create(:dialog_group, :label => '&nbsp;foobar&gt;')
       node = TreeNodeBuilder.build(group, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'DialogField node' do
       field = FactoryGirl.build(:dialog_field, :name => 'random field name')
       node = TreeNodeBuilder.build(field, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'EmsFolder node' do
       folder = FactoryGirl.build(:ems_folder)
       node = TreeNodeBuilder.build(folder, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'valid EmsCluster node' do
       cluster = FactoryGirl.create(:ems_cluster, :name => "My Cluster")
       node = TreeNodeBuilder.build(cluster, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
 
-      node[:key].should eq("c-#{MiqRegion.compress_id(cluster.id)}")
-      node[:title].should eq(cluster.name)
-      node[:icon].should eq("cluster.png")
-      node[:tooltip].should eq("Cluster / Deployment Role: #{cluster.name}")
+      expect(node[:key]).to eq("c-#{MiqRegion.compress_id(cluster.id)}")
+      expect(node[:title]).to eq(cluster.name)
+      expect(node[:icon]).to eq("cluster.png")
+      expect(node[:tooltip]).to eq("Cluster / Deployment Role: #{cluster.name}")
     end
 
     it 'valid Host Node' do
       host = FactoryGirl.create(:host, :name => "My Host")
       node = TreeNodeBuilder.build(host, nil, {})
 
-      node[:key].should eq("h-#{MiqRegion.compress_id(host.id)}")
-      node[:title].should eq(host.name)
-      node[:icon].should eq("host.png")
-      node[:tooltip].should eq("Host / Node: #{host.name}")
+      expect(node[:key]).to eq("h-#{MiqRegion.compress_id(host.id)}")
+      expect(node[:title]).to eq(host.name)
+      expect(node[:icon]).to eq("host.png")
+      expect(node[:tooltip]).to eq("Host / Node: #{host.name}")
     end
 
     it 'IsoDatastore node' do
       mgmt_system = FactoryGirl.build(:ems_redhat)
       datastore = FactoryGirl.build(:iso_datastore, :ext_management_system => mgmt_system)
       node = TreeNodeBuilder.build(datastore, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'IsoImage node' do
       image = FactoryGirl.create(:iso_image)
       node = TreeNodeBuilder.build(image, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'ResourcePool node' do
       pool = FactoryGirl.build(:resource_pool)
       node = TreeNodeBuilder.build(pool, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'Vm node' do
       vm = FactoryGirl.build(:vm_amazon)
       node = TreeNodeBuilder.build(vm, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAeClass node' do
       namespace = FactoryGirl.build(:miq_ae_namespace)
       aclass = FactoryGirl.build(:miq_ae_class, :namespace_id => namespace.id)
       node = TreeNodeBuilder.build(aclass, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAeInstance node' do
       instance = FactoryGirl.build(:miq_ae_instance)
       node = TreeNodeBuilder.build(instance, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAeNamespace node' do
@@ -135,209 +135,209 @@ describe TreeNodeBuilder do
 
       namespace = FactoryGirl.build(:miq_ae_namespace)
       node = TreeNodeBuilder.build(namespace, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAlertSet node' do
       set = FactoryGirl.build(:miq_alert_set)
       node = TreeNodeBuilder.build(set, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqReport node' do
       report = FactoryGirl.build(:miq_report)
       node = TreeNodeBuilder.build(report, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqReportResult node' do
       report_result = FactoryGirl.create(:miq_report_result)
       node = TreeNodeBuilder.build(report_result, nil, {})
-      node.should_not be_nil
-      node[:icon].should == "report_result.png"
+      expect(node).not_to be_nil
+      expect(node[:icon]).to eq("report_result.png")
     end
 
     it 'MiqSchedule node' do
       zone   = FactoryGirl.build(:zone)
       server = FactoryGirl.build(:miq_server, :zone => zone)
-      MiqServer.stub(:my_server).and_return(server)
+      allow(MiqServer).to receive(:my_server).and_return(server)
       schedule = FactoryGirl.build(:miq_schedule)
       node = TreeNodeBuilder.build(schedule, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqServer node' do
       zone   = FactoryGirl.build(:zone)
       server = FactoryGirl.build(:miq_server, :zone => zone)
       node = TreeNodeBuilder.build(server, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqTemplate node' do
       template = FactoryGirl.build(:miq_template, :name => "template", :location => "abc/abc.vmtx", :template => true, :vendor => "vmware")
       node = TreeNodeBuilder.build(template, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAlert node' do
       alert = FactoryGirl.build(:miq_alert)
       node = TreeNodeBuilder.build(alert, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqAction node' do
       action = FactoryGirl.build(:miq_action, :name => "raise_automation_event")
       node = TreeNodeBuilder.build(action, nil, :tree => :action_tree)
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqEventDefinition node' do
       event = FactoryGirl.build(:miq_event_definition)
       node = TreeNodeBuilder.build(event, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqGroup node' do
       group = FactoryGirl.build(:miq_group)
       node = TreeNodeBuilder.build(group, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqPolicy node' do
       policy = FactoryGirl.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control')
       node = TreeNodeBuilder.build(policy, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqPolicySet node' do
       policy_set = FactoryGirl.build(:miq_policy_set, :name => 'Just a set')
       node = TreeNodeBuilder.build(policy_set, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqUserRole node' do
       role = FactoryGirl.build(:miq_user_role)
       node = TreeNodeBuilder.build(role, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
     it 'PxeImage node' do
       image = FactoryGirl.build(:pxe_image)
       node = TreeNodeBuilder.build(image, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'WindowsImage node' do
       image = FactoryGirl.build(:windows_image)
       node = TreeNodeBuilder.build(image, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'PxeImageType node' do
       image_type = FactoryGirl.create(:pxe_image_type)
       node = TreeNodeBuilder.build(image_type, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'PxeServer node' do
       server = FactoryGirl.build(:pxe_server)
       node = TreeNodeBuilder.build(server, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'Service node' do
       service = FactoryGirl.create(:service)
       node = TreeNodeBuilder.build(service, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'ServiceResource node' do
       resource = FactoryGirl.create(:service_resource)
       node = TreeNodeBuilder.build(resource, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'ServiceTemplate node' do
       template = FactoryGirl.build(:service_template, :name => 'test template')
       node = TreeNodeBuilder.build(template, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'ServiceTemplateCatalog node' do
       catalog = FactoryGirl.build(:service_template_catalog)
       node = TreeNodeBuilder.build(catalog, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'Storage node' do
       storage = FactoryGirl.build(:storage)
       node = TreeNodeBuilder.build(storage, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'User node' do
       user = FactoryGirl.build(:user)
       node = TreeNodeBuilder.build(user, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqDialog node' do
       dialog = FactoryGirl.build(:miq_dialog)
       node = TreeNodeBuilder.build(dialog, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqRegion node' do
       region = FactoryGirl.build(:miq_region, :description => 'Elbonia')
       node = TreeNodeBuilder.build(region, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqWidget node' do
       widget = FactoryGirl.build(:miq_widget)
       node = TreeNodeBuilder.build(widget, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'MiqWidgetSet node' do
       widget_set = FactoryGirl.build(:miq_widget_set)
       node = TreeNodeBuilder.build(widget_set, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'VmdbTableEvm node' do
       table = FactoryGirl.build(:vmdb_table_evm, :name => 'a table')
       node = TreeNodeBuilder.build(table, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'VmdbIndex node' do
       index = FactoryGirl.create(:vmdb_index)
       node = TreeNodeBuilder.build(index, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it 'Zone node' do
       zone = FactoryGirl.build(:zone)
       node = TreeNodeBuilder.build(zone, nil, {})
-      node.should_not be_nil
+      expect(node).not_to be_nil
     end
 
     it "expand attribute of node should be set to true when open_all is true and expand is nil in options" do
       tenant = FactoryGirl.build(:tenant)
       node = TreeNodeBuilder.build(tenant, "root", :expand => nil, :open_all => true)
-      node[:expand].should eq(true)
+      expect(node[:expand]).to eq(true)
     end
 
     it "expand attribute of node should be set to nil when open_all is true and expand is set to false in options" do
       tenant = FactoryGirl.build(:tenant)
       node = TreeNodeBuilder.build(tenant, "root", :expand => false, :open_all => true)
-      node[:expand].should eq(nil)
+      expect(node[:expand]).to eq(nil)
     end
 
     it "expand attribute of node should be set to true when open_all and expand are true in options" do
       tenant = FactoryGirl.build(:tenant)
       node = TreeNodeBuilder.build(tenant, "root", :expand => true, :open_all => true)
-      node[:expand].should eq(true)
+      expect(node[:expand]).to eq(true)
     end
   end
 
@@ -350,7 +350,7 @@ describe TreeNodeBuilder do
                                   :name    => "test1",
                                   :enabled => false)
       node = TreeNodeBuilder.build(domain, nil, {})
-      node[:title].should eq('test1 (Disabled)')
+      expect(node[:title]).to eq('test1 (Disabled)')
     end
 
     it "should return node text with Locked in the text for Locked domain" do
@@ -358,7 +358,7 @@ describe TreeNodeBuilder do
                                   :name   => "test1",
                                   :system => true)
       node = TreeNodeBuilder.build(domain, nil, {})
-      node[:title].should eq('test1 (Locked)')
+      expect(node[:title]).to eq('test1 (Locked)')
     end
 
     it "should return node text with Locked & Disabled in the text for Locked & Disabled domain" do
@@ -367,13 +367,13 @@ describe TreeNodeBuilder do
                                   :enabled => false,
                                   :system  => true)
       node = TreeNodeBuilder.build(domain, nil, {})
-      node[:title].should eq('test1 (Locked & Disabled)')
+      expect(node[:title]).to eq('test1 (Locked & Disabled)')
     end
 
     it "should return node text with no suffix when Domain is not Locked or Disabled" do
       domain = FactoryGirl.create(:miq_ae_domain, :name => "test1")
       node = TreeNodeBuilder.build(domain, nil, {})
-      node[:title].should eq('test1')
+      expect(node[:title]).to eq('test1')
     end
   end
 end

--- a/spec/replication/evm_dbsync_spec.rb
+++ b/spec/replication/evm_dbsync_spec.rb
@@ -87,15 +87,15 @@ describe "evm:dbsync" do
   end
 
   def assert_replication_enabled
-    @slave_connection.tables.should include "#{@rr_prefix}_pending_changes"
-    @slave_connection.tables.should include "#{@rr_prefix}_sync_state"
-    @slave_connection.tables.should include "#{@rr_prefix}_logged_events"
+    expect(@slave_connection.tables).to include "#{@rr_prefix}_pending_changes"
+    expect(@slave_connection.tables).to include "#{@rr_prefix}_sync_state"
+    expect(@slave_connection.tables).to include "#{@rr_prefix}_logged_events"
 
     # TODO: assert sync_state content
   end
 
   def assert_initial_replicated_records
-    pending "Before cb47c448822, the assertions below weren't running since we weren't populating the initial records.  Now, they fail sporadically."
+    skip "Before cb47c448822, the assertions below weren't running since we weren't populating the initial records.  Now, they fail sporadically."
 
     excluded_tables = @replication_config[:exclude_tables].join("|")
     excluded_tables = "^(#{excluded_tables})$"
@@ -107,7 +107,7 @@ describe "evm:dbsync" do
 
       expected = (t =~ excluded_tables_regex ? 0 : row_count(@slave_connection, t))
       got      = row_count(@master_connection, t)
-      got.should eq(expected), "on table: #{t}\nexpected: #{expected}\n     got: #{got} (using ==)"
+      expect(got).to eq(expected), "on table: #{t}\nexpected: #{expected}\n     got: #{got} (using ==)"
     end
   end
 

--- a/spec/replication/evm_dbsync_spec.rb
+++ b/spec/replication/evm_dbsync_spec.rb
@@ -95,7 +95,8 @@ describe "evm:dbsync" do
   end
 
   def assert_initial_replicated_records
-    skip "Before cb47c448822, the assertions below weren't running since we weren't populating the initial records.  Now, they fail sporadically."
+    skip "Before cb47c448822, the assertions below weren't running since we weren't populating the initial records. " \
+         "Now, they fail sporadically."
 
     excluded_tables = @replication_config[:exclude_tables].join("|")
     excluded_tables = "^(#{excluded_tables})$"

--- a/spec/task_helpers/dialog_exporter_spec.rb
+++ b/spec/task_helpers/dialog_exporter_spec.rb
@@ -9,18 +9,18 @@ describe TaskHelpers::DialogExporter do
     let(:filename) { "filename" }
 
     before do
-      File.stub(:write)
-      dialog_yaml_serializer.stub(:serialize).and_return("dialog_yaml")
-      Dialog.stub(:all).and_return(["all the dialogs"])
+      allow(File).to receive(:write)
+      allow(dialog_yaml_serializer).to receive(:serialize).and_return("dialog_yaml")
+      allow(Dialog).to receive(:all).and_return(["all the dialogs"])
     end
 
     it "exports the dialog yaml to the filename" do
-      dialog_yaml_serializer.should_receive(:serialize).with(["all the dialogs"])
+      expect(dialog_yaml_serializer).to receive(:serialize).with(["all the dialogs"])
       dialog_exporter.export(filename)
     end
 
     it "writes the serialized yaml to the file" do
-      File.should_receive(:write).with(filename, "dialog_yaml")
+      expect(File).to receive(:write).with(filename, "dialog_yaml")
       dialog_exporter.export(filename)
     end
   end

--- a/spec/task_helpers/dialog_import_helper_spec.rb
+++ b/spec/task_helpers/dialog_import_helper_spec.rb
@@ -8,18 +8,18 @@ describe TaskHelpers::DialogImportHelper do
     let(:filename) { "filename" }
 
     before do
-      $log.stub(:info)
-      Kernel.stub(:puts)
+      allow($log).to receive(:info)
+      allow(Kernel).to receive(:puts)
     end
 
     it "logs a message for yielded results" do
-      dialog_import_service.stub(:import_from_file).with(filename).and_yield("label" => "label")
-      $log.should_receive(:info).with("Skipping importing of dialog with label label as it already exists")
+      allow(dialog_import_service).to receive(:import_from_file).with(filename).and_yield("label" => "label")
+      expect($log).to receive(:info).with("Skipping importing of dialog with label label as it already exists")
       dialog_import_helper.import(filename)
     end
 
     it "delegates to the dialog_import_service" do
-      dialog_import_service.should_receive(:import_from_file).with(filename).and_yield("label" => "label")
+      expect(dialog_import_service).to receive(:import_from_file).with(filename).and_yield("label" => "label")
       dialog_import_helper.import(filename)
     end
   end


### PR DESCRIPTION
Converts some smaller specs areas to the RSpec 3 `expect` syntax.

Includes:
* replication specs
* mailer specs
* presenter specs
* task_helper specs