### PR TITLE
Fix for BZ1282949 - Service dialog Tag Control elements do not render when service is ordered

### DIFF
--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -49,6 +49,10 @@
                        options_for_select(category_tags, wf.value(field.name)),
                        drop_down_options(field, url).merge(:multiple => true))
 
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('#{field.name}', '#{url}');
+
       - else
         - value = wf.value(field.name) || ''
         - classification_ids = value.split(',')


### PR DESCRIPTION
Enable selectpicker javascript for tag control dialog fields

https://bugzilla.redhat.com/show_bug.cgi?id=1282949

@dclarizio Please Review