### PR TITLE
Tier fixed/variable rating.

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -415,3 +415,12 @@ iframe, .iframe {
     right: 0;
     bottom: 0;
 }
+
+/* Used at Chargeback edit view */
+
+tr.rdetail > td {
+  white-space: nowrap;
+}
+td.action > .btn.btn-default {
+    width: 50px;
+}

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -700,25 +700,21 @@ class ChargebackController < ApplicationController
   def cb_rate_get_form_vars
     @sb[:rate] = @edit[:rate]
     @edit[:new][:description] = params[:description] if params[:description]
-    @edit[:new][:details].each_with_index do |_detail, detail_index|
-      _detail[:per_time] =
-        params["per_time_#{detail_index}".to_sym] if params["per_time_#{detail_index}".to_sym]
-      _detail[:per_unit] =
-        params["per_unit_#{detail_index}".to_sym] if params["per_unit_#{detail_index}".to_sym]
+    @edit[:new][:details].each_with_index do |detail, detail_index|
+      %i{per_time per_unit}.each do |measure|
+        key = "#{measure}_#{detail_index}".to_sym
+        detail[measure] = params[key] if params[key]
+      end
       # Add currencies to chargeback_controller.rb
-      _detail[:currency] = params[:currency] if params[:currency]
+      detail[:currency] = params[:currency] if params[:currency]
 
       # Save tiers into @edit
       (0..@sb[:num_tiers][detail_index].to_i - 1).each do |tier_index|
-        @edit [:new][:tiers][detail_index][tier_index] = {} unless @edit[:new][:tiers][detail_index][tier_index]
-        @edit[:new][:tiers][detail_index][tier_index][:fixed_rate] =
-          params["fixed_rate_#{detail_index}_#{tier_index}".to_sym] if params["fixed_rate_#{detail_index}_#{tier_index}".to_sym]
-        @edit[:new][:tiers][detail_index][tier_index][:variable_rate] =
-          params["variable_rate_#{detail_index}_#{tier_index}".to_sym] if params["variable_rate_#{detail_index}_#{tier_index}".to_sym]
-        @edit[:new][:tiers][detail_index][tier_index][:start] =
-          params["start_#{detail_index}_#{tier_index}".to_sym] if params["start_#{detail_index}_#{tier_index}".to_sym]
-        @edit[:new][:tiers][detail_index][tier_index][:end] =
-          params["end_#{detail_index}_#{tier_index}".to_sym] if params["end_#{detail_index}_#{tier_index}".to_sym]
+        tier = @edit[:new][:tiers][detail_index][tier_index] || {}
+        %i{fixed_rate variable_rate start end}.each do |field|
+          key = "#{field}_#{detail_index}_#{tier_index}".to_sym
+          tier[field] = params[key] if params[key]
+        end
       end
     end
   end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -55,7 +55,7 @@ class ChargebackController < ApplicationController
                        when :cb_assignments_tree then _("All Assignments")
                        when :cb_reports_tree     then _("All Saved Chargeback Reports")
                        end
-    set_form_locals
+    set_form_locals if @in_a_form
     session[:changed] = false
 
     render :layout => "application" unless request.xml_http_request?
@@ -105,196 +105,88 @@ class ChargebackController < ApplicationController
     assert_privileges(params[:pressed]) if params[:pressed]
     case params[:button]
     when "cancel"
-      add_flash("#{!@sb[:rate] || @sb[:rate].id.blank? ? _("Add of new %{model} was cancelled by the user") %
-          {:model => ui_lookup(:model => "ChargebackRate")} :
-        _("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description}}")
+      add_flash("#{params[:id] ?
+        _("Edit of %{model} \"%{name}\" was cancelled by the user") %
+          {:model => ui_lookup(:model => "ChargebackRate"), :name => session[:edit][:new][:description]} :
+        _("Add of new %{model} was cancelled by the user") %
+          {:model => ui_lookup(:model => "ChargebackRate")}}")
       get_node_info(x_node)
-      @sb[:rate] = @sb[:rate_details] = @sb[:num_tiers] = nil
       @edit = session[:edit] = nil  # clean out the saved info
       session[:changed] =  false
       replace_right_cell
     when "save", "add"
       id = params[:id] && params[:button] == "save" ? params[:id] : "new"
       return unless load_edit("cbrate_edit__#{id}", "replace_cell__chargeback")
-      @sb[:rate] = @edit[:rate] if @edit && @edit[:rate]
+      @rate = params[:button] == "add" ? ChargebackRate.new : ChargebackRate.find(params[:id])
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         add_flash(_("Description is required"), :error)
-        @sb[:rate] = @sb[:rate_details] = @sb[:tiers] = nil
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
         return
       end
-      @sb[:rate].description = @edit[:new][:description]
-      @sb[:rate].rate_type = @edit[:new][:rate_type] if @edit[:new][:rate_type]
-      if params[:button] == "add"
-        cb_rate_set_record_vars
-        @sb[:rate].chargeback_rate_details.replace(@sb[:rate_details])
-        @sb[:rate].chargeback_rate_details.each_with_index do |detail, i|
-          detail.chargeback_tiers.replace(@sb[:tiers][i])
+      @rate.description = @edit[:new][:description]
+      @rate.rate_type   = @edit[:new][:rate_type] if @edit[:new][:rate_type]
+
+      cb_rate_set_record_vars
+      # Detect errors saving tiers
+      tiers_valid = @rate_tiers.all? { |tiers| tiers.all?(&:valid?) }
+
+      # Replace the tiers
+      # if tiers_valid
+      #   @rate.chargeback_rate_details.each_with_index do |_detail, i|
+      #     @rate_details[i].save_tiers(@rate_tiers[i])
+      #   end
+      # end
+
+      # Detect errors saving rate details
+      rate_details_valid = @rate_details.all?(&:valid?)
+
+      if tiers_valid && rate_details_valid && @rate.save
+        @rate.chargeback_rate_details.replace(@rate_details)
+        @rate.chargeback_rate_details.each_with_index do |_detail, i|
+          #@rate_details[i].save_tiers(@rate_tiers[i])
+          @rate_details[i].chargeback_tiers.replace(@rate_tiers[i])
         end
 
-        if @sb[:rate].save
-          AuditEvent.success(build_saved_audit(@sb[:rate], @edit))
-          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description})
-          @edit = session[:edit] = nil  # clean out the saved info
-          session[:changed] =  @changed = false
-          get_node_info(x_node)
-          @sb[:rate] = @sb[:rate_details] = @sb[:tiers] = nil
-          replace_right_cell([:cb_rates])
+        if params[:button] == "add"
+          AuditEvent.success(build_created_audit(@rate, @edit))
+          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @rate.description})
         else
-          @sb[:rate].errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
-          end
-          @sb[:rate_details].each do |detail|
-            detail.errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.capitalize} #{msg}", :error) }
-            detail.chargeback_tiers.each do |tier|
-              tier.errors.each do |field, msg|
-                 add_flash("'#{detail.description}' #{field.to_s.capitalize} #{msg}", :error)
-              end
-            end
-          end
-          @changed = session[:changed] = (@edit[:new] != @edit[:current])
-          @sb[:rate] = @sb[:rate_details] = @sb[:tiers] = nil
-          render :update do |page|
-            page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          AuditEvent.success(build_saved_audit(@rate, @edit))
+          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @rate.description})
+        end
+        @edit = session[:edit] = nil  # clean out the saved info
+        session[:changed] =  @changed = false
+        get_node_info(x_node)
+        replace_right_cell([:cb_rates])
+      else
+        @rate.errors.each do |field, msg|
+          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        end
+        @rate_details.each do |detail|
+          display_detail_errors(detail, detail.errors)
+        end
+        @rate_tiers.each_with_index do |tiers, detail_index|
+          tiers.each do |tier|
+            display_detail_errors(@rate_details[detail_index], tier.errors)
           end
         end
-      else      # for save button
-        cb_rate_set_record_vars
-
-        # Detect errors saving tiers
-        tiers_valid = @sb[:tiers].all? { |tiers| tiers.all?(&:valid?) }
-
-        # Replace the tiers
-        if tiers_valid
-          @sb[:rate].chargeback_rate_details.each_with_index do |_detail, i|
-            @sb[:rate_details][i].save_tiers(@sb[:tiers][i])
-          end
-        end
-        # Detect errors saving rate details
-        rate_details_valid = @sb[:rate_details].all?(&:valid?)
-
-        if rate_details_valid && tiers_valid && @sb[:rate].save
-          @sb[:rate_details].each(&:save)
-          @sb[:rate].chargeback_rate_details.each { |detail| detail.chargeback_tiers = [] } # Clear the chargeback tiers
-          @sb[:tiers].each { |tiers| tiers.each(&:save) } # Save tiers
-          AuditEvent.success(build_saved_audit(@sb[:rate], @edit))
-          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description})
-          @edit = session[:edit] = nil  # clean out the saved info
-          @changed = false
-          get_node_info(x_node)
-          @sb[:rate] = @sb[:rate_details] = @sb[:tiers] = nil
-          replace_right_cell([:cb_rates])
-        else
-          @sb[:rate].errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
-          end
-          @sb[:rate_details].each do |detail|
-            display_detail_errors(detail, detail.errors)
-          end
-          @sb[:tiers].each_with_index do |tiers, detail_index|
-            tiers.each do |tier|
-              display_detail_errors(@sb[:rate_details][detail_index], tier.errors)
-            end
-          end
-          @changed = session[:changed] = (@edit[:new] != @edit[:current])
-          @sb[:rate] = @sb[:rate_details] = @sb[:tiers] = nil
-          render :update do |page|
-            page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-          end
+        @changed = session[:changed] = (@edit[:new] != @edit[:current])
+        render :update do |page|
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
+
     when "reset", nil  # Reset or first time in
       obj = find_checked_items                              # editing from list view
       obj[0] = params[:id] if obj.blank? && params[:id]      # editing from show screen
       if params[:typ] == "copy" # if tab was not changed
         session[:changed] = true
-        @sb[:rate_details] = []
-        @sb[:num_tiers] = []
-        @sb[:tiers] = []
-        rate = ChargebackRate.find(obj[0])
-        @sb[:rate] = ChargebackRate.new
-        @sb[:rate].description = _("Copy of %{description}") % {:description => rate.description}
-        @sb[:rate].rate_type = rate.rate_type
-        rate_details = rate.chargeback_rate_details.to_a
-        rate_details.sort_by! { |rd| [rd.group.downcase, rd.description.downcase] }
-        # Create new rate detail records for copied rate record
-        rate_details.each_with_index do |detail, detail_index|
-          @sb[:tiers][detail_index] = []
-          detail_copy = ChargebackRateDetail.new(:description                        => detail[:description],
-                                                 :source                             => detail[:source],
-                                                 :per_time                           => detail[:per_time],
-                                                 :group                              => detail[:group],
-                                                 :per_unit                           => detail[:per_unit],
-                                                 :metric                             => detail[:metric],
-                                                 :chargeback_rate_detail_measure_id  => detail[:chargeback_rate_detail_measure_id],
-                                                 :chargeback_rate_detail_currency_id => detail[:chargeback_rate_detail_currency_id])
-          detail.chargeback_tiers.each do |tier|
-            tier_copy = ChargebackTier.new(:start                     => tier[:start],
-                                           :end                       => tier[:end],
-                                           :fixed_rate                => tier[:fixed_rate],
-                                           :variable_rate             => tier[:variable_rate],
-                                           :chargeback_rate_detail_id => detail_copy.id)
-            @sb[:tiers][detail_index].push(tier_copy)
-          end
-          @sb[:rate_details].push(detail_copy) unless @sb[:rate_details].include?(detail_copy)
-          @sb[:num_tiers][detail_index] = @sb[:tiers][detail_index].size
-        end
+        @rate = ChargebackRate.find(obj[0]).clone
       else
         session[:changed] = false
