### PR TITLE
Fix ruby 2.3.0 warning: constant Object::TimeoutError is deprecated

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -316,7 +316,7 @@ class Condition < ActiveRecord::Base
         end
         to = 20 # allow 20 seconds for script to complete
         Timeout::timeout(to) { t.join }
-      rescue TimeoutError => err
+      rescue Timeout::Error => err
         t.exit
         _log.error  "The following error occurred during ruby evaluation"
         _log.error  "  #{err.class}: #{err.message}"

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -29,7 +29,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
       begin
         vim_ds = vim.getVimDataStore(datastore.name)
         return vim_ds.dsFolderFileList
-      rescue Handsoap::Fault, StandardError, TimeoutError, DRb::DRbConnError => err
+      rescue Handsoap::Fault, StandardError, Timeout::Error, DRb::DRbConnError => err
         _log.log_backtrace(err)
         raise MiqException::MiqStorageError, "Error communicating with Host: [#{name}]"
       ensure

--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -152,7 +152,7 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
     rescue MiqException::MiqVimBrokerUnavailable => err
       MiqVimBrokerWorker.broker_unavailable(err.class.name,  err.to_s)
       _log.warn("Reported the broker unavailable")
-    rescue TimeoutError
+    rescue Timeout::Error
       _log.warn "Timeout encountered during log collection for Host [#{name}]"
     ensure
       vim.disconnect rescue nil

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -320,7 +320,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
       _log.error("#{msg}...Failed after [#{attempts}] retry attempts")
       _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
       raise MiqException::MiqCommunicationsTimeoutError, err.message
-    rescue TimeoutError
+    rescue Timeout::Error
       _log.error("#{log_header} Timeout Error during metrics data collection")
       _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
       raise MiqException::MiqTimeoutError, err.message

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -441,7 +441,7 @@ class MiqAlert < ActiveRecord::Base
     alarms = []
     begin
       Timeout.timeout(to) { alarms = ems.get_alarms if ems.respond_to?(:get_alarms) }
-    rescue TimeoutError
+    rescue Timeout::Error
       msg = "Request to retrieve alarms timed out after #{to} seconds"
       $log.warn(msg)
       raise msg

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -340,7 +340,7 @@ class MiqQueue < ActiveRecord::Base
         message = "Message not processed.  Retrying #{err.options[:deliver_on] ? "at #{err.options[:deliver_on]}" : 'immediately'}"
         _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_RETRY
-      rescue TimeoutError
+      rescue Timeout::Error
         message = "timed out after #{Time.now - delivered_on} seconds.  Timeout threshold [#{msg_timeout}]"
         _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_TIMEOUT

--- a/app/models/miq_replication_worker/runner.rb
+++ b/app/models/miq_replication_worker/runner.rb
@@ -115,7 +115,7 @@ class MiqReplicationWorker::Runner < MiqWorker::Runner
           heartbeat
         end
       end
-    rescue TimeoutError
+    rescue Timeout::Error
       _log.info("#{log_prefix} Killing replication process with pid=#{@pid}")
       Process.kill(9, @pid)
     end

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -72,7 +72,7 @@ module MiqServer::LogManagement
         )
 
         logfile.upload
-      rescue StandardError, TimeoutError => err
+      rescue StandardError, Timeout::Error => err
         logfile.update_attributes(:state => "error")
         _log.error("Posting of historical logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
         raise
@@ -196,7 +196,7 @@ module MiqServer::LogManagement
       )
 
       logfile.upload
-    rescue StandardError, TimeoutError => err
+    rescue StandardError, Timeout::Error => err
       _log.error("#{log_prefix} Posting of current logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
       logfile.update_attributes(:state => "error")
       raise

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -56,7 +56,7 @@ class VmScan < Job
     rescue => err
       _log.log_backtrace(err)
       signal(:abort, err.message, "error")
-    rescue TimeoutError
+    rescue Timeout::Error
       msg = "Request to check policy timed out"
       _log.error(msg)
       signal(:abort, msg, "error")
@@ -170,7 +170,7 @@ class VmScan < Job
       _log.log_backtrace(err)
       signal(:abort, err.message, "error")
       return
-    rescue TimeoutError
+    rescue Timeout::Error
       msg = case options[:snapshot]
             when :smartProxy, :skipped then "Request to log snapshot user event with EMS timed out."
             else "Request to create snapshot timed out"
@@ -215,7 +215,7 @@ class VmScan < Job
 
       _log.info "[#{host.name}] communicates with [#{scan_ci_type}:#{ems_list[scan_ci_type][:hostname]}(#{ems_list[scan_ci_type][:address]})] to scan vm [#{vm.name}]" if agent_class == "MiqServer" && !ems_list[scan_ci_type].nil?
       vm.scan_metadata(options[:categories], "taskid" => jobid, "host" => host, "args" => [YAML.dump(scan_args)])
-    rescue TimeoutError
+    rescue Timeout::Error
       message = "timed out attempting to scan, aborting"
       _log.error("#{message}")
       signal(:abort, message, "error")
@@ -286,7 +286,7 @@ class VmScan < Job
         rescue => err
           _log.error("#{err}")
           return
-        rescue TimeoutError
+        rescue Timeout::Error
           msg = "Request to delete snapshot timed out"
           _log.error("#{msg}")
         end
@@ -317,7 +317,7 @@ class VmScan < Job
                        "taskid" => jobid,
                        "host"   => host
                       )
-    rescue TimeoutError
+    rescue Timeout::Error
       message = "timed out attempting to synchronize, aborting"
       _log.error("#{message}")
       signal(:abort, message, "error")

--- a/app/models/vm_synchronize.rb
+++ b/app/models/vm_synchronize.rb
@@ -21,7 +21,7 @@ class VmSynchronize < Job
       host = Host.find(agent_id)
       vm   = VmOrTemplate.find(target_id)
       vm.sync_metadata(options[:categories], "taskid" => jobid, "host" => host)
-    rescue TimeoutError
+    rescue Timeout::Error
       message = "timed out attempting to synchronize, aborting"
       _log.error("#{message}")
       signal(:abort, message, "error")

--- a/gems/pending/util/diag/miqping.rb
+++ b/gems/pending/util/diag/miqping.rb
@@ -44,8 +44,8 @@ module Manageiq
         begin
           t1 = Time.now
           result = driver.send(ws, cfg.data)
-        rescue TimeoutError
-          puts "ERROR: TimeoutError after [#{Time.now - t1}] seconds"
+        rescue Timeout::Error
+          puts "ERROR: Timeout::Error after [#{Time.now - t1}] seconds"
         rescue => err
           puts "ERROR: #{err}"
         end

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -149,7 +149,7 @@ class MiqLdap
 
   def search(opts, &blk)
     Timeout.timeout(@search_timeout) { _search(opts, &blk) }
-  rescue TimeoutError
+  rescue Timeout::Error
     _log.error("LDAP search timed out after #{@search_timeout} seconds")
     raise
   end


### PR DESCRIPTION
```
TimeoutError = Timeout::Error
class Object
  deprecate_constant :TimeoutError
end
```
https://github.com/ruby/ruby/blob/v2_3_0_preview2/lib/timeout.rb#L124