### PR TITLE
Container Topology - remove hardcoded image paths from JS

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -79,9 +79,7 @@ angular.module('topologyApp', ['kubernetesUI','ui.bootstrap'])
         added.append("title");
         added.on("dblclick", function(d) {return dblclick(d)});
         added.append("image")
-            .attr("xlink:href",function(d) {
-                return "/images/icons/new/" + class_name(d) + ".png";
-            })
+            .attr("xlink:href", function(d) { return d.item.icon; })
             .attr("y", function(d) { return getDimensions(d).y})
             .attr("x", function(d) { return getDimensions(d).x})
             .attr("height", function(d) { return getDimensions(d).height})
@@ -178,4 +176,4 @@ angular.module('topologyApp', ['kubernetesUI','ui.bootstrap'])
 
     }
 
-    }]);
+}]);

--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -1,168 +1,215 @@
-angular.module('topologyApp', ['kubernetesUI','ui.bootstrap'])
+angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
 .config(['$httpProvider', function($httpProvider) {
-    $httpProvider.defaults.headers.common['X-CSRF-Token'] = jQuery('meta[name=csrf-token]').attr('content');
+  $httpProvider.defaults.headers.common['X-CSRF-Token'] = jQuery('meta[name=csrf-token]').attr('content');
 }])