-        @sb[:rate] = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0])
-        @sb[:num_tiers] = []
-        @sb[:tiers] = []
-        @sb[:rate_details] = @sb[:rate].chargeback_rate_details.to_a
-        @sb[:rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
-        @sb[:rate_details].each_with_index do |detail, i|
-          @sb[:tiers][i] = detail.chargeback_tiers.to_a
-          @sb[:num_tiers][i] = detail.chargeback_tiers.to_a.size
-        end
-        if @sb[:rate_details].blank?
-          fixture_file = File.join(@@fixture_dir, "chargeback_rates.yml")
-          if File.exist?(fixture_file)
-            fixture = YAML.load_file(fixture_file)
-            fixture.each do |cbr|
-              if cbr[:rate_type] == x_node.split('-').last
-                rates = cbr.delete(:rates)
-                rates.each_with_index do |detail, detail_index|
-                  detail_new = ChargebackRateDetail.new(:description => detail[:description],
-                                                        :source      => detail[:source],
-                                                        :per_time    => detail[:per_time],
-                                                        :group       => detail[:group],
-                                                        :per_unit    => detail[:per_unit],
-                                                        :metric      => detail[:metric])
-                  @sb[:tiers][detail_index] = []
-                  tiers = detail.delete(:tiers)
-                  rate_tiers = []
-                  tiers.each do |tier|
-                    tier_new = ChargebackTier.new(:start                     => tier.delete(:start),
-                                                  :end                       => tier.delete(:end),
-                                                  :fixed_rate                => tier.delete(:fixed_rate),
-                                                  :variable_rate             => tier.delete(:variable_rate),
-                                                  :chargeback_rate_detail_id => detail_new.id)
-                    rate_tiers.append(tier_new)
-                  end
-                  # if the rate detail has a measure associated
-                  unless detail[:measure].nil?
-                    # Copy the measure id of the rate_detail linkig with the rate_detail_measure
-                    id_measure = ChargebackRateDetailMeasure.find_by(:name => detail[:measure]).id
-                    detail_new.chargeback_rate_detail_measure_id = id_measure
-                  end
-                  # Copy the currency id of the rate detail linking with the rate_detail_currency
-                  if detail[:type_currency]
-                    id_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency]).id
-                    detail_new.chargeback_rate_detail_currency_id = id_currency
-                  end
-                  @sb[:rate_details].push(detail_new) unless @sb[:rate_details].include?(detail_new)
-                  @sb[:tiers][detail_index] = rate_tiers
-                end
-              end
-            end
-          end
-        end
+        @rate = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0])
       end
       cb_rate_set_form_vars
       @in_a_form = true
@@ -320,20 +212,20 @@ class ChargebackController < ApplicationController
         next if new_rate_details[:currency] == current_rate_details[:currency]
 
         current_rate_details[:currency] = new_rate_details[:currency]
-        params[:code_currency] = new_rate_detail_currency.code
-        params[:id_column] = i
-        params[:num_tiers] = @sb[:num_tiers][i]
-        page.replace("column_currency_#{i}", :partial => "cb_new_currency_column")
+        locals = {
+          :code_currency => new_rate_detail_currency.code,
+          :id_column => i,
+          :num_tiers => @edit[:new][:num_tiers][i]
+        }
+        page.replace("column_currency_#{i}", :partial => "cb_new_currency_column", :locals => locals)
       end
       page << javascript_for_miq_button_visibility(changed)
     end
-    cb_rate_get_form_vars
   end
 
   def cb_rate_show
     @display = "main"
-    @sb[:selected_rate_details] = @record.chargeback_rate_details.to_a
-    @sb[:selected_rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
+    @record.chargeback_rate_details.to_a.sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
     if @record.nil?
       redirect_to :action => "cb_rates_list", :flash_msg => _("Error: Record no longer exists in the database"), :flash_error => true
       return
@@ -408,11 +300,11 @@ class ChargebackController < ApplicationController
     @edit  = session[:edit]
     detail = @edit[:new][:details][ii]
 
-    @sb[:num_tiers][ii] = detail[:chargeback_tiers].to_a.length if detail[:chargeback_tiers]
-    @sb[:num_tiers][ii] = 1 unless @sb[:num_tiers][ii] || @sb[:num_tiers][ii] == 0
-    @sb[:num_tiers][ii] += 1
+    @edit[:new][:num_tiers][ii] = detail[:chargeback_tiers].to_a.length if detail[:chargeback_tiers]
+    @edit[:new][:num_tiers][ii] = 1 unless @edit[:new][:num_tiers][ii] || @edit[:new][:num_tiers][ii] == 0
+    @edit[:new][:num_tiers][ii] += 1
 
-    tier_index = @sb[:num_tiers][ii] - 1
+    tier_index = @edit[:new][:num_tiers][ii] - 1
     tier_list = @edit[:new][:tiers][ii]
     tier_list[tier_index] = {}
 
@@ -422,9 +314,8 @@ class ChargebackController < ApplicationController
     tier[:fixed_rate]    = 0.0
     tier[:variable_rate] = 0.0
 
-    params[:code_currency] = ChargebackRateDetailCurrency.find_by(:id => detail[:currency]).code
-
-    add_row(detail_index, tier_index - 1)
+    code_currency = ChargebackRateDetailCurrency.find_by(:id => detail[:currency]).code
+    add_row(detail_index, tier_index - 1, code_currency)
   end
 
   # Remove the selected tier
@@ -432,19 +323,20 @@ class ChargebackController < ApplicationController
     @edit = session[:edit]
     index = params[:index]
     detail_index, tier_to_remove_index = index.split("-")
+    detail = @edit[:new][:details][detail_index.to_i]
     params[:detail_index] = detail_index
+    code_currency = ChargebackRateDetailCurrency.find_by(:id => detail[:currency]).code
     detail_index = detail_index.to_i
     tier_to_remove_index = tier_to_remove_index.to_i
-    @sb[:num_tiers][detail_index] = @sb[:num_tiers][detail_index] - 1
+    @edit[:new][:num_tiers][detail_index] = @edit[:new][:num_tiers][detail_index] - 1
     tiers = @edit[:new][:tiers][detail_index]
     @edit[:new][:tiers][detail_index].each_with_index do |_tier, tier_index|
       next if tier_index <= tier_to_remove_index
       @edit[:new][:tiers][detail_index][tier_index - 1] = @edit[:new][:tiers][detail_index][tier_index]
     end
-    replace_rows(detail_index, tiers, tier_to_remove_index) # Replace tiers in the view
     # Delete tier records
-    @edit[:new][:tiers][detail_index].delete_at(@sb[:num_tiers][detail_index])
-    @sb[:tiers][detail_index].delete_at(@sb[:num_tiers][detail_index])
+    @edit[:new][:tiers][detail_index].delete_at(@edit[:new][:num_tiers][detail_index])
+    replace_rows(detail_index, tiers, tier_to_remove_index, code_currency) # Replace tiers in the view
   end
 
   def cb_assign_update
@@ -558,10 +450,10 @@ class ChargebackController < ApplicationController
     node = valid_active_node(node)
     if x_active_tree == :cb_rates_tree
       if node == "root"
-        @sb[:rate] = @record = @sb[:selected_rate_details] = nil
+        @record = nil
         @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "ChargebackRate")}
       elsif ["xx-Compute", "xx-Storage"].include?(node)
-        @sb[:rate] = @record = @sb[:selected_rate_details] = nil
+        @record = nil
         @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
         cb_rates_list
       else
@@ -663,34 +555,85 @@ class ChargebackController < ApplicationController
   # Set form variables for edit
   def cb_rate_set_form_vars
     @edit = {}
-    @edit[:rate] = @sb[:rate]
-    @edit[:key] = "cbrate_edit__#{@sb[:rate].id || "new"}"
-    @edit[:rate_details] = @sb[:rate_details]
     @edit[:new]     = HashWithIndifferentAccess.new
     @edit[:current] = HashWithIndifferentAccess.new
-    @edit[:rec_id] = @sb[:rate].id || nil
     @in_a_form = true
+    @edit[:new][:tiers]     = []
+    @edit[:new][:num_tiers] = []
+    rate_details = @rate.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }
+    tiers = []
 
-    @edit[:new][:description] = @sb[:rate].description
-    @edit[:new][:rate_type] = @sb[:rate].rate_type ? @sb[:rate].rate_type : x_node.split('-').last
+    @edit[:new][:description] = @rate.description
+    @edit[:new][:rate_type] = @rate.rate_type || x_node.split('-').last
     @edit[:new][:details] = []
-    # Select the currency of the first chargeback_rate_detail. All the chargeback_rate_details have the same currency
-    @edit[:new][:currency] = @sb[:rate_details][0].chargeback_rate_detail_currency_id
-    @edit[:new][:tiers] = []
 
-    @sb[:rate_details].each_with_index do |detail, detail_index|
-      temp = {}
-      temp = detail.slice(:per_time, :per_unit, :detail_measure)
-      temp[:per_time] ||= "hourly"
-      temp[:currency] = detail.detail_currency.id
-      @edit[:new][:tiers][detail_index] = []
-      @sb[:tiers][detail_index].each do |tier|
-        temp2 = {}
-        temp2 = tier.slice(:fixed_rate, :variable_rate, :start, :end)
-        temp2[:chargeback_rate_detail_id] = detail.id
-        @edit[:new][:tiers][detail_index].push(temp2)
+    # need to figure out a way to do this without reading yaml
+    if rate_details.blank?
+      fixture_file = File.join(@@fixture_dir, "chargeback_rates.yml")
+      if File.exist?(fixture_file)
+        fixture = YAML.load_file(fixture_file)
+        fixture.each do |cbr|
+          if cbr[:rate_type] == x_node.split('-').last
+            rates = cbr.delete(:rates)
+            rates.each_with_index do |detail, detail_index|
+              detail_new = ChargebackRateDetail.new(:description => detail[:description],
+                                                    :source      => detail[:source],
+                                                    :per_time    => detail[:per_time],
+                                                    :group       => detail[:group],
+                                                    :per_unit    => detail[:per_unit],
+                                                    :metric      => detail[:metric])
+              @edit[:new][:tiers][detail_index] = []
+              cb_tiers = detail.delete(:tiers)
+              rate_tiers = []
+              cb_tiers.each do |tier|
+                tier_new = ChargebackTier.new(:start                     => tier.delete(:start),
+                                              :end                       => tier.delete(:end),
+                                              :fixed_rate                => tier.delete(:fixed_rate),
+                                              :variable_rate             => tier.delete(:variable_rate),
+                                              :chargeback_rate_detail_id => detail_new.id)
+                rate_tiers.append(tier_new)
+              end
+              # if the rate detail has a measure associated
+              unless detail[:measure].nil?
+                # Copy the measure id of the rate_detail linkig with the rate_detail_measure
+                id_measure = ChargebackRateDetailMeasure.find_by(:name => detail[:measure]).id
+                detail_new.chargeback_rate_detail_measure_id = id_measure
+              end
+              # Copy the currency id of the rate detail linking with the rate_detail_currency
+              if detail[:type_currency]
+                id_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency]).id
+                detail_new.chargeback_rate_detail_currency_id = id_currency
+              end
+              rate_details.push(detail_new) unless rate_details.include?(detail_new)
+              tiers.push(rate_tiers)
+            end
+          end
+        end
       end
-      @sb[:num_tiers][detail_index] = @sb[:tiers][detail_index].length
+    end
+
+    # Select the currency of the first chargeback_rate_detail. All the chargeback_rate_details have the same currency
+    @edit[:new][:currency] = rate_details[0].chargeback_rate_detail_currency_id
+    @edit[:new][:code_currency] = rate_details[0].detail_currency.code
+
+    rate_details.each_with_index do |detail, detail_index|
+      temp                    = detail.slice(:per_time, :per_unit, :detail_measure, :group, :source)
+      temp[:id]               = params[:typ] == "copy" ? nil : detail.id
+      temp[:per_time]         ||= "hourly"
+      temp[:group]            = detail.group
+      temp[:description]      = detail.description
+      temp[:per_unit_display] = detail.per_unit_display
+      temp[:currency]         = detail.detail_currency.id
+
+      tiers[detail_index] = []
+      detail.chargeback_tiers.each do |tier|
+        temp2 = tier.slice(:fixed_rate, :variable_rate, :start, :end)
+        temp2[:id] = params[:typ] == "copy" ? nil : tier.id
+        temp2[:chargeback_rate_detail_id] = params[:typ] == "copy" ? nil : detail.id
+        tiers[detail_index].push(temp2)
+      end
+      @edit[:new][:tiers][detail_index] = tiers[detail_index]
+      @edit[:new][:num_tiers][detail_index] = tiers[detail_index].size
       @edit[:new][:details].push(temp)
     end
 
