### PR TITLE
Add Automate -> Log start page

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -218,3 +218,8 @@
   :url: /miq_task/index?jobs_tab=alltasks
   :rbac_feature_name: tasks
   :startup: true
+- :name: miq_automate_log
+  :description: Automate Log
+  :url: /miq_ae_tools/log
+  :rbac_feature_name: miq_ae_class_log
+  :startup: true


### PR DESCRIPTION
Users who are (via role) allowed to view automate logs only
will land on this page upon login. Otherwise, these users
would not be able to log in at all.

https://bugzilla.redhat.com/show_bug.cgi?id=1229210