### PR TITLE
Entry point service dialog fix

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -516,10 +516,10 @@ function miqMenuChangeRow(action, elem) {
 }
 
 function miqSetAETreeNodeSelectionClass(id, prevId, bValidNode) {
-  if (prevId) {
+  if (prevId && $('#' + prevId).length) {
     miqDynatreeNodeRemoveClass("automate_tree", prevId);
   }
-  if (bValidNode == "true") {
+  if (bValidNode == "true" && $('#' + id).length) {
     miqDynatreeNodeAddClass("automate_tree", id, "ae-valid-node");
   }
 }

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -65,7 +65,8 @@
                     :title  => t)
 :javascript
   $(function(){
-    $("button[data-dismiss='modal']").click(function(){
+    $("button[data-dismiss='modal']").off('click');
+    $("button[data-dismiss='modal']").on('click', function(){
       miqJqueryRequest("ae_tree_select_toggle?button=cancel", {beforeSend: true});
       return true;
     });


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1287204
It fixes issue with entry point disappearing when they were selected on other entry point dialog. It was caused by bug when tree want to select node that not exist yet in tree context, because children are generated on demand. It cant happen in UI by clicking in tree, but it can happen you click on multiple different entry points.

If tree cant preselected node, it just dont select it and user have to select it manually.

@h-kataria please review