@@ -700,13 +643,15 @@ class ChargebackController < ApplicationController
       "weekly"  => "Weekly",
       "monthly" => "Monthly"
     }
+    @rate.id = nil if params[:typ] == "copy"
+    @edit[:rec_id] = @rate.id || nil
+    @edit[:key] = "cbrate_edit__#{@rate.id || "new"}"
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit] = @edit
-  end
+      end
 
   # Get variables from edit form
   def cb_rate_get_form_vars
-    @sb[:rate] = @edit[:rate]
     @edit[:new][:description] = params[:description] if params[:description]
     @edit[:new][:details].each_with_index do |detail, detail_index|
       %i{per_time per_unit}.each do |measure|
@@ -717,7 +662,7 @@ class ChargebackController < ApplicationController
       detail[:currency] = params[:currency] if params[:currency]
 
       # Save tiers into @edit
-      (0..@sb[:num_tiers][detail_index].to_i - 1).each do |tier_index|
+      (0..@edit[:new][:num_tiers][detail_index].to_i - 1).each do |tier_index|
         tier = @edit[:new][:tiers][detail_index][tier_index] || {}
         %i{fixed_rate variable_rate start end}.each do |field|
           key = "#{field}_#{detail_index}_#{tier_index}".to_sym
@@ -728,24 +673,31 @@ class ChargebackController < ApplicationController
   end
 
   def cb_rate_set_record_vars
-    @edit[:new][:details].each_with_index do |_detail, detail_index|
-      @sb[:rate_details][detail_index].per_time           = _detail[:per_time]
-      @sb[:rate_details][detail_index].per_unit           = _detail[:per_unit]
+    @rate_details = []
+    @rate_tiers = []
+    @edit[:new][:details].each_with_index do |detail, detail_index|
+      rate_detail = detail[:id] ? ChargebackRateDetail.find(detail[:id]) : ChargebackRateDetail.new
+      rate_detail.per_time    = detail[:per_time]
+      rate_detail.per_unit    = detail[:per_unit]
+      rate_detail.source      = detail[:source]
+      rate_detail.group       = detail[:group]
+      rate_detail.description = detail[:description]
       # C: Record the currency selected in the edit view, in my chargeback_rate_details table
-      @sb[:rate_details][detail_index].chargeback_rate_detail_currency_id = @edit[:new][:details][detail_index][:currency]
-      @sb[:rate_details][detail_index].chargeback_rate_id = @sb[:rate].id
+      rate_detail.chargeback_rate_detail_currency_id = @edit[:new][:details][detail_index][:currency]
+      rate_detail.chargeback_rate_id = @rate.id
       # Save tiers into @sb
-      @edit[:new][:tiers][detail_index].each_with_index do |_tier, tier_index|
-        @sb[:tiers][detail_index][tier_index] =
-          ChargebackTier.new(:start                     => _tier[:start],
-                             :end                       => _tier[:end],
-                             :fixed_rate                => _tier[:fixed_rate],
-                             :variable_rate             => _tier[:variable_rate],
-                             :chargeback_rate_detail_id => @sb[:rate_details][detail_index].id)
-        if tier_index >= @sb[:num_tiers][detail_index]
-          break
-        end
+      rate_tiers = []
+      @edit[:new][:tiers][detail_index].each do |tier|
+        rate_tier = tier[:id] ? ChargebackTier.find(tier[:id]) : ChargebackTier.new
+        rate_tier.start = tier[:start]
+        rate_tier.end   = tier[:end]
+        rate_tier.chargeback_rate_detail_id = rate_detail.id
+        rate_tier.fixed_rate  = tier[:fixed_rate]
+        rate_tier.variable_rate = tier[:variable_rate]
+        rate_tiers.push(rate_tier)
       end
+      @rate_tiers[detail_index] = rate_tiers
+      @rate_details.push(rate_detail)
     end
   end
 
@@ -1005,19 +957,26 @@ class ChargebackController < ApplicationController
     errors.each { |field, msg| add_flash("'#{detail.description}' #{field.to_s.capitalize} #{msg}", :error) }
   end
 
-  def add_row(i, pos)
+  def add_row(i, pos, code_currency)
+    locals = {:code_currency => code_currency}
     render :update do |page|
       # Update the first row to change the colspan
-      page.replace("rate_detail_row_#{i}_0", :partial => "tier_first_row")
+      page.replace("rate_detail_row_#{i}_0",
+                   :partial => "tier_first_row",
+                   :locals  => locals)
       # Insert the new tier after the last one
-      page.insert_html(:after, "rate_detail_row_#{i}_#{pos}", :partial => "tier_row")
+      page.insert_html(:after,
+                       "rate_detail_row_#{i}_#{pos}",
+                       :partial => "tier_row",
+                       :locals  => locals)
       page << javascript_for_miq_button_visibility(true)
     end
   end
 
-  def replace_rows(detail_index, tiers, tier_to_remove_index)
+  def replace_rows(detail_index, tiers, tier_to_remove_index, code_currency)
+    @changed = session[:changed] = (@edit[:new] != @edit[:current])
     render :update do |page|
-      page.replace("rate_detail_row_#{detail_index}_0", :partial => "tier_first_row")
+      page.replace("rate_detail_row_#{detail_index}_0", :partial => "tier_first_row", :locals => {:code_currency => code_currency})
       tiers.each_with_index do |_tier, tier_index|
         next if tier_index <= tier_to_remove_index
         # Move up tiers not to have blank rows
@@ -1027,9 +986,9 @@ class ChargebackController < ApplicationController
         params[:tier_row] = nil
       end
       # Delete the last row
-      # delete_row(detail_index, @sb[:num_tiers][detail_index])
-      page.replace("rate_detail_row_#{detail_index}_#{@sb[:num_tiers][detail_index]}", '')
-      page << javascript_for_miq_button_visibility(true)
+      # delete_row(detail_index, @edit[:new][:num_tiers][detail_index])
+      page.replace("rate_detail_row_#{detail_index}_#{@edit[:new][:num_tiers][detail_index]}", '')
+      page << javascript_for_miq_button_visibility(@changed)
     end
   end
 end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -298,8 +298,8 @@ class ChargebackController < ApplicationController
     tier_list[tier_index] = {}
 
     tier                 = tier_list[tier_index]
-    tier[:start]         = tier_list[tier_index - 1][:end]
-    tier[:end]           = Float::INFINITY
+    tier[:start]         = tier_list[tier_index - 1][:finish]
+    tier[:finish]        = Float::INFINITY
     tier[:fixed_rate]    = 0.0
     tier[:variable_rate] = 0.0
 
@@ -571,7 +571,7 @@ class ChargebackController < ApplicationController
 
       tiers[detail_index] = []
       detail.chargeback_tiers.order(:start).each do |tier|
-        temp2 = tier.slice(:fixed_rate, :variable_rate, :start, :end)
+        temp2 = tier.slice(:fixed_rate, :variable_rate, :start, :finish)
         temp2[:id] = params[:typ] == "copy" ? nil : tier.id
         temp2[:chargeback_rate_detail_id] = params[:typ] == "copy" ? nil : detail.id
         tiers[detail_index].push(temp2)
@@ -592,7 +592,7 @@ class ChargebackController < ApplicationController
     @edit[:key] = "cbrate_edit__#{@rate.id || "new"}"
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit] = @edit
-      end
+  end
 
   # Get variables from edit form
   def cb_rate_get_form_vars
@@ -608,7 +608,7 @@ class ChargebackController < ApplicationController
       # Save tiers into @edit
       (0..@edit[:new][:num_tiers][detail_index].to_i - 1).each do |tier_index|
         tier = @edit[:new][:tiers][detail_index][tier_index] || {}
-        %i{fixed_rate variable_rate start end}.each do |field|
+        %i{fixed_rate variable_rate start finish}.each do |field|
           key = "#{field}_#{detail_index}_#{tier_index}".to_sym
           tier[field] = params[key] if params[key]
         end
@@ -633,8 +633,8 @@ class ChargebackController < ApplicationController
       rate_tiers = []
       @edit[:new][:tiers][detail_index].each do |tier|
         rate_tier = tier[:id] ? ChargebackTier.find(tier[:id]) : ChargebackTier.new
-        rate_tier.start = tier[:start]
-        rate_tier.end   = tier[:end]
+        rate_tier.start  = tier[:start]
+        rate_tier.finish = tier[:finish]
         rate_tier.chargeback_rate_detail_id = rate_detail.id
         rate_tier.fixed_rate  = tier[:fixed_rate]
         rate_tier.variable_rate = tier[:variable_rate]

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -169,7 +169,7 @@ class ChargebackController < ApplicationController
         # Replace the tiers
         if tiers_valid
           @sb[:rate].chargeback_rate_details.each_with_index do |_detail, i|
-            @sb[:rate_details][i].chargeback_tiers = @sb[:tiers][i]
+            @sb[:rate_details][i].save_tiers(@sb[:tiers][i])
           end
         end
         # Detect errors saving rate details
