### PR TITLE
Fixed code to redirect to Requests list after dialog is submitted.

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -46,15 +46,11 @@ module ApplicationController::DialogRunner
             @in_a_form = false
             if session[:edit][:explorer]
               add_flash(flash)
-              if request.parameters[:controller] == "catalog"
-                # only do this Service PRovision requests
-                render :update do |page|
-                  page.redirect_to :controller => 'miq_request',
-                                   :action     => 'show_list',
-                                   :flash_msg  => flash  # redirect to miq_request show_list screen
-                end
-              else
-                replace_right_cell
+              # redirect to miq_request show_list screen
+              render :update do |page|
+                page.redirect_to :controller => 'miq_request',
+                                 :action     => 'show_list',
+                                 :flash_msg  => flash
               end
             else
               render :update do |page|

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -134,4 +134,28 @@ describe CatalogController do
       expect(dialog_field.value).to eq('04/05/2015 14:06')
     end
   end
+
+  describe "#dialog_form_button_pressed" do
+    let(:dialog) { active_record_instance_double("Dialog") }
+    let(:wf) { double(:dialog => dialog) }
+
+    before do
+      edit = {:rec_id => 1, :wf => wf, :key => 'dialog_edit__foo', :explorer => 'true'}
+      controller.instance_variable_set(:@edit, edit)
+      controller.instance_variable_set(:@sb, {})
+      session[:edit] = edit
+    end
+
+    it "redirects to requests show list after dialog is submitted" do
+      controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
+      controller.stub(:role_allows).and_return(true)
+      wf.stub(:submit_request).and_return({})
+      page = mock('page')
+      page.should_receive(:redirect_to).with(:controller => "miq_request",
+                                             :action     => "show_list",
+                                             :flash_msg  => "Order Request was Submitted")
+      controller.should_receive(:render).with(:update).and_yield(page)
+      controller.send(:dialog_form_button_pressed)
+    end
+  end
 end


### PR DESCRIPTION
- Added spec test to verify redirect.

https://bugzilla.redhat.com/show_bug.cgi?id=1221333

@dclarizio please review/merge.

before:
![service_reconfigure_before](https://cloud.githubusercontent.com/assets/3450808/11791460/2b117668-a26f-11e5-93e7-fd4e060fe9ec.png)

after:
![service_reconfigure_after](https://cloud.githubusercontent.com/assets/3450808/11791467/2f3a8220-a26f-11e5-8133-ebeb37683397.png)
