### PR TITLE
Allow users to see report results in their groups

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -21,7 +21,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}", :model => "Saved Report"}
-    if admin_user? || rr.miq_group_id == current_group_id
+    if admin_user? || current_user.groups_include?(rr.miq_group)
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
       task = MiqTask.find_by_id(rr.miq_task_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -226,6 +226,10 @@ class User < ActiveRecord::Base
     miq_groups
   end
 
+  def groups_include?(group)
+    miq_group_ids.include?(group.id)
+  end
+
   def admin?
     userid == "admin"
   end

--- a/app/presenters/tree_builder_report_reports_class.rb
+++ b/app/presenters/tree_builder_report_reports_class.rb
@@ -19,10 +19,10 @@ class TreeBuilderReportReportsClass < TreeBuilder
 
     # Admin users can see all saved reports
     unless u.admin_user?
-      cond[0] << ' AND miq_group_id=?'
-      cond.push(u.current_group_id)
+      cond[0] << " AND miq_group_id IN (?)"
+      cond.push(u.miq_groups.collect(&:id))
     end
 
-    cond.flatten
+    cond
   end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1310,6 +1310,18 @@ describe ReportController do
           expected_report_id = controller.instance_variable_get(:@view).table.data.last.miq_report_id
           expect(expected_report_id).to eq(@rpt.id)
         end
+
+        it "is allowed to see miq report result for User1(with current group Group2)" do
+          report_result_id = @rpt.miq_report_results.first.id
+          controller.instance_variable_set(:@_params, :id => controller.to_cid(report_result_id),
+                                                      :controller => "report", :action => "explorer")
+          controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
+          controller.stub(:get_all_reps)
+          controller.send(:show_saved_report)
+          fetched_report_result = controller.instance_variable_get(:@report_result)
+          expect(fetched_report_result.id).to eq(@rpt.miq_report_results.first.id)
+          expect(fetched_report_result.miq_report.id).to eq(@rpt.id)
+        end
       end
     end
   end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -38,6 +38,17 @@ describe TreeBuilderReportSavedReports do
           # logged User1 can see report with Group1
           expect(displayed_report_ids).to include(@rpt.id)
         end
+
+        it "is allowed to see report result created under Group1 for User 1(with current group Group2)" do
+          # there is calling of x_get_tree_roots
+          tree = TreeBuilderReportSavedReports.new('savedreports_tree', 'savedreports', {})
+          cond = tree.send(:set_saved_reports_condition, @rpt.id)
+
+          displayed_report_result_ids = MiqReportResult.where(cond).collect(&:id)
+
+          # logged User1 can see report with Group1
+          expect(displayed_report_result_ids).to include(@rpt.miq_report_results.first.id)
+        end
       end
     end
   end


### PR DESCRIPTION
Users can see reports but they don't see report resutls of their group which is not current
It allows to see report results in tree and display content of report result by fetching standalone report result.

Part of #5681 

Method  set_saved_reports_condition shoudl refactored as is mentioned in issue https://github.com/ManageIQ/manageiq/issues/5708