@@ -250,7 +250,7 @@ class ChargebackController < ApplicationController
         @sb[:rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
         @sb[:rate_details].each_with_index do |detail, i|
           @sb[:tiers][i] = detail.chargeback_tiers.to_a
-          @sb[:num_tiers][i] = detail.chargeback_tiers.to_a.length
+          @sb[:num_tiers][i] = detail.chargeback_tiers.to_a.size
         end
         if @sb[:rate_details].blank?
           fixture_file = File.join(@@fixture_dir, "chargeback_rates.yml")

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -132,21 +132,10 @@ class ChargebackController < ApplicationController
       # Detect errors saving tiers
       tiers_valid = @rate_tiers.all? { |tiers| tiers.all?(&:valid?) }
 
-      # Replace the tiers
-      # if tiers_valid
-      #   @rate.chargeback_rate_details.each_with_index do |_detail, i|
-      #     @rate_details[i].save_tiers(@rate_tiers[i])
-      #   end
-      # end
-
-      # Detect errors saving rate details
-      rate_details_valid = @rate_details.all?(&:valid?)
-
-      if tiers_valid && rate_details_valid && @rate.save
+      if tiers_valid && @rate.save
         @rate.chargeback_rate_details.replace(@rate_details)
         @rate.chargeback_rate_details.each_with_index do |_detail, i|
-          #@rate_details[i].save_tiers(@rate_tiers[i])
-          @rate_details[i].chargeback_tiers.replace(@rate_tiers[i])
+          @rate_details[i].save_tiers(@rate_tiers[i])
         end
 
         if params[:button] == "add"

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -570,7 +570,7 @@ class ChargebackController < ApplicationController
       temp[:currency]         = detail.detail_currency.id
 
       tiers[detail_index] = []
-      detail.chargeback_tiers.each do |tier|
+      detail.chargeback_tiers.order(:start).each do |tier|
         temp2 = tier.slice(:fixed_rate, :variable_rate, :start, :end)
         temp2[:id] = params[:typ] == "copy" ? nil : tier.id
         temp2[:chargeback_rate_detail_id] = params[:typ] == "copy" ? nil : detail.id

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -402,20 +402,28 @@ class ChargebackController < ApplicationController
 
   # Add a new tier at the end
   def cb_tier_add
-    @edit = session[:edit]
     detail_index = params[:detail_index]
     ii = detail_index.to_i
-    @sb[:num_tiers][ii] =
-      @edit[:new][:details][ii][:chargeback_tiers].to_a.length if @edit[:new][:details][ii][:chargeback_tiers]
+
+    @edit  = session[:edit]
+    detail = @edit[:new][:details][ii]
+
+    @sb[:num_tiers][ii] = detail[:chargeback_tiers].to_a.length if detail[:chargeback_tiers]
     @sb[:num_tiers][ii] = 1 unless @sb[:num_tiers][ii] || @sb[:num_tiers][ii] == 0
     @sb[:num_tiers][ii] += 1
+
     tier_index = @sb[:num_tiers][ii] - 1
-    @edit[:new][:tiers][ii][tier_index] = {}
-    @edit[:new][:tiers][ii][tier_index][:start] = @edit[:new][:tiers][ii][tier_index - 1][:end]
-    @edit[:new][:tiers][ii][tier_index][:end] = Float::INFINITY
-    @edit[:new][:tiers][ii][tier_index][:fixed_rate] = 0.0
-    @edit[:new][:tiers][ii][tier_index][:variable_rate] = 0.0
-    params[:code_currency] = ChargebackRateDetailCurrency.find_by(:id => @edit[:new][:details][ii][:currency]).code
+    tier_list = @edit[:new][:tiers][ii]
+    tier_list[tier_index] = {}
+
+    tier                 = tier_list[tier_index]
+    tier[:start]         = tier_list[tier_index - 1][:end]
+    tier[:end]           = Float::INFINITY
+    tier[:fixed_rate]    = 0.0
+    tier[:variable_rate] = 0.0
+
+    params[:code_currency] = ChargebackRateDetailCurrency.find_by(:id => detail[:currency]).code
+
     add_row(detail_index, tier_index - 1)
   end
 

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -132,10 +132,10 @@ class ChargebackRate < ApplicationRecord
           tiers = rate_detail.delete(:tiers)
           tiers.each do |tier|
             tier_start = ChargebackTier.to_float(tier.delete(:start))
-            tier_end = ChargebackTier.to_float(tier.delete(:end))
+            tier_finish = ChargebackTier.to_float(tier.delete(:finish))
             fixed_rate = tier.delete(:fixed_rate)
             variable_rate = tier.delete(:variable_rate)
-            cbt = ChargebackTier.create(:start => tier_start, :end => tier_end, :fixed_rate => fixed_rate, :variable_rate => variable_rate)
+            cbt = ChargebackTier.create(:start => tier_start, :finish => tier_finish, :fixed_rate => fixed_rate, :variable_rate => variable_rate)
             rate_tiers.append(cbt)
           end
           rate_detail[:chargeback_tiers] = rate_tiers

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -128,6 +128,17 @@ class ChargebackRate < ApplicationRecord
           if currency
             rate_detail[:chargeback_rate_detail_currency_id] = currency.id
           end
+          rate_tiers = []
+          tiers = rate_detail.delete(:tiers)
+          tiers.each do |tier|
+            tier_start = ChargebackTier.to_float(tier.delete(:start))
+            tier_end = ChargebackTier.to_float(tier.delete(:end))
+            fixed_rate = tier.delete(:fixed_rate)
+            variable_rate = tier.delete(:variable_rate)
+            cbt = ChargebackTier.create(:start => tier_start, :end => tier_end, :fixed_rate => fixed_rate, :variable_rate => variable_rate)
+            rate_tiers.append(cbt)
+          end
+          rate_detail[:chargeback_tiers] = rate_tiers
         end
         if rec.nil?
           _log.info("Creating [#{cbr[:description]}] with guid=[#{cbr[:guid]}]")

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,7 +12,7 @@ class ChargebackRateDetail < ApplicationRecord
     variable_rate = 0.0
     chargeback_tiers.each do |tier|
       next if value < rate_adjustment(tier.start)
-      next if value >= rate_adjustment(tier.end)
+      next if value >= rate_adjustment(tier.finish)
       fixed_rate = tier.fixed_rate
       variable_rate = tier.variable_rate
       break
@@ -117,7 +117,7 @@ class ChargebackRateDetail < ApplicationRecord
       ChargebackTier.where(:chargeback_rate_detail_id => id).each do |tier|
         # Example: Daily @ .02 per MHz from 0.0 to Infinity
         s += "#{per_time.to_s.capitalize} @ #{tier.fixed_rate} + "\
-             "#{tier.variable_rate} per #{per_unit_display} from #{tier.start} to #{tier.end}\n"
+             "#{tier.variable_rate} per #{per_unit_display} from #{tier.start} to #{tier.finish}\n"
       end
       s.chomp
     end
@@ -201,6 +201,6 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def consecutive_tiers?(tier, previous_tier)
-    tier.start == previous_tier.end
+    tier.start == previous_tier.finish
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -47,7 +47,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def hourly_rate
-    (fixed_rate, variable_rate) = find_rate(0.0)
+    variable_rate = find_rate(0.0)
     rate = variable_rate
     return 0.0 if rate.zero?
 
@@ -116,8 +116,9 @@ class ChargebackRateDetail < ApplicationRecord
     else
       s = ""
       ChargebackTier.where(:chargeback_rate_detail_id => id).each do |tier|
-        # Example: Daily @ .02 per MHz
-        s += "#{per_time.to_s.capitalize} @ #{tier.fixed_rate} + #{tier.variable_rate} per #{per_unit_display} from #{tier.start} to #{tier.end}\n"
+        # Example: Daily @ .02 per MHz from 0.0 to Infinity
+        s += "#{per_time.to_s.capitalize} @ #{tier.fixed_rate}"\
+             "#{tier.variable_rate} per #{per_unit_display} from #{tier.start} to #{tier.end}\n"
       end
       s.chomp
     end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -143,7 +143,14 @@ class ChargebackRateDetail < ApplicationRecord
   def save_tiers(tiers)
     temp = self.class.new(:chargeback_tiers => tiers)
     if temp.contiguous_tiers?
-      self.chargeback_tiers = tiers
+      tiers.each do |tier|
+        unless tier.valid?
+          errors.add(:tier, tier.errors.full_messages.first)
+          return
+        end
+        tier.save
+      end
+      self.chargeback_tiers.replace(tiers)
     else
       temp.errors.each {|a, e| errors.add(a, e)}
     end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -47,16 +47,15 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def hourly_rate
-    variable_rate = find_rate(0.0)
-    rate = variable_rate
-    return 0.0 if rate.zero?
+    _fixed_rate, variable_rate = find_rate(0.0)
+    return 0.0 if variable_rate.zero?
 
     hr = case per_time
-         when "hourly"  then rate
-         when "daily"   then rate / 24
-         when "weekly"  then rate / 24 / 7
-         when "monthly" then rate / 24 / 30
-         when "yearly"  then rate / 24 / 365
+         when "hourly"  then variable_rate
+         when "daily"   then variable_rate / 24
+         when "weekly"  then variable_rate / 24 / 7
+         when "monthly" then variable_rate / 24 / 30
+         when "yearly"  then variable_rate / 24 / 365
          else raise _("rate time unit of '%{time_type}' not supported") % {:time_type => per_time}
          end
 
@@ -117,7 +116,7 @@ class ChargebackRateDetail < ApplicationRecord
       s = ""
       ChargebackTier.where(:chargeback_rate_detail_id => id).each do |tier|
         # Example: Daily @ .02 per MHz from 0.0 to Infinity
-        s += "#{per_time.to_s.capitalize} @ #{tier.fixed_rate}"\
+        s += "#{per_time.to_s.capitalize} @ #{tier.fixed_rate} + "\
              "#{tier.variable_rate} per #{per_unit_display} from #{tier.start} to #{tier.end}\n"
       end
       s.chomp

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -4,7 +4,7 @@ class ChargebackTier < ApplicationRecord
 
   def self.to_float(s)
     if s.to_s.include?("Infinity")
-        Float::INFINITY
+      Float::INFINITY
     else
       s
     end

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -1,6 +1,8 @@
 class ChargebackTier < ApplicationRecord
   belongs_to :chargeback_rate_detail
   validates :fixed_rate, :variable_rate, :start, :end, :numericality => true
+  validates :start, :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
+  validates :end,   :numericality => {:greater_than_or_equal_to => 0}
 
   def self.to_float(s)
     if s.to_s.include?("Infinity")

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -1,0 +1,12 @@
+class ChargebackTier < ApplicationRecord
+  belongs_to :chargeback_rate_detail
+  validates :fixed_rate, :variable_rate, :start, :end, :numericality => true
+
+  def self.to_float(s)
+    if s.to_s.include?("Infinity")
+        Float::INFINITY
+    else
+      s
+    end
+  end
+end

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -11,4 +11,12 @@ class ChargebackTier < ApplicationRecord
       s
     end
   end
+
+  def starts_with_zero?
+    start.zero?
+  end
+
+  def ends_with_infinity?
+    self.end == Float::INFINITY
+  end
 end

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -1,8 +1,8 @@
 class ChargebackTier < ApplicationRecord
   belongs_to :chargeback_rate_detail
-  validates :fixed_rate, :variable_rate, :start, :end, :numericality => true
-  validates :start, :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
-  validates :end,   :numericality => {:greater_than_or_equal_to => 0}
+  validates :fixed_rate, :variable_rate, :start, :finish, :numericality => true
+  validates :start,  :numericality => {:greater_than_or_equal_to => 0, :less_than => Float::INFINITY}
+  validates :finish, :numericality => {:greater_than_or_equal_to => 0}
 
   def self.to_float(s)
     if s.to_s.include?("Infinity")
@@ -17,6 +17,6 @@ class ChargebackTier < ApplicationRecord
   end
 
   def ends_with_infinity?
-    self.end == Float::INFINITY
+    finish == Float::INFINITY
   end
 end

--- a/app/views/chargeback/_cb_new_currency_column.html.haml
+++ b/app/views/chargeback/_cb_new_currency_column.html.haml
@@ -1,5 +1,3 @@
 /In this view, the currency column is updated with the code of the currency selected by the user
-- i = params[:id_column]
-- num_tiers = params[:num_tiers]
-%td{:id => "column_currency_#{i}", :rowspan => num_tiers}
- = params[:code_currency]
+%td{:id => "column_currency_#{id_column}", :rowspan => num_tiers}
+ = code_currency

--- a/app/views/chargeback/_cb_new_currency_column.html.haml
+++ b/app/views/chargeback/_cb_new_currency_column.html.haml
@@ -1,4 +1,5 @@
 /In this view, the currency column is updated with the code of the currency selected by the user
 - i = params[:id_column]
-%td{:id => "column_currency_#{i}"}
+- num_tiers = params[:num_tiers]
+%td{:id => "column_currency_#{i}", :rowspan => num_tiers}
  = params[:code_currency]

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,5 +1,6 @@
 - url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
+#flash_msg_div
 #form_div
   %h3
     = _('Basic Info')
@@ -31,41 +32,93 @@
   %table.table.table-bordered
     %thead
       %tr
-        %th= _('Group')
-        %th= _('Description')
-        %th= _('Rate')
-        %th= _('Per Time')
-        %th= _('Per Unit')
-        %th= _('Currency')
+        %th{:rowspan => "2"}= _('Group')
+        %th{:rowspan => "2"}= _('Description')
+        %th{:colspan => "2"}= _('Range')
+        %th{:colspan => "2"}= _('Rate')
+        %th{:rowspan => "2"}= _('Add/Remove Tier')
+        %th{:rowspan => "2"}= _('Per Time')
+        %th{:rowspan => "2"}= _('Per Unit')
+        %th{:rowspan => "2"}= _('Currency')
+      %tr
+        %th= _("Start")
+        %th= _("End")
+        %th= _("Fixed")
+        %th= _("Variable")
     %tbody
       - code_currency = @sb[:rate_details][0].detail_currency.code
-      - @sb[:rate_details].each_with_index do |r, i|
-        - @cur_group = r[:group] if @cur_group.nil?
-        - if @cur_group != r[:group]
-          - @cur_group = r[:group]
+      %strong
+        = _('* Caution: The value Range end will not be included in the tier.')
+      - currency_code = @sb[:rate_details][0].detail_currency.code
+      - @sb[:rate_details].each_with_index do |detail, detail_index|
+        - @cur_group = detail[:group] if @cur_group.nil?
+        - if @cur_group != detail[:group]
+          - @cur_group = detail[:group]
           %tr
-            %td.active{:colspan => "6"} &nbsp;
-        %tr
+            %td.active{:colspan => "10"} &nbsp;
+        - num_tiers = @sb[:tiers][detail_index].blank? ? "1" : @sb[:tiers][detail_index].length.to_s
+
+        %tr{:id => "rate_detail_row_#{detail_index}_0"}
+          %td{:rowspan => num_tiers}
+            = h(rate_detail_group(detail[:group]))
+          %td{:rowspan => num_tiers}
+            = detail[:description]
           %td
-            = h(rate_detail_group(r[:group]))
+            = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
           %td
-            = r[:description]
+            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:end],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %td{:align => 'right'}
-            = text_field_tag("rate_#{i}", @edit[:new][:details][i][:rate],
+            = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td{:align => 'right'}
+            = text_field_tag("variable_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:variable_rate],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %td
-            = select_tag("per_time_#{i}",
-              options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][i][:per_time]),
+            = button_tag(_(""),
+                         :class   => "btn btn-default  pficon-add-circle-o",
+                         :alt     => t = _("Add a new tier"),
+                         :title   => t,
+                         :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
+                                                               :detail_index => detail_index,
+                                                               :button       => "add")}');")
+          %td{:rowspan => num_tiers}
+            = select_tag("per_time_#{detail_index}",
+              options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][detail_index][:per_time]),
               "data-miq_observe" => {:url => url}.to_json)
