### PR TITLE
Coalesce chrony appliance checks

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -261,7 +261,7 @@ class MiqServer < ActiveRecord::Base
 
     Vmdb::Appliance.log_config_on_startup
 
-    svr.ntp_reload(svr.server_ntp_settings) if MiqEnvironment::Command.is_appliance?
+    svr.ntp_reload(svr.server_ntp_settings)
     # Update the config settings in the db table for MiqServer
     svr.config_updated(OpenStruct.new(:name => cfg.get(:server, :name)))
 

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -26,6 +26,8 @@ module MiqServer::NtpManagement
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in atStartup of miq_server and on a configuration change for the server
   def ntp_reload(ntp_settings = server_ntp_settings)
+    return unless MiqEnvironment::Command.is_appliance?
+
     if @ntp_settings && @ntp_settings == ntp_settings
       _log.info("Skipping reload of ntp settings since they are unchanged")
       return
@@ -50,9 +52,9 @@ module MiqServer::NtpManagement
     @ntp_settings = ntp_settings
   end
 
-  def apply_ntp_server_settings(settings)
-    return unless Sys::Platform::IMPL == :linux
+  private
 
+  def apply_ntp_server_settings(settings)
     chrony_conf = LinuxAdmin::Chrony.new
     chrony_conf.clear_servers
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -138,12 +138,10 @@ describe MiqServer do
       let(:zone_ntp)   { {:server => ["zone.pool.com"]} }
       let(:chrony)     { double }
 
-      before do
-        stub_const("Sys::Platform::IMPL", platform)
-      end
-
-      context "on a Linux platform" do
-        let(:platform) { :linux }
+      context "on an appliance" do
+        before do
+          allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
+        end
 
         it "syncs with server settings with zone and server configured" do
           @zone.update_attribute(:settings, :ntp => zone_ntp)
@@ -180,7 +178,9 @@ describe MiqServer do
       end
 
       context "on a non-Linux platform" do
-        let(:platform) { :macosx }
+        before do
+          allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
+        end
 
         it "does not apply NTP settings" do
           expect(LinuxAdmin::Chrony).to_not receive(:new)


### PR DESCRIPTION
Remove check for linux os in favor of check for appliance

@Fryguy 