### PR TITLE
Fix travis issue with bundler

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -5,7 +5,7 @@
 #   PWD
 
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
-travis_retry gem install bundler -v ">= 1.8.4"
+travis_retry gem install bundler -v "~> 1.10.6"
 
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,8 +1,4 @@
-# source this and dont run it
-# this can change:
-#   BUNDLE_GEMFILE
-#   BUNDLE_WITHOUT
-#   PWD
+set -v
 
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
 travis_retry gem install bundler -v "~> 1.10.6"
@@ -12,10 +8,12 @@ if [[ -n "${GEM}" ]] ; then
 else
   [[ -z "${SPA_UI}" ]] || nvm install 0.12
 
-  [[ -f certs/v2_key.dev ]] && cp certs/v2_key.dev certs/v2_key
   echo "1" > REGION
+  cp certs/v2_key.dev certs/v2_key
   cp config/database.pg.yml config/database.yml
   psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
   export BUNDLE_WITHOUT=development
 fi
 export BUNDLE_GEMFILE=${PWD}/Gemfile
+
+set +v

--- a/tools/ci/before_script.sh
+++ b/tools/ci/before_script.sh
@@ -1,3 +1,4 @@
+set -v
 
 if [[ -n "$TEST_SUITE" ]] ; then
   if [[ -n "$SPA_UI" ]] ; then
@@ -9,3 +10,5 @@ if [[ -n "$TEST_SUITE" ]] ; then
   fi
   bundle exec rake test:$TEST_SUITE:setup
 fi
+
+set +v


### PR DESCRIPTION
Lock bundler to ~>1.10.6 since 1.11 doesn't work.  This is just a temporary fix to unlock the broken PRs.

The error we see when using 1.11 is below.  This is likely because the
Ruby 2.2 series on Travis uses Ruby 2.2.0p0.

    /home/travis/.rvm/gems/ruby-2.2.0/gems/bundler-1.11.0/lib/bundler/runtime.rb:34:in `block in setup': You have already activated psych 2.0.8, but your Gemfile requires psych 2.0.16. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
        from /home/travis/.rvm/gems/ruby-2.2.0/gems/bundler-1.11.0/lib/bundler/runtime.rb:19:in `setup'
        from /home/travis/.rvm/gems/ruby-2.2.0/gems/bundler-1.11.0/lib/bundler.rb:92:in `setup'
        from /home/travis/.rvm/gems/ruby-2.2.0/gems/bundler-1.11.0/lib/bundler/setup.rb:8:in `<top (required)>'
        from /home/travis/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/travis/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    The command "source ${TRAVIS_BUILD_DIR}/tools/ci/before_script.sh" failed and exited with 1 during .