-            - measure = @edit[:new][:details][i][:detail_measure]
-            - if measure.nil?
-              /if the rate detail don't have a metric associated, display the per_unit_display
-              %td
-                = r.per_unit_display
-            - else
-              /if the rate detail have a metric associated, display an options field with per_unit selected
-              %td
-                = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+          - measure = @edit[:new][:details][detail_index][:detail_measure]
+          - if measure.nil?
+            /if the rate detail don't have a metric associated, display the per_unit_display
+            %td{:rowspan => num_tiers}
+              = detail.per_unit_display
+          - else
+            /if the rate detail have a metric associated, display an options field with per_unit selected
+            %td{:rowspan => num_tiers}
+              = select_tag("per_unit_#{detail_index}", options_for_select(measure.measures, detail.per_unit), "data-miq_observe" => {:url => url}.to_json)
           /Show the code of the currency selected by the user
-          %td{:id => "column_currency_#{i}"}
+          %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
             = code_currency
+        - (1..num_tiers.to_i - 1).each do |tier_index|
+          - tier = @sb[:tiers][detail_index][tier_index]
+          %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
+            %td
+              = text_field_tag("start_#{detail_index}_#{tier_index}", tier.start,
+                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %td
+              = text_field_tag("end_#{detail_index}_#{tier_index}", tier.end,
+                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %td{:align => "right"}
+              = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier.fixed_rate,
+                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %td{:align => "right"}
+              = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier.variable_rate,
+                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %td
+              = button_tag(_(""),
+                   :class   => "btn btn-default pficon-delete",
+                   :alt     => t = _("Remove the tier"),
+                   :title   => t,
+                   :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
+                                                         :index  => "#{detail_index}-#{tier_index}",
+                                                         :button => "remove")}');")

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -78,7 +78,7 @@
             = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
           %td
-            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:end],
+            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:finish],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %td{:align => 'right'}
             = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
