### PR TITLE
Removing support for evaluating Ruby code in expressions once and for all

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -486,9 +486,7 @@ class MiqExpression
     when "value exists"
       clause = operands2rubyvalue(operator, exp[operator], context_type)
     when "ruby"
-      operands = operands2rubyvalue(operator, exp[operator], context_type)
-      col_type = get_col_type(exp[operator]["field"]) || "string"
-      clause = "__start_ruby__ __start_context__#{operands[0]}__type__#{col_type}__end_context__ __start_script__#{operands[1]}__end_script__ __end_ruby__"
+      raise "Ruby scripts in expressions are no longer supported. Please use the regular expression feature of conditions instead."
     when "is"
       col_name = exp[operator]["field"]
       col_ruby, dummy = operands2rubyvalue(operator, {"field" => col_name}, context_type)

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -22,7 +22,7 @@ describe Condition do
 
       it "valid expression" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2</check></find>"
-        Condition.subst(expr, @cluster, nil).should be_true
+        Condition.subst(expr, @cluster, nil).should be
       end
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do
@@ -30,34 +30,28 @@ describe Condition do
         expect { Condition.subst(expr, @cluster, nil) }.not_to raise_error
       end
 
-      it "valid expression as a tainted object should not raise security error" do
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> >= 0</check></find>"
-        expr.taint
-        expect { Condition.subst(expr, @cluster, nil) }.to raise_error(RuntimeError, "Ruby script raised error [Insecure operation - eval]")
-      end
-
       it "tests all allowed operators in find/check expression clause" do
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> == 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> == 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'false'
 
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> > 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> > 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'true'
 
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> >= 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'true'
 
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> < 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'true'</search><check mode=count><count> < 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'false'
 
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> <= 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> <= 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'false'
 
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> != 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> != 0</check></find>"
         Condition.subst(expr, @cluster, nil).should == 'true'
       end
 
       it "rejects and expression with an illegal operator" do
-        expr = "<find><search>__start_ruby__ __start_context__<value ref=host, type=raw>/virtual/vms/hostnames</value>__type__string_set__end_context__ __start_script__return true__end_script__ __end_ruby__</search><check mode=count><count> !! 0</check></find>"
+        expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> !! 0</check></find>"
         expect { Condition.subst(expr, @cluster, nil).should == 'false' }.to raise_error(RuntimeError, "Illegal operator, '!!'")
       end
     end

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -15,6 +15,11 @@ describe MiqExpression do
       exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "/[]/"})
       expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\/\\[\\]\\//")
     end
+
+    it "raises error if expression contains ruby script" do
+      exp = MiqExpression.new("RUBY" => {"field" => "Host-name", "value" => "puts 'Hello world!'"})
+      expect { exp.to_ruby }.to raise_error(RuntimeError, "Ruby scripts in expressions are no longer supported. Please use the regular expression feature of conditions instead.")
+    end
   end
 
   it "supports yaml" do


### PR DESCRIPTION
This also eliminates the need to set the SAFE level  to 3 which will raise an error in Ruby 2.3