### PR TITLE
Catalog Item : Changing the VMWare provider template after selecting a datacenter fails

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -112,7 +112,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     src = get_source_and_targets
     vm, ems = load_ar_obj(src[:vm]), src[:ems]
 
-    clear_field_values([:placement_host_name, :placement_ds_name, :placement_folder_name, :placement_cluster_name, :placement_rp_name, :linked_clone, :snapshot])
+    clear_field_values([:placement_host_name, :placement_ds_name, :placement_folder_name, :placement_cluster_name, :placement_rp_name, :linked_clone, :snapshot, :placement_dc_name])
 
     if vm.nil?
       clear_field_values([:number_of_cpus, :number_of_sockets, :cores_per_socket, :vm_memory, :cpu_limit, :memory_limit, :cpu_reserve, :memory_reserve])
@@ -172,7 +172,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     auto_placement = show_flag = auto_placement_enabled? ? :hide : :edit
-    f[show_flag] += [:placement_host_name, :placement_ds_name, :host_filter, :ds_filter, :cluster_filter, :placement_cluster_name, :rp_filter, :placement_rp_name]
+    f[show_flag] += [:placement_host_name, :placement_ds_name, :host_filter, :ds_filter, :cluster_filter, :placement_cluster_name, :rp_filter, :placement_rp_name, :placement_dc_name]
 
     show_flag = get_value(@values[:sysprep_enabled]).in?(%w(fields file)) || self.supports_pxe? || self.supports_iso? ? :edit : :hide
     f[show_flag] += [:addr_mode]

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -31,6 +31,29 @@ describe MiqRequestController do
       partial = controller.send(:dialog_partial_for_workflow)
       expect(partial).to eq('prov_configured_system_foreman_dialog')
     end
+
+    it "clears the request datacenter name field when the source VM is changed" do
+      datacenter = FactoryGirl.create(:datacenter, :name => 'dcname')
+      ems_folder = FactoryGirl.create(:ems_folder)
+      ems = FactoryGirl.create(:ems_vmware)
+      vm1 = FactoryGirl.create(:vm_vmware)
+      vm2 = FactoryGirl.create(:vm_vmware)
+      datacenter.ext_management_system = ems
+      ems_folder.ext_management_system = ems
+      @wf.instance_variable_set(:@dialogs, :dialogs => {:environment => {:fields => {:placement_dc_name => {:values => {datacenter.id.to_s => datacenter.name}}}}})
+      controller.instance_variable_set(:@edit, :wf => @wf, :new => {:src_vm_id => vm1.id.to_s})
+      controller.instance_variable_set(:@last_vm_id, vm2.id)
+      controller.instance_variable_set(:@_params, 'service__src_vm_id' => vm1.id, :id => "new", :controller => "miq_request")
+      @wf.instance_variable_set(:@values, :placement_dc_name=>[datacenter.id.to_s, datacenter.name])
+      edit = {:wf => @wf, :new => {:placement_dc_name => [datacenter.id, datacenter.name]}}
+      @wf.instance_variable_set(:@edit, edit)
+      allow(controller).to receive(:load_edit).and_return(true)
+      allow(controller).to receive(:render).and_return(true)
+      allow(@wf).to receive(:get_field).and_return(:values => {:placement_dc_name=>[datacenter.id.to_s, datacenter.name]})
+      controller.send(:prov_field_changed)
+      values = @wf.instance_variable_get(:@values)
+      expect(values.to_s).to_not include('dcname')
+    end
   end
 
   describe '#prov_edit' do


### PR DESCRIPTION
Catalog Item : Changing the VMWare provider template after selecting a data center fails.
Will add fixes for editing an existing VMWare catalog item and rspecs.

https://bugzilla.redhat.com/show_bug.cgi?id=1240443