### PR TITLE
OpenStack allow to specify path to CA certificate

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -32,7 +32,14 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       username = options[:user] || authentication_userid(options[:auth_type])
       password = options[:pass] || authentication_password(options[:auth_type])
 
-      osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol)
+      vmdb_config = VMDB::Config.new("vmdb").config
+      extra_options = {
+        :ssl_ca_file    => vmdb_config.fetch_path(:ssl, :ssl_ca_file),
+        :ssl_ca_path    => vmdb_config.fetch_path(:ssl, :ssl_ca_path),
+        :ssl_cert_store => OpenSSL::X509::Store.new
+      }
+
+      osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}
       osh
     end

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -237,6 +237,9 @@ smtp:
 snapshots:
   :create_free_percent: 100
   :remove_free_percent: 100
+ssl:
+  :ssl_ca_file:
+  :ssl_ca_path:
 storage:
   inventory:
     :full_refresh_schedule: "38 * * * *"


### PR DESCRIPTION
OpenStack allow to specify path to CA certificate, which will be
passed to Excon.