-.controller('containerTopologyController', ['$scope', '$http', '$interval', "$location",  function($scope, $http, $interval, $location) {
-    $scope.vs = null;
-    $scope.refresh = function() {
-        var id;
-        if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
-            id = '';
-        }
-        else {
-            id = '/'+ (/container_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
-        }
-        var currentSelectedKinds = $scope.kinds;
-        var url = '/container_topology/data'+id;
-        $http.get(url).success(function(data) {
-            $scope.items = data.data.items;
-            $scope.relations = data.data.relations;
-            $scope.kinds = data.data.kinds;
-            if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length !=  Object.keys($scope.kinds).length)) {
-                $scope.kinds = currentSelectedKinds;
-            }
-        });
+.controller('containerTopologyController', ['$scope', '$http', '$interval', "$location", function($scope, $http, $interval, $location) {
+  $scope.vs = null;
 
-    };
+  $scope.refresh = function() {
+    var id;
+    if ($location.absUrl().match("show/$") || $location.absUrl().match("show$")) {
+      id = '';
+    } else {
+      id = '/'+ (/container_topology\/show\/(\d+)/.exec($location.absUrl())[1]);
+    }
 
-    $scope.checkboxModel = {
-        value : false
-    };
-    $scope.legendTooltip = "Click here to show/hide entities of this type";
+    var currentSelectedKinds = $scope.kinds;
+    var url = '/container_topology/data'+id;
 
-    $scope.show_hide_names = function() {
-       var vertices = $scope.vs;
+    $http.get(url).success(function(data) {
+      $scope.items = data.data.items;
+      $scope.relations = data.data.relations;
+      $scope.kinds = data.data.kinds;
 
-       if($scope.checkboxModel.value) {
-            vertices.selectAll("text")
-               .style("display", "block");
-       }
-       else {
-           vertices.selectAll("text")
-              .style("display", "none");
-       }
-    };
+      if (currentSelectedKinds && (Object.keys(currentSelectedKinds).length != Object.keys($scope.kinds).length)) {
+        $scope.kinds = currentSelectedKinds;
+      }
+    });
+  };
 
-    $scope.refresh();
-    var promise = $interval( $scope.refresh, 1000*60*3);
+  $scope.checkboxModel = {
+    value: false
+  };
+  $scope.legendTooltip = "Click here to show/hide entities of this type";
 
-    $scope.$on('$destroy', function() {
-        $interval.cancel(promise);
+  $scope.show_hide_names = function() {
+     var vertices = $scope.vs;
+
+     if ($scope.checkboxModel.value) {
+       vertices.selectAll("text")
+         .style("display", "block");
+     } else {
+       vertices.selectAll("text")
+         .style("display", "none");
+     }
+  };
+
+  $scope.refresh();
+  var promise = $interval($scope.refresh, 1000 * 60 * 3);
+
+  $scope.$on('$destroy', function() {
+    $interval.cancel(promise);
+  });
+
+  $scope.$on("render", function(ev, vertices, added) {
+    /*
+     * We are passed two selections of <g> elements:
+     * vertices: All the elements
+     * added: Just the ones that were added
+     */
+
+    added.attr("class", function(d) {
+      return d.item.kind;
     });
 
-    $scope.$on("render", function(ev, vertices, added) {
-        /*
-         * We are passed two selections of <g> elements:
-         * vertices: All the elements
-         * added: Just the ones that were added
-         */
-        added.attr("class", function(d) { return d.item.kind; });
-        added.append("circle").attr("r", function(d) { return getDimensions(d).r}).style("stroke", function(d) {
-            switch (d.item.status) {
-                case "OK":
-                case "On":
-                case "Ready":
-                case "Running":
-                case "Succeeded":
-                    return "#3F9C35";
-                case "NotReady":
-                case "Failed":
-                    return "#CC0000";
-                case 'Warning':
-                case 'Waiting':
-                case 'Pending':
-                    return "#EC7A08";
-                case 'Unknown':
-                case 'Terminated':
-                    return "#bbb";
-            }});
-        added.append("title");
-        added.on("dblclick", function(d) {return dblclick(d)});
-        added.append("image")
-            .attr("xlink:href", function(d) { return d.item.icon; })
-            .attr("y", function(d) { return getDimensions(d).y})
-            .attr("x", function(d) { return getDimensions(d).x})
-            .attr("height", function(d) { return getDimensions(d).height})
-            .attr("width", function(d) { return getDimensions(d).width});
-        added.append("text")
-            .attr("x", 26)
-            .attr("y", 24)
-            .text(function(d) { return d.item.name }).style("font-size", function(d) {return "12px"}).style("fill", function(d) {return "black"})
-            .style("display", function(d) {if ($scope.checkboxModel.value) {return "block"} else {return "none"}});
+    added.append("circle")
+      .attr("r", function(d) {
+        return getDimensions(d).r;
+      })
+      .style("stroke", function(d) {
+        switch (d.item.status) {
+          case "OK":
+          case "On":
+          case "Ready":
+          case "Running":
+          case "Succeeded":
+            return "#3F9C35";
+          case "NotReady":
+          case "Failed":
+            return "#CC0000";
+          case 'Warning':
+          case 'Waiting':
+          case 'Pending':
+            return "#EC7A08";
+          case 'Unknown':
+          case 'Terminated':
+            return "#bbb";
+        }
+      });
 
-        added.selectAll("title").text(function(d) {
-            var status = "Name: " + d.item.name + "\nType: " + d.item.kind + "\nStatus: " + d.item.status;
-            if (d.item.kind == 'Host' || d.item.kind == 'VM') {
-                    status += "\nProvider: " + d.item.provider;
-            }
-            return status;
-        });
-        $scope.vs = vertices;
+    added.append("title");
 
-        /* Don't do default rendering */
-        ev.preventDefault();
+    added.on("dblclick", function(d) {
+      return dblclick(d);
     });
 
-    function class_name(d) {
-        switch (d.item.kind) {
-            case "Service":
-            case "Route":
-            case "Node":
-            case "Replicator":
-                return "container_" + d.item.kind.toLowerCase();
+    added.append("image")
+      .attr("xlink:href", function(d) {
+        return d.item.icon;
+      })
+      .attr("y", function(d) {
+        return getDimensions(d).y;
+      })
+      .attr("x", function(d) {
+        return getDimensions(d).x;
+      })
+      .attr("height", function(d) {
+        return getDimensions(d).height;
+      })
+      .attr("width", function(d) {
+        return getDimensions(d).width;
+      });
 
-            case "VM":
-            case "Host":
-            case "Container":
-                return d.item.kind.toLowerCase();
-
-            case "Pod":
-                return "container_group";
-
-            case "Kubernetes":
-            case "Openshift":
-            case "Atomic":
-            case "OpenshiftEnterprise":
-            case "AtomicEnterprise":
-                return "vendor-" + _.snakeCase(d.item.kind);
+    added.append("text")
+      .attr("x", 26)
+      .attr("y", 24)
+      .text(function(d) {
+        return d.item.name;
+      })
+      .style("font-size", function(d) {
+        return "12px";
+      })
+      .style("fill", function(d) {
+        return "black";
+      })
+      .style("display", function(d) {
+        if ($scope.checkboxModel.value) {
+          return "block";
+        } else {
+          return "none";
         }
+      });
+
+    added.selectAll("title").text(function(d) {
+      var status = [
+        "Name: " + d.item.name,
+        "Type: " + d.item.kind,
+        "Status: " + d.item.status,
+      ];
+
+      if (d.item.kind == 'Host' || d.item.kind == 'VM') {
+        status.push("Provider: " + d.item.provider);
+      }
+
+      return status.join("\n");
+    });
+
+    $scope.vs = vertices;
+
+    /* Don't do default rendering */
+    ev.preventDefault();
+  });
+
+  function class_name(d) {
+    switch (d.item.kind) {
+      case "Service":
+      case "Route":
+      case "Node":
+      case "Replicator":
+        return "container_" + d.item.kind.toLowerCase();
+
+      case "VM":
+      case "Host":
+      case "Container":
+        return d.item.kind.toLowerCase();
+
+      case "Pod":
+        return "container_group";
+
+      case "Kubernetes":
+      case "Openshift":
+      case "Atomic":
+      case "OpenshiftEnterprise":
+      case "AtomicEnterprise":
+        return "vendor-" + _.snakeCase(d.item.kind);
+    }
+  }
+
+  function dblclick(d) {
+    var entity_url = "";
+    switch (d.item.kind) {
+      case "Kubernetes":
+      case "Openshift":
+      case "Atomic":
+      case "OpenshiftEnterprise":
+      case "AtomicEnterprise":
+        entity_url = "ems_container";
+        break;
+      default :
+        entity_url = class_name(d);
     }
 
-    function dblclick(d) {
-        var entity_url = "";
-        switch (d.item.kind) {
-            case "Kubernetes":
-            case "Openshift":
-            case "Atomic":
-            case "OpenshiftEnterprise":
-            case "AtomicEnterprise":
-                entity_url = "ems_container";
-                break;
-            default :
-                entity_url = class_name(d);
-        }
-        var url = '/' + entity_url + '/show/' + d.item.miq_id;
-        window.location.assign(url);
-    }
+    var url = '/' + entity_url + '/show/' + d.item.miq_id;
+    window.location.assign(url);
+  }
 
-    function getDimensions(d) {
-        switch (d.item.kind) {
-            case "Kubernetes":
-            case "Openshift":
-            case "Atomic":
-            case "OpenshiftEnterprise":
-            case "AtomicEnterprise":
-                return { x: -20, y: -20, height: 40, width: 40, r: 28};
-            case "Container" :
-                return { x: -7, y: -7,height: 14, width: 14, r: 13};
-            case "Node" :
-            case "VM" :
-            case "Host" :
-                return { x: -12, y: -12, height: 23, width: 23, r: 19};
-            default :
-                return { x: -9, y: -9, height: 18, width: 18, r: 17};
-        }
-
+  function getDimensions(d) {
+    switch (d.item.kind) {
+      case "Kubernetes":
+      case "Openshift":
+      case "Atomic":
+      case "OpenshiftEnterprise":
+      case "AtomicEnterprise":
+        return { x: -20, y: -20, height: 40, width: 40, r: 28 };
+      case "Container":
+        return { x: -7, y: -7, height: 14, width: 14, r: 13 };
+      case "Node":
+      case "VM":
+      case "Host":
+        return { x: -12, y: -12, height: 23, width: 23, r: 19 };
+      default:
+        return { x: -9, y: -9, height: 18, width: 18, r: 17 };
     }
+  }
 
 }]);

--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -104,39 +104,28 @@ angular.module('topologyApp', ['kubernetesUI','ui.bootstrap'])
     });
 
     function class_name(d) {
-        var class_name = "";
         switch (d.item.kind) {
             case "Service":
             case "Route":
             case "Node":
             case "Replicator":
-                class_name = "container_" + d.item.kind.toLowerCase();
-                break;
+                return "container_" + d.item.kind.toLowerCase();
+
             case "VM":
             case "Host":
             case "Container":
-                class_name = d.item.kind.toLowerCase();
-                break;
+                return d.item.kind.toLowerCase();
+
             case "Pod":
-                class_name = "container_group";
-                break;
+                return "container_group";
+
             case "Kubernetes":
-                class_name = "vendor-kubernetes";
-                break;
             case "Openshift":
-                class_name = "vendor-openshift";
-                break;
             case "Atomic":
-                class_name = "vendor-atomic";
-                break;
             case "OpenshiftEnterprise":
-                class_name = "vendor-openshift_enterprise";
-                break;
             case "AtomicEnterprise":
-                class_name = "vendor-atomic_enterprise";
-                break;
+                return "vendor-" + _.snakeCase(d.item.kind);
         }
-        return class_name;
     }
 
     function dblclick(d) {

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -3,6 +3,11 @@ require "spec_helper"
 describe ContainerTopologyService do
 
   let(:container_topology_service) { described_class.new(nil) }
+  let(:long_id) { "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" }
+
+  def icon(f)
+    "/images/icons/new/#{f}.png"
+  end
 
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
@@ -24,7 +29,7 @@ describe ContainerTopologyService do
       expect(subject.keys).to match_array([:items, :kinds, :relations])
     end
 
-    let(:container) { Container.create(:name => "ruby-example", :ems_ref => "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest", :state => 'running') }
+    let(:container) { Container.create(:name => "ruby-example", :ems_ref => long_id, :state => 'running') }
     let(:container_condition) { ContainerCondition.create(:name => 'Ready', :status => 'True') }
     let(:container_def) { ContainerDefinition.create(:name => "ruby-example", :ems_ref => 'b6976f84-5184-11e5-950e-001a4a231290_ruby-helloworld_172.30.194.30:5000/test/origin-ruby-sample@sha256:0cd076c9beedb3b1f5cf3ba43da6b749038ae03f5886b10438556e36ec2a0dd9', :container => container) }
     let(:container_node) { ContainerNode.create(:ext_management_system => ems_kube, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition], :lives_on => vm_rhev) }
@@ -56,15 +61,70 @@ describe ContainerTopologyService do
                                                   :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1", :container_routes => [container_route])
       expect(subject[:items]).to eq(
-        ems_kube.id.to_s                       => {:id => ems_kube.id.to_s, :name => ems_kube.name, :status => "Unknown", :kind => "Kubernetes", :miq_id => ems_kube.id},
-        "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id => container_node.ems_ref, :name => container_node.name, :status => "Ready", :kind => "Node", :miq_id => container_node.id},
-        "8f8ca74c-3a41-11e5-a79a-001a4a231290" => {:id => container_replicator.ems_ref, :name => container_replicator.name, :status => "OK", :kind => "Replicator", :miq_id => container_replicator.id},
-        "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id => container_service.ems_ref, :name => container_service.name, :status => "Unknown", :kind => "Service", :miq_id => container_service.id},
-        "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id => container_group.ems_ref, :name => container_group.name, :status => "Running", :kind => "Pod", :miq_id => container_group.id},
-        "ab5za74c-3a41-11e5-a79a-001a4a231290" => {:id => container_route.ems_ref, :name => container_route.name, :status => "Unknown", :kind => "Route", :miq_id => container_route.id},
-        "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" => {:id => container.ems_ref, :name => container.name, :status => "Running", :kind => "Container", :miq_id => container.id},
-        "558d9a08-7b13-11e5-8546-129aa6621998" => {:id => vm_rhev.uid_ems, :name => vm_rhev.name, :status => "On", :kind => "VM", :miq_id => vm_rhev.id, :provider => ems_rhev.name},
-        "abcd9a08-7b13-11e5-8546-129aa6621999" => {:id => host.uid_ems, :name => host.name, :status => "On", :kind => "Host", :miq_id => host.id, :provider => ems_rhev.name}
+        ems_kube.id.to_s                       => {:id       => ems_kube.id.to_s,
+                                                   :name     => ems_kube.name,
+                                                   :status   => "Unknown",
+                                                   :kind     => "Kubernetes",
+                                                   :miq_id   => ems_kube.id,
+                                                   :icon     => icon('vendor-kubernetes')},
+
+        "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_node.ems_ref,
+                                                   :name     => container_node.name,
+                                                   :status   => "Ready",
+                                                   :kind     => "Node",
+                                                   :miq_id   => container_node.id,
+                                                   :icon     => icon('container_node')},
+
+        "8f8ca74c-3a41-11e5-a79a-001a4a231290" => {:id       => container_replicator.ems_ref,
+                                                   :name     => container_replicator.name,
+                                                   :status   => "OK",
+                                                   :kind     => "Replicator",
+                                                   :miq_id   => container_replicator.id,
+                                                   :icon     => icon('container_replicator')},
+
+        "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_service.ems_ref,
+                                                   :name     => container_service.name,
+                                                   :status   => "Unknown",
+                                                   :kind     => "Service",
+                                                   :miq_id   => container_service.id,
+                                                   :icon     => icon('container_service')},
+
+        "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_group.ems_ref,
+                                                   :name     => container_group.name,
+                                                   :status   => "Running",
+                                                   :kind     => "Pod",
+                                                   :miq_id   => container_group.id,
+                                                   :icon     => icon('container_group')},
+
+        "ab5za74c-3a41-11e5-a79a-001a4a231290" => {:id       => container_route.ems_ref,
+                                                   :name     => container_route.name,
+                                                   :status   => "Unknown",
+                                                   :kind     => "Route",
+                                                   :miq_id   => container_route.id,
+                                                   :icon     => icon('container_route')},
+
+        long_id                                => {:id       => container.ems_ref,
+                                                   :name     => container.name,
+                                                   :status   => "Running",
+                                                   :kind     => "Container",
+                                                   :miq_id   => container.id,
+                                                   :icon     => icon('container')},
+
+        "558d9a08-7b13-11e5-8546-129aa6621998" => {:id       => vm_rhev.uid_ems,
+                                                   :name     => vm_rhev.name,
+                                                   :status   => "On",
+                                                   :kind     => "VM",
+                                                   :miq_id   => vm_rhev.id,
+                                                   :provider => ems_rhev.name,
+                                                   :icon     => icon('vm')},
+
+        "abcd9a08-7b13-11e5-8546-129aa6621999" => {:id       => host.uid_ems,
+                                                   :name     => host.name,
+                                                   :status   => "On",
+                                                   :kind     => "Host",
+                                                   :miq_id   => host.id,
+                                                   :provider => ems_rhev.name,
+                                                   :icon     => icon('host')}
       )
 
       expect(subject[:relations].size).to eq(8)
@@ -92,12 +152,48 @@ describe ContainerTopologyService do
       container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
 
       expect(subject[:items]).to eq(
-        "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id => container_node.ems_ref, :name => container_node.name, :status => "Ready", :kind => "Node", :miq_id => container_node.id},
-        "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id => container_service.ems_ref, :name => container_service.name, :status => "Unknown", :kind => "Service", :miq_id => container_service.id},
-        "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id => container_group.ems_ref, :name => container_group.name, :status => "Running", :kind => "Pod", :miq_id => container_group.id},
-        "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" => {:id => container.ems_ref, :name => container.name, :status => "Running", :kind => "Container", :miq_id => container.id},
-        "558d9a08-7b13-11e5-8546-129aa6621998" => {:id => vm_rhev.uid_ems, :name => vm_rhev.name, :status => "Off", :kind => "VM", :miq_id => vm_rhev.id, :provider => ems_rhev.name},
-        ems_kube.id.to_s                       => {:id => ems_kube.id.to_s, :name => ems_kube.name, :status => "Unknown", :kind => "Kubernetes", :miq_id => ems_kube.id}
+        "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_node.ems_ref,
+                                                   :name     => container_node.name,
+                                                   :status   => "Ready",
+                                                   :kind     => "Node",
+                                                   :miq_id   => container_node.id,
+                                                   :icon     => icon('container_node')},
+
+        "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_service.ems_ref,
+                                                   :name     => container_service.name,
+                                                   :status   => "Unknown",
+                                                   :kind     => "Service",
+                                                   :miq_id   => container_service.id,
+                                                   :icon     => icon('container_service')},
+
+        "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_group.ems_ref,
+                                                   :name     => container_group.name,
+                                                   :status   => "Running",
+                                                   :kind     => "Pod",
+                                                   :miq_id   => container_group.id,
+                                                   :icon     => icon('container_group')},
+
+        long_id =>                                {:id       => container.ems_ref,
+                                                   :name     => container.name,
+                                                   :status   => "Running",
+                                                   :kind     => "Container",
+                                                   :miq_id   => container.id,
+                                                   :icon     => icon('container')},
+
+        "558d9a08-7b13-11e5-8546-129aa6621998" => {:id       => vm_rhev.uid_ems,
+                                                   :name     => vm_rhev.name,
+                                                   :status   => "Off",
+                                                   :kind     => "VM",
+                                                   :miq_id   => vm_rhev.id,
+                                                   :provider => ems_rhev.name,
+                                                   :icon     => icon('vm')},
+
+        ems_kube.id.to_s                       => {:id       => ems_kube.id.to_s,
+                                                   :name     => ems_kube.name,
+                                                   :status   => "Unknown",
+                                                   :kind     => "Kubernetes",
+                                                   :miq_id   => ems_kube.id,
+                                                   :icon     => icon('vendor-kubernetes')}
       )
 
       expect(subject[:relations].size).to eq(5)


### PR DESCRIPTION
The icons for topology graph items would get generated in JS,
that will break with @skateman's asset pipeline changes
    
This moves the image path logic to ContainerTopologyService, which can use the image_path helper
    
(note that as of now, the URL generated is exactly the same)

(If you're reviewing, go commit by commit, because the last one changes all whitespace in there.)

Related PRs: https://github.com/ManageIQ/manageiq/pull/5709, https://github.com/ManageIQ/manageiq-appliance/pull/47
(but not depending on either)