### PR TITLE
$SAFE is slowly going away - remove or remind us to remove some references

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimBroker.rb
+++ b/gems/pending/VMwareWebService/MiqVimBroker.rb
@@ -91,7 +91,6 @@ class MiqVimBroker
       @selectorHash = @@selectorHash
       @cacheScope   = @@cacheScope
 
-      # $SAFE = 1
       acl = ACL.new(%w( deny all allow 127.0.0.1/32 ))
       DRb.install_acl(acl)
       DRb.start_service("druby://127.0.0.1:#{port}", self, :idconv => VimBrokerIdConv.new)

--- a/lib/extensions/ar_process.rb
+++ b/lib/extensions/ar_process.rb
@@ -1,5 +1,6 @@
 class << Process
   def pid_with_safe
+    warn "Remove me: #{__FILE__}:#{__LINE__}.  Safe level 2-4 are no longer supported as of ruby 2.3!" if RUBY_VERSION >= "2.3"
     $SAFE < 2 ? pid_without_safe : 0
   end
   alias_method_chain :pid, :safe


### PR DESCRIPTION
As of Ruby 2.3 preview2:
```
* $SAFE
  * $SAFE=2 and $SAFE=3 are obsolete.  If $SAFE is set to 2 or larger,
    an ArgumentError is raised.  [Feature #5455]
```
https://github.com/ruby/ruby/blob/v2_3_0_preview2/NEWS#L268-L270