### PR TITLE
Always render blank view_tb unless another is used

### DIFF
--- a/app/views/layouts/_view_buttons.html.haml
+++ b/app/views/layouts/_view_buttons.html.haml
@@ -10,3 +10,5 @@
   && (!@layout.starts_with?("miq_request")) && !@treesize_buttons |
   && @display == "main" && @showtype == "main" && !@in_a_form |
   - defered_toolbar_render('view_tb', controller.send(:restful?) ? "summary_view_restful_tb" : "summary_view_tb")
+- else
+  - defered_toolbar_render('view_tb', 'blank_view_tb')

--- a/app/views/layouts/_x_view_buttons.html.haml
+++ b/app/views/layouts/_x_view_buttons.html.haml
@@ -8,3 +8,5 @@
   - defered_toolbar_render('view_tb', @report ? "report_view_tb" : "blank_view_tb")
 - elsif %w(provider_foreman).include?(@layout)
   - defered_toolbar_render('view_tb', @showtype == 'main' ? "x_summary_view_tb" : "x_gtl_view_tb")
+- else
+  - defered_toolbar_render('view_tb', 'blank_view_tb')


### PR DESCRIPTION
Fixes view toolbar not appearing on AJAX transitions from pages which didn't have it.

https://bugzilla.redhat.com/show_bug.cgi?id=1289190