@@ -104,7 +104,7 @@
               = text_field_tag("start_#{detail_index}_#{tier_index}", tier[:start],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td
-              = text_field_tag("end_#{detail_index}_#{tier_index}", tier[:end],
+              = text_field_tag("end_#{detail_index}_#{tier_index}", tier[:finish],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td{:align => "right"}
               = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -34,11 +34,11 @@
       %tr
         %th{:rowspan => "2"}= _('Group')
         %th{:rowspan => "2"}= _('Description')
-        %th{:colspan => "2"}= _('Range')
-        %th{:colspan => "2"}= _('Rate')
-        %th{:rowspan => "2"}= _('Add/Remove Tier')
         %th{:rowspan => "2"}= _('Per Time')
         %th{:rowspan => "2"}= _('Per Unit')
+        %th{:colspan => "2"}= _('Range')
+        %th{:colspan => "2"}= _('Rate')
+        %th{:rowspan => "2"}= _('Actions')
         %th{:rowspan => "2"}= _('Currency')
       %tr
         %th= _("Start")
@@ -58,31 +58,11 @@
             %td.active{:colspan => "10"} &nbsp;
         - num_tiers = @sb[:tiers][detail_index].blank? ? "1" : @sb[:tiers][detail_index].length.to_s
 
-        %tr{:id => "rate_detail_row_#{detail_index}_0"}
+        %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
           %td{:rowspan => num_tiers}
             = h(rate_detail_group(detail[:group]))
           %td{:rowspan => num_tiers}
             = detail[:description]
-          %td
-            = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
-          %td
-            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:end],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td{:align => 'right'}
-            = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td{:align => 'right'}
-            = text_field_tag("variable_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:variable_rate],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td
-            = button_tag(_(""),
-                         :class   => "btn btn-default  pficon-add-circle-o",
-                         :alt     => t = _("Add a new tier"),
-                         :title   => t,
-                         :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
-                                                               :detail_index => detail_index,
-                                                               :button       => "add")}');")
           %td{:rowspan => num_tiers}
             = select_tag("per_time_#{detail_index}",
               options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][detail_index][:per_time]),
@@ -96,6 +76,26 @@
             /if the rate detail have a metric associated, display an options field with per_unit selected
             %td{:rowspan => num_tiers}
               = select_tag("per_unit_#{detail_index}", options_for_select(measure.measures, detail.per_unit), "data-miq_observe" => {:url => url}.to_json)
+          %td
+            = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+          %td
+            = text_field_tag("end_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:end],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td{:align => 'right'}
+            = text_field_tag("fixed_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:fixed_rate],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td{:align => 'right'}
+            = text_field_tag("variable_rate_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:variable_rate],
+              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %td.action
+            = button_tag(_("Add"),
+                         :class   => "btn btn-default",
+                         :alt     => t = _("Add a new tier"),
+                         :title   => t,
+                         :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
+                                                               :detail_index => detail_index,
+                                                               :button       => "add")}');")
           /Show the code of the currency selected by the user
           %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
             = code_currency
@@ -114,9 +114,9 @@
             %td{:align => "right"}
               = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier.variable_rate,
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %td
-              = button_tag(_(""),
-                   :class   => "btn btn-default pficon-delete",
+            %td.action
+              = button_tag(_("Delete"),
+                   :class   => "btn btn-default",
                    :alt     => t = _("Remove the tier"),
                    :title   => t,
                    :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
 #flash_msg_div
 #form_div
@@ -46,16 +46,15 @@
         %th= _("Fixed")
         %th= _("Variable")
     %tbody
-      - code_currency = @sb[:rate_details][0].detail_currency.code
       %strong
         = _('* Caution: The value Range end will not be included in the tier.')
-      - @sb[:rate_details].each_with_index do |detail, detail_index|
+      - @edit[:new][:details].each_with_index do |detail, detail_index|
         - @cur_group = detail[:group] if @cur_group.nil?
         - if @cur_group != detail[:group]
           - @cur_group = detail[:group]
           %tr
             %td.active{:colspan => "10"} &nbsp;
-        - num_tiers = @sb[:tiers][detail_index].blank? ? "1" : @sb[:tiers][detail_index].length.to_s
+        - num_tiers = @edit[:new][:tiers][detail_index].blank? ? "1" : @edit[:new][:tiers][detail_index].length.to_s
 
         %tr.rdetail{:id => "rate_detail_row_#{detail_index}_0"}
           %td{:rowspan => num_tiers}
@@ -70,11 +69,11 @@
           - if measure.nil?
             /if the rate detail don't have a metric associated, display the per_unit_display
             %td{:rowspan => num_tiers}
-              = detail.per_unit_display
+              = detail[:per_unit_display]
           - else
             /if the rate detail have a metric associated, display an options field with per_unit selected
             %td{:rowspan => num_tiers}
-              = select_tag("per_unit_#{detail_index}", options_for_select(measure.measures, detail.per_unit), "data-miq_observe" => {:url => url}.to_json)
+              = select_tag("per_unit_#{detail_index}", options_for_select(measure.measures, detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
           %td
             = text_field_tag("start_#{detail_index}_0", @edit[:new][:tiers][detail_index][0][:start],
               :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
@@ -97,21 +96,21 @@
                                                                :button       => "add")}');")
           /Show the code of the currency selected by the user
           %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
-            = code_currency
+            = @edit[:new][:code_currency]
         - (1..num_tiers.to_i - 1).each do |tier_index|
-          - tier = @sb[:tiers][detail_index][tier_index]
+          - tier = @edit[:new][:tiers][detail_index][tier_index]
           %tr{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
             %td
-              = text_field_tag("start_#{detail_index}_#{tier_index}", tier.start,
+              = text_field_tag("start_#{detail_index}_#{tier_index}", tier[:start],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td
-              = text_field_tag("end_#{detail_index}_#{tier_index}", tier.end,
+              = text_field_tag("end_#{detail_index}_#{tier_index}", tier[:end],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td{:align => "right"}
-              = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier.fixed_rate,
+              = text_field_tag("fixed_rate_#{detail_index}_#{tier_index}", tier[:fixed_rate],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td{:align => "right"}
-              = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier.variable_rate,
+              = text_field_tag("variable_rate_#{detail_index}_#{tier_index}", tier[:variable_rate],
                 :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %td.action
               = button_tag(_("Delete"),

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -49,7 +49,6 @@
       - code_currency = @sb[:rate_details][0].detail_currency.code
       %strong
         = _('* Caution: The value Range end will not be included in the tier.')
-      - currency_code = @sb[:rate_details][0].detail_currency.code
       - @sb[:rate_details].each_with_index do |detail, detail_index|
         - @cur_group = detail[:group] if @cur_group.nil?
         - if @cur_group != detail[:group]

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -45,7 +45,7 @@
           %td
             = tier.start ? tier.start : 0
           %td
-            = tier.end ? tier.end : Float::INFINITY.to_s
+            = tier.finish ? tier.finish : Float::INFINITY.to_s
           %td{:align => "right"}
             = tier.fixed_rate ? tier.fixed_rate : 0.0
           %td{:align => "right"}
@@ -58,7 +58,7 @@
             %td
               = tier.start
             %td
-              = tier.end
+              = tier.finish
             %td{:align => "right"}
               = tier.fixed_rate
             %td{:align => "right"}

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -29,18 +29,19 @@
       /Currency code is the same for all the chargeback_rate_details
       - code_currency = @record.chargeback_rate_details.first.detail_currency.code
       - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each do |detail|
+      - tiers = detail.chargeback_tiers.order(:start)
         - @cur_group = detail[:group] if @cur_group.nil?
         - if @cur_group != detail[:group]
           - @cur_group = detail[:group]
           %tr
             %td.active{:colspan => "9"} &nbsp;
-        - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : detail.chargeback_tiers.to_a.length.to_s
+        - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
         %tr
           %td{:rowspan => num_tiers}
             = h(rate_detail_group(detail[:group]))
           %td{:rowspan => num_tiers}
             = detail[:description]
-          - tier = detail.chargeback_tiers.first
+          - tier = tiers.first
           %td
             = tier.start ? tier.start : 0
           %td
@@ -52,7 +53,7 @@
           %td{:align => "right", :rowspan => num_tiers}
             = detail.show_rates(code_currency)
         - (1..num_tiers.to_i - 1).each do |tier_index|
-          - tier = detail.chargeback_tiers.to_a[tier_index]
+          - tier = tiers.to_a[tier_index]
           %tr
             %td
               = tier.start

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -15,25 +15,52 @@
   %table.table.table-bordered
     %thead
       %tr
-        %th= _('Group')
-        %th= _('Description')
-        %th= _('Rate')
-        %th= _('Units')
+        %th{:rowspan => "2"}= _('Group')
+        %th{:rowspan => "2"}= _('Description')
+        %th{:colspan => "2"}= _('Range')
+        %th{:colspan => "2"}= _('Rate')
+        %th{:rowspan => "2"}= _('Units')
+      %tr
+        %th= _("Start")
+        %th= _("End")
+        %th= _("Fixed")
+        %th= _("Variable")
     %tbody
       /Currency code is the same for all the chargeback_rate_details
       - code_currency = @sb[:selected_rate_details].first.detail_currency.code
-      - @sb[:selected_rate_details].each do |r|
-        - @cur_group = r[:group] if @cur_group.nil?
-        - if @cur_group != r[:group]
-          - @cur_group = r[:group]
+      - @sb[:selected_rate_details].each do |detail|
+        - @cur_group = detail[:group] if @cur_group.nil?
+        - if @cur_group != detail[:group]
+          - @cur_group = detail[:group]
           %tr
-            %td.active{:colspan => "4"} &nbsp;
+            %td.active{:colspan => "9"} &nbsp;
+        - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : detail.chargeback_tiers.to_a.length.to_s
         %tr
+          %td{:rowspan => num_tiers}
+            = h(rate_detail_group(detail[:group]))
+          %td{:rowspan => num_tiers}
+            = detail[:description]
+          - tier = detail.chargeback_tiers.first
           %td
-            = h(rate_detail_group(r[:group]))
+            = tier.start ? tier.start : 0
           %td
-            = r[:description]
-          %td{:align => 'right'}
-            = r[:rate]
+            = tier.end ? tier.end : Float::INFINITY.to_s
           %td{:align => "right"}
-            = r.show_rates(code_currency)
+            = tier.fixed_rate ? tier.fixed_rate : 0.0
+          %td{:align => "right"}
+            = tier.variable_rate ? tier.variable_rate : 0.0
+          %td{:align => "right", :rowspan => num_tiers}
+            = detail.show_rates(code_currency)
+        - (1..num_tiers.to_i - 1).each do |tier_index|
+          - tier = detail.chargeback_tiers.to_a[tier_index]
+          %tr
+            %td
+              = tier.start
+            %td
+              = tier.end
+            %td{:align => "right"}
+              = tier.fixed_rate
+            %td{:align => "right"}
+              = tier.variable_rate
+        %tr
+          %td{:colspan => "9"}

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -27,8 +27,8 @@
         %th= _("Variable")
     %tbody
       /Currency code is the same for all the chargeback_rate_details
-      - code_currency = @sb[:selected_rate_details].first.detail_currency.code
-      - @sb[:selected_rate_details].each do |detail|
+      - code_currency = @record.chargeback_rate_details.first.detail_currency.code
+      - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each do |detail|
         - @cur_group = detail[:group] if @cur_group.nil?
         - if @cur_group != detail[:group]
           - @cur_group = detail[:group]

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -1,7 +1,7 @@
 - i = params[:detail_index]
-- r = @sb[:rate_details][i.to_i]
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
-- n = @sb[:num_tiers][i.to_i]
+- r = @edit[:new][:details][i.to_i]
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- n = @edit[:new][:num_tiers][i.to_i]
 
 %tr.rdetail{:id => "rate_detail_row_#{i}_0"}
   %td{:rowspan => n.to_s}
@@ -17,11 +17,11 @@
   - if measure.nil?
     /if the rate detail don't have a metric associated, display the per_unit_display
     %td{:rowspan => n.to_s}
-      = r.per_unit_display
+      = r[:per_unit_display]
   - else
     /if the rate detail have a metric associated, display an options field with per_unit selected
     %td{:rowspan => n.to_s}
-      = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+      = select_tag("per_unit_#{i}", options_for_select(measure[:measures], r[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
   %td
     = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
@@ -44,4 +44,4 @@
                                                        :button       => "add")}');")
   /Show the code of the currency selected by the user
   %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
-    = params[:code_currency]
+    = code_currency

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -3,31 +3,11 @@
 - url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
 - n = @sb[:num_tiers][i.to_i]
 
-%tr{:id => "rate_detail_row_#{i}_0"}
+%tr.rdetail{:id => "rate_detail_row_#{i}_0"}
   %td{:rowspan => n.to_s}
     = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
   %td{:rowspan => n.to_s}
     = r[:description]
-  %td
-    = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
-  %td
-    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:end],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %td{:align => 'right'}
-    = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %td{:align => 'right'}
-    = text_field_tag("variable_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:variable_rate],
-      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %td
-    = button_tag(_(""),
-                 :class   => "btn btn-default pficon-add-circle-o",
-                 :alt     => t = _("Add a new tier"),
-                 :title   => t,
-                 :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
-                                                       :detail_index => i,
-                                                       :button       => "add")}');")
   %td{:rowspan => n.to_s}
     - per_time_types = {"hourly"  => "Hourly", "daily"   => "Daily", "weekly"  => "Weekly", "monthly" => "Monthly"}
     = select_tag("per_time_#{i}",
@@ -42,6 +22,26 @@
     /if the rate detail have a metric associated, display an options field with per_unit selected
     %td{:rowspan => n.to_s}
       = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+  %td
+    = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+  %td
+    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:end],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("variable_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:variable_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td.action
+    = button_tag(_("Add"),
+                 :class   => "btn btn-default",
+                 :alt     => t = _("Add a new tier"),
+                 :title   => t,
+                 :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
+                                                       :detail_index => i,
+                                                       :button       => "add")}');")
   /Show the code of the currency selected by the user
   %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
     = params[:code_currency]

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -1,0 +1,47 @@
+- i = params[:detail_index]
+- r = @sb[:rate_details][i.to_i]
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
+- n = @sb[:num_tiers][i.to_i]
+
+%tr{:id => "rate_detail_row_#{i}_0"}
+  %td{:rowspan => n.to_s}
+    = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
+  %td{:rowspan => n.to_s}
+    = r[:description]
+  %td
+    = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
+  %td
+    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:end],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("variable_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:variable_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td
+    = button_tag(_(""),
+                 :class   => "btn btn-default pficon-add-circle-o",
+                 :alt     => t = _("Add a new tier"),
+                 :title   => t,
+                 :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
+                                                       :detail_index => i,
+                                                       :button       => "add")}');")
+  %td{:rowspan => n.to_s}
+    - per_time_types = {"hourly"  => "Hourly", "daily"   => "Daily", "weekly"  => "Weekly", "monthly" => "Monthly"}
+    = select_tag("per_time_#{i}",
+      options_for_select(per_time_types.invert, @edit[:new][:details][i.to_i][:per_time]),
+      "data-miq_observe" => {:url => url}.to_json)
+  - measure = @edit[:new][:details][i.to_i][:detail_measure]
+  - if measure.nil?
+    /if the rate detail don't have a metric associated, display the per_unit_display
+    %td{:rowspan => n.to_s}
+      = r.per_unit_display
+  - else
+    /if the rate detail have a metric associated, display an options field with per_unit selected
+    %td{:rowspan => n.to_s}
+      = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+  /Show the code of the currency selected by the user
+  %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
+    = params[:code_currency]

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -26,7 +26,7 @@
     = text_field_tag("start_#{i}_0", @edit[:new][:tiers][i.to_i][0][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json, :disabled => "disabled")
   %td
-    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:end],
+    = text_field_tag("end_#{i}_0", @edit[:new][:tiers][i.to_i][0][:finish],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_0", @edit[:new][:tiers][i.to_i][0][:fixed_rate],

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -8,7 +8,7 @@
     = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td
-    = text_field_tag("end_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:end],
+    = text_field_tag("end_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:finish],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   %td{:align => 'right'}
     = text_field_tag("fixed_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:fixed_rate],

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -1,0 +1,26 @@
+- i = params[:detail_index]
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
+- n = @sb[:num_tiers][i.to_i]
+- n = params[:tier_row] if params[:tier_row]
+
+%tr{:id => "rate_detail_row_#{i}_#{n - 1}"}
+  %td
+    = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td
+    = text_field_tag("end_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:end],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("fixed_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:fixed_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td{:align => 'right'}
+    = text_field_tag("variable_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:variable_rate],
+      :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  %td
+    = button_tag(_(""),
+                 :class   => "btn btn-default pficon-delete",
+                 :alt     => t = _("Remove the tier"),
+                 :title   => t,
+                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
+                                                       :index  => i + "-#{n - 1}",
+                                                       :button => "remove")}');")

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -3,7 +3,7 @@
 - n = @sb[:num_tiers][i.to_i]
 - n = params[:tier_row] if params[:tier_row]
 
-%tr{:id => "rate_detail_row_#{i}_#{n - 1}"}
+%tr.rdetail{:id => "rate_detail_row_#{i}_#{n - 1}"}
   %td
     = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
@@ -16,9 +16,9 @@
   %td{:align => 'right'}
     = text_field_tag("variable_rate_#{i}_#{n - 1}", @edit[:new][:tiers][i.to_i][n - 1][:variable_rate],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  %td
-    = button_tag(_(""),
-                 :class   => "btn btn-default pficon-delete",
+  %td.action
+    = button_tag(_("Delete"),
+                 :class   => "btn btn-default",
                  :alt     => t = _("Remove the tier"),
                  :title   => t,
                  :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -1,6 +1,6 @@
 - i = params[:detail_index]
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
-- n = @sb[:num_tiers][i.to_i]
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@edit[:rec_id] || "new"}")
+- n = @edit[:new][:num_tiers][i.to_i]
 - n = params[:tier_row] if params[:tier_row]
 
 %tr.rdetail.new_tier{:id => "rate_detail_row_#{i}_#{n - 1}"}

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -3,7 +3,7 @@
 - n = @sb[:num_tiers][i.to_i]
 - n = params[:tier_row] if params[:tier_row]
 
-%tr.rdetail{:id => "rate_detail_row_#{i}_#{n - 1}"}
+%tr.rdetail.new_tier{:id => "rate_detail_row_#{i}_#{n - 1}"}
   %td
     = text_field_tag("start_#{i}_#{n - 1}",  @edit[:new][:tiers][i.to_i][n - 1][:start],
       :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
@@ -24,3 +24,8 @@
                  :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_remove",
                                                        :index  => i + "-#{n - 1}",
                                                        :button => "remove")}');")
+  :javascript
+    $(document).ready(function () {
+        $('.new_tier').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
+        $('.new_tier').addClass('new_tier_off').removeClass('new_tier');
+    });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,8 @@ Vmdb::Application.routes.draw do
         cb_rate_show
         cb_rates_delete
         cb_rates_list
+        cb_tier_add
+        cb_tier_remove
         saved_report_paging
         tree_autoload_dynatree
         tree_select

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -8,67 +8,103 @@
       :group: cpu
       :source: used
       :metric: cpu_usagemhz_rate_average
-      :rate: 0.02
       :per_time: daily
       :per_unit: megahertz
       :measure: Hz Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.02
     - :description: Allocated CPU Count
       :group: cpu
       :source: allocated
       :metric: derived_vm_numvcpus
-      :rate: 0
       :per_time: daily
       :per_unit: cpu
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 1.0
+          :variable_rate: 0.0
     - :description: Used Memory
       :group: memory
       :source: used
       :metric: derived_memory_used
-      :rate: 0.02
       :per_time: daily
       :per_unit: megabytes
       :measure: Bytes Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.02
     - :description: Allocated Memory
       :group: memory
       :source: allocated
       :metric: derived_memory_available
-      :rate: 0
       :per_time: daily
       :per_unit: megabytes
       :measure: Bytes Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
     - :description: Used Network I/O
       :group: net_io
       :source: used
       :metric: net_usage_rate_average
-      :rate: 0.005
       :per_time: hourly
       :per_unit: kbps
       :measure: Bytes per Second Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: 100
+          :fixed_rate: 0.5
+          :variable_rate: 0.0
+        - :start: 100
+          :end: Infinity
+          :fixed_rate: 0.5
+          :variable_rate: 0.005
     - :description: Used Disk I/O
       :group: disk_io
       :source: used
       :metric: disk_usage_rate_average
-      :rate: 0.005
       :per_time: hourly
       :per_unit: kbps
       :measure: Bytes per Second Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.005
     - :description: Fixed Compute Cost 1
       :group: fixed
       :source: compute_1
-      :rate: 0
       :per_time: daily
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
     - :description: Fixed Compute Cost 2
       :group: fixed
       :source: compute_2
-      :rate: 0
       :per_time: monthly
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
 - :description: Default
   :guid: 7d7aaf20-5214-11df-a888-001d09066d98
   :rate_type: Storage
@@ -78,29 +114,45 @@
       :group: storage
       :source: allocated
       :metric: derived_vm_allocated_disk_storage
-      :rate: 0
       :per_time: monthly
       :per_unit: gigabytes
       :measure: Bytes Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 1.0
+          :variable_rate: 0.0
     - :description: Used Disk Storage
       :group: storage
       :source: used
       :metric: derived_vm_used_disk_storage
-      :rate: 2.0
       :per_time: monthly
       :per_unit: gigabytes
       :measure: Bytes Units
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 2.0
     - :description: Fixed Storage Cost 1
       :group: fixed
       :source: storage_1
-      :rate: 0
       :per_time: daily
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
     - :description: Fixed Storage Cost 2
       :group: fixed
       :source: storage_2
-      :rate: 0
       :per_time: monthly
       :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :end: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -14,7 +14,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.02
     - :description: Allocated CPU Count
@@ -26,7 +26,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 1.0
           :variable_rate: 0.0
     - :description: Used Memory
@@ -39,7 +39,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.02
     - :description: Allocated Memory
@@ -52,7 +52,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0
     - :description: Used Network I/O
@@ -65,11 +65,11 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: 100
+          :finish: 100
           :fixed_rate: 0.5
           :variable_rate: 0.0
         - :start: 100
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.5
           :variable_rate: 0.005
     - :description: Used Disk I/O
@@ -82,7 +82,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.005
     - :description: Fixed Compute Cost 1
@@ -92,7 +92,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0
     - :description: Fixed Compute Cost 2
@@ -102,7 +102,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0
 - :description: Default
@@ -120,7 +120,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 1.0
           :variable_rate: 0.0
     - :description: Used Disk Storage
@@ -133,7 +133,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 2.0
     - :description: Fixed Storage Cost 1
@@ -143,7 +143,7 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0
     - :description: Fixed Storage Cost 2
@@ -153,6 +153,6 @@
       :type_currency: Dollars
       :tiers:
         - :start: 0
-          :end: Infinity
+          :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0

--- a/db/migrate/20151104115400_create_chargeback_tiers.rb
+++ b/db/migrate/20151104115400_create_chargeback_tiers.rb
@@ -3,7 +3,7 @@ class CreateChargebackTiers < ActiveRecord::Migration
     create_table :chargeback_tiers do |t|
       t.bigint :chargeback_rate_detail_id
       t.float :start
-      t.float :end
+      t.float :finish
       t.float :fixed_rate
       t.float :variable_rate
 

--- a/db/migrate/20151104115400_create_chargeback_tiers.rb
+++ b/db/migrate/20151104115400_create_chargeback_tiers.rb
@@ -1,0 +1,13 @@
+class CreateChargebackTiers < ActiveRecord::Migration
+  def change
+    create_table :chargeback_tiers do |t|
+      t.bigint :chargeback_rate_detail_id
+      t.float :start
+      t.float :end
+      t.float :fixed_rate
+      t.float :variable_rate
+
+      t.timestamp :null => false
+    end
+  end
+end

--- a/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
+++ b/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
@@ -10,7 +10,11 @@ class TransferRateValueToTiers < ActiveRecord::Migration
     ChargebackRateDetail.reset_column_information
     ChargebackRateDetail.all.to_a.each do |detail|
       if detail.respond_to?(:rate)
-        ChargebackTier.create(:chargeback_rate_detail_id => detail.id, :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0, :variable_rate => detail.rate)
+        ChargebackTier.create(:chargeback_rate_detail_id => detail.id,
+                              :start                     => 0,
+                              :end                       => Float::INFINITY,
+                              :fixed_rate                => 0.0,
+                              :variable_rate             => detail.rate)
       end
     end
   end

--- a/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
+++ b/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
@@ -1,0 +1,17 @@
+class TransferRateValueToTiers < ActiveRecord::Migration
+  class ChargebackRateDetail < ActiveRecord::Base
+    has_many :chargeback_tiers
+  end
+  class ChargebackTier < ActiveRecord::Base
+    belongs_to :chargeback_rate_detail
+  end
+
+  def change
+    ChargebackRateDetail.reset_column_information
+    ChargebackRateDetail.all.to_a.each do |detail|
+      if detail.respond_to?(:rate)
+        ChargebackTier.create(:chargeback_rate_detail_id => detail.id, :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0, :variable_rate => detail.rate)
+      end
+    end
+  end
+end

--- a/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
+++ b/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
@@ -12,7 +12,7 @@ class TransferRateValueToTiers < ActiveRecord::Migration
       if detail.respond_to?(:rate)
         ChargebackTier.create(:chargeback_rate_detail_id => detail.id,
                               :start                     => 0,
-                              :end                       => Float::INFINITY,
+                              :finish                    => Float::INFINITY,
                               :fixed_rate                => 0.0,
                               :variable_rate             => detail.rate)
       end

--- a/db/migrate/20160301111647_remove_rate_column_from_chargeback_rate_detail.rb
+++ b/db/migrate/20160301111647_remove_rate_column_from_chargeback_rate_detail.rb
@@ -1,0 +1,5 @@
+class RemoveRateColumnFromChargebackRateDetail < ActiveRecord::Migration
+  def change
+    remove_column :chargeback_rate_details, :rate, :string
+  end
+end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail do
-    rate    0
     group   "unknown"
     source  "unknown"
   end

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -1,8 +1,5 @@
 FactoryGirl.define do
   factory :chargeback_tier do
-  end
-
-  factory :chargeback_tier_singular, :parent => :chargeback_tier do
     start 0
     add_attribute :end, Float::INFINITY
     fixed_rate 0.0

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :chargeback_tier do
+  end
+end

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :chargeback_tier do
     start 0
-    add_attribute :end, Float::INFINITY
+    finish Float::INFINITY
     fixed_rate 0.0
     variable_rate 0.0
   end

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -1,4 +1,11 @@
 FactoryGirl.define do
   factory :chargeback_tier do
   end
+
+  factory :chargeback_tier_singular, :parent => :chargeback_tier do
+    start 0
+    add_attribute :end, Float::INFINITY
+    fixed_rate 0.0
+    variable_rate 0.0
+  end
 end

--- a/spec/migrations/20151104120951_transfer_rate_value_to_tiers_spec.rb
+++ b/spec/migrations/20151104120951_transfer_rate_value_to_tiers_spec.rb
@@ -1,0 +1,16 @@
+require_migration
+
+describe TransferRateValueToTiers do
+  let(:chargeback_rate_detail_stub) { migration_stub(:ChargebackRateDetail) }
+
+  migration_context :up do
+    it "transfers rate value" do
+      cbrd = chargeback_rate_detail_stub.create(:rate => 1.0)
+      migrate
+      cbrd.reload
+      expect(cbrd.chargeback_tiers.length).to eq(1)
+      expect(cbrd.chargeback_tiers[0].fixed_rate).to eq(0.0)
+      expect(cbrd.chargeback_tiers[0].variable_rate).to eq(1.0)
+    end
+  end
+end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -200,14 +200,14 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :end => 5)
       cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
 
-      expect(cbd.complete_tiers).to be false
+      expect(cbd.contiguous_tiers?).to be false
     end
 
     it "add an initial valid tier" do
       cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :end => Float::INFINITY)
       cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
 
-      expect(cbd.complete_tiers).to be true
+      expect(cbd.contiguous_tiers?).to be true
     end
 
     it "add an invalid tier to an existing tier set" do
@@ -218,7 +218,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbt1.end = 5
       cbd.chargeback_tiers << cbt2
 
-      expect(cbd.complete_tiers).to be false
+      expect(cbd.contiguous_tiers?).to be false
     end
 
     it "add a valid tier to an existing tier set" do
@@ -229,7 +229,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbt1.end = 5
       cbd.chargeback_tiers << cbt2
 
-      expect(cbd.complete_tiers).to be true
+      expect(cbd.contiguous_tiers?).to be true
     end
 
     it "remove a tier from an existing tier set, leaving the set invalid" do
@@ -239,7 +239,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
 
       cbd.chargeback_tiers = [cbt1]
 
-      expect(cbd.complete_tiers).to be false
+      expect(cbd.contiguous_tiers?).to be false
     end
 
     it "remove a tier from an existing set of tiers" do
@@ -250,7 +250,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbt1.end = Float::INFINITY
       cbd.chargeback_tiers = [cbt1]
 
-      expect(cbd.complete_tiers).to be true
+      expect(cbd.contiguous_tiers?).to be true
     end
 
     it "remove last tier" do
@@ -258,7 +258,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
       cbd.chargeback_tiers = []
 
-      expect(cbd.complete_tiers).to be true
+      expect(cbd.contiguous_tiers?).to be true
     end
 
     it "tiers should contain no gaps" do
@@ -266,7 +266,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       cbt2 = FactoryGirl.build(:chargeback_tier, :start => 6, :end => Float::INFINITY)
       cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt2, cbt1])
 
-      expect(cbd.complete_tiers).to be false
+      expect(cbd.contiguous_tiers?).to be false
     end
 
     it "must contain one start" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -293,5 +293,13 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       expect(cbd).not_to be_valid
       expect(cbd.errors[:chargeback_tiers]).to be_present
     end
+
+    it "middle tier must not start infinity" do
+      cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :end => Float::INFINITY)
+      cbt2 = FactoryGirl.build(:chargeback_tier, :start => Float::INFINITY, :end => Float::INFINITY)
+      cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt2, cbt1])
+
+      expect(cbd).not_to be_valid
+    end
   end
 end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -93,7 +93,7 @@ describe ChargebackRateDetail do
     expect(cbd.friendly_rate).to eq(friendly_rate)
 
     cbd = FactoryGirl.build(:chargeback_rate_detail, :group => 'fixed', :per_time => 'monthly')
-    cbt = FactoryGirl.create(:chargeback_tier, :start => 0, :chargeback_rate_detail_id =>  cbd.id,
+    cbt = FactoryGirl.create(:chargeback_tier, :start => 0, :chargeback_rate_detail_id => cbd.id,
                        :end => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 2.0)
     cbd.update(:chargeback_tiers => [cbt])
     expect(cbd.friendly_rate).to eq("3.0 Monthly")
@@ -185,13 +185,13 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost,
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
-                            )
+                           )
     expect(cbd.show_rates(cbc.code)).to eq("EUR / Day")
 
     cbd = FactoryGirl.build(:chargeback_rate_detail_memory_allocated,
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
-                            )
+                           )
     expect(cbd.show_rates(cbc.code)).to eq("EUR / Day / MB")
   end
 

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -83,17 +83,32 @@ describe Chargeback do
     subject { Chargeback.build_results_for_report_chargeback(@options).first.first }
 
     it "cpu" do
-      FactoryGirl.create(:chargeback_rate_detail_cpu_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_cpu_allocated,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @count_hourly_rate.to_s,
-                        )
-
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_allocated,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
       expect(subject.cpu_allocated_metric).to eq(@cpu_count * @metric_size)
       expect(subject.cpu_used_metric).to eq(@cpu_usagemhz_rate * @metric_size)
       expect(subject.cpu_metric).to eq(subject.cpu_allocated_metric + subject.cpu_used_metric)
@@ -104,16 +119,32 @@ describe Chargeback do
     end
 
     it "memory" do
-      FactoryGirl.create(:chargeback_rate_detail_memory_allocated,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_memory_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_memory_allocated,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_memory_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.memory_allocated_metric).to eq(@memory_available * @metric_size)
       expect(subject.memory_used_metric).to eq(@memory_used * @metric_size)
@@ -125,11 +156,19 @@ describe Chargeback do
     end
 
     it "disk io" do
-      FactoryGirl.create(:chargeback_rate_detail_disk_io_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_disk_io_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.disk_io_used_metric).to eq(@disk_usage_rate * @metric_size)
       expect(subject.disk_io_metric).to eq(subject.disk_io_metric)
@@ -139,11 +178,19 @@ describe Chargeback do
     end
 
     it "net io" do
-      FactoryGirl.create(:chargeback_rate_detail_net_io_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_net_io_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.net_io_used_metric).to eq(@net_usage_rate * @metric_size)
       expect(subject.net_io_metric).to eq(subject.net_io_metric)
@@ -154,29 +201,45 @@ describe Chargeback do
 
     it "storage" do
       cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
-      FactoryGirl.create(:chargeback_rate_detail_storage_used,
-                         :chargeback_rate_id                => @cbr.id,
-                         :per_time                          => "hourly",
-                         :metric                            => "derived_vm_used_disk_storage",
-                         :per_unit                          => "gigabytes",
-                         :rate                              => @count_hourly_rate.to_s,
-                         :chargeback_rate_detail_measure_id => cbdm.id
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_storage_allocated,
-                         :chargeback_rate_id                => @cbr.id,
-                         :per_time                          => "hourly",
-                         :per_unit                          => "gigabytes",
-                         :rate                              => @count_hourly_rate.to_s,
-                         :metric                            => "derived_vm_allocated_disk_storage",
-                         :chargeback_rate_detail_measure_id => cbdm.id
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_storage_used,
+                               :chargeback_rate_id                => @cbr.id,
+                               :per_time                          => "hourly",
+                               :metric                            => "derived_vm_used_disk_storage",
+                               :per_unit                          => "gigabytes",
+                               :chargeback_rate_detail_measure_id => cbdm.id
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_storage_allocated,
+                               :chargeback_rate_id                => @cbr.id,
+                               :per_time                          => "hourly",
+                               :per_unit                          => "gigabytes",
+                               :metric                            => "derived_vm_allocated_disk_storage",
+                               :chargeback_rate_detail_measure_id => cbdm.id
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
-      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
   end
@@ -260,16 +323,32 @@ describe Chargeback do
     subject { Chargeback.build_results_for_report_chargeback(@options).first.first }
 
     it "cpu" do
-      FactoryGirl.create(:chargeback_rate_detail_cpu_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_cpu_allocated,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @count_hourly_rate.to_s,
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_allocated,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.cpu_allocated_metric).to eq(@cpu_count * @metric_size)
       expect(subject.cpu_used_metric).to eq(@cpu_usagemhz_rate * @metric_size)
@@ -281,17 +360,32 @@ describe Chargeback do
     end
 
     it "memory" do
-      FactoryGirl.create(:chargeback_rate_detail_memory_allocated,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_memory_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_memory_allocated,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_memory_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
       expect(subject.memory_allocated_metric).to eq(@memory_available * @metric_size)
       expect(subject.memory_used_metric).to eq(@memory_used * @metric_size)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
@@ -302,11 +396,19 @@ describe Chargeback do
     end
 
     it "disk io" do
-      FactoryGirl.create(:chargeback_rate_detail_disk_io_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_disk_io_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
 
       expect(subject.disk_io_used_metric).to eq(@disk_usage_rate * @metric_size)
       expect(subject.disk_io_metric).to eq(subject.disk_io_metric)
@@ -316,12 +418,19 @@ describe Chargeback do
     end
 
     it "net io" do
-      FactoryGirl.create(:chargeback_rate_detail_net_io_used,
-                         :chargeback_rate_id => @cbr.id,
-                         :per_time           => "hourly",
-                         :rate               => @hourly_rate.to_s,
-                        )
-
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_net_io_used,
+                               :chargeback_rate_id => @cbr.id,
+                               :per_time           => "hourly"
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
       expect(subject.net_io_used_metric).to eq(@net_usage_rate * @metric_size)
       expect(subject.net_io_metric).to eq(subject.net_io_metric)
 
@@ -331,25 +440,40 @@ describe Chargeback do
 
     it "storage" do
       cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
-      FactoryGirl.create(:chargeback_rate_detail_storage_used,
-                         :chargeback_rate_id                => @cbr.id,
-                         :per_time                          => "hourly",
-                         :rate                              => @count_hourly_rate.to_s,
-                         :chargeback_rate_detail_measure_id => cbdm.id
-                        )
-      FactoryGirl.create(:chargeback_rate_detail_storage_allocated,
-                         :chargeback_rate_id                => @cbr.id,
-                         :per_time                          => "hourly",
-                         :rate                              => @count_hourly_rate.to_s,
-                         :chargeback_rate_detail_measure_id => cbdm.id
-                        )
-
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_storage_used,
+                               :chargeback_rate_id                => @cbr.id,
+                               :per_time                          => "hourly",
+                               :chargeback_rate_detail_measure_id => cbdm.id
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
+      cbrd = FactoryGirl.build(:chargeback_rate_detail_storage_allocated,
+                               :chargeback_rate_id                => @cbr.id,
+                               :per_time                          => "hourly",
+                               :chargeback_rate_detail_measure_id => cbdm.id
+                              )
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbrd.id,
+                               :start                     => 0,
+                               :end                       => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => @count_hourly_rate.to_s
+                              )
+      cbrd.chargeback_tiers = [cbt]
+      cbrd.save
       expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
-      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
 

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -238,7 +238,9 @@ describe Chargeback do
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes *
+                                                   @count_hourly_rate *
+                                                   @metric_size)
       expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
@@ -472,7 +474,9 @@ describe Chargeback do
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes *
+                                                   @count_hourly_rate *
+                                                   @metric_size)
       expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -90,7 +90,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -103,7 +103,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )
@@ -126,7 +126,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -139,7 +139,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -163,7 +163,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -185,7 +185,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -211,7 +211,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )
@@ -227,7 +227,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )
@@ -333,7 +333,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -346,7 +346,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )
@@ -370,7 +370,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -383,7 +383,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -406,7 +406,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -428,7 +428,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @hourly_rate.to_s
                               )
@@ -451,7 +451,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )
@@ -465,7 +465,7 @@ describe Chargeback do
       cbt = FactoryGirl.create(:chargeback_tier,
                                :chargeback_rate_detail_id => cbrd.id,
                                :start                     => 0,
-                               :end                       => Float::INFINITY,
+                               :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
                                :variable_rate             => @count_hourly_rate.to_s
                               )

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -282,7 +282,7 @@ describe Chargeback do
     subject { Chargeback.build_results_for_report_chargeback(@options_tenant).first.first }
 
     it "report a chargeback of a subtenant" do
-      tier = FactoryGirl.create(:chargeback_tier_singular)
+      tier = FactoryGirl.create(:chargeback_tier)
       FactoryGirl.create(:chargeback_rate_detail_cpu_allocated,
                          :chargeback_rate_id => @cbr.id,
                          :per_time           => "hourly",

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -282,10 +282,11 @@ describe Chargeback do
     subject { Chargeback.build_results_for_report_chargeback(@options_tenant).first.first }
 
     it "report a chargeback of a subtenant" do
+      tier = FactoryGirl.create(:chargeback_tier_singular)
       FactoryGirl.create(:chargeback_rate_detail_cpu_allocated,
                          :chargeback_rate_id => @cbr.id,
                          :per_time           => "hourly",
-                         :rate               => @count_hourly_rate.to_s,
+                         :chargeback_tiers   => [tier],
                         )
       expect(subject.vm_name).to eq(@vm_tenant.name)
     end

--- a/spec/models/chargeback_tier_spec.rb
+++ b/spec/models/chargeback_tier_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe ChargebackTier do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can fetch chargeback rate details" do
-    chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail)
+    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+    chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                         :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                         :variable_rate => 0.0)
+    chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
     chargeback_rate = FactoryGirl.create(:chargeback_rate,
                                          :chargeback_rate_details => [chargeback_rate_detail])
 
@@ -44,7 +48,11 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can fetch an individual chargeback rate detail" do
-    chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "5")
+    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
+    chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                         :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                         :variable_rate => 0.0)
+    chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
     chargeback_rate = FactoryGirl.create(:chargeback_rate,
                                          :chargeback_rate_details => [chargeback_rate_detail])
 
@@ -56,23 +64,24 @@ RSpec.describe "chargebacks API" do
       "chargeback_rate_id" => chargeback_rate.id,
       "href"               => "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}",
       "id"                 => chargeback_rate_detail.id,
-      "rate"               => "5"
+      "description"        => "rate_1"
     )
     expect_request_success
   end
 
   context "with an appropriate role" do
     it "can create a new chargeback rate detail" do
