### PR TITLE
vm analysis tasks: fix container image link

### DIFF
--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -95,7 +95,7 @@
                 - click = "DoNav('/vm/show/#{to_cid(rec.destination_id)}');"
                 - title = _("Click to view this VM")
             - when "Job"
-              - click = "DoNav('/vm/show/#{to_cid(row["target_id"])}');"
+              - click = "DoNav('/#{row['target_class'].underscore}/show/#{to_cid(row["target_id"])}');"
             - when @vm && view.db
               - click = "DoNav('/vm/#{@listicon.pluralize}/#{@vm.id}?show=#{@id}');"
             - when "Action"


### PR DESCRIPTION
In the tasks screen, clicking the image of the job status should lead to the scanned image screen. Instead it led to /vm/show/#{id}

The image in question is the circled v:
![screenshot from 2015-12-13 15-38-57](https://cloud.githubusercontent.com/assets/3010449/11767253/3d4e1e18-a1b0-11e5-82b1-b5c97af94396.png)

![screenshot from 2015-12-13 15-39-05](https://cloud.githubusercontent.com/assets/3010449/11767259/6180ab16-a1b0-11e5-8ed0-078921b08d8b.png)