+      pending "until ChargebackTier is included in the API"
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
 
       expect do
         run_post rates_url,
-                 :rate    => "0",
-                 :group   => "fixed",
-                 :source  => "used",
-                 :enabled => true
+                 :description => "rate_0",
+                 :group       => "fixed",
+                 :source      => "used",
+                 :enabled     => true
       end.to change(ChargebackRateDetail, :count).by(1)
-      expect_result_to_match_hash(response_hash["results"].first, "rate" => "0", "enabled" => true)
+      expect_result_to_match_hash(response_hash["results"].first, "description" => "rate_0", "enabled" => true)
       expect_request_success
     end
 
@@ -81,37 +90,52 @@ RSpec.describe "chargebacks API" do
 
       expect do
         run_post rates_url,
-                 :rate    => "0",
-                 :enabled => true
+                 :description => "rate_0",
+                 :enabled     => true
       end.not_to change(ChargebackRateDetail, :count)
       expect_bad_request(/group can't be blank/i)
       expect_bad_request(/source can't be blank/i)
     end
 
     it "can edit a chargeback rate detail through POST" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
+      run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_1")
 
-      expect(response_hash["rate"]).to eq("0.02")
+      expect(response_hash["description"]).to eq("rate_1")
       expect_request_success
-      expect(chargeback_rate_detail.reload.rate).to eq("0.02")
+      expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end
 
     it "can edit a chargeback rate detail through PATCH" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "rate", :value => "0.02"}]
+      run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "description", :value => "rate_1"}]
 
-      expect(response_hash["rate"]).to eq("0.02")
+      expect(response_hash["description"]).to eq("rate_1")
       expect_request_success
-      expect(chargeback_rate_detail.reload.rate).to eq("0.02")
+      expect(chargeback_rate_detail.reload.description).to eq("rate_1")
     end
 
     it "can delete a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :delete)
 
@@ -122,7 +146,12 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can delete a chargeback rate detail through POST" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :delete)
 
@@ -137,23 +166,33 @@ RSpec.describe "chargebacks API" do
     it "cannot create a chargeback rate detail" do
       api_basic_authorize
 
-      expect { run_post rates_url, :rate => "0", :enabled => true }.not_to change(ChargebackRateDetail, :count)
+      expect { run_post rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail, :count)
       expect_request_forbidden
     end
 
     it "cannot edit a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail, :rate => "0")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize
 
       expect do
-        run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :rate => "0.02")
-      end.not_to change { chargeback_rate_detail.reload.rate }
+        run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_2")
+      end.not_to change { chargeback_rate_detail.reload.description }
       expect_request_forbidden
     end
 
     it "cannot delete a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.create(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
+                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :variable_rate => 0.0)
+      chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
+      chargeback_rate_detail.save
 
       api_basic_authorize
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -166,7 +166,8 @@ RSpec.describe "chargebacks API" do
     it "cannot create a chargeback rate detail" do
       api_basic_authorize
 
-      expect { run_post rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail, :count)
+      expect { run_post rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail,
+                                                                                              :count)
       expect_request_forbidden
     end
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "chargebacks API" do
 
   context "with an appropriate role" do
     it "can create a new chargeback rate detail" do
-      pending "until ChargebackTier is included in the API"
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
 
       expect do

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "chargebacks API" do
   it "can fetch chargeback rate details" do
     chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
     chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                         :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                         :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                          :variable_rate => 0.0)
     chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
     chargeback_rate = FactoryGirl.create(:chargeback_rate,
@@ -50,7 +50,7 @@ RSpec.describe "chargebacks API" do
   it "can fetch an individual chargeback rate detail" do
     chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
     chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                         :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                         :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                          :variable_rate => 0.0)
     chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
     chargeback_rate = FactoryGirl.create(:chargeback_rate,
@@ -99,7 +99,7 @@ RSpec.describe "chargebacks API" do
     it "can edit a chargeback rate detail through POST" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
@@ -115,7 +115,7 @@ RSpec.describe "chargebacks API" do
     it "can edit a chargeback rate detail through PATCH" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
@@ -131,7 +131,7 @@ RSpec.describe "chargebacks API" do
     it "can delete a chargeback rate detail" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
@@ -147,7 +147,7 @@ RSpec.describe "chargebacks API" do
     it "can delete a chargeback rate detail through POST" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
@@ -173,7 +173,7 @@ RSpec.describe "chargebacks API" do
     it "cannot edit a chargeback rate detail" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
@@ -189,7 +189,7 @@ RSpec.describe "chargebacks API" do
     it "cannot delete a chargeback rate detail" do
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
-                                           :start => 0, :end => Float::INFINITY, :fixed_rate => 0.0,
+                                           :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -114,7 +114,7 @@ describe ApiController do
     end
 
     example "query Rates" do
-      FactoryGirl.create(:chargeback_rate_detail)
+      FactoryGirl.build(:chargeback_rate_detail)
       test_collection_query(:rates, rates_url, ChargebackRateDetail)
     end
 


### PR DESCRIPTION
Currently, ManageIQ only supports defining continuous variable rates. This branch allows defining rates based on tiers with both fixed and variable rates. For instance:

Allocated CPU:

        Tier 0: -∞ - 0 CPU = 0$/month + 0$/month/cpu

        Tier 1: 0 - 4  CPU = 3$/month (fixed) + 5$/month/cpu

        Tier 2: 4 - 8  CPU = 3$/month + 4€/month/cpu

        Tier 3: 8 - +∞  CPU = 3$/month + 3.5€/month/cpu

![allocated](https://cloud.githubusercontent.com/assets/6978386/11781980/3010e212-a26e-11e5-823b-a92732a0f1c1.png)

NOTE: The interval end is not included