### PR TITLE
Convert provider model specs to RSpec 2.99.2 syntax

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
@@ -53,7 +53,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status d
     expect(status.deleted?).to     be_falsey
     expect(status.rolled_back?).to be_falsey
     expect(status.updated?).to     be_truthy
-    expect(status.normalized_status).to eq(['update_complete', 'OK'])
+    expect(status.normalized_status).to eq(%w(update_complete OK))
   end
 
   it 'parses transient status' do

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack/status_spec.rb
@@ -3,67 +3,67 @@ require "spec_helper"
 describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status do
   it 'parses CREATE_COMPLETE' do
     status = described_class.new('CREATE_COMPLETE', '')
-    status.completed?.should   be_true
-    status.succeeded?.should   be_true
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['create_complete', '']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_truthy
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['create_complete', ''])
   end
 
   it 'parses ROLLBACK_COMPLETE' do
     status = described_class.new('ROLLBACK_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_true
-    status.updated?.should     be_false
-    status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_truthy
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['rollback_complete', 'Stack was rolled back'])
   end
 
   it 'parses DELETE_COMPLETE' do
     status = described_class.new('DELETE_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_true
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_truthy
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['delete_complete', 'Stack was deleted'])
   end
 
   it 'parses ROLLBACK_FAILED' do
     status = described_class.new('ROLLBACK_FAILED', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_true
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['failed', 'Stack creation failed']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
   end
 
   it 'parses UPDATE_COMPLETE' do
     status = described_class.new('UPDATE_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_true
-    status.normalized_status.should == ['update_complete', 'OK']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_truthy
+    expect(status.normalized_status).to eq(['update_complete', 'OK'])
   end
 
   it 'parses transient status' do
     status = described_class.new('CREATING', nil)
-    status.completed?.should   be_false
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == %w(transient CREATING)
+    expect(status.completed?).to   be_falsey
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(%w(transient CREATING))
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
@@ -32,9 +32,9 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
         expect(raw_stacks).to receive(:create).and_return(the_raw_stack)
 
         stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
-        stack.class.should == described_class
-        stack.name.should == 'mystack'
-        stack.ems_ref.should == the_raw_stack.stack_id
+        expect(stack.class).to eq(described_class)
+        expect(stack.name).to eq('mystack')
+        expect(stack.ems_ref).to eq(the_raw_stack.stack_id)
       end
 
       it 'catches errors from provider' do
@@ -78,14 +78,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
         rstatus = orchestration_stack.raw_status
         expect(rstatus).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
 
-        orchestration_stack.raw_exists?.should be_true
+        expect(orchestration_stack.raw_exists?).to be_truthy
       end
 
       it 'parses error message to determine stack not exist' do
         allow(raw_stacks).to receive(:[]).with(orchestration_stack.name).and_throw("Stack xxx does not exist")
         expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
 
-        orchestration_stack.raw_exists?.should be_false
+        expect(orchestration_stack.raw_exists?).to be_falsey
       end
 
       it 'catches errors from provider' do

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
@@ -11,12 +11,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
   context "#find_destination_in_vmdb" do
     it "VM in same sub-class" do
       vm = FactoryGirl.create(:vm_amazon, :ext_management_system => provider, :ems_ref => "vm_1")
-      subject.find_destination_in_vmdb("vm_1").should == vm
+      expect(subject.find_destination_in_vmdb("vm_1")).to eq(vm)
     end
 
     it "VM in different sub-class" do
       vm = FactoryGirl.create(:vm_openstack, :ext_management_system => provider, :ems_ref => "vm_1")
-      subject.find_destination_in_vmdb("vm_1").should be_nil
+      expect(subject.find_destination_in_vmdb("vm_1")).to be_nil
     end
   end
 
@@ -24,22 +24,22 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
     let(:vm) { FactoryGirl.create(:vm_amazon, :ext_management_system => provider) }
 
     it "with valid name" do
-      subject.stub(:dest_name).and_return("new_vm_1")
+      allow(subject).to receive(:dest_name).and_return("new_vm_1")
       expect { subject.validate_dest_name }.to_not raise_error
     end
 
     it "with a black name" do
-      subject.stub(:dest_name).and_return("")
+      allow(subject).to receive(:dest_name).and_return("")
       expect { subject.validate_dest_name }.to raise_error
     end
 
     it "with a nil name" do
-      subject.stub(:dest_name).and_return(nil)
+      allow(subject).to receive(:dest_name).and_return(nil)
       expect { subject.validate_dest_name }.to raise_error
     end
 
     it "with a duplicate name" do
-      subject.stub(:dest_name).and_return(vm.name)
+      allow(subject).to receive(:dest_name).and_return(vm.name)
       expect { subject.validate_dest_name }.to raise_error
     end
   end
@@ -48,47 +48,47 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
     before do
       flavor            = FactoryGirl.create(:flavor_amazon)
       availability_zone = FactoryGirl.create(:availability_zone_amazon)
-      subject.stub(:source).and_return(template)
-      subject.stub(:instance_type).and_return(flavor)
-      subject.stub(:dest_availability_zone).and_return(availability_zone)
-      subject.should_receive(:validate_dest_name)
+      allow(subject).to receive(:source).and_return(template)
+      allow(subject).to receive(:instance_type).and_return(flavor)
+      allow(subject).to receive(:dest_availability_zone).and_return(availability_zone)
+      expect(subject).to receive(:validate_dest_name)
     end
 
     context "security_groups" do
       it "with no security groups" do
-        subject.prepare_for_clone_task[:security_group_ids].should == []
+        expect(subject.prepare_for_clone_task[:security_group_ids]).to eq([])
       end
 
       it "with one security group" do
         security_group = FactoryGirl.create(:security_group_amazon, :name => "group_1")
         subject.options[:security_groups] = [security_group.id]
-        subject.prepare_for_clone_task[:security_group_ids].should == [security_group.ems_ref]
+        expect(subject.prepare_for_clone_task[:security_group_ids]).to eq([security_group.ems_ref])
       end
 
       it "with two security group" do
         security_group_1 = FactoryGirl.create(:security_group_amazon, :name => "group_1")
         security_group_2 = FactoryGirl.create(:security_group_amazon, :name => "group_2")
         subject.options[:security_groups] = [security_group_1.id, security_group_2.id]
-        subject.prepare_for_clone_task[:security_group_ids].should match_array([security_group_1.ems_ref, security_group_2.ems_ref])
+        expect(subject.prepare_for_clone_task[:security_group_ids]).to match_array([security_group_1.ems_ref, security_group_2.ems_ref])
       end
 
       it "with a missing security group" do
         security_group = FactoryGirl.create(:security_group_amazon, :name => "group_1")
         bad_security_group_id = security_group.id + 1
         subject.options[:security_groups] = [security_group.id, bad_security_group_id]
-        subject.prepare_for_clone_task[:security_group_ids].should == [security_group.ems_ref]
+        expect(subject.prepare_for_clone_task[:security_group_ids]).to eq([security_group.ems_ref])
       end
     end
 
     context "cloud_subnet" do
       it "without a subnet" do
-        subject.prepare_for_clone_task[:subnet].should be_nil
+        expect(subject.prepare_for_clone_task[:subnet]).to be_nil
       end
 
       it "with a subnet" do
         cloud_subnet = FactoryGirl.create(:cloud_subnet)
         subject.options[:cloud_subnet] = [cloud_subnet.id, cloud_subnet.name]
-        subject.prepare_for_clone_task[:subnet].should == cloud_subnet.ems_ref
+        expect(subject.prepare_for_clone_task[:subnet]).to eq(cloud_subnet.ems_ref)
       end
     end
   end
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
                                  :options      => options)
 
     workflow_class = ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow
-    workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+    allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
 
     expect(vm_prov.workflow.class).to eq workflow_class
     expect(vm_prov.workflow_class).to eq workflow_class

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
@@ -69,7 +69,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
         security_group_1 = FactoryGirl.create(:security_group_amazon, :name => "group_1")
         security_group_2 = FactoryGirl.create(:security_group_amazon, :name => "group_2")
         subject.options[:security_groups] = [security_group_1.id, security_group_2.id]
-        expect(subject.prepare_for_clone_task[:security_group_ids]).to match_array([security_group_1.ems_ref, security_group_2.ems_ref])
+        expect(subject.prepare_for_clone_task[:security_group_ids])
+          .to match_array([security_group_1.ems_ref, security_group_2.ems_ref])
       end
 
       it "with a missing security group" do

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -40,19 +40,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     it "#allowed_availability_zones" do
       az = FactoryGirl.create(:availability_zone_amazon)
       ems.availability_zones << az
-      expect(workflow.allowed_availability_zones).to eq({az.id => az.name})
+      expect(workflow.allowed_availability_zones).to eq(az.id => az.name)
     end
 
     it "#allowed_guest_access_key_pairs" do
       kp = AuthPrivateKey.create(:name => "auth_1")
       ems.key_pairs << kp
-      expect(workflow.allowed_guest_access_key_pairs).to eq({kp.id => kp.name})
+      expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
     end
 
     it "#allowed_security_groups" do
       sg = FactoryGirl.create(:security_group_amazon, :name => "sq_1")
       ems.security_groups << sg
-      expect(workflow.allowed_security_groups).to eq({sg.id => sg.name})
+      expect(workflow.allowed_security_groups).to eq(sg.id => sg.name)
     end
   end
 
@@ -217,25 +217,21 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
     context "#allowed_availability_zones" do
       it "with no placement options" do
-        expect(workflow.allowed_availability_zones).to eq({
-          @az1.id => @az1.name,
-          @az2.id => @az2.name,
-          @az3.id => @az3.name
-        })
+        expect(workflow.allowed_availability_zones).to eq(@az1.id => @az1.name,
+                                                          @az2.id => @az2.name,
+                                                          @az3.id => @az3.name)
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        expect(workflow.allowed_availability_zones).to eq({
-          @az1.id => @az1.name,
-          @az2.id => @az2.name
-        })
+        expect(workflow.allowed_availability_zones).to eq(@az1.id => @az1.name,
+                                                          @az2.id => @az2.name)
       end
 
       it "with a cloud_network and cloud_subnet" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
         workflow.values[:cloud_subnet]  = [@cs2.id, @cs2.name]
-        expect(workflow.allowed_availability_zones).to eq({@az2.id => @az2.name})
+        expect(workflow.allowed_availability_zones).to eq(@az2.id => @az2.name)
       end
     end
 
@@ -259,23 +255,23 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
     context "#allowed_floating_ip_addresses" do
       it "without a cloud_network" do
-        expect(workflow.allowed_floating_ip_addresses).to eq({@ip2.id => @ip2.address})
+        expect(workflow.allowed_floating_ip_addresses).to eq(@ip2.id => @ip2.address)
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        expect(workflow.allowed_floating_ip_addresses).to eq({@ip1.id => @ip1.address})
+        expect(workflow.allowed_floating_ip_addresses).to eq(@ip1.id => @ip1.address)
       end
     end
 
     context "#allowed_security_groups" do
       it "without a cloud_network" do
-        expect(workflow.allowed_security_groups).to eq({@sg2.id => @sg2.name})
+        expect(workflow.allowed_security_groups).to eq(@sg2.id => @sg2.name)
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        expect(workflow.allowed_security_groups).to eq({@sg1.id => @sg1.name})
+        expect(workflow.allowed_security_groups).to eq(@sg1.id => @sg1.name)
       end
     end
   end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
   let(:workflow) do
     stub_dialog
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    ManageIQ::Providers::CloudManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
+    allow_any_instance_of(ManageIQ::Providers::CloudManager::ProvisionWorkflow).to receive(:update_field_visibility)
     wf = described_class.new({:src_vm_id => template.id}, admin.userid)
     wf.instance_variable_set("@ems_xml_nodes", {})
     wf
@@ -24,15 +24,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
   context "with empty relationships" do
     it "#allowed_availability_zones" do
-      workflow.allowed_availability_zones.should == {}
+      expect(workflow.allowed_availability_zones).to eq({})
     end
 
     it "#allowed_guest_access_key_pairs" do
-      workflow.allowed_guest_access_key_pairs.should == {}
+      expect(workflow.allowed_guest_access_key_pairs).to eq({})
     end
 
     it "#allowed_security_groups" do
-      workflow.allowed_security_groups.should == {}
+      expect(workflow.allowed_security_groups).to eq({})
     end
   end
 
@@ -40,19 +40,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     it "#allowed_availability_zones" do
       az = FactoryGirl.create(:availability_zone_amazon)
       ems.availability_zones << az
-      workflow.allowed_availability_zones.should == {az.id => az.name}
+      expect(workflow.allowed_availability_zones).to eq({az.id => az.name})
     end
 
     it "#allowed_guest_access_key_pairs" do
       kp = AuthPrivateKey.create(:name => "auth_1")
       ems.key_pairs << kp
-      workflow.allowed_guest_access_key_pairs.should == {kp.id => kp.name}
+      expect(workflow.allowed_guest_access_key_pairs).to eq({kp.id => kp.name})
     end
 
     it "#allowed_security_groups" do
       sg = FactoryGirl.create(:security_group_amazon, :name => "sq_1")
       ems.security_groups << sg
-      workflow.allowed_security_groups.should == {sg.id => sg.name}
+      expect(workflow.allowed_security_groups).to eq({sg.id => sg.name})
     end
   end
 
@@ -63,14 +63,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
         ems.availability_zones << az
         filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.size.should == 1
-        filtered.first.name.should == az.name
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(az.name)
       end
 
       it "returns an empty array when no targets are found" do
         filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.should == []
+        expect(filtered).to eq([])
       end
     end
 
@@ -81,8 +81,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
           ems.security_groups << sg
           filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, SecurityGroup,
                                    'security_groups.non_cloud_network')
-          filtered.size.should == 1
-          filtered.first.name.should == sg.name
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg.name)
         end
       end
 
@@ -93,8 +93,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
                                      :cloud_network => cn1)
           ems.security_groups << sg_cn
           filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, SecurityGroup, 'security_groups')
-          filtered.size.should == 1
-          filtered.first.name.should == sg_cn.name
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg_cn.name)
         end
       end
     end
@@ -104,8 +104,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
         flavor = FactoryGirl.create(:flavor, :name => "t1.micro", :supports_32_bit => true, :supports_64_bit => true)
         ems.flavors << flavor
         filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, Flavor, 'flavors')
-        filtered.size.should == 1
-        filtered.first.name.should == flavor.name
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(flavor.name)
       end
     end
   end
@@ -134,33 +134,33 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
     context "availability_zones" do
       it "#get_targets_for_ems" do
-        ems.availability_zones.size.should == 2
-        ems.availability_zones.first.tags.size.should == 1
-        ems.availability_zones.last.tags.size.should == 0
+        expect(ems.availability_zones.size).to eq(2)
+        expect(ems.availability_zones.first.tags.size).to eq(1)
+        expect(ems.availability_zones.last.tags.size).to eq(0)
         filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.size.should == 1
+        expect(filtered.size).to eq(1)
       end
     end
 
     context "security groups" do
       it "#get_targets_for_ems" do
-        ems.security_groups.size.should == 2
-        ems.security_groups.first.tags.size.should == 1
-        ems.security_groups.last.tags.size.should == 0
+        expect(ems.security_groups.size).to eq(2)
+        expect(ems.security_groups.first.tags.size).to eq(1)
+        expect(ems.security_groups.last.tags.size).to eq(0)
 
         filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, SecurityGroup, 'security_groups')
-        filtered.size.should == 1
+        expect(filtered.size).to eq(1)
       end
     end
 
     context "instance types (Flavor)" do
       it "#get_targets_for_ems" do
-        ems.flavors.size.should == 2
-        ems.flavors.first.tags.size.should == 1
-        ems.flavors.last.tags.size.should == 0
+        expect(ems.flavors.size).to eq(2)
+        expect(ems.flavors.first.tags.size).to eq(1)
+        expect(ems.flavors.last.tags.size).to eq(0)
 
-        workflow.send(:get_targets_for_ems, ems, :cloud_filter, Flavor, 'flavors').size.should == 1
+        expect(workflow.send(:get_targets_for_ems, ems, :cloud_filter, Flavor, 'flavors').size).to eq(1)
       end
     end
   end
@@ -168,7 +168,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
   context "when a template object is returned from the provider" do
     context "with empty relationships" do
       it "#allowed_instance_types" do
-        workflow.allowed_instance_types.should == {}
+        expect(workflow.allowed_instance_types).to eq({})
       end
     end
 
@@ -182,12 +182,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
       it "#allowed_instance_types with 32-bit image" do
         template.hardware = FactoryGirl.create(:hardware, :bitness => 32)
-        workflow.allowed_instance_types.length.should == 1
+        expect(workflow.allowed_instance_types.length).to eq(1)
       end
 
       it "#allowed_instance_types with 64-bit image" do
         template.hardware = FactoryGirl.create(:hardware, :bitness => 64)
-        workflow.allowed_instance_types.length.should == 2
+        expect(workflow.allowed_instance_types.length).to eq(2)
       end
     end
   end
@@ -212,70 +212,70 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     end
 
     it "#allowed_cloud_networks" do
-      workflow.allowed_cloud_networks.length.should == 1
+      expect(workflow.allowed_cloud_networks.length).to eq(1)
     end
 
     context "#allowed_availability_zones" do
       it "with no placement options" do
-        workflow.allowed_availability_zones.should == {
+        expect(workflow.allowed_availability_zones).to eq({
           @az1.id => @az1.name,
           @az2.id => @az2.name,
           @az3.id => @az3.name
-        }
+        })
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        workflow.allowed_availability_zones.should == {
+        expect(workflow.allowed_availability_zones).to eq({
           @az1.id => @az1.name,
           @az2.id => @az2.name
-        }
+        })
       end
 
       it "with a cloud_network and cloud_subnet" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
         workflow.values[:cloud_subnet]  = [@cs2.id, @cs2.name]
-        workflow.allowed_availability_zones.should == {@az2.id => @az2.name}
+        expect(workflow.allowed_availability_zones).to eq({@az2.id => @az2.name})
       end
     end
 
     context "#allowed_cloud_subnets" do
       it "without a cloud_network" do
-        workflow.allowed_cloud_subnets.length.should be_zero
+        expect(workflow.allowed_cloud_subnets.length).to be_zero
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        workflow.allowed_cloud_subnets.length.should == 2
+        expect(workflow.allowed_cloud_subnets.length).to eq(2)
       end
 
       it "with an cloud_network and Availability Zone" do
         workflow.values[:cloud_network]               = [@cn1.id, @cn1.name]
         workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
 
-        workflow.allowed_cloud_subnets.length.should == 1
+        expect(workflow.allowed_cloud_subnets.length).to eq(1)
       end
     end
 
     context "#allowed_floating_ip_addresses" do
       it "without a cloud_network" do
-        workflow.allowed_floating_ip_addresses.should == {@ip2.id => @ip2.address}
+        expect(workflow.allowed_floating_ip_addresses).to eq({@ip2.id => @ip2.address})
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        workflow.allowed_floating_ip_addresses.should == {@ip1.id => @ip1.address}
+        expect(workflow.allowed_floating_ip_addresses).to eq({@ip1.id => @ip1.address})
       end
     end
 
     context "#allowed_security_groups" do
       it "without a cloud_network" do
-        workflow.allowed_security_groups.should == {@sg2.id => @sg2.name}
+        expect(workflow.allowed_security_groups).to eq({@sg2.id => @sg2.name})
       end
 
       it "with a cloud_network" do
         workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
-        workflow.allowed_security_groups.should == {@sg1.id => @sg1.name}
+        expect(workflow.allowed_security_groups).to eq({@sg1.id => @sg1.name})
       end
     end
   end
@@ -284,12 +284,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     let(:flavor) { FactoryGirl.create(:flavor_amazon, :name => "test_flavor") }
 
     it "with name only" do
-      workflow.display_name_for_name_description(flavor).should == "test_flavor"
+      expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor")
     end
 
     it "with name and description" do
       flavor.description = "Small"
-      workflow.display_name_for_name_description(flavor).should == "test_flavor: Small"
+      expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor: Small")
     end
   end
 
@@ -319,12 +319,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
     it "#allowed_instance_types with 32-bit and hvm image" do
       template.hardware = FactoryGirl.create(:hardware, :bitness => 32, :virtualization_type => 'hvm')
-      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_32)
+      expect(workflow.allowed_instance_types.collect { |_, v| v }).to match_array(@instance_types_32)
     end
 
     it "#allowed_instance_types with 64-bit and pv image" do
       template.hardware = FactoryGirl.create(:hardware, :bitness => 64, :virtualization_type => 'paravirtual')
-      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
+      expect(workflow.allowed_instance_types.collect { |_, v| v }).to match_array(@instance_types_64)
     end
   end
 
@@ -359,7 +359,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
                                              :bitness             => 32,
                                              :virtualization_type => 'paravirtual',
                                              :root_device_type    => 'instance_store')
-      workflow.allowed_instance_types.collect { |_, v| v }.should be_empty
+      expect(workflow.allowed_instance_types.collect { |_, v| v }).to be_empty
     end
 
     it "#allowed_instance_types with 64-bit, pv and ebs" do
@@ -367,7 +367,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
                                              :bitness             => 64,
                                              :virtualization_type => 'paravirtual',
                                              :root_device_type    => 'ebs')
-      workflow.allowed_instance_types.collect { |_, v| v }.should match_array(@instance_types_64)
+      expect(workflow.allowed_instance_types.collect { |_, v| v }).to match_array(@instance_types_64)
     end
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -211,7 +211,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
     expect(v.ext_management_system).to eq(@ems)
     expect(v.availability_zone).to eq(@az)
-    expect(v.floating_ip).to            be_nil
+    expect(v.floating_ip).to be_nil
     expect(v.flavor).to eq(@flavor)
     expect(v.cloud_network).to          be_nil
     expect(v.cloud_subnet).to           be_nil
@@ -266,6 +266,6 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_subnet_required
     @flavor = ManageIQ::Providers::Amazon::CloudManager::Flavor.where(:name => "t2.small").first
-    expect(@flavor).to have_attributes(:cloud_subnet_required  => true)
+    expect(@flavor).to have_attributes(:cloud_subnet_required => true)
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -32,49 +32,49 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    Flavor.count.should == 54
-    AvailabilityZone.count.should == 3
-    FloatingIp.count.should == 1
-    AuthPrivateKey.count.should == 2
-    SecurityGroup.count.should == 2
-    FirewallRule.count.should == 4
-    VmOrTemplate.count.should == 3
-    Vm.count.should == 2
-    MiqTemplate.count.should == 1
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(Flavor.count).to eq(54)
+    expect(AvailabilityZone.count).to eq(3)
+    expect(FloatingIp.count).to eq(1)
+    expect(AuthPrivateKey.count).to eq(2)
+    expect(SecurityGroup.count).to eq(2)
+    expect(FirewallRule.count).to eq(4)
+    expect(VmOrTemplate.count).to eq(3)
+    expect(Vm.count).to eq(2)
+    expect(MiqTemplate.count).to eq(1)
 
-    CustomAttribute.count.should == 0
-    Disk.count.should == 1
-    GuestDevice.count.should == 0
-    Hardware.count.should == 3
-    Network.count.should == 4
-    OperatingSystem.count.should == 0 # TODO: Should this be 15 (set on all vms)?
-    Snapshot.count.should == 0
-    SystemService.count.should == 0
+    expect(CustomAttribute.count).to eq(0)
+    expect(Disk.count).to eq(1)
+    expect(GuestDevice.count).to eq(0)
+    expect(Hardware.count).to eq(3)
+    expect(Network.count).to eq(4)
+    expect(OperatingSystem.count).to eq(0) # TODO: Should this be 15 (set on all vms)?
+    expect(Snapshot.count).to eq(0)
+    expect(SystemService.count).to eq(0)
 
-    Relationship.count.should == 2
-    MiqQueue.count.should == 5
+    expect(Relationship.count).to eq(2)
+    expect(MiqQueue.count).to eq(5)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => nil, # TODO: Should be 3.0
       :uid_ems     => nil
     )
 
-    @ems.flavors.size.should == 54
-    @ems.availability_zones.size.should == 3
-    @ems.floating_ips.size.should == 1
-    @ems.key_pairs.size.should == 2
-    @ems.security_groups.size.should == 2
-    @ems.vms_and_templates.size.should == 3
-    @ems.vms.size.should == 2
-    @ems.miq_templates.size.should == 1
+    expect(@ems.flavors.size).to eq(54)
+    expect(@ems.availability_zones.size).to eq(3)
+    expect(@ems.floating_ips.size).to eq(1)
+    expect(@ems.key_pairs.size).to eq(2)
+    expect(@ems.security_groups.size).to eq(2)
+    expect(@ems.vms_and_templates.size).to eq(3)
+    expect(@ems.vms.size).to eq(2)
+    expect(@ems.miq_templates.size).to eq(1)
   end
 
   def assert_specific_flavor
     @flavor = ManageIQ::Providers::Amazon::CloudManager::Flavor.where(:name => "t1.micro").first
-    @flavor.should have_attributes(
+    expect(@flavor).to have_attributes(
       :name                 => "t1.micro",
       :description          => "T1 Micro",
       :enabled              => true,
@@ -87,19 +87,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :supports_paravirtual => true
     )
 
-    @flavor.ext_management_system.should == @ems
+    expect(@flavor.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_az
     @az = ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-west-1a").first
-    @az.should have_attributes(
+    expect(@az).to have_attributes(
       :name => "us-west-1a",
     )
   end
 
   def assert_specific_floating_ip
     ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.215.0.230").first
-    ip.should have_attributes(
+    expect(ip).to have_attributes(
       :address            => "54.215.0.230",
       :ems_ref            => "54.215.0.230",
       :cloud_network_only => false
@@ -108,7 +108,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_key_pair
     @kp = ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.where(:name => "EmsRefreshSpec-KeyPair-OtherRegion").first
-    @kp.should have_attributes(
+    expect(@kp).to have_attributes(
       :name        => "EmsRefreshSpec-KeyPair-OtherRegion",
       :fingerprint => "fc:53:30:aa:d2:23:c7:8d:e2:e8:05:95:a0:d2:90:fb:15:30:a2:51"
     )
@@ -116,14 +116,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_security_group
     @sg = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-OtherRegion").first
-    @sg.should have_attributes(
+    expect(@sg).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-OtherRegion",
       :description => "EmsRefreshSpec-SecurityGroup-OtherRegion",
       :ems_ref     => "sg-2b87746f"
     )
 
-    @sg.firewall_rules.size.should == 1
-    @sg.firewall_rules.first.should have_attributes(
+    expect(@sg.firewall_rules.size).to eq(1)
+    expect(@sg.firewall_rules.first).to have_attributes(
       :host_protocol            => "TCP",
       :direction                => "inbound",
       :port                     => 0,
@@ -135,7 +135,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_template
     @template = ManageIQ::Providers::Amazon::CloudManager::Template.where(:name => "EmsRefreshSpec-Image-OtherRegion").first
-    @template.should have_attributes(
+    expect(@template).to have_attributes(
       :template              => true,
       :ems_ref               => "ami-183e175d",
       :ems_ref_obj           => nil,
@@ -160,12 +160,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    @template.ext_management_system.should == @ems
-    @template.operating_system.should       be_nil # TODO: This should probably not be nil
-    @template.custom_attributes.size.should == 0
-    @template.snapshots.size.should == 0
+    expect(@template.ext_management_system).to eq(@ems)
+    expect(@template.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(@template.custom_attributes.size).to eq(0)
+    expect(@template.snapshots.size).to eq(0)
 
-    @template.hardware.should have_attributes(
+    expect(@template.hardware).to have_attributes(
       :guest_os           => "linux",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -176,15 +176,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :bitness            => 64
     )
 
-    @template.hardware.disks.size.should == 0
-    @template.hardware.guest_devices.size.should == 0
-    @template.hardware.nics.size.should == 0
-    @template.hardware.networks.size.should == 0
+    expect(@template.hardware.disks.size).to eq(0)
+    expect(@template.hardware.guest_devices.size).to eq(0)
+    expect(@template.hardware.nics.size).to eq(0)
+    expect(@template.hardware.networks.size).to eq(0)
   end
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion", :raw_power_state => "running").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "i-dc1ee486",
       :ems_ref_obj           => nil,
@@ -209,19 +209,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.availability_zone.should == @az
-    v.floating_ip.should            be_nil
-    v.flavor.should == @flavor
-    v.cloud_network.should          be_nil
-    v.cloud_subnet.should           be_nil
-    v.security_groups.should == [@sg]
-    v.key_pairs.should == [@kp]
-    v.operating_system.should       be_nil # TODO: This should probably not be nil
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.availability_zone).to eq(@az)
+    expect(v.floating_ip).to            be_nil
+    expect(v.flavor).to eq(@flavor)
+    expect(v.cloud_network).to          be_nil
+    expect(v.cloud_subnet).to           be_nil
+    expect(v.security_groups).to eq([@sg])
+    expect(v.key_pairs).to eq([@kp])
+    expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "linux",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -232,40 +232,40 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :bitness            => 64
     )
 
-    v.hardware.disks.size.should == 0 # TODO: Change to a flavor that has disks
-    v.hardware.guest_devices.size.should == 0
-    v.hardware.nics.size.should == 0
+    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.guest_devices.size).to eq(0)
+    expect(v.hardware.nics.size).to eq(0)
 
-    v.hardware.networks.size.should == 2
+    expect(v.hardware.networks.size).to eq(2)
     network = v.hardware.networks.where(:description => "public").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "public",
       :ipaddress   => "204.236.137.154",
       :hostname    => "ec2-204-236-137-154.us-west-1.compute.amazonaws.com"
     )
     network = v.hardware.networks.where(:description => "private").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "private",
       :ipaddress   => "10.191.129.95",
       :hostname    => "ip-10-191-129-95.us-west-1.compute.internal"
     )
 
     v.with_relationship_type("genealogy") do
-      v.parent.should == @template
+      expect(v.parent).to eq(@template)
     end
   end
 
   def assert_specific_vm_in_other_region
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-Basic").first
-    v.should be_nil
+    expect(v).to be_nil
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree({})
+    expect(@ems.descendants_arranged).to match_relationship_tree({})
   end
 
   def assert_subnet_required
     @flavor = ManageIQ::Providers::Amazon::CloudManager::Flavor.where(:name => "t2.small").first
-    @flavor.should have_attributes(:cloud_subnet_required  => true)
+    expect(@flavor).to have_attributes(:cloud_subnet_required  => true)
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -39,60 +39,60 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    Flavor.count.should == 54
-    AvailabilityZone.count.should == 5
-    FloatingIp.count.should == 5
-    AuthPrivateKey.count.should == 7
-    CloudNetwork.count.should == 3
-    CloudSubnet.count.should == 4
-    OrchestrationTemplate.count.should == 2
-    OrchestrationStack.count.should == 2
-    OrchestrationStackParameter.count.should == 5
-    OrchestrationStackOutput.count.should == 1
-    OrchestrationStackResource.count.should == 24
-    SecurityGroup.count.should == 13
-    FirewallRule.count.should == 43
-    VmOrTemplate.count.should == 46
-    Vm.count.should == 27
-    MiqTemplate.count.should == 19
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(Flavor.count).to eq(54)
+    expect(AvailabilityZone.count).to eq(5)
+    expect(FloatingIp.count).to eq(5)
+    expect(AuthPrivateKey.count).to eq(7)
+    expect(CloudNetwork.count).to eq(3)
+    expect(CloudSubnet.count).to eq(4)
+    expect(OrchestrationTemplate.count).to eq(2)
+    expect(OrchestrationStack.count).to eq(2)
+    expect(OrchestrationStackParameter.count).to eq(5)
+    expect(OrchestrationStackOutput.count).to eq(1)
+    expect(OrchestrationStackResource.count).to eq(24)
+    expect(SecurityGroup.count).to eq(13)
+    expect(FirewallRule.count).to eq(43)
+    expect(VmOrTemplate.count).to eq(46)
+    expect(Vm.count).to eq(27)
+    expect(MiqTemplate.count).to eq(19)
 
-    CustomAttribute.count.should == 0
-    Disk.count.should == 14
-    GuestDevice.count.should == 0
-    Hardware.count.should == 46
-    Network.count.should == 15
-    OperatingSystem.count.should == 0 # TODO: Should this be 13 (set on all vms)?
-    Snapshot.count.should == 0
-    SystemService.count.should == 0
+    expect(CustomAttribute.count).to eq(0)
+    expect(Disk.count).to eq(14)
+    expect(GuestDevice.count).to eq(0)
+    expect(Hardware.count).to eq(46)
+    expect(Network.count).to eq(15)
+    expect(OperatingSystem.count).to eq(0) # TODO: Should this be 13 (set on all vms)?
+    expect(Snapshot.count).to eq(0)
+    expect(SystemService.count).to eq(0)
 
-    Relationship.count.should == 25
-    MiqQueue.count.should == 48
+    expect(Relationship.count).to eq(25)
+    expect(MiqQueue.count).to eq(48)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => nil, # TODO: Should be 3.0
       :uid_ems     => nil
     )
 
-    @ems.flavors.size.should == 54
-    @ems.availability_zones.size.should == 5
-    @ems.floating_ips.size.should == 5
-    @ems.key_pairs.size.should == 7
-    @ems.cloud_networks.size.should == 3
-    @ems.security_groups.size.should == 13
-    @ems.vms_and_templates.size.should == 46
-    @ems.vms.size.should == 27
-    @ems.miq_templates.size.should == 19
-    @ems.orchestration_stacks.size.should == 2
+    expect(@ems.flavors.size).to eq(54)
+    expect(@ems.availability_zones.size).to eq(5)
+    expect(@ems.floating_ips.size).to eq(5)
+    expect(@ems.key_pairs.size).to eq(7)
+    expect(@ems.cloud_networks.size).to eq(3)
+    expect(@ems.security_groups.size).to eq(13)
+    expect(@ems.vms_and_templates.size).to eq(46)
+    expect(@ems.vms.size).to eq(27)
+    expect(@ems.miq_templates.size).to eq(19)
+    expect(@ems.orchestration_stacks.size).to eq(2)
 
-    @ems.direct_orchestration_stacks.size.should == 1
+    expect(@ems.direct_orchestration_stacks.size).to eq(1)
   end
 
   def assert_specific_flavor
     @flavor = ManageIQ::Providers::Amazon::CloudManager::Flavor.where(:name => "t1.micro").first
-    @flavor.should have_attributes(
+    expect(@flavor).to have_attributes(
       :name                     => "t1.micro",
       :description              => "T1 Micro",
       :enabled                  => true,
@@ -108,19 +108,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :ephemeral_disk_count     => 0
     )
 
-    @flavor.ext_management_system.should == @ems
+    expect(@flavor.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_az
     @az = ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1b").first
-    @az.should have_attributes(
+    expect(@az).to have_attributes(
       :name => "us-east-1b",
     )
   end
 
   def assert_specific_floating_ip
     @ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.221.202.53").first
-    @ip.should have_attributes(
+    expect(@ip).to have_attributes(
       :address            => "54.221.202.53",
       :ems_ref            => "54.221.202.53",
       :cloud_network_only => false
@@ -129,7 +129,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_floating_ip_for_cloud_network
     ip = ManageIQ::Providers::Amazon::CloudManager::FloatingIp.where(:address => "54.208.119.197").first
-    ip.should have_attributes(
+    expect(ip).to have_attributes(
       :address            => "54.208.119.197",
       :ems_ref            => "54.208.119.197",
       :cloud_network_only => true
@@ -138,7 +138,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_key_pair
     @kp = ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.where(:name => "EmsRefreshSpec-KeyPair").first
-    @kp.should have_attributes(
+    expect(@kp).to have_attributes(
       :name        => "EmsRefreshSpec-KeyPair",
       :fingerprint => "49:9f:3f:a4:26:48:39:94:26:06:dd:25:73:e5:da:9b:4b:1b:6c:93"
     )
@@ -146,7 +146,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_cloud_network
     @cn = CloudNetwork.where(:name => "EmsRefreshSpec-VPC").first
-    @cn.should have_attributes(
+    expect(@cn).to have_attributes(
       :name    => "EmsRefreshSpec-VPC",
       :ems_ref => "vpc-ff49ff91",
       :cidr    => "10.0.0.0/16",
@@ -154,27 +154,27 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :enabled => true
     )
 
-    @cn.cloud_subnets.size.should == 2
+    expect(@cn.cloud_subnets.size).to eq(2)
     @subnet = @cn.cloud_subnets.where(:name => "EmsRefreshSpec-Subnet1").first
-    @subnet.should have_attributes(
+    expect(@subnet).to have_attributes(
       :name    => "EmsRefreshSpec-Subnet1",
       :ems_ref => "subnet-f849ff96",
       :cidr    => "10.0.0.0/24"
     )
-    @subnet.availability_zone.should == ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1e").first
+    expect(@subnet.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1e").first)
 
     subnet2 = @cn.cloud_subnets.where(:name => "EmsRefreshSpec-Subnet2").first
-    subnet2.should have_attributes(
+    expect(subnet2).to have_attributes(
       :name    => "EmsRefreshSpec-Subnet2",
       :ems_ref => "subnet-16c70477",
       :cidr    => "10.0.1.0/24"
     )
-    subnet2.availability_zone.should == ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1d").first
+    expect(subnet2.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1d").first)
   end
 
   def assert_specific_security_group
     @sg = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup").first
-    @sg.should have_attributes(
+    expect(@sg).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup",
       :description => "EmsRefreshSpec-SecurityGroup",
       :ems_ref     => "sg-88af19e3"
@@ -195,29 +195,29 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       {:host_protocol => "UDP",  :direction => "inbound", :port => 3,  :end_port => 4,     :source_ip_range => nil,          :source_security_group_id => @sg.id}
     ]
 
-    @sg.firewall_rules.size.should == 12
+    expect(@sg.firewall_rules.size).to eq(12)
     @sg.firewall_rules
       .order(:host_protocol, :direction, :port, :end_port, :source_ip_range, :source_security_group_id)
       .zip(expected_firewall_rules)
       .each do |actual, expected|
-        actual.should have_attributes(expected)
+        expect(actual).to have_attributes(expected)
       end
   end
 
   def assert_specific_security_group_on_cloud_network
     @sg_on_cn = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup-VPC").first
-    @sg_on_cn.should have_attributes(
+    expect(@sg_on_cn).to have_attributes(
       :name        => "EmsRefreshSpec-SecurityGroup-VPC",
       :description => "EmsRefreshSpec-SecurityGroup-VPC",
       :ems_ref     => "sg-80f755ef"
     )
 
-    @sg_on_cn.cloud_network.should == @cn
+    expect(@sg_on_cn.cloud_network).to eq(@cn)
   end
 
   def assert_specific_template
     @template = ManageIQ::Providers::Amazon::CloudManager::Template.where(:name => "EmsRefreshSpec-Image").first
-    @template.should have_attributes(
+    expect(@template).to have_attributes(
       :template              => true,
       :ems_ref               => "ami-5769193e",
       :ems_ref_obj           => nil,
@@ -242,12 +242,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    @template.ext_management_system.should == @ems
-    @template.operating_system.should       be_nil # TODO: This should probably not be nil
-    @template.custom_attributes.size.should == 0
-    @template.snapshots.size.should == 0
+    expect(@template.ext_management_system).to eq(@ems)
+    expect(@template.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(@template.custom_attributes.size).to eq(0)
+    expect(@template.snapshots.size).to eq(0)
 
-    @template.hardware.should have_attributes(
+    expect(@template.hardware).to have_attributes(
       :guest_os            => "linux",
       :guest_os_full_name  => nil,
       :bios                => nil,
@@ -260,20 +260,20 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :root_device_type    => "ebs"
     )
 
-    @template.hardware.disks.size.should == 0
-    @template.hardware.guest_devices.size.should == 0
-    @template.hardware.nics.size.should == 0
-    @template.hardware.networks.size.should == 0
+    expect(@template.hardware.disks.size).to eq(0)
+    expect(@template.hardware.guest_devices.size).to eq(0)
+    expect(@template.hardware.nics.size).to eq(0)
+    expect(@template.hardware.networks.size).to eq(0)
   end
 
   def assert_specific_shared_template
     t = ManageIQ::Providers::Amazon::CloudManager::Template.where(:ems_ref => "ami-5e094837").first # TODO: Share an EmsRefreshSpec specific template
-    t.should_not be_nil
+    expect(t).not_to be_nil
   end
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-Basic", :raw_power_state => "running").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "i-7ab3c301",
       :ems_ref_obj           => nil,
@@ -298,20 +298,20 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.availability_zone.should == @az
-    v.floating_ip.should == @ip
-    v.flavor.should == @flavor
-    v.key_pairs.should == [@kp]
-    v.cloud_network.should          be_nil
-    v.cloud_subnet.should           be_nil
-    v.security_groups.should        match_array [@sg, ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.availability_zone).to eq(@az)
+    expect(v.floating_ip).to eq(@ip)
+    expect(v.flavor).to eq(@flavor)
+    expect(v.key_pairs).to eq([@kp])
+    expect(v.cloud_network).to          be_nil
+    expect(v.cloud_subnet).to           be_nil
+    expect(v.security_groups).to        match_array [@sg, ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
 
-    v.operating_system.should       be_nil # TODO: This should probably not be nil
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os            => "linux",
       :guest_os_full_name  => nil,
       :bios                => nil,
@@ -323,32 +323,32 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :virtualization_type => "paravirtual"
     )
 
-    v.hardware.disks.size.should == 0 # TODO: Change to a flavor that has disks
-    v.hardware.guest_devices.size.should == 0
-    v.hardware.nics.size.should == 0
+    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.guest_devices.size).to eq(0)
+    expect(v.hardware.nics.size).to eq(0)
 
-    v.hardware.networks.size.should == 2
+    expect(v.hardware.networks.size).to eq(2)
     network = v.hardware.networks.where(:description => "public").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "public",
       :ipaddress   => @ip.address,
       :hostname    => "ec2-54-221-202-53.compute-1.amazonaws.com"
     )
     network = v.hardware.networks.where(:description => "private").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "private",
       :ipaddress   => "10.46.222.159",
       :hostname    => "ip-10-46-222-159.ec2.internal"
     )
 
     v.with_relationship_type("genealogy") do
-      v.parent.should == @template
+      expect(v.parent).to eq(@template)
     end
   end
 
   def assert_specific_vm_powered_off
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOff", :raw_power_state => "stopped").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "i-79188d11",
       :ems_ref_obj           => nil,
@@ -373,18 +373,18 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.availability_zone.should == ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.find_by_name("us-east-1d")
-    v.floating_ip.should            be_nil
-    v.key_pairs.should == [@kp]
-    v.cloud_network.should          be_nil
-    v.cloud_subnet.should           be_nil
-    v.security_groups.should == [@sg]
-    v.operating_system.should       be_nil # TODO: This should probably not be nil
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.find_by_name("us-east-1d"))
+    expect(v.floating_ip).to            be_nil
+    expect(v.key_pairs).to eq([@kp])
+    expect(v.cloud_network).to          be_nil
+    expect(v.cloud_subnet).to           be_nil
+    expect(v.security_groups).to eq([@sg])
+    expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "linux",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -395,19 +395,19 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :bitness            => 64
     )
 
-    v.hardware.disks.size.should == 0 # TODO: Change to a flavor that has disks
-    v.hardware.guest_devices.size.should == 0
-    v.hardware.nics.size.should == 0
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.guest_devices.size).to eq(0)
+    expect(v.hardware.nics.size).to eq(0)
+    expect(v.hardware.networks.size).to eq(0)
 
     v.with_relationship_type("genealogy") do
-      v.parent.should == @template
+      expect(v.parent).to eq(@template)
     end
   end
 
   def assert_specific_vm_on_cloud_network
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-VPC").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "i-8b5739f2",
       :ems_ref_obj           => nil,
@@ -432,30 +432,31 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.cloud_network.should == @cn
-    v.cloud_subnet.should == @subnet
-    v.security_groups.should == [@sg_on_cn]
+    expect(v.cloud_network).to eq(@cn)
+    expect(v.cloud_subnet).to eq(@subnet)
+    expect(v.security_groups).to eq([@sg_on_cn])
   end
 
   def assert_specific_orchestration_template
     @orch_template = OrchestrationTemplateCfn.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6").first
-    @orch_template.should have_attributes(
+    expect(@orch_template).to have_attributes(
       :md5 => "e929859521d64ac28ee29f8526d33e8f",
     )
-    @orch_template.description.should start_with("AWS CloudFormation Sample Template WordPress_Simple:")
-    @orch_template.content.should start_with("{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",")
+    expect(@orch_template.description).to start_with("AWS CloudFormation Sample Template WordPress_Simple:")
+    expect(@orch_template.content).to start_with("{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",")
   end
 
   def assert_specific_orchestration_stack
-    ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec").first.status_reason.should ==
+    expect(ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec").first.status_reason).to eq(
       "The following resource(s) failed to create: [IPAddress, WebServerWaitCondition]. "
+    )
 
     @orch_stack = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6").first
-    @orch_stack.should have_attributes(
+    expect(@orch_stack).to have_attributes(
       :status  => "CREATE_COMPLETE",
       :ems_ref => "arn:aws:cloudformation:us-east-1:123456789012:stack/cloudformation-spec-WebServerInstance-QS899ZNAHZU6/1dedba70-5322-11e4-b33b-50e241629418",
     )
-    @orch_stack.description.should start_with("AWS CloudFormation Sample Template WordPress_Simple:")
+    expect(@orch_stack.description).to start_with("AWS CloudFormation Sample Template WordPress_Simple:")
 
     assert_specific_orchestration_stack_parameters
     assert_specific_orchestration_stack_resources
@@ -465,10 +466,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack_parameters
     parameters = @orch_stack.parameters.order("ems_ref")
-    parameters.should have(2).items
+    expect(parameters.size).to eq(2)
 
     # assert one of the parameter models
-    parameters[1].should have_attributes(
+    expect(parameters[1]).to have_attributes(
       :name  => "InstanceType",
       :value => "t1.micro"
     )
@@ -476,10 +477,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack_resources
     resources = @orch_stack.resources.order("ems_ref")
-    resources.should have(4).items
+    expect(resources.size).to eq(4)
 
     # assert one of the resource models
-    resources[3].should have_attributes(
+    expect(resources[3]).to have_attributes(
       :name                   => "WebServer",
       :logical_resource       => "WebServer",
       :physical_resource      => "i-b98fdd57",
@@ -491,8 +492,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack_outputs
     outputs = @orch_stack.outputs
-    outputs.should have(1).items
-    outputs[0].should have_attributes(
+    expect(outputs.size).to eq(1)
+    expect(outputs[0]).to have_attributes(
       :key         => "WebsiteURL",
       :value       => "http://ec2-54-205-248-16.compute-1.amazonaws.com/wordpress",
       :description => "WordPress Website"
@@ -501,34 +502,34 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack_associations
     # orchestration stack belongs to a provider
-    @orch_stack.ext_management_system.should == @ems
+    expect(@orch_stack.ext_management_system).to eq(@ems)
 
     # orchestration stack belongs to an orchestration template
-    @orch_stack.orchestration_template.should == @orch_template
+    expect(@orch_stack.orchestration_template).to eq(@orch_template)
 
     # orchestration stack can be nested
     parent_stack = OrchestrationStack.where(:name => "cloudformation-spec").first
-    @orch_stack.parent.should == parent_stack
+    expect(@orch_stack.parent).to eq(parent_stack)
 
     # orchestration stack can have vms
     vm = Vm.where(:name => "i-b98fdd57").first
-    vm.orchestration_stack.should == @orch_stack
+    expect(vm.orchestration_stack).to eq(@orch_stack)
 
     # orchestration stack can have security groups
     sg = SecurityGroup.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6-WebServerSecurityGroup-F458PFAVKR11").first
-    sg.orchestration_stack.should == @orch_stack
+    expect(sg.orchestration_stack).to eq(@orch_stack)
 
     # orchestration stack can have cloud networks
     vpc = CloudNetwork.where(:name => "vpc-5b6fe83e").first
-    vpc.orchestration_stack.should == parent_stack
+    expect(vpc.orchestration_stack).to eq(parent_stack)
   end
 
   def assert_specific_vm_in_other_region
     v = ManageIQ::Providers::Amazon::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-OtherRegion").first
-    v.should be_nil
+    expect(v).to be_nil
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree({})
+    expect(@ems.descendants_arranged).to match_relationship_tree({})
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -161,7 +161,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :ems_ref => "subnet-f849ff96",
       :cidr    => "10.0.0.0/24"
     )
-    expect(@subnet.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1e").first)
+    expect(@subnet.availability_zone)
+      .to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1e").first)
 
     subnet2 = @cn.cloud_subnets.where(:name => "EmsRefreshSpec-Subnet2").first
     expect(subnet2).to have_attributes(
@@ -169,7 +170,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :ems_ref => "subnet-16c70477",
       :cidr    => "10.0.1.0/24"
     )
-    expect(subnet2.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1d").first)
+    expect(subnet2.availability_zone)
+      .to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.where(:name => "us-east-1d").first)
   end
 
   def assert_specific_security_group
@@ -305,7 +307,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(v.key_pairs).to eq([@kp])
     expect(v.cloud_network).to          be_nil
     expect(v.cloud_subnet).to           be_nil
-    expect(v.security_groups).to        match_array [@sg, ManageIQ::Providers::Amazon::CloudManager::SecurityGroup.where(:name => "EmsRefreshSpec-SecurityGroup2").first]
+    sg_2 = ManageIQ::Providers::Amazon::CloudManager::SecurityGroup
+           .where(:name => "EmsRefreshSpec-SecurityGroup2").first
+    expect(v.security_groups)
+      .to match_array [@sg, sg_2]
 
     expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
     expect(v.custom_attributes.size).to eq(0)
@@ -374,13 +379,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     )
 
     expect(v.ext_management_system).to eq(@ems)
-    expect(v.availability_zone).to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.find_by_name("us-east-1d"))
-    expect(v.floating_ip).to            be_nil
+    expect(v.availability_zone)
+      .to eq(ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.find_by_name("us-east-1d"))
+    expect(v.floating_ip).to be_nil
     expect(v.key_pairs).to eq([@kp])
-    expect(v.cloud_network).to          be_nil
-    expect(v.cloud_subnet).to           be_nil
+    expect(v.cloud_network).to be_nil
+    expect(v.cloud_subnet).to be_nil
     expect(v.security_groups).to eq([@sg])
-    expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
+    expect(v.operating_system).to be_nil # TODO: This should probably not be nil
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(0)
 
@@ -447,9 +453,9 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_specific_orchestration_stack
-    expect(ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec").first.status_reason).to eq(
-      "The following resource(s) failed to create: [IPAddress, WebServerWaitCondition]. "
-    )
+    stack = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec").first
+    expect(stack.status_reason)
+      .to eq("The following resource(s) failed to create: [IPAddress, WebServerWaitCondition]. ")
 
     @orch_stack = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.where(:name => "cloudformation-spec-WebServerInstance-QS899ZNAHZU6").first
     expect(@orch_stack).to have_attributes(

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Amazon::CloudManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'ec2'
+    expect(described_class.ems_type).to eq('ec2')
   end
 
   it ".description" do
-    described_class.description.should == 'Amazon EC2'
+    expect(described_class.description).to eq('Amazon EC2')
   end
 
   describe ".metrics_collector_queue_name" do
@@ -33,100 +33,100 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     end
 
     def assert_region(ems, name)
-      ems.name.should == name
-      ems.provider_region.should == name.split(" ").first
-      ems.auth_user_pwd.should == [@ec2_user, @ec2_pass]
+      expect(ems.name).to eq(name)
+      expect(ems.provider_region).to eq(name.split(" ").first)
+      expect(ems.auth_user_pwd).to eq([@ec2_user, @ec2_pass])
     end
 
     def assert_region_on_another_account(ems, name)
-      ems.name.should == name
-      ems.provider_region.should == name.split(" ").first
-      ems.auth_user_pwd.should == [@ec2_user2, @ec2_pass2]
+      expect(ems.name).to eq(name)
+      expect(ems.provider_region).to eq(name.split(" ").first)
+      expect(ems.auth_user_pwd).to eq([@ec2_user2, @ec2_pass2])
     end
 
-    it "with no existing records" do
+    it "with no existing records" do |example|
       found = recorded_discover(example)
-      found.count.should == 2
+      expect(found.count).to eq(2)
 
       emses = ManageIQ::Providers::Amazon::CloudManager.order(:name)
-      emses.count.should == 2
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "us-east-1")
       assert_region(emses[1], "us-west-1")
     end
 
-    it "with no existing records and greenfield Amazon" do
+    it "with no existing records and greenfield Amazon" do |example|
       found = recorded_discover(example)
-      found.count.should == 1
+      expect(found.count).to eq(1)
 
       emses = ManageIQ::Providers::Amazon::CloudManager.order(:name)
-      emses.count.should == 1
+      expect(emses.count).to eq(1)
       assert_region(emses[0], "us-east-1")
     end
 
-    it "with some existing records" do
+    it "with some existing records" do |example|
       FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :provider_region => "us-west-1")
 
       found = recorded_discover(example)
-      found.count.should == 1
+      expect(found.count).to eq(1)
 
       emses = ManageIQ::Providers::Amazon::CloudManager.order(:name)
-      emses.count.should == 2
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "us-east-1")
       assert_region(emses[1], "us-west-1")
     end
 
-    it "with all existing records" do
+    it "with all existing records" do |example|
       FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-east-1", :provider_region => "us-east-1")
       FactoryGirl.create(:ems_amazon_with_authentication, :name => "us-west-1", :provider_region => "us-west-1")
 
       found = recorded_discover(example)
-      found.count.should == 0
+      expect(found.count).to eq(0)
 
       emses = ManageIQ::Providers::Amazon::CloudManager.order(:name)
-      emses.count.should == 2
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "us-east-1")
       assert_region(emses[1], "us-west-1")
     end
 
     context "with records from a different account" do
-      it "with the same name" do
+      it "with the same name" do |example|
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
-        found.count.should == 2
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Amazon::CloudManager.order(:name).includes(:authentications)
-        emses.count.should == 3
+        expect(emses.count).to eq(3)
         assert_region(emses[0], "us-east-1")
         assert_region_on_another_account(emses[1], "us-west-1")
         assert_region(emses[2], "us-west-1 #{@ec2_user}")
       end
 
-      it "with the same name and backup name" do
+      it "with the same name and backup name" do |example|
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
-        found.count.should == 2
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Amazon::CloudManager.order(:name).includes(:authentications)
-        emses.count.should == 4
+        expect(emses.count).to eq(4)
         assert_region(emses[0], "us-east-1")
         assert_region_on_another_account(emses[1], "us-west-1")
         assert_region_on_another_account(emses[2], "us-west-1 #{@ec2_user}")
         assert_region(emses[3], "us-west-1 1")
       end
 
-      it "with the same name, backup name, and secondary backup name" do
+      it "with the same name, backup name, and secondary backup name" do |example|
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1", :provider_region => "us-west-1")
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 #{@ec2_user}", :provider_region => "us-west-1")
         FactoryGirl.create(:ems_amazon_with_authentication_on_other_account, :name => "us-west-1 1", :provider_region => "us-west-1")
 
         found = recorded_discover(example)
-        found.count.should == 2
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Amazon::CloudManager.order(:name).includes(:authentications)
-        emses.count.should == 5
+        expect(emses.count).to eq(5)
         assert_region(emses[0], "us-east-1")
         assert_region_on_another_account(emses[1], "us-west-1")
         assert_region_on_another_account(emses[2], "us-west-1 #{@ec2_user}")
@@ -138,10 +138,10 @@ describe ManageIQ::Providers::Amazon::CloudManager do
 
   it "#description" do
     ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-east-1")
-    ems.description.should == "US East (Northern Virginia)"
+    expect(ems.description).to eq("US East (Northern Virginia)")
 
     ems = FactoryGirl.build(:ems_amazon, :provider_region => "us-west-1")
-    ems.description.should == "US West (Northern California)"
+    expect(ems.description).to eq("US West (Northern California)")
   end
 
   context "validates_uniqueness_of" do
@@ -177,23 +177,23 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     end
 
     it "preserves and logs message for unknown exceptions" do
-      @ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
-      $log.should_receive(:error).with(/unlikely/)
+      allow(@ems).to receive(:with_provider_connection).and_raise(StandardError, "unlikely")
+      expect($log).to receive(:error).with(/unlikely/)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Unexpected.*unlikely/)
     end
 
     it "handles SignatureDoesNotMatch" do
-      @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
+      allow(@ems).to receive(:with_provider_connection).and_raise(AWS::EC2::Errors::SignatureDoesNotMatch)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Signature.*match/)
     end
 
     it "handles AuthFailure" do
-      @ems.stub(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
+      allow(@ems).to receive(:with_provider_connection).and_raise(AWS::EC2::Errors::AuthFailure)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Login failed/)
     end
 
     it "handles MissingCredentialsErrror" do
-      @ems.stub(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
+      allow(@ems).to receive(:with_provider_connection).and_raise(AWS::Errors::MissingCredentialsError)
       expect { @ems.verify_credentials }.to raise_error(MiqException::MiqHostError, /Missing credentials/i)
     end
   end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/status_spec.rb
@@ -3,51 +3,51 @@ require "spec_helper"
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack::Status do
   it 'parses Succeeded' do
     status = described_class.new('Succeeded', '')
-    status.completed?.should   be_true
-    status.succeeded?.should   be_true
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.normalized_status.should == ['create_complete', '']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_truthy
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_complete', ''])
   end
 
   it 'parses Failed' do
     status = described_class.new('Failed', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_true
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.normalized_status.should == ['failed', 'Stack creation failed']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
   end
 
   it 'parses Deleted' do
     status = described_class.new('Deleted', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_true
-    status.rolled_back?.should be_false
-    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_truthy
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['delete_complete', 'Stack was deleted'])
   end
 
   it 'parses Canceled' do
     status = described_class.new('Canceled', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.canceled?.should    be_true
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.normalized_status.should == ['create_canceled', 'Stack creation was canceled']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.canceled?).to    be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(['create_canceled', 'Stack creation was canceled'])
   end
 
   it 'parses transient status' do
     status = described_class.new('CREATING', nil)
-    status.completed?.should   be_false
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.normalized_status.should == %w(transient CREATING)
+    expect(status.completed?).to   be_falsey
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.normalized_status).to eq(%w(transient CREATING))
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -31,9 +31,9 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
         expect(orchestration_service).to receive(:create).and_return(the_raw_stack)
 
         stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
-        stack.class.should   == described_class
-        stack.name.should    == 'mystack'
-        stack.ems_ref.should == the_raw_stack.id
+        expect(stack.class).to   eq(described_class)
+        expect(stack.name).to    eq('mystack')
+        expect(stack.ems_ref).to eq(the_raw_stack.id)
       end
 
       it 'catches errors from provider' do
@@ -76,14 +76,14 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
         rstatus = orchestration_stack.raw_status
         expect(rstatus).to have_attributes(:status => 'Succeeded', :reason => nil)
 
-        orchestration_stack.raw_exists?.should be_true
+        expect(orchestration_stack.raw_exists?).to be_truthy
       end
 
       it 'parses error message to determine stack not exist' do
         allow(orchestration_service).to receive(:get).and_throw("Deployment xxx could not be found")
         expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
 
-        orchestration_stack.raw_exists?.should be_false
+        expect(orchestration_stack.raw_exists?).to be_falsey
       end
 
       it 'catches errors from provider' do

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
     @ems.update_attributes(:azure_tenant_id => "a50f9983-d1a2-4a8d-be7d-123456789012")
 
     # A true thread may fail the test with VCR
-    Thread.stub(:new) do |*args, &block|
+    allow(Thread).to receive(:new) do |*args, &block|
       block.call(*args)
       Class.new do
         def join; end
@@ -43,44 +43,44 @@ describe ManageIQ::Providers::Azure::CloudManager do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should eql(1)
-    Flavor.count.should eql(33)
-    AvailabilityZone.count.should eql(1)
-    VmOrTemplate.count.should eql(13)
-    Vm.count.should eql(9)
-    MiqTemplate.count.should eql(4)
-    Disk.count.should eql(11)
-    GuestDevice.count.should eql(0)
-    Hardware.count.should eql(13)
-    Network.count.should eql(15)
-    OperatingSystem.count.should eql(9)
-    Relationship.count.should eql(0)
-    MiqQueue.count.should eql(13)
-    OrchestrationTemplate.count.should eql(3)
-    OrchestrationStack.count.should eql(7)
-    OrchestrationStackParameter.count.should eql(72)
-    OrchestrationStackOutput.count.should eql(5)
-    OrchestrationStackResource.count.should eql(32)
+    expect(ExtManagementSystem.count).to eql(1)
+    expect(Flavor.count).to eql(33)
+    expect(AvailabilityZone.count).to eql(1)
+    expect(VmOrTemplate.count).to eql(13)
+    expect(Vm.count).to eql(9)
+    expect(MiqTemplate.count).to eql(4)
+    expect(Disk.count).to eql(11)
+    expect(GuestDevice.count).to eql(0)
+    expect(Hardware.count).to eql(13)
+    expect(Network.count).to eql(15)
+    expect(OperatingSystem.count).to eql(9)
+    expect(Relationship.count).to eql(0)
+    expect(MiqQueue.count).to eql(13)
+    expect(OrchestrationTemplate.count).to eql(3)
+    expect(OrchestrationStack.count).to eql(7)
+    expect(OrchestrationStackParameter.count).to eql(72)
+    expect(OrchestrationStackOutput.count).to eql(5)
+    expect(OrchestrationStackResource.count).to eql(32)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => nil,
       :uid_ems     => "a50f9983-d1a2-4a8d-be7d-123456789012"
     )
-    @ems.flavors.size.should eql(33)
-    @ems.availability_zones.size.should eql(1)
-    @ems.vms_and_templates.size.should eql(13)
-    @ems.vms.size.should eql(9)
-    @ems.miq_templates.size.should eq(4)
+    expect(@ems.flavors.size).to eql(33)
+    expect(@ems.availability_zones.size).to eql(1)
+    expect(@ems.vms_and_templates.size).to eql(13)
+    expect(@ems.vms.size).to eql(9)
+    expect(@ems.miq_templates.size).to eq(4)
 
-    @ems.orchestration_stacks.size.should eql(7)
-    @ems.direct_orchestration_stacks.size.should eql(6)
+    expect(@ems.orchestration_stacks.size).to eql(7)
+    expect(@ems.direct_orchestration_stacks.size).to eql(6)
   end
 
   def assert_specific_flavor
     @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Standard_A0").first
-    @flavor.should have_attributes(
+    expect(@flavor).to have_attributes(
       :name                     => "Standard_A0",
       :description              => nil,
       :enabled                  => true,
@@ -96,19 +96,19 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :swap_disk_size           => 20.megabytes
     )
 
-    @flavor.ext_management_system.should == @ems
+    expect(@flavor.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_az
     @az = ManageIQ::Providers::Azure::CloudManager::AvailabilityZone.first
-    @az.should have_attributes(
+    expect(@az).to have_attributes(
       :name => @ems.name,
     )
   end
 
   def assert_specific_cloud_network
     @cn = CloudNetwork.where(:name => "Chef-Prod").first
-    @cn.should have_attributes(
+    expect(@cn).to have_attributes(
       :name    => "Chef-Prod",
       :ems_ref => "/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485"\
                   "/resourceGroups/Chef-Prod/providers/Microsoft.Network"\
@@ -118,9 +118,9 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :enabled => true
     )
 
-    @cn.cloud_subnets.size.should eq(1)
+    expect(@cn.cloud_subnets.size).to eq(1)
     @subnet = @cn.cloud_subnets.where(:name => "default").first
-    @subnet.should have_attributes(
+    expect(@subnet).to have_attributes(
       :name              => "default",
       :ems_ref           => "/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485"\
                              "/resourceGroups/Chef-Prod/providers/Microsoft.Network"\
@@ -133,7 +133,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Azure::CloudManager::Vm.where(:name => "Chef-Prod", :raw_power_state => "VM running").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\chef-prod"\
                                 "\\microsoft.compute/virtualmachines\\Chef-Prod",
@@ -161,18 +161,18 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should eql(@ems)
-    v.availability_zone.should eql(@az)
-    v.flavor.should eql(@flavor)
-    v.operating_system.product_name.should eql("chef-server chefbyol")
-    v.custom_attributes.size.should eql(0)
-    v.snapshots.size.should eql(0)
+    expect(v.ext_management_system).to eql(@ems)
+    expect(v.availability_zone).to eql(@az)
+    expect(v.flavor).to eql(@flavor)
+    expect(v.operating_system.product_name).to eql("chef-server chefbyol")
+    expect(v.custom_attributes.size).to eql(0)
+    expect(v.snapshots.size).to eql(0)
 
     assert_specific_vm_powered_on_hardware(v)
   end
 
   def assert_specific_vm_powered_on_hardware(v)
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os            => nil,
       :guest_os_full_name  => nil,
       :bios                => nil,
@@ -184,23 +184,23 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :virtualization_type => nil
     )
 
-    v.hardware.disks.size.should eql(1) # TODO: Change to a flavor that has disks
-    v.hardware.guest_devices.size.should eql(0)
-    v.hardware.nics.size.should eql(0)
+    expect(v.hardware.disks.size).to eql(1) # TODO: Change to a flavor that has disks
+    expect(v.hardware.guest_devices.size).to eql(0)
+    expect(v.hardware.nics.size).to eql(0)
 
     assert_specific_vm_powered_on_hardware_networks(v)
   end
 
   def assert_specific_vm_powered_on_hardware_networks(v)
-    v.hardware.networks.size.should eql(2)
+    expect(v.hardware.networks.size).to eql(2)
     network = v.hardware.networks.where(:description => "public").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "public",
       :ipaddress   => "40.76.199.78",
       :hostname    => "ipconfig1"
     )
     network = v.hardware.networks.where(:description => "private").first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description => "private",
       :ipaddress   => "10.2.0.4",
       :hostname    => "ipconfig1"
@@ -215,20 +215,20 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
     assert_specific_vm_powered_off_attributes(v)
 
-    v.ext_management_system.should eql(@ems)
-    v.availability_zone.should eql(az1)
-    v.floating_ip.should be_nil
-    v.cloud_network.should be_nil
-    v.cloud_subnet.should be_nil
-    v.operating_system.product_name.should eql("UbuntuServer 14.04.3 LTS")
-    v.custom_attributes.size.should eql(0)
-    v.snapshots.size.should eql(0)
+    expect(v.ext_management_system).to eql(@ems)
+    expect(v.availability_zone).to eql(az1)
+    expect(v.floating_ip).to be_nil
+    expect(v.cloud_network).to be_nil
+    expect(v.cloud_subnet).to be_nil
+    expect(v.operating_system.product_name).to eql("UbuntuServer 14.04.3 LTS")
+    expect(v.custom_attributes.size).to eql(0)
+    expect(v.snapshots.size).to eql(0)
 
     assert_specific_vm_powered_off_hardware(v)
   end
 
   def assert_specific_vm_powered_off_attributes(v)
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "462f2af8-e67e-40c6-9fbf-02824d1dd485\\computevms\\"\
                                 "microsoft.compute/virtualmachines\\MIQ2",
@@ -258,7 +258,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
   end
 
   def assert_specific_vm_powered_off_hardware(v)
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => nil,
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -269,16 +269,16 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :bitness            => nil
     )
 
-    v.hardware.disks.size.should eql(1)
-    v.hardware.guest_devices.size.should eql(0)
-    v.hardware.nics.size.should eql(0)
-    v.hardware.networks.size.should eql(2)
+    expect(v.hardware.disks.size).to eql(1)
+    expect(v.hardware.guest_devices.size).to eql(0)
+    expect(v.hardware.nics.size).to eql(0)
+    expect(v.hardware.networks.size).to eql(2)
   end
 
   def assert_specific_template
     name      = "Images/postgres-cont/postgres-osDisk"
     @template = ManageIQ::Providers::Azure::CloudManager::Template.where(:name => name).first
-    @template.should have_attributes(
+    expect(@template).to have_attributes(
       :template              => true,
       :ems_ref               => "https://chefprod5120.blob.core.windows.net/system/"\
                                 "Microsoft.Compute/Images/postgres-cont/"\
@@ -307,12 +307,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :cpu_shares_level      => nil
     )
 
-    @template.ext_management_system.should eq(@ems)
-    @template.operating_system.should eq(nil)
-    @template.custom_attributes.size.should eq(0)
-    @template.snapshots.size.should eq(0)
+    expect(@template.ext_management_system).to eq(@ems)
+    expect(@template.operating_system).to eq(nil)
+    expect(@template.custom_attributes.size).to eq(0)
+    expect(@template.snapshots.size).to eq(0)
 
-    @template.hardware.should have_attributes(
+    expect(@template.hardware).to have_attributes(
       :guest_os            => "Windows",
       :guest_os_full_name  => nil,
       :bios                => nil,
@@ -324,26 +324,26 @@ describe ManageIQ::Providers::Azure::CloudManager do
       :root_device_type    => nil
     )
 
-    @template.hardware.disks.size.should eq(0)
-    @template.hardware.guest_devices.size.should eq(0)
-    @template.hardware.nics.size.should eq(0)
-    @template.hardware.networks.size.should eq(0)
+    expect(@template.hardware.disks.size).to eq(0)
+    expect(@template.hardware.guest_devices.size).to eq(0)
+    expect(@template.hardware.nics.size).to eq(0)
+    expect(@template.hardware.networks.size).to eq(0)
   end
 
   def assert_specific_orchestration_template
     @orch_template = OrchestrationTemplateAzure.where(:name => "spec-deployment1-dont-delete").first
-    @orch_template.should have_attributes(
+    expect(@orch_template).to have_attributes(
       :md5 => "83c7f9914808a5ca7c000477a6daa7df"
     )
-    @orch_template.description.should eql('contentVersion: 1.0.0.0')
-    @orch_template.content.should start_with("{\n  \"$schema\": \"http://schema.management.azure.com"\
+    expect(@orch_template.description).to eql('contentVersion: 1.0.0.0')
+    expect(@orch_template.content).to start_with("{\n  \"$schema\": \"http://schema.management.azure.com"\
       "/schemas/2015-01-01/deploymentTemplate.json\"")
   end
 
   def assert_specific_orchestration_stack
     @orch_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(
       :name => "spec-deployment1-dont-delete").first
-    @orch_stack.should have_attributes(
+    expect(@orch_stack).to have_attributes(
       :status         => "Succeeded",
       :description    => 'spec-deployment1-dont-delete',
       :resource_group => 'ComputeVMs',
@@ -359,10 +359,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
   def assert_specific_orchestration_stack_parameters
     parameters = @orch_stack.parameters.order("ems_ref")
-    parameters.should have(13).items
+    expect(parameters.size).to eq(13)
 
     # assert one of the parameter models
-    parameters[1].should have_attributes(
+    expect(parameters[1]).to have_attributes(
       :name    => "adminUsername",
       :value   => "serveradmin",
       :ems_ref => '/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups'\
@@ -372,10 +372,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
   def assert_specific_orchestration_stack_resources
     resources = @orch_stack.resources.order("ems_ref")
-    resources.should have(9).items
+    expect(resources.size).to eq(9)
 
     # assert one of the resource models
-    resources.first.should have_attributes(
+    expect(resources.first).to have_attributes(
       :name                   => "myAvSet",
       :logical_resource       => "myAvSet",
       :physical_resource      => "6543c69e-1c83-47d1-96a6-d08d612fea76",
@@ -390,8 +390,8 @@ describe ManageIQ::Providers::Azure::CloudManager do
   def assert_specific_orchestration_stack_outputs
     outputs = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(
       :name => "spec-deployment2-dont-delete").first.outputs
-    outputs.should have(1).items
-    outputs[0].should have_attributes(
+    expect(outputs.size).to eq(1)
+    expect(outputs[0]).to have_attributes(
       :key         => "siteUri",
       :value       => "hard-coded output for test",
       :description => "siteUri",
@@ -402,24 +402,24 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
   def assert_specific_orchestration_stack_associations
     # orchestration stack belongs to a provider
-    @orch_stack.ext_management_system.should eql(@ems)
+    expect(@orch_stack.ext_management_system).to eql(@ems)
 
     # orchestration stack belongs to an orchestration template
-    @orch_stack.orchestration_template.should eql(@orch_template)
+    expect(@orch_stack.orchestration_template).to eql(@orch_template)
 
     # orchestration stack can be nested
     parent_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(
       :name => "spec-deployment2-dont-delete").first
     child_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.where(
       :name => "spec-nested-deployment-dont-delete").first
-    child_stack.parent.should eql(parent_stack)
+    expect(child_stack.parent).to eql(parent_stack)
 
     # orchestration stack can have vms
     vm = ManageIQ::Providers::Azure::CloudManager::Vm.where(:name => "spec-VM1").first
-    vm.orchestration_stack.should eql(@orch_stack)
+    expect(vm.orchestration_stack).to eql(@orch_stack)
 
     # orchestration stack can have cloud networks
     cloud_network = CloudNetwork.where(:name => 'spec-VNET').first
-    cloud_network.orchestration_stack.should eql(@orch_stack)
+    expect(cloud_network.orchestration_stack).to eql(@orch_stack)
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Azure::CloudManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'azure'
+    expect(described_class.ems_type).to eq('azure')
   end
 
   it ".description" do
-    described_class.description.should == 'Azure'
+    expect(described_class.description).to eq('Azure')
   end
 
   context "#connectivity" do
@@ -18,30 +18,30 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
     context "#connect " do
       it "defaults" do
-        described_class.should_receive(:raw_connect).with do |clientid, clientkey|
-          clientid.should eq("klmnopqrst")
-          clientkey.should eq("1234567890")
-        end
+        expect(described_class).to receive(:raw_connect).with { |clientid, clientkey|
+          expect(clientid).to eq("klmnopqrst")
+          expect(clientkey).to eq("1234567890")
+        }
         @e.connect
       end
 
       it "accepts overrides" do
-        described_class.should_receive(:raw_connect).with do |clientid, clientkey|
-          clientid.should eq("user")
-          clientkey.should eq("pass")
-        end
+        expect(described_class).to receive(:raw_connect).with { |clientid, clientkey|
+          expect(clientid).to eq("user")
+          expect(clientkey).to eq("pass")
+        }
         @e.connect(:user => "user", :pass => "pass")
       end
     end
 
     context "#validation" do
       it "handles unknown error" do
-        ManageIQ::Providers::Azure::CloudManager.stub(:raw_connect).and_raise(StandardError)
+        allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(StandardError)
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Unexpected response returned*/)
       end
 
       it "handles incorrect password" do
-        ManageIQ::Providers::Azure::CloudManager.stub(:raw_connect).and_raise(
+        allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(
           Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqHostError, /Incorrect credentials*/)
       end
@@ -72,17 +72,17 @@ describe ManageIQ::Providers::Azure::CloudManager do
     end
 
     def assert_region(ems, name)
-      ems.name.should eq(name)
-      ems.provider_region.should eq(name[AZURE_PREFIX, 1])
-      ems.auth_user_pwd.should eq([@user, @pass])
-      ems.azure_tenant_id.should eq(@tenant_id)
+      expect(ems.name).to eq(name)
+      expect(ems.provider_region).to eq(name[AZURE_PREFIX, 1])
+      expect(ems.auth_user_pwd).to eq([@user, @pass])
+      expect(ems.azure_tenant_id).to eq(@tenant_id)
     end
 
     def assert_region_on_another_account(ems, name)
-      ems.name.should eq(name)
-      ems.provider_region.should eq(name[AZURE_PREFIX, 1])
-      ems.auth_user_pwd.should eq([@another_user, @another_password])
-      ems.azure_tenant_id.should eq(@another_tenant_id)
+      expect(ems.name).to eq(name)
+      expect(ems.provider_region).to eq(name[AZURE_PREFIX, 1])
+      expect(ems.auth_user_pwd).to eq([@another_user, @another_password])
+      expect(ems.azure_tenant_id).to eq(@another_tenant_id)
     end
 
     def create_factory_ems(name, region)
@@ -95,56 +95,56 @@ describe ManageIQ::Providers::Azure::CloudManager do
       ems.authentications << FactoryGirl.create(:authentication, cred)
     end
 
-    it "with no existing records" do
+    it "with no existing records" do |example|
       found = recorded_discover(example)
-      found.count.should eq(2)
+      expect(found.count).to eq(2)
 
       emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
-      emses.count.should eq(2)
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "Azure-eastus")
       assert_region(emses[1], "Azure-westus")
     end
 
-    it "with some existing records" do
+    it "with some existing records" do |example|
       create_factory_ems("Azure-eastus", "eastus")
 
       found = recorded_discover(example)
-      found.count.should eq(1)
+      expect(found.count).to eq(1)
 
       emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
-      emses.count.should eq(2)
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "Azure-eastus")
       assert_region(emses[1], "Azure-westus")
     end
 
-    it "with all existing records" do
+    it "with all existing records" do |example|
       create_factory_ems("Azure-eastus", "eastus")
       create_factory_ems("Azure-westus", "westus")
 
       found = recorded_discover(example)
-      found.count.should eq(0)
+      expect(found.count).to eq(0)
 
       emses = ManageIQ::Providers::Azure::CloudManager.order(:name)
-      emses.count.should eq(2)
+      expect(emses.count).to eq(2)
       assert_region(emses[0], "Azure-eastus")
       assert_region(emses[1], "Azure-westus")
     end
 
     context "with records from a different account" do
-      it "with the same name" do
+      it "with the same name" do |example|
         FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus", :provider_region => "westus")
 
         found = recorded_discover(example)
-        found.count.should eq(2)
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
-        emses.count.should eq(3)
+        expect(emses.count).to eq(3)
         assert_region(emses[0], "Azure-eastus")
         assert_region_on_another_account(emses[1], "Azure-westus")
         assert_region(emses[2], "Azure-westus #{@user}")
       end
 
-      it "with the same name and backup name" do
+      it "with the same name and backup name" do |example|
         FactoryGirl.create(
           :ems_azure_with_authentication,
           :name            => "Azure-westus",
@@ -155,10 +155,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
           :provider_region => "westus")
 
         found = recorded_discover(example)
-        found.count.should eq(2)
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
-        emses.count.should eq(4)
+        expect(emses.count).to eq(4)
 
         assert_region(emses[0], "Azure-eastus")
         assert_region_on_another_account(emses[1], "Azure-westus")
@@ -166,7 +166,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
         assert_region(emses[3], "Azure-westus 1")
       end
 
-      it "with the same name, backup name, and secondary backup name" do
+      it "with the same name, backup name, and secondary backup name" do |example|
         FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus", :provider_region => "westus")
         FactoryGirl.create(
           :ems_azure_with_authentication,
@@ -175,10 +175,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
         FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus 1", :provider_region => "westus")
 
         found = recorded_discover(example)
-        found.count.should eq(2)
+        expect(found.count).to eq(2)
 
         emses = ManageIQ::Providers::Azure::CloudManager.order(:name).includes(:authentications)
-        emses.count.should eq(5)
+        expect(emses.count).to eq(5)
 
         assert_region(emses[0], "Azure-eastus")
         assert_region_on_another_account(emses[1], "Azure-westus")

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -6,7 +6,7 @@ describe EmsCloud do
                       ManageIQ::Providers::Azure::CloudManager,
                       ManageIQ::Providers::Openstack::CloudManager,
                       ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
-    described_class.types.should match_array(expected_types)
+    expect(described_class.types).to match_array(expected_types)
   end
 
   it ".supported_subclasses" do
@@ -14,7 +14,7 @@ describe EmsCloud do
                            ManageIQ::Providers::Azure::CloudManager,
                            ManageIQ::Providers::Openstack::CloudManager,
                            ManageIQ::Providers::Google::CloudManager]
-    described_class.supported_subclasses.should match_array(expected_subclasses)
+    expect(described_class.supported_subclasses).to match_array(expected_subclasses)
   end
 
   it ".supported_types" do
@@ -22,6 +22,6 @@ describe EmsCloud do
                       ManageIQ::Providers::Azure::CloudManager,
                       ManageIQ::Providers::Openstack::CloudManager,
                       ManageIQ::Providers::Google::CloudManager].collect(&:ems_type)
-    described_class.supported_types.should match_array(expected_types)
+    expect(described_class.supported_types).to match_array(expected_types)
   end
 end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -16,7 +16,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
     workflow = FactoryGirl.build(:miq_provision_configured_system_foreman_workflow)
 
     workflow.instance_variable_set(:@values, :src_configured_system_ids => [cs.id])
-    ConfiguredSystem.should_receive(:common_configuration_profiles_for_selected_configured_systems).with([cs.id]).and_return([cp])
+    expect(ConfiguredSystem).to receive(:common_configuration_profiles_for_selected_configured_systems).with([cs.id]).and_return([cp])
 
     expect(workflow.allowed_configuration_profiles).to eq(cp.id => cp.name)
   end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/provision_workflow_spec.rb
@@ -16,7 +16,9 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionWorkflow d
     workflow = FactoryGirl.build(:miq_provision_configured_system_foreman_workflow)
 
     workflow.instance_variable_set(:@values, :src_configured_system_ids => [cs.id])
-    expect(ConfiguredSystem).to receive(:common_configuration_profiles_for_selected_configured_systems).with([cs.id]).and_return([cp])
+    expect(ConfiguredSystem).to receive(:common_configuration_profiles_for_selected_configured_systems)
+      .with([cs.id])
+      .and_return([cp])
 
     expect(workflow.allowed_configuration_profiles).to eq(cp.id => cp.name)
   end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/refresh_parser_spec.rb
@@ -125,7 +125,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::RefreshParser do
         :organizations            => organizations,
       )
 
-      expect(result[:needs_provisioning_refresh]).not_to be_true
+      expect(result[:needs_provisioning_refresh]).not_to be_truthy
     end
 
     context "without os flavor" do
@@ -140,7 +140,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::RefreshParser do
           :organizations            => organizations,
         )
 
-        expect(result[:needs_provisioning_refresh]).to be_true
+        expect(result[:needs_provisioning_refresh]).to be_truthy
       end
     end
 

--- a/spec/models/manageiq/providers/foreman/configuration_manager/refresher_locations_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/refresher_locations_spec.rb
@@ -25,7 +25,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::Refresher do
   let(:locs) { provisioning_manager.configuration_locations.where(spec_related).sort_by(&:name) }
 
   it "loads data with locations and organizations" do
-    EmsRefresh.stub(:queue_refresh) { |*args| EmsRefresh.refresh(*args) }
+    allow(EmsRefresh).to receive(:queue_refresh) { |*args| EmsRefresh.refresh(*args) }
 
     2.times do
       VCR.use_cassette("#{described_class.name.underscore}_api_locations_v2") do

--- a/spec/models/manageiq/providers/foreman/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/refresher_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::Providers::Foreman::ConfigurationManager::Refresher do
   it "will perform a full refresh on api v2" do
     # Stub the queueing of the refresh so that when the manager
     #  queues up an alternate refresh we will execute it immediately.
-    EmsRefresh.stub(:queue_refresh) { |*args| EmsRefresh.refresh(*args) }
+    allow(EmsRefresh).to receive(:queue_refresh) { |*args| EmsRefresh.refresh(*args) }
 
     VCR.use_cassette("#{described_class.name.underscore}_api_v2") do
       EmsRefresh.refresh(configuration_manager)

--- a/spec/models/manageiq/providers/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager_spec.rb
@@ -3,16 +3,16 @@ require "spec_helper"
 describe EmsInfra do
   it ".types" do
     expected_types = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
-    described_class.types.should match_array(expected_types)
+    expect(described_class.types).to match_array(expected_types)
   end
 
   it ".supported_subclasses" do
     expected_subclasses = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Openstack::InfraManager]
-    described_class.supported_subclasses.should match_array(expected_subclasses)
+    expect(described_class.supported_subclasses).to match_array(expected_subclasses)
   end
 
   it ".supported_types" do
     expected_types = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
-    described_class.supported_types.should match_array(expected_types)
+    expect(described_class.supported_types).to match_array(expected_types)
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
@@ -11,7 +11,7 @@ describe ContainerImage do
       :container_image,
       :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
                       FactoryGirl.create(:container, :name => "container_b", :container_group => group)]
-      ).container_nodes.count).to eq(1)
+    ).container_nodes.count).to eq(1)
     end
 end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_image_spec.rb
@@ -7,11 +7,11 @@ describe ContainerImage do
       :name => "group",
       :container_node => FactoryGirl.create(:container_node, :name => "node")
     )
-    FactoryGirl.create(
+    expect(FactoryGirl.create(
       :container_image,
       :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
                       FactoryGirl.create(:container, :name => "container_b", :container_group => group)]
-      ).container_nodes.count.should == 1
+      ).container_nodes.count).to eq(1)
     end
 end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
@@ -7,11 +7,11 @@ describe ContainerNode do
     :name => "s",
     :container_routes => [FactoryGirl.create(:container_route, :name => "rt")]
     )
-    FactoryGirl.create(
+    expect(FactoryGirl.create(
     :container_node,
     :name => "n",
     :container_groups => [FactoryGirl.create(:container_group, :name => "g1", :container_services => [service]),
                           FactoryGirl.create(:container_group, :name => "g2", :container_services => [service])]
-    ).container_routes.count.should == 1
+    ).container_routes.count).to eq(1)
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_project_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_project_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe ContainerProject do
   it "has distinct nodes" do
     node = FactoryGirl.create(:container_node, :name => "n")
-    FactoryGirl.create(
+    expect(FactoryGirl.create(
     :container_project,
     :container_groups => [FactoryGirl.create(:container_group, :name => "g1", :container_node => node),
                           FactoryGirl.create(:container_group, :name => "g2", :container_node => node)]
-    ).container_nodes.count.should == 1
+    ).container_nodes.count).to eq(1)
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_route_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_route_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe ContainerRoute do
   it "has distinct nodes" do
     node = FactoryGirl.create(:container_node, :name => "n")
-    FactoryGirl.create(
+    expect(FactoryGirl.create(
       :container_route,
       :name => "rt",
       :container_service => FactoryGirl.create(
@@ -12,6 +12,6 @@ describe ContainerRoute do
         :container_groups => [FactoryGirl.create(:container_group, :name => "g1", :container_node => node),
                               FactoryGirl.create(:container_group, :name => "g2", :container_node => node)]
       )
-    ).container_nodes.count.should == 1
+    ).container_nodes.count).to eq(1)
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -125,17 +125,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     it "node counters and gauges are correctly processed" do
       METRICS_EXERCISES.each do |exercise|
         exercise[:counters].each do |metrics|
-          described_class::CaptureContext
-            .any_instance
-            .stub(:fetch_counters_data)
+          allow_any_instance_of(described_class::CaptureContext)
+            .to receive(:fetch_counters_data)
             .with("machine/node/#{metrics[:args]}")
             .and_return(metrics[:data])
         end
 
         exercise[:gauges].each do |metrics|
-          described_class::CaptureContext
-            .any_instance
-            .stub(:fetch_gauges_data)
+          allow_any_instance_of(described_class::CaptureContext)
+            .to receive(:fetch_gauges_data)
             .with("machine/node/#{metrics[:args]}")
             .and_return(metrics[:data])
         end
@@ -149,17 +147,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
     it "container counters and gauges are correctly processed" do
       METRICS_EXERCISES.each do |exercise|
         exercise[:counters].each do |metrics|
-          described_class::CaptureContext
-            .any_instance
-            .stub(:fetch_counters_data)
+          allow_any_instance_of(described_class::CaptureContext)
+            .to receive(:fetch_counters_data)
             .with("container/group/#{metrics[:args]}")
             .and_return(metrics[:data])
         end
 
         exercise[:gauges].each do |metrics|
-          described_class::CaptureContext
-            .any_instance
-            .stub(:fetch_gauges_data)
+          allow_any_instance_of(described_class::CaptureContext)
+            .to receive(:fetch_gauges_data)
             .with("container/group/#{metrics[:args]}")
             .and_return(metrics[:data])
         end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -360,80 +360,69 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             }
           }
         )
-      )).to eq({
-        :name                  => 'test-quota',
-        :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-        :creation_timestamp    => '2015-08-17T09:16:46Z',
-        :resource_version      => '165339',
-        :project               => nil,
-        :container_quota_items => [
-          {
-            :resource       => "cpu",
-            :quota_desired  => "30",
-            :quota_enforced => "30",
-            :quota_observed => "100m"
-          }
-        ]
-      })
+      )).to eq(:name                  => 'test-quota',
+               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :creation_timestamp    => '2015-08-17T09:16:46Z',
+               :resource_version      => '165339',
+               :project               => nil,
+               :container_quota_items => [
+                 {
+                   :resource       => "cpu",
+                   :quota_desired  => "30",
+                   :quota_enforced => "30",
+                   :quota_observed => "100m"
+                 }
+               ]
+              )
     end
 
     it "handles quotas with no specification" do
-      expect(parser.send(
-        :parse_quota,
-        RecursiveOpenStruct.new(
-          :metadata => {
-            :name              => 'test-quota',
-            :namespace         => 'test-namespace',
-            :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-            :resourceVersion   => '165339',
-            :creationTimestamp => '2015-08-17T09:16:46Z',
-          },
-          :spec     => {},
-          :status   => {}
-        )
-      )).to eq({
-        :name                  => 'test-quota',
-        :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-        :creation_timestamp    => '2015-08-17T09:16:46Z',
-        :resource_version      => '165339',
-        :project               => nil,
-        :container_quota_items => []
-      })
+      expect(parser.send(:parse_quota,
+                         RecursiveOpenStruct.new(
+                           :metadata => {
+                             :name              => 'test-quota',
+                             :namespace         => 'test-namespace',
+                             :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+                             :resourceVersion   => '165339',
+                             :creationTimestamp => '2015-08-17T09:16:46Z',
+                           },
+                           :spec     => {},
+                           :status   => {})))
+        .to eq(:name                  => 'test-quota',
+               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :creation_timestamp    => '2015-08-17T09:16:46Z',
+               :resource_version      => '165339',
+               :project               => nil,
+               :container_quota_items => [])
     end
 
     it "handles quotas with no status" do
-      expect(parser.send(
-        :parse_quota,
-        RecursiveOpenStruct.new(
-          :metadata => {
-            :name              => 'test-quota',
-            :namespace         => 'test-namespace',
-            :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-            :resourceVersion   => '165339',
-            :creationTimestamp => '2015-08-17T09:16:46Z',
-          },
-          :spec     => {
-            :hard => {
-              :cpu => '30'
-            }
-          },
-          :status   => {}
-        )
-      )).to eq({
-        :name                  => 'test-quota',
-        :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-        :creation_timestamp    => '2015-08-17T09:16:46Z',
-        :resource_version      => '165339',
-        :project               => nil,
-        :container_quota_items => [
-          {
-            :resource       => "cpu",
-            :quota_desired  => "30",
-            :quota_enforced => nil,
-            :quota_observed => nil
-          }
-        ]
-      })
+      expect(parser.send(:parse_quota,
+                         RecursiveOpenStruct.new(
+                           :metadata => {
+                             :name              => 'test-quota',
+                             :namespace         => 'test-namespace',
+                             :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+                             :resourceVersion   => '165339',
+                             :creationTimestamp => '2015-08-17T09:16:46Z'},
+                           :spec     => {
+                             :hard => {
+                               :cpu => '30'
+                             }},
+                           :status   => {})))
+        .to eq(:name                  => 'test-quota',
+               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :creation_timestamp    => '2015-08-17T09:16:46Z',
+               :resource_version      => '165339',
+               :project               => nil,
+               :container_quota_items => [
+                 {
+                   :resource       => "cpu",
+                   :quota_desired  => "30",
+                   :quota_enforced => nil,
+                   :quota_observed => nil
+                 }
+               ])
     end
   end
 
@@ -482,31 +471,27 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
     end
 
     it "handles limits without specification" do
-      expect(parser.send(
-        :parse_range,
-        RecursiveOpenStruct.new(
-          :metadata => {
-            :name              => 'test-range',
-            :namespace         => 'test-namespace',
-            :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-            :resourceVersion   => '2',
-            :creationTimestamp => '2015-08-17T09:16:46Z',
-          },
-          :spec     => {
-            :limits => []
-          },
-        )
-      )).to eq({
-        :name                  => 'test-range',
-        :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-        :creation_timestamp    => '2015-08-17T09:16:46Z',
-        :resource_version      => '2',
-        :project               => nil,
-        :container_limit_items => []
-      })
+      expect(parser.send(:parse_range,
+                         RecursiveOpenStruct.new(
+                           :metadata => {
+                             :name              => 'test-range',
+                             :namespace         => 'test-namespace',
+                             :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+                             :resourceVersion   => '2',
+                             :creationTimestamp => '2015-08-17T09:16:46Z',
+                           },
+                           :spec     => {
+                             :limits => []
+                           })))
+        .to eq(:name                  => 'test-range',
+               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+               :creation_timestamp    => '2015-08-17T09:16:46Z',
+               :resource_version      => '2',
+               :project               => nil,
+               :container_limit_items => [])
     end
   end
-  
+
   describe "parse_container_image" do
     shared_image_without_host = "shared/image"
     shared_image_with_host = "host:1234/shared/image"

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -90,8 +90,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       it "tests '#{ex[:image_name]}'" do
         result_image, result_registry = parser.send(:parse_image_name, ex[:image_name], example_ref)
 
-        result_image.should == ex[:image]
-        result_registry.should == ex[:registry]
+        expect(result_image).to eq(ex[:image])
+        expect(result_registry).to eq(ex[:registry])
       end
     end
   end
@@ -247,7 +247,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       parsed_volumes = parser.send(:parse_volumes, example_volumes.collect { |ex| ex[:volume] })
 
       example_volumes.zip(parsed_volumes).each do |example, parsed|
-        parsed.should have_attributes(
+        expect(parsed).to have_attributes(
           :name                  => example[:name],
           :git_repository        => example[:git_repository],
           :empty_dir_medium_type => example[:empty_dir_medium_type],
@@ -303,7 +303,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       it "tests '#{ex[:name]}'" do
         parsed_component_status = parser.send(:parse_component_status, ex[:component_status])
 
-        parsed_component_status.should have_attributes(
+        expect(parsed_component_status).to have_attributes(
           :name      => ex[:name],
           :condition => ex[:condition],
           :status    => ex[:status],
@@ -336,7 +336,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
 
   describe "quota parsing" do
     it "handles simple data" do
-      parser.send(
+      expect(parser.send(
         :parse_quota,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -360,7 +360,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             }
           }
         )
-      ).should == {
+      )).to eq({
         :name                  => 'test-quota',
         :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
         :creation_timestamp    => '2015-08-17T09:16:46Z',
@@ -374,11 +374,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             :quota_observed => "100m"
           }
         ]
-      }
+      })
     end
 
     it "handles quotas with no specification" do
-      parser.send(
+      expect(parser.send(
         :parse_quota,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -391,18 +391,18 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
           :spec     => {},
           :status   => {}
         )
-      ).should == {
+      )).to eq({
         :name                  => 'test-quota',
         :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
         :creation_timestamp    => '2015-08-17T09:16:46Z',
         :resource_version      => '165339',
         :project               => nil,
         :container_quota_items => []
-      }
+      })
     end
 
     it "handles quotas with no status" do
-      parser.send(
+      expect(parser.send(
         :parse_quota,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -419,7 +419,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
           },
           :status   => {}
         )
-      ).should == {
+      )).to eq({
         :name                  => 'test-quota',
         :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
         :creation_timestamp    => '2015-08-17T09:16:46Z',
@@ -433,7 +433,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             :quota_observed => nil
           }
         ]
-      }
+      })
     end
   end
 
@@ -477,12 +477,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         from_k8s[:spec][:limits][0][k8s_name.to_sym] = {:cpu => '512Mi'}
         parsed[:container_limit_items][0][k8s_name.underscore.to_sym] = '512Mi'
         # note each iteration ADDS ANOTHER limit type to data & result
-        parser.send(:parse_range, RecursiveOpenStruct.new(from_k8s)).should == parsed
+        expect(parser.send(:parse_range, RecursiveOpenStruct.new(from_k8s))).to eq(parsed)
       end
     end
 
     it "handles limits without specification" do
-      parser.send(
+      expect(parser.send(
         :parse_range,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -496,14 +496,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             :limits => []
           },
         )
-      ).should == {
+      )).to eq({
         :name                  => 'test-range',
         :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
         :creation_timestamp    => '2015-08-17T09:16:46Z',
         :resource_version      => '2',
         :project               => nil,
         :container_limit_items => []
-      }
+      })
     end
   end
   
@@ -518,7 +518,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         first_obj  = parser.parse_container_image(shared_image, shared_ref)
         second_obj = parser.parse_container_image(shared_image, unique_ref)
 
-        first_obj.should_not be(second_obj)
+        expect(first_obj).not_to be(second_obj)
       end
     end
 
@@ -527,7 +527,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         first_obj  = parser.parse_container_image(shared_image, shared_ref)
         second_obj = parser.parse_container_image(shared_image, unique_ref)
 
-        first_obj.should_not == second_obj
+        expect(first_obj).not_to eq(second_obj)
       end
     end
 
@@ -536,7 +536,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         first_obj  = parser.parse_container_image(shared_image, shared_ref)
         second_obj = parser.parse_container_image(shared_image, shared_ref)
 
-        first_obj.should be(second_obj)
+        expect(first_obj).to be(second_obj)
       end
     end
   end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision/placement_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision/placement_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     end
 
     it "#automatic_placement" do
-      @task.should_receive(:get_most_suitable_host_and_storage).and_return([@host, @storage])
+      expect(@task).to receive(:get_most_suitable_host_and_storage).and_return([@host, @storage])
       @task.options[:placement_auto] = true
       check
     end
@@ -41,15 +41,15 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     it "automate returns nothing" do
       @task.options[:placement_host_name] = @host.id
       @task.options[:placement_ds_name]   = @storage.id
-      @task.should_receive(:get_most_suitable_host_and_storage).and_return([nil, nil])
+      expect(@task).to receive(:get_most_suitable_host_and_storage).and_return([nil, nil])
       @task.options[:placement_auto] = true
       check
     end
 
     def check
       host, storage = @task.send(:placement)
-      host.should eql(@host)
-      storage.should eql(@storage)
+      expect(host).to eql(@host)
+      expect(storage).to eql(@storage)
     end
   end
 end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision/state_machine_spec.rb
@@ -24,44 +24,44 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     end
 
     it "#create_destination" do
-      @task.should_receive(:determine_placement)
+      expect(@task).to receive(:determine_placement)
       @task.create_destination
     end
 
     it "#determine_placement" do
-      @task.stub(:placement).and_return(@host, @storage)
-      @task.should_receive(:prepare_provision)
+      allow(@task).to receive(:placement).and_return(@host, @storage)
+      expect(@task).to receive(:prepare_provision)
       @task.determine_placement
     end
 
     it "#start_clone_task" do
-      @task.stub(:update_and_notify_parent)
-      @task.stub(:log_clone_options)
-      @task.stub(:start_clone)
+      allow(@task).to receive(:update_and_notify_parent)
+      allow(@task).to receive(:log_clone_options)
+      allow(@task).to receive(:start_clone)
 
-      @task.should_receive(:poll_clone_complete)
+      expect(@task).to receive(:poll_clone_complete)
       @task.start_clone_task
     end
 
     context "#poll_clone_complete" do
       it "cloning" do
-        @task.should_receive(:clone_complete?).and_return(false)
-        @task.should_receive(:requeue_phase)
+        expect(@task).to receive(:clone_complete?).and_return(false)
+        expect(@task).to receive(:requeue_phase)
         @task.poll_clone_complete
       end
 
       it "clone complete" do
-        @task.should_receive(:clone_complete?).and_return(true)
-        EmsRefresh.should_receive(:queue_refresh)
-        @task.should_receive(:poll_destination_in_vmdb)
+        expect(@task).to receive(:clone_complete?).and_return(true)
+        expect(EmsRefresh).to receive(:queue_refresh)
+        expect(@task).to receive(:poll_destination_in_vmdb)
 
         @task.poll_clone_complete
       end
     end
 
     it "#customize_destination" do
-      @task.stub(:update_and_notify_parent)
-      @task.should_receive(:autostart_destination)
+      allow(@task).to receive(:update_and_notify_parent)
+      expect(@task).to receive(:autostart_destination)
       @task.customize_destination
     end
   end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -44,7 +44,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     context "SCVMM provisioning" do
       it "#workflow" do
         workflow_class = ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow
-        workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
 
         expect(vm_prov.workflow.class).to eq workflow_class
         expect(vm_prov.workflow_class).to eq workflow_class
@@ -54,13 +54,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     context "#prepare_for_clone_task" do
       before do
         @host = FactoryGirl.create(:host_microsoft, :ems_ref => "test_ref")
-        vm_prov.stub(:dest_host).and_return(@host)
+        allow(vm_prov).to receive(:dest_host).and_return(@host)
       end
 
       it "with default options" do
         clone_options = vm_prov.prepare_for_clone_task
-        clone_options[:name].should == @target_vm_name
-        clone_options[:host].should == @host
+        expect(clone_options[:name]).to eq(@target_vm_name)
+        expect(clone_options[:host]).to eq(@host)
       end
     end
 
@@ -68,11 +68,11 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       before do
         ds_name = "file://server.local/C:/ClusterStorage/CLUSP04%20Prod%20Volume%203-1"
         @datastore = FactoryGirl.create(:storage, :name => ds_name)
-        vm_prov.stub(:dest_datastore).and_return(@datastore)
+        allow(vm_prov).to receive(:dest_datastore).and_return(@datastore)
       end
 
       it "valid drive" do
-        vm_prov.dest_mount_point.should == "C:\\ClusterStorage\\CLUSP04 Prod Volume 3-1"
+        expect(vm_prov.dest_mount_point).to eq("C:\\ClusterStorage\\CLUSP04 Prod Volume 3-1")
       end
     end
 
@@ -100,7 +100,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       end
 
       it "set vm" do
-        vm_prov.cpu_ps_script.should == "-CPUCount 2 "
+        expect(vm_prov.cpu_ps_script).to eq("-CPUCount 2 ")
       end
     end
 
@@ -112,7 +112,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       end
 
       it "set vm" do
-        vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUMaximumPercent 40 "
+        expect(vm_prov.cpu_ps_script).to eq("-CPUCount 2 -CPUMaximumPercent 40 ")
       end
     end
 
@@ -124,7 +124,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       end
 
       it "set vm" do
-        vm_prov.cpu_ps_script.should == "-CPUCount 2 -CPUReserve 15 "
+        expect(vm_prov.cpu_ps_script).to eq("-CPUCount 2 -CPUReserve 15 ")
       end
     end
   end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
   let(:template) { FactoryGirl.create(:template_microsoft, :name => "template", :ext_management_system => ems) }
 
   before do
-    described_class.any_instance.stub(:update_field_visibility)
+    allow_any_instance_of(described_class).to receive(:update_field_visibility)
   end
 
   it "pass platform attributes to automate" do

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -36,52 +36,52 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    EmsFolder.count.should == 4 # HACK: Folder structure for UI a la VMware
-    EmsCluster.count.should == 1
-    Host.count.should == 3
-    ResourcePool.count.should == 0
-    Vm.count.should == 23
-    VmOrTemplate.count.should == 28
-    CustomAttribute.count.should == 0
-    CustomizationSpec.count.should == 0
-    Disk.count.should == 23
-    GuestDevice.count.should == 11
-    Hardware.count.should == 31
-    Lan.count.should == 0
-    MiqScsiLun.count.should == 0
-    MiqScsiTarget.count.should == 0
-    Network.count.should == 23
-    OperatingSystem.count.should == 31
-    Snapshot.count.should == 9
-    Switch.count.should == 0
-    SystemService.count.should == 0
-    Relationship.count.should == 35
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsFolder.count).to eq(4) # HACK: Folder structure for UI a la VMware
+    expect(EmsCluster.count).to eq(1)
+    expect(Host.count).to eq(3)
+    expect(ResourcePool.count).to eq(0)
+    expect(Vm.count).to eq(23)
+    expect(VmOrTemplate.count).to eq(28)
+    expect(CustomAttribute.count).to eq(0)
+    expect(CustomizationSpec.count).to eq(0)
+    expect(Disk.count).to eq(23)
+    expect(GuestDevice.count).to eq(11)
+    expect(Hardware.count).to eq(31)
+    expect(Lan.count).to eq(0)
+    expect(MiqScsiLun.count).to eq(0)
+    expect(MiqScsiTarget.count).to eq(0)
+    expect(Network.count).to eq(23)
+    expect(OperatingSystem.count).to eq(31)
+    expect(Snapshot.count).to eq(9)
+    expect(Switch.count).to eq(0)
+    expect(SystemService.count).to eq(0)
+    expect(Relationship.count).to eq(35)
 
-    MiqQueue.count.should == 28
-    Storage.count.should == 6
+    expect(MiqQueue.count).to eq(28)
+    expect(Storage.count).to eq(6)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => "2.1.0",
       :uid_ems     => "aa767b2f-7ca4-4a2c-bdb3-d269cbef3f8f"
     )
-    @ems.ems_folders.size.should == 4 # HACK: Folder structure for UI a la VMware
-    @ems.ems_clusters.size.should == 1
-    @ems.resource_pools.size.should == 0
+    expect(@ems.ems_folders.size).to eq(4) # HACK: Folder structure for UI a la VMware
+    expect(@ems.ems_clusters.size).to eq(1)
+    expect(@ems.resource_pools.size).to eq(0)
 
-    @ems.storages.size.should == 6
-    @ems.hosts.size.should == 3
-    @ems.vms_and_templates.size.should == 28
-    @ems.vms.size.should == 23
-    @ems.miq_templates.size.should == 5
-    @ems.customization_specs.size.should == 0
+    expect(@ems.storages.size).to eq(6)
+    expect(@ems.hosts.size).to eq(3)
+    expect(@ems.vms_and_templates.size).to eq(28)
+    expect(@ems.vms.size).to eq(23)
+    expect(@ems.miq_templates.size).to eq(5)
+    expect(@ems.customization_specs.size).to eq(0)
   end
 
   def assert_specific_storage
     @storage = Storage.find_by_name("file://hyperv-h01.manageiq.com/G:/")
-    @storage.should have_attributes(
+    expect(@storage).to have_attributes(
       :ems_ref                     => "afc847e1-9d85-4488-91bb-4284c9a29d07",
       :name                        => "file://hyperv-h01.manageiq.com/G:/",
       :store_type                  => "NTFS",
@@ -96,7 +96,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
   def assert_specific_cluster
     @cluster = EmsCluster.find_by_name("US_East")
-    @cluster.should have_attributes(
+    expect(@cluster).to have_attributes(
       :ems_ref => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
       :uid_ems => "0be27f13-2a7a-4803-8d12-a460b94fdd71",
       :name    => "US_East",
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
   def assert_specific_host
     @host = ManageIQ::Providers::Microsoft::InfraManager::Host.find_by_name("hyperv-h01.manageiq.com")
-    @host.should have_attributes(
+    expect(@host).to have_attributes(
       :ems_ref          => "60e92646-b9f8-432a-a71a-5bc169ceeca2",
       :name             => "hyperv-h01.manageiq.com",
       :hostname         => "hyperv-h01.manageiq.com",
@@ -117,13 +117,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :connection_state => "connected"
     )
 
-    @host.operating_system.should have_attributes(
+    expect(@host.operating_system).to have_attributes(
       :product_name => "Microsoft Windows Server 2012 R2 Datacenter ",
       :version      => "6.3.9600",
       :product_type => "microsoft"
     )
 
-    @host.hardware.should have_attributes(
+    expect(@host.hardware).to have_attributes(
       :cpu_speed            => 2394,
       :cpu_type             => "Intel Xeon 179",
       :manufacturer         => "Intel",
@@ -140,10 +140,10 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :memory_usage         => nil
     )
 
-    @host.hardware.guest_devices.size.should == 5
-    @host.hardware.nics.size.should == 4
+    expect(@host.hardware.guest_devices.size).to eq(5)
+    expect(@host.hardware.nics.size).to eq(4)
     nic = @host.hardware.nics.find_by_device_name("Ethernet")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :device_name     => "Ethernet",
       :device_type     => "ethernet",
       :location        => "PCI bus 1, device 0, function 0",
@@ -152,13 +152,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
 
     @host2 = Host.find_by_name("SFBronagh.manageiq.com")
-    @host2.ems_cluster.should == @cluster
+    expect(@host2.ems_cluster).to eq(@cluster)
   end
 
   def assert_specific_vm
     v = ManageIQ::Providers::Microsoft::InfraManager::Vm.find_by_name("Salesforce_A")
 
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template         => false,
       :ems_ref          => "ae9c0f43-295e-4a73-adba-b4cbc7875563",
       :vendor           => "Microsoft",
@@ -169,17 +169,17 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :connection_state => "connected",
     )
 
-    v.ext_management_system.should == @ems
-    v.host.should == @host
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.host).to eq(@host)
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "64-bit edition of Windows Server 2008 R2 Standard"
     )
 
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 1
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(1)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "64-bit edition of Windows Server 2008 R2 Standard",
       :guest_os_full_name => "64-bit edition of Windows Server 2008 R2 Standard",
       :bios               => "67b7b7ae-34aa-474e-9050-02ed3c633f6c",
@@ -188,9 +188,9 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :memory_mb          => 512
     )
 
-    v.hardware.disks.size.should == 1
+    expect(v.hardware.disks.size).to eq(1)
     disk = v.hardware.disks.find_by_device_name("WS2008R2Corex64Ent_F5C854FE-D17D-4AE1-BC32-B55F189D807A")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "WS2008R2Corex64Ent_F5C854FE-D17D-4AE1-BC32-B55F189D807A",
       :device_type     => "disk",
       :controller_type => "IDE",
@@ -205,7 +205,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
 
     v.snapshots.size == 1
     snapshot = v.snapshots.find_by_name("Salesforce_A - (05/05/2014 07:57:13)")
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "51629E91-8D04-4266-98F5-1DB77E88EE9A",
       :ems_ref     => "51629E91-8D04-4266-98F5-1DB77E88EE9A",
       :parent_uid  => "194AE824-BA4A-4809-B3BB-86E0ACA1489B",
@@ -214,9 +214,9 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
     # TODO: Add "Stored" status value in DB. This is a VM that has been provisioned but not deployed
 
-    v.hardware.guest_devices.size.should == 1
+    expect(v.hardware.guest_devices.size).to eq(1)
     dvd = v.hardware.guest_devices.first
-    dvd.should have_attributes(
+    expect(dvd).to have_attributes(
       :device_name     => "rhel-server-6.2-x86_64-boot.iso",
       :device_type     => "cdrom",
       :filename        => "C:\\ProgramData\\Microsoft\\Windows\\Hyper-V\\Salesforce_A\\rhel-server-6.2-x86_64-boot.iso",
@@ -226,23 +226,23 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
 
     v = Vm.find_by_name("SCVMM1111")
-    v.hardware.networks.size.should == 1
+    expect(v.hardware.networks.size).to eq(1)
     network = v.hardware.networks.first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :hostname  => "SCVMM1111.manageiq.com",
       :ipaddress => "192.168.252.90"
     )
 
     v = Vm.find_by_name("ERP_A")
     dvd = v.hardware.guest_devices.first
-    dvd.should have_attributes(
+    expect(dvd).to have_attributes(
       :device_name => "ERP_A",
       :filename    => "D:",
     )
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree(
+    expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
         [EmsFolder, "SCVMM", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {

--- a/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
@@ -2,15 +2,15 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Microsoft::InfraManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'scvmm'
+    expect(described_class.ems_type).to eq('scvmm')
   end
 
   it ".description" do
-    described_class.description.should == 'Microsoft System Center VMM'
+    expect(described_class.description).to eq('Microsoft System Center VMM')
   end
 
   it ".auth_url handles ipv6" do
-    described_class.auth_url("::1").should == "http://[::1]:5985/wsman"
+    expect(described_class.auth_url("::1")).to eq("http://[::1]:5985/wsman")
   end
 
   context "#connect with ssl" do
@@ -20,23 +20,23 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      described_class.should_receive(:raw_connect).with do |url, protocol, creds|
-        url.should match(/host/)
-        protocol.should be == "ssl"
-        creds[:user].should be == "user"
-        creds[:pass].should be == "pass"
-      end
+      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+        expect(url).to match(/host/)
+        expect(protocol).to eq("ssl")
+        expect(creds[:user]).to eq("user")
+        expect(creds[:pass]).to eq("pass")
+      }
 
       @e.connect
     end
 
     it "accepts overrides" do
-      described_class.should_receive(:raw_connect).with do |url, protocol, creds|
-        url.should match(/host2/)
-        protocol.should be == "ssl"
-        creds[:user].should be == "user2"
-        creds[:pass].should be == "pass2"
-      end
+      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+        expect(url).to match(/host2/)
+        expect(protocol).to eq("ssl")
+        expect(creds[:user]).to eq("user2")
+        expect(creds[:pass]).to eq("pass2")
+      }
 
       @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
     end
@@ -49,25 +49,25 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      described_class.should_receive(:raw_connect).with do |url, protocol, creds|
-        url.should match(/host/)
-        protocol.should be == "kerberos"
-        creds[:user].should be == "user"
-        creds[:pass].should be == "pass"
-        creds[:realm].should be == "pretendrealm"
-      end
+      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+        expect(url).to match(/host/)
+        expect(protocol).to eq("kerberos")
+        expect(creds[:user]).to eq("user")
+        expect(creds[:pass]).to eq("pass")
+        expect(creds[:realm]).to eq("pretendrealm")
+      }
 
       @e.connect
     end
 
     it "accepts overrides" do
-      described_class.should_receive(:raw_connect).with do |url, protocol, creds|
-        url.should match(/host2/)
-        protocol.should be == "kerberos"
-        creds[:user].should be == "user2"
-        creds[:pass].should be == "pass2"
-        creds[:realm].should be == "pretendrealm"
-      end
+      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+        expect(url).to match(/host2/)
+        expect(protocol).to eq("kerberos")
+        expect(creds[:user]).to eq("user2")
+        expect(creds[:pass]).to eq("pass2")
+        expect(creds[:realm]).to eq("pretendrealm")
+      }
 
       @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
     end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   before(:each) do
-    MiqServer.stub(:my_zone).and_return("default")
+    allow(MiqServer).to receive(:my_zone).and_return("default")
     @ems = FactoryGirl.create(:ems_openshift, :hostname => "10.35.0.174")
   end
 
@@ -26,18 +26,18 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_table_counts
-    ContainerGroup.count.should == 5
-    ContainerNode.count.should == 1
-    Container.count.should == 5
-    ContainerService.count.should == 4
-    ContainerPortConfig.count.should == 4
-    ContainerDefinition.count.should == 5
-    ContainerRoute.count.should == 1
-    ContainerProject.count.should == 4
+    expect(ContainerGroup.count).to eq(5)
+    expect(ContainerNode.count).to eq(1)
+    expect(Container.count).to eq(5)
+    expect(ContainerService.count).to eq(4)
+    expect(ContainerPortConfig.count).to eq(4)
+    expect(ContainerDefinition.count).to eq(5)
+    expect(ContainerRoute.count).to eq(1)
+    expect(ContainerProject.count).to eq(4)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :port => "8443",
       :type => "ManageIQ::Providers::Openshift::ContainerManager"
     )
@@ -45,93 +45,93 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
 
   def assert_specific_container
     @container = Container.find_by_name("ruby-helloworld-database")
-    @container.should have_attributes(
+    expect(@container).to have_attributes(
       :name          => "ruby-helloworld-database",
       :restart_count => 0,
     )
-    @container[:backing_ref].should_not be_nil
+    expect(@container[:backing_ref]).not_to be_nil
 
     # Check the relation to container node
-    @container.container_group.should have_attributes(
+    expect(@container.container_group).to have_attributes(
       :name => "database-1-a20bt"
     )
   end
 
   def assert_specific_container_group
     @containergroup = ContainerGroup.find_by_name("database-1-a20bt")
-    @containergroup.should have_attributes(
+    expect(@containergroup).to have_attributes(
       :name           => "database-1-a20bt",
       :restart_policy => "Always",
       :dns_policy     => "ClusterFirst",
     )
 
     # Check the relation to container node
-    @containergroup.container_node.should have_attributes(
+    expect(@containergroup.container_node).to have_attributes(
       :name => "dhcp-0-129.tlv.redhat.com"
     )
 
     # Check the relation to containers
-    @containergroup.containers.count.should == 1
-    @containergroup.containers.last.should have_attributes(
+    expect(@containergroup.containers.count).to eq(1)
+    expect(@containergroup.containers.last).to have_attributes(
       :name => "ruby-helloworld-database"
     )
 
-    @containergroup.container_project.should == ContainerProject.find_by(:name => "test")
-    @containergroup.ext_management_system.should == @ems
+    expect(@containergroup.container_project).to eq(ContainerProject.find_by(:name => "test"))
+    expect(@containergroup.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_container_node
     @containernode = ContainerNode.first
-    @containernode.should have_attributes(
+    expect(@containernode).to have_attributes(
       :name          => "dhcp-0-129.tlv.redhat.com",
       :lives_on_type => nil,
       :lives_on_id   => nil
     )
 
-    @containernode.ext_management_system.should == @ems
+    expect(@containernode.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_container_service
     @containersrv = ContainerService.find_by_name("frontend")
-    @containersrv.should have_attributes(
+    expect(@containersrv).to have_attributes(
       :name             => "frontend",
       :session_affinity => "None",
       :portal_ip        => "172.30.141.69"
     )
 
-    @containersrv.container_project.should == ContainerProject.find_by(:name => "test")
-    @containersrv.ext_management_system.should == @ems
+    expect(@containersrv.container_project).to eq(ContainerProject.find_by(:name => "test"))
+    expect(@containersrv.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_container_project
     @container_pr = ContainerProject.find_by_name("test")
-    @container_pr.should have_attributes(
+    expect(@container_pr).to have_attributes(
       :name         => "test",
       :display_name => ""
     )
 
-    @container_pr.container_groups.count.should == 4
-    @container_pr.container_routes.count.should == 1
-    @container_pr.container_replicators.count.should == 2
-    @container_pr.container_services.count.should == 2
-    @container_pr.ext_management_system.should == @ems
+    expect(@container_pr.container_groups.count).to eq(4)
+    expect(@container_pr.container_routes.count).to eq(1)
+    expect(@container_pr.container_replicators.count).to eq(2)
+    expect(@container_pr.container_services.count).to eq(2)
+    expect(@container_pr.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_container_route
     @container_route = ContainerRoute.find_by_name("route-edge")
-    @container_route.should have_attributes(
+    expect(@container_route).to have_attributes(
       :name      => "route-edge",
       :host_name => "www.example.com"
     )
 
-    @container_route.container_service.should have_attributes(
+    expect(@container_route.container_service).to have_attributes(
       :name => "frontend"
     )
 
-    @container_route.container_project.should have_attributes(
+    expect(@container_route.container_project).to have_attributes(
       :name    => "test"
     )
 
-    @container_route.ext_management_system.should == @ems
+    expect(@container_route.ext_management_system).to eq(@ems)
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
@@ -3,19 +3,19 @@ require "spec_helper"
 describe ManageIQ::Providers::Openstack::CloudManager::EventCatcher do
   before do
     @ems = FactoryGirl.create(:ems_openstack)
-    @ems.stub(:authentication_status_ok?).and_return(true)
-    ManageIQ::Providers::Openstack::CloudManager::EventCatcher.stub(:all_ems_in_zone).and_return([@ems])
+    allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+    allow(ManageIQ::Providers::Openstack::CloudManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 
   it "logs info about EMS that do not have Event Monitors available" do
-    @ems.stub(:event_monitor_available?).and_return(false)
-    $log.should_receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone.should_not include @ems
+    allow(@ems).to receive(:event_monitor_available?).and_return(false)
+    expect($log).to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
+    expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).not_to include @ems
   end
 
   it "does not log info about unavailable Event Monitors when EMS can provide an event monitor" do
-    @ems.stub(:event_monitor_available?).and_return(true)
-    $log.should_not_receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone.should include @ems
+    allow(@ems).to receive(:event_monitor_available?).and_return(true)
+    expect($log).not_to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
+    expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).to include @ems
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
@@ -11,19 +11,19 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
     @mock_stats_data = OpenstackMetricStatsData.new
 
     @metering = double(:metering)
-    @metering.stub(:list_meters).and_return(
+    allow(@metering).to receive(:list_meters).and_return(
       OpenstackApiResult.new(@mock_meter_list.list_meters("resource_counters")),
       OpenstackApiResult.new(@mock_meter_list.list_meters("metadata_counters")))
 
     @ems_openstack = FactoryGirl.create(:ems_openstack, :zone => @zone)
-    @ems_openstack.stub(:connect).with(:service => "Metering").and_return(@metering)
+    allow(@ems_openstack).to receive(:connect).with(:service => "Metering").and_return(@metering)
 
     @vm = FactoryGirl.create(:vm_perf_openstack, :ext_management_system => @ems_openstack)
   end
 
   context "with standard interval data" do
     before :each do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         OpenstackApiResult.new(@mock_stats_data.get_statistics(name))
       end
     end
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       _counters, values_by_id_and_ts = @vm.perf_collect_metrics("realtime")
       ts = Time.parse(values_by_id_and_ts[@vm.ems_ref].keys.max)
 
-      ts_as_utc.should eq ts
+      expect(ts_as_utc).to eq ts
     end
 
     it "translates cumulative meters into discrete values" do
@@ -91,14 +91,14 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
       read_ts1_period = api_time_as_utc(read_bytes1)
       read_ts2_period = api_time_as_utc(read_bytes2)
-      result[read_ts1_period.iso8601]["disk_usage_rate_average"].should eq disk_val1
-      result[read_ts2_period.iso8601]["disk_usage_rate_average"].should eq disk_val2
+      expect(result[read_ts1_period.iso8601]["disk_usage_rate_average"]).to eq disk_val1
+      expect(result[read_ts2_period.iso8601]["disk_usage_rate_average"]).to eq disk_val2
     end
   end
 
   context "with irregular interval data" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         OpenstackApiResult.new(@mock_stats_data.get_statistics(name, "irregular_interval"))
       end
 
@@ -156,15 +156,15 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
       # First 3 stats are nil, cause disk.write.bytes starts at "2013-08-28T11:00:20". All the stats are collected
       # together by capturing algorithm.
-      (0..2).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq nil }
+      (0..2).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq nil }
       # ensure that the next three statistics match avg_stat1
-      (3..5).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat1 }
+      (3..5).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next three statistics match avg_stat2
-      (6..8).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat2 }
+      (6..8).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next three statistics match avg_stat3
-      (9..11).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat3 }
+      (9..11).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 4 statistics match avg_stat4
-      (12..15).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat4 }
+      (12..15).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat4 }
     end
 
     it "makes sure cpu_usage_rate_average stats continuous block of 20s is correct" do
@@ -175,12 +175,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 28
+      expect(stats_counter).to eq 28
     end
 
     ###################################################################################################################
@@ -271,12 +271,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 3, 4)
 
       # ensure computations are equal
-      avg_stat1_manual.should eq avg_stat1_computed_elsewhere
-      avg_stat4_manual.should eq avg_stat4_computed_elsewhere
-      avg_stat1.should eq avg_stat1_computed_elsewhere
-      avg_stat2.should eq avg_stat2_computed_elsewhere
-      avg_stat3.should eq avg_stat3_computed_elsewhere
-      avg_stat4.should eq avg_stat4_computed_elsewhere
+      expect(avg_stat1_manual).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat4_manual).to eq avg_stat4_computed_elsewhere
+      expect(avg_stat1).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat2).to eq avg_stat2_computed_elsewhere
+      expect(avg_stat3).to eq avg_stat3_computed_elsewhere
+      expect(avg_stat4).to eq avg_stat4_computed_elsewhere
     end
 
     it "aligns not aligned data of the disk_usage_rate_average counters and computes stats correctly" do
@@ -297,24 +297,24 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 6, 7)
 
       # ensure that the first 6 statistics match avg_stat1
-      (0..5).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat1 }
+      (0..5).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 6 statistics match avg_stat2
-      (6..11).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat2 }
+      (6..11).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 6 statistics match avg_stat3
-      (12..17).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat3 }
+      (12..17).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 7 statistics match avg_stat4
-      (18..24).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat4 }
+      (18..24).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat4 }
       # ensure that the next 6 statistics match avg_stat5
-      (25..30).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat5 }
+      (25..30).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat5 }
       # ensure that the next 6 statistics match avg_stat6
-      (31..36).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat6 }
+      (31..36).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat6 }
       # ensure that the next 6 statistics match avg_stat7
-      (37..42).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat7 }
+      (37..42).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat7 }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct
-      @ts_keys.count.should eq 43
+      expect(@ts_keys.count).to eq 43
     end
 
     it "makes sure disk_usage_rate_average stats continuous block of 20s is correct" do
@@ -325,12 +325,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 43
+      expect(stats_counter).to eq 43
     end
 
     it "makes sure start time and end time of collection periods are correct" do
@@ -342,8 +342,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       expected_stats_period_start = parse_datetime('2013-08-28 11:00:20')
       expected_stats_period_end   = parse_datetime('2013-08-28 11:14:40Z')
 
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should   eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to   eq expected_stats_period_end
     end
   end
 
@@ -358,7 +358,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
   context "1. collection period from 2 collection periods total, end of this period has incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         first_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                     "multiple_collection_periods"),
                                                     '<=',
@@ -447,26 +447,26 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 4, 5)
 
       # ensure that the first 30 statistics match avg_stat1
-      (0..29).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (30..59).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (30..59).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (60..89).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (60..89).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 31 statistics match avg_stat4
-      (90..120).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (90..120).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
       # ensure that the next 30 statistics match avg_stat5
-      (121..150).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat5 }
+      (121..150).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat5 }
     end
 
     it "checks that the net_usage_rate_average should have last incomplete stat not saved" do
       # Ensure that the last 30 statistics match nil. This happens because net usage stat has been incomplete, so we s
       # tore nil values, these nil values should be rewritten in next collection period.
-      (151..180).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq nil }
+      (151..180).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 151 data stats and 30 nil stats
-      @ts_keys.count.should eq 181
+      expect(@ts_keys.count).to eq 181
     end
 
     it "tests that last computed statistic has the right value" do
@@ -475,7 +475,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
       # Test that last value of 1. collection period is this. This test continues in 2. collection period test. This
       # value has to be different to first value of 2.collection period
-      avg_stat5.should eq LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat5).to eq LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "make sure disk_usage_rate_average stats continuous block of 20s is correct" do
@@ -486,12 +486,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 151
+      expect(stats_counter).to eq 151
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -503,15 +503,15 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime('2013-08-28 11:01:20')
       expected_stats_period_end = parse_datetime(LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
   context "2. collection period from 2 collection periods total, start and middle of this period has one "\
           "incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         second_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                      "multiple_collection_periods"),
                                                      '>',
@@ -574,14 +574,14 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 3, 4)
 
       # ensure that the next 30 statistics match avg_stat1
-      (21..50).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (21..50).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (51..80).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (51..80).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (81..110).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (81..110).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 60 statistics match avg_stat4
       # This test assures us that this value fills the empty space caused by corrupted data with missing stat.
-      (111..170).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (111..170).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
     end
 
     it "checks that the net_usage_rate_average should have last incomplete stat not saved" do
@@ -589,12 +589,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # net usage stat has been incomplete, so we store nil values, those nil values has been filled with the right
       # value in previous collection period.
       # !!!!!!! It's up to saving mechanism to not overwrite the old values with nil. !!!!!!!!!!!
-      (0..20).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq nil }
+      (0..20).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 150 data stats and 21 nil stats
-      @ts_keys.count.should eq 171
+      expect(@ts_keys.count).to eq 171
     end
 
     it "checks that last sample of 1. collection period is different to first sample of 2. collection period" do
@@ -602,11 +602,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       avg_stat1 = make_calculation(@counter_info, "network.incoming.bytes", "network.outgoing.bytes", @write_bytes,
                                    @read_bytes, 0, 1)
 
-      avg_stat1.should_not eq LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat1).not_to eq LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "there is missing stat in the middle of the period, make sure we log warning of corrupted data exactly once" do
-      $log.should_receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:once)
+      expect($log).to receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:once)
       @vm.perf_collect_metrics("realtime")
     end
 
@@ -617,12 +617,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 150
+      expect(stats_counter).to eq 150
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -634,8 +634,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime(LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
       expected_stats_period_end = parse_datetime('2013-08-28 12:41:40Z')
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
@@ -649,7 +649,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
   context "1. collection period from 2 collection periods total, all stats are complete" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         first_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                     "multiple_collection_periods"),
                                                     '<=',
@@ -726,22 +726,22 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 5, 6)
 
       # ensure that the first 30 statistics match avg_stat1
-      (0..29).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (30..59).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (30..59).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (60..89).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (60..89).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 31 statistics match avg_stat4
-      (90..120).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (90..120).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
       # ensure that the next 30 statistics match avg_stat5
-      (121..150).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat5 }
+      (121..150).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat5 }
       # ensure that the next 30 statistics match avg_stat6
-      (151..180).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat6 }
+      (151..180).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat6 }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 181 data stats
-      @ts_keys.count.should eq 181
+      expect(@ts_keys.count).to eq 181
     end
 
     it "tests that last computed statistic has the right value" do
@@ -750,7 +750,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
 
       # Test that last value of 1. collection period is this. This test continues in 2. collection period test. This
       # value has to be different to first value of 2.collection period
-      avg_stat5.should eq ALIGNED_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat5).to eq ALIGNED_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "make sure disk_usage_rate_average stats continuous block of 20s is correct" do
@@ -761,12 +761,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 181
+      expect(stats_counter).to eq 181
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -778,15 +778,15 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime('2013-08-28 11:01:20')
       expected_stats_period_end = parse_datetime(ALIGNED_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
   context "2. collection period from 2 collection periods total, middle of this period has one "\
           "incomplete stat, otherwise all stats are complete" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         second_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                      "multiple_collection_periods"),
                                                      '>',
@@ -847,19 +847,19 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
                                    @read_bytes, 3, 4)
 
       # ensure that the next 30 statistics match avg_stat1
-      (0..29).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (30..59).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (30..59).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (60..89).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (60..89).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 60 statistics match avg_stat4
       # This test assures us that this value fills the empty space caused by corrupted data with missing stat.
-      (90..149).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (90..149).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 150 data stats and 21 nil stats
-      @ts_keys.count.should eq 150
+      expect(@ts_keys.count).to eq 150
     end
 
     it "checks that last sample of 1. collection period is the same as first sample of 2. collection period" do
@@ -867,11 +867,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       avg_stat1 = make_calculation(@counter_info, "network.incoming.bytes", "network.outgoing.bytes", @write_bytes,
                                    @read_bytes, 0, 1)
 
-      avg_stat1.should eq ALIGNED_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat1).to eq ALIGNED_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "there is missing stat in the middle of the period, make sure we log warning of corrupted data exactly once" do
-      $log.should_receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:once)
+      expect($log).to receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:once)
       @vm.perf_collect_metrics("realtime")
     end
 
@@ -882,12 +882,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 150
+      expect(stats_counter).to eq 150
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -899,8 +899,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime(ALIGNED_FIRST_VALUE_OF_LAST_COLLECTING_PERIOD_TIMESTAMP)
       expected_stats_period_end = parse_datetime('2013-08-28 12:41:40Z')
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
@@ -3,67 +3,67 @@ require "spec_helper"
 describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Status do
   it 'parses CREATE_COMPLETE' do
     status = described_class.new('CREATE_COMPLETE', '')
-    status.completed?.should   be_true
-    status.succeeded?.should   be_true
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['create_complete', '']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_truthy
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['create_complete', ''])
   end
 
   it 'parses ROLLBACK_COMPLETE' do
     status = described_class.new('ROLLBACK_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_true
-    status.updated?.should     be_false
-    status.normalized_status.should == ['rollback_complete', 'Stack was rolled back']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_truthy
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['rollback_complete', 'Stack was rolled back'])
   end
 
   it 'parses DELETE_COMPLETE' do
     status = described_class.new('DELETE_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_true
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['delete_complete', 'Stack was deleted']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_truthy
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['delete_complete', 'Stack was deleted'])
   end
 
   it 'parses ROLLBACK_FAILED' do
     status = described_class.new('ROLLBACK_FAILED', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_true
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == ['failed', 'Stack creation failed']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_truthy
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
   end
 
   it 'parses UPDATE_COMPLETE' do
     status = described_class.new('UPDATE_COMPLETE', nil)
-    status.completed?.should   be_true
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_true
-    status.normalized_status.should == ['update_complete', 'OK']
+    expect(status.completed?).to   be_truthy
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_truthy
+    expect(status.normalized_status).to eq(['update_complete', 'OK'])
   end
 
   it 'parses transient status' do
     status = described_class.new('CREATING', nil)
-    status.completed?.should   be_false
-    status.succeeded?.should   be_false
-    status.failed?.should      be_false
-    status.deleted?.should     be_false
-    status.rolled_back?.should be_false
-    status.updated?.should     be_false
-    status.normalized_status.should == %w(transient CREATING)
+    expect(status.completed?).to   be_falsey
+    expect(status.succeeded?).to   be_falsey
+    expect(status.failed?).to      be_falsey
+    expect(status.deleted?).to     be_falsey
+    expect(status.rolled_back?).to be_falsey
+    expect(status.updated?).to     be_falsey
+    expect(status.normalized_status).to eq(%w(transient CREATING))
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack/status_spec.rb
@@ -53,7 +53,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack::Statu
     expect(status.deleted?).to     be_falsey
     expect(status.rolled_back?).to be_falsey
     expect(status.updated?).to     be_truthy
-    expect(status.normalized_status).to eq(['update_complete', 'OK'])
+    expect(status.normalized_status).to eq(%w(update_complete OK))
   end
 
   it 'parses transient status' do

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
@@ -42,10 +42,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
         expect(the_new_stack).to receive(:save).and_return(the_new_stack)
 
         stack = OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
-        stack.class.should == described_class
-        stack.name.should == 'mystack'
-        stack.ems_ref.should == 'new_id'
-        stack.cloud_tenant.should == tenant
+        expect(stack.class).to eq(described_class)
+        expect(stack.name).to eq('mystack')
+        expect(stack.ems_ref).to eq('new_id')
+        expect(stack.cloud_tenant).to eq(tenant)
       end
 
       it 'catches errors from provider' do
@@ -89,14 +89,14 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
         rstatus = orchestration_stack.raw_status
         expect(rstatus).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
 
-        orchestration_stack.raw_exists?.should be_true
+        expect(orchestration_stack.raw_exists?).to be_truthy
       end
 
       it 'determines stack not exist' do
         allow(raw_stacks).to receive(:get).with(orchestration_stack.name, orchestration_stack.ems_ref).and_return(nil)
         expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
 
-        orchestration_stack.raw_exists?.should be_false
+        expect(orchestration_stack.raw_exists?).to be_falsey
       end
 
       it 'catches errors from provider' do

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
@@ -24,19 +24,19 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision do
 
   context "#validate_dest_name" do
     it "with valid name" do
-      subject.stub(:dest_name).and_return("new_vm_1")
+      allow(subject).to receive(:dest_name).and_return("new_vm_1")
 
       expect { subject.validate_dest_name }.to_not raise_error
     end
 
     it "with a nil name" do
-      subject.stub(:dest_name).and_return(nil)
+      allow(subject).to receive(:dest_name).and_return(nil)
 
       expect { subject.validate_dest_name }.to raise_error(MiqException::MiqProvisionError)
     end
 
     it "with a duplicate name" do
-      subject.stub(:dest_name).and_return(vm_openstack.name)
+      allow(subject).to receive(:dest_name).and_return(vm_openstack.name)
 
       expect { subject.validate_dest_name }.to raise_error(MiqException::MiqProvisionError)
     end
@@ -94,7 +94,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision do
 
   it "#workflow" do
     workflow_class = ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow
-    workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+    allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
 
     expect(vm_prov.workflow.class).to eq workflow_class
     expect(vm_prov.workflow_class).to eq workflow_class

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -14,7 +14,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
   context "without applied tags" do
     let(:workflow) do
       stub_dialog
-      described_class.any_instance.stub(:update_field_visibility)
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
       described_class.new({:src_vm_id => template.id}, admin.userid)
     end
     context "availability_zones" do
@@ -23,14 +23,14 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         provider.availability_zones << az
         filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.size.should == 1
-        filtered.first.name.should == az.name
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(az.name)
       end
 
       it "returns an empty array when no targets are found" do
         filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.should == []
+        expect(filtered).to eq([])
       end
     end
 
@@ -41,8 +41,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           provider.security_groups << sg
           filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup,
                                    'security_groups.non_cloud_network')
-          filtered.size.should == 1
-          filtered.first.name.should == sg.name
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg.name)
         end
       end
 
@@ -53,8 +53,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
                                      :cloud_network => cn1)
           provider.security_groups << sg_cn
           filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups')
-          filtered.size.should == 1
-          filtered.first.name.should == sg_cn.name
+          expect(filtered.size).to eq(1)
+          expect(filtered.first.name).to eq(sg_cn.name)
         end
       end
     end
@@ -64,8 +64,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         flavor = FactoryGirl.create(:flavor_openstack, :name => "test_flavor_2")
         provider.flavors << flavor
         filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors')
-        filtered.size.should == 1
-        filtered.first.name.should == flavor.name
+        expect(filtered.size).to eq(1)
+        expect(filtered.first.name).to eq(flavor.name)
       end
     end
   end
@@ -73,7 +73,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
   context "with applied tags" do
     let(:workflow) do
       stub_dialog
-      described_class.any_instance.stub(:update_field_visibility)
+      allow_any_instance_of(described_class).to receive(:update_field_visibility)
       described_class.new({:src_vm_id => template.id}, admin.userid)
     end
 
@@ -104,43 +104,43 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
 
     context "availability_zones" do
       it "#get_targets_for_ems" do
-        provider.availability_zones.size.should == 2
-        provider.availability_zones.first.tags.size.should == 1
-        provider.availability_zones.last.tags.size.should == 0
+        expect(provider.availability_zones.size).to eq(2)
+        expect(provider.availability_zones.first.tags.size).to eq(1)
+        expect(provider.availability_zones.last.tags.size).to eq(0)
 
         filtered = workflow.send(:get_targets_for_ems, provider, :cloud_filter, AvailabilityZone,
                                  'availability_zones.available')
-        filtered.size.should == 1
+        expect(filtered.size).to eq(1)
       end
     end
 
     context "security groups" do
       it "#get_targets_for_ems" do
-        provider.security_groups.size.should == 2
-        provider.security_groups.first.tags.size.should == 1
-        provider.security_groups.last.tags.size.should == 0
+        expect(provider.security_groups.size).to eq(2)
+        expect(provider.security_groups.first.tags.size).to eq(1)
+        expect(provider.security_groups.last.tags.size).to eq(0)
 
-        workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups').size.should == 1
+        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups').size).to eq(1)
       end
     end
 
     context "instance types (Flavor)" do
       it "#get_targets_for_ems" do
-        provider.flavors.size.should == 2
-        provider.flavors.first.tags.size.should == 1
-        provider.flavors.last.tags.size.should == 0
+        expect(provider.flavors.size).to eq(2)
+        expect(provider.flavors.first.tags.size).to eq(1)
+        expect(provider.flavors.last.tags.size).to eq(0)
 
-        workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors').size.should == 1
+        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, Flavor, 'flavors').size).to eq(1)
       end
     end
 
     context "allowed_tenants" do
       it "#get_targets_for_ems" do
-        provider.cloud_tenants.size.should == 2
-        provider.cloud_tenants.first.tags.size.should == 1
-        provider.cloud_tenants.last.tags.size.should == 0
+        expect(provider.cloud_tenants.size).to eq(2)
+        expect(provider.cloud_tenants.first.tags.size).to eq(1)
+        expect(provider.cloud_tenants.last.tags.size).to eq(0)
 
-        workflow.send(:get_targets_for_ems, provider, :cloud_filter, CloudTenant, 'cloud_tenants').size.should == 1
+        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, CloudTenant, 'cloud_tenants').size).to eq(1)
       end
     end
   end
@@ -156,25 +156,25 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
     context "With a Valid Template" do
       let(:workflow) do
         stub_dialog
-        described_class.any_instance.stub(:update_field_visibility)
+        allow_any_instance_of(described_class).to receive(:update_field_visibility)
         described_class.new({:src_vm_id => template.id}, admin.userid)
       end
 
       context "with empty relationships" do
         it "#allowed_instance_types" do
-          workflow.allowed_instance_types.should == {}
+          expect(workflow.allowed_instance_types).to eq({})
         end
 
         it "#allowed_availability_zones" do
-          workflow.allowed_availability_zones.should == {}
+          expect(workflow.allowed_availability_zones).to eq({})
         end
 
         it "#allowed_guest_access_key_pairs" do
-          workflow.allowed_guest_access_key_pairs.should == {}
+          expect(workflow.allowed_guest_access_key_pairs).to eq({})
         end
 
         it "#allowed_security_groups" do
-          workflow.allowed_security_groups.should == {}
+          expect(workflow.allowed_security_groups).to eq({})
         end
       end
 
@@ -182,13 +182,13 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         it "#allowed_instance_types" do
           flavor = FactoryGirl.create(:flavor, :name => "flavor_1")
           provider.flavors << flavor
-          workflow.allowed_instance_types.should == {flavor.id => flavor.name}
+          expect(workflow.allowed_instance_types).to eq({flavor.id => flavor.name})
         end
 
         it "#allowed_availability_zones" do
           az = FactoryGirl.create(:availability_zone_openstack)
           provider.availability_zones << az
-          workflow.allowed_availability_zones.should == {az.id => az.name}
+          expect(workflow.allowed_availability_zones).to eq({az.id => az.name})
         end
 
         it "#allowed_availability_zones with NULL AZ" do
@@ -196,20 +196,20 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           provider.availability_zones << FactoryGirl.create(:availability_zone_openstack_null, :ems_ref => "null_az")
 
           azs = workflow.allowed_availability_zones
-          azs.length.should == 1
-          azs.first.should == [az.id, az.name]
+          expect(azs.length).to eq(1)
+          expect(azs.first).to eq([az.id, az.name])
         end
 
         it "#allowed_guest_access_key_pairs" do
           kp = AuthPrivateKey.create(:name => "auth_1")
           provider.key_pairs << kp
-          workflow.allowed_guest_access_key_pairs.should == {kp.id => kp.name}
+          expect(workflow.allowed_guest_access_key_pairs).to eq({kp.id => kp.name})
         end
 
         it "#allowed_security_groups" do
           sg = FactoryGirl.create(:security_group_openstack, :name => "sq_1")
           provider.security_groups << sg
-          workflow.allowed_security_groups.should == {sg.id => sg.name}
+          expect(workflow.allowed_security_groups).to eq({sg.id => sg.name})
         end
       end
 
@@ -217,12 +217,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         let(:flavor) { FactoryGirl.create(:flavor_openstack, :name => "test_flavor") }
 
         it "with name only" do
-          workflow.display_name_for_name_description(flavor).should == "test_flavor"
+          expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor")
         end
 
         it "with name and description" do
           flavor.description = "Small"
-          workflow.display_name_for_name_description(flavor).should == "test_flavor: Small"
+          expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor: Small")
         end
       end
 
@@ -247,12 +247,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           it "#allowed_cloud_networks with tenant selected" do
             workflow.values.merge!(:cloud_tenant => @ct2.id)
             cns = workflow.allowed_cloud_networks
-            cns.keys.should match_array [@cn2.id]
+            expect(cns.keys).to match_array [@cn2.id]
           end
 
           it "#allowed_cloud_networks with tenant not selected" do
             cns = workflow.allowed_cloud_networks
-            cns.keys.should match_array [@cn2.id, @cn1.id]
+            expect(cns.keys).to match_array [@cn2.id, @cn1.id]
           end
         end
 
@@ -269,12 +269,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           it "#allowed_security_groups with tenant selected" do
             workflow.values.merge!(:cloud_tenant => @ct2.id)
             sgs = workflow.allowed_security_groups
-            sgs.keys.should match_array [@sg2.id]
+            expect(sgs.keys).to match_array [@sg2.id]
           end
 
           it "#allowed_security_groups with tenant not selected" do
             sgs = workflow.allowed_security_groups
-            sgs.keys.should match_array [@sg2.id, @sg1.id]
+            expect(sgs.keys).to match_array [@sg2.id, @sg1.id]
           end
         end
 
@@ -291,12 +291,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
           it "#allowed_floating_ip_addresses with tenant selected" do
             workflow.values.merge!(:cloud_tenant => @ct2.id)
             ips = workflow.allowed_floating_ip_addresses
-            ips.keys.should match_array [@ip2.id]
+            expect(ips.keys).to match_array [@ip2.id]
           end
 
           it "#allowed_floating_ip_addresses with tenant not selected" do
             ips = workflow.allowed_floating_ip_addresses
-            ips.keys.should match_array [@ip2.id, @ip1.id]
+            expect(ips.keys).to match_array [@ip2.id, @ip1.id]
           end
         end
       end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -120,7 +120,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         expect(provider.security_groups.first.tags.size).to eq(1)
         expect(provider.security_groups.last.tags.size).to eq(0)
 
-        expect(workflow.send(:get_targets_for_ems, provider, :cloud_filter, SecurityGroup, 'security_groups').size).to eq(1)
+        expect(workflow.send(:get_targets_for_ems,
+                             provider,
+                             :cloud_filter,
+                             SecurityGroup,
+                             'security_groups').size)
+          .to eq(1)
       end
     end
 
@@ -182,13 +187,13 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         it "#allowed_instance_types" do
           flavor = FactoryGirl.create(:flavor, :name => "flavor_1")
           provider.flavors << flavor
-          expect(workflow.allowed_instance_types).to eq({flavor.id => flavor.name})
+          expect(workflow.allowed_instance_types).to eq(flavor.id => flavor.name)
         end
 
         it "#allowed_availability_zones" do
           az = FactoryGirl.create(:availability_zone_openstack)
           provider.availability_zones << az
-          expect(workflow.allowed_availability_zones).to eq({az.id => az.name})
+          expect(workflow.allowed_availability_zones).to eq(az.id => az.name)
         end
 
         it "#allowed_availability_zones with NULL AZ" do
@@ -203,13 +208,13 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         it "#allowed_guest_access_key_pairs" do
           kp = AuthPrivateKey.create(:name => "auth_1")
           provider.key_pairs << kp
-          expect(workflow.allowed_guest_access_key_pairs).to eq({kp.id => kp.name})
+          expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
         end
 
         it "#allowed_security_groups" do
           sg = FactoryGirl.create(:security_group_openstack, :name => "sq_1")
           provider.security_groups << sg
-          expect(workflow.allowed_security_groups).to eq({sg.id => sg.name})
+          expect(workflow.allowed_security_groups).to eq(sg.id => sg.name)
         end
       end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -223,7 +223,7 @@ module Openstack
     end
 
     def assert_ems
-      @ems.should have_attributes(
+      expect(@ems).to have_attributes(
         :api_version => identity_service.to_s,
         :uid_ems     => nil
       )
@@ -284,7 +284,7 @@ module Openstack
         :type => ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone, :ems_id => @ems.id).first
       # standard openstack AZs have their ems_ref set to their name ("nova" in the test case)...
       # the "null" openstack AZ has a unique ems_ref and name
-      @nova_az.should have_attributes(
+      expect(@nova_az).to have_attributes(
         :ems_ref => @nova_az.name
       )
     end
@@ -292,7 +292,7 @@ module Openstack
     def assert_availability_zone_null
       # This tests OpenStack functionality more than ManageIQ
       @az_null = ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull.where(:ems_id => @ems.id).first
-      @az_null.should have_attributes(
+      expect(@az_null).to have_attributes(
         :ems_ref => "null_az"
       )
     end
@@ -301,8 +301,8 @@ module Openstack
       assert_objects_with_hashes(CloudTenant.all, identity_data.projects)
 
       CloudTenant.all.each do |tenant|
-        tenant.should be_kind_of(CloudTenant)
-        tenant.ext_management_system.should == @ems
+        expect(tenant).to be_kind_of(CloudTenant)
+        expect(tenant.ext_management_system).to eq(@ems)
       end
     end
 
@@ -325,7 +325,7 @@ module Openstack
     end
 
     def assert_security_group_rules_neutron(security_group)
-      security_group.ems_ref.should be_guid
+      expect(security_group.ems_ref).to be_guid
       # Each security group starts with these rules created
       default_test_data = [{
         :direction => "outbound",
@@ -362,7 +362,7 @@ module Openstack
       assert_objects_with_hashes(networks, network_data.networks, network_data.network_translate_table)
 
       networks.each do |network|
-        network.ems_ref.should be_guid
+        expect(network.ems_ref).to be_guid
 
         assert_objects_with_hashes(network.cloud_subnets,
                                    network_data.subnets(network.name),
@@ -415,7 +415,7 @@ module Openstack
         expect(network_router.network_ports.first).to  be_kind_of(ManageIQ::Providers::Openstack::CloudManager::NetworkPort)
         expect(network_router.cloud_networks.count).to be > 0
         expect(network_router.cloud_networks.first).to be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private)
-        network_router.cloud_networks.should match_array network_router.private_networks
+        expect(network_router.cloud_networks).to match_array network_router.private_networks
         expect(network_router.cloud_network).to        be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public)
         expect(network_router.cloud_network).to        be == network_router.public_network
         expect(network_router.vms.first).to            be_kind_of(ManageIQ::Providers::Openstack::CloudManager::Vm)
@@ -470,7 +470,7 @@ module Openstack
 
       # TODO(lsmola) expose below in Builder's data
       without_aki_and_ari.each do |template|
-        template.should have_attributes(
+        expect(template).to have_attributes(
           :template              => true,
           #:publicly_available    => is_public, # is not exposed now
           :ems_ref_obj           => nil,
@@ -493,7 +493,7 @@ module Openstack
           :cpu_shares            => nil,
           :cpu_shares_level      => nil
         )
-        template.ems_ref.should be_guid
+        expect(template.ems_ref).to be_guid
 
         expect(template.ext_management_system).to  eq @ems
         expect(template.operating_system).to       be_nil # TODO: This should probably not be nil
@@ -545,7 +545,7 @@ module Openstack
       vm = ManageIQ::Providers::Openstack::CloudManager::Vm.where(:name => vm_name).first
       vm_expected = compute_data.servers.detect { |x| x[:name] == vm_name }
 
-      vm.should have_attributes({
+      expect(vm).to have_attributes({
         :template              => false,
         :cloud                 => true,
         :ems_ref_obj           => nil,
@@ -586,7 +586,7 @@ module Openstack
         expect(vm.network_ports.count).to   be > 0
         expect(vm.network_ports.first).to   be_kind_of(ManageIQ::Providers::Openstack::CloudManager::NetworkPort)
         expect(vm.cloud_networks.count).to  be > 0
-        vm.cloud_networks.should match_array vm.private_networks
+        expect(vm.cloud_networks).to match_array vm.private_networks
         expect(vm.cloud_networks.first).to  be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private)
         expect(vm.cloud_subnets.count).to   be > 0
         expect(vm.cloud_subnets.first).to   be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudSubnet)
@@ -595,16 +595,16 @@ module Openstack
         expect(vm.public_networks.count).to be > 0
         expect(vm.public_networks.first).to be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public)
 
-        vm.private_networks.map(&:name).should match_array [vm_expected[:__network_name]]
+        expect(vm.private_networks.map(&:name)).to match_array [vm_expected[:__network_name]]
       end
 
       if vm_expected[:security_groups].kind_of?(Array)
-        vm.security_groups.map(&:name).should match_array vm_expected[:security_groups]
+        expect(vm.security_groups.map(&:name)).to match_array vm_expected[:security_groups]
       else
         expect(vm.security_groups.map(&:name)).to eq [vm_expected[:security_groups]]
       end
 
-      vm.hardware.should have_attributes(
+      expect(vm.hardware).to have_attributes(
         :cpu_sockets   => vm.flavor.cpus,
         :memory_mb     => vm.flavor.memory / 1.megabyte,
         :disk_capacity => 2.5.gigabytes # TODO(lsmola) Where is this coming from?
@@ -617,19 +617,19 @@ module Openstack
       flavor_expected = compute_data.flavors.detect { |x| x[:name] == vm.flavor.name }
 
       disk = vm.hardware.disks.find_by_device_name("Root disk")
-      disk.should have_attributes(
+      expect(disk).to have_attributes(
         :device_name => "Root disk",
         :device_type => "disk",
         :size        => flavor_expected[:disk].gigabyte
       )
       disk = vm.hardware.disks.find_by_device_name("Ephemeral disk")
-      disk.should have_attributes(
+      expect(disk).to have_attributes(
         :device_name => "Ephemeral disk",
         :device_type => "disk",
         :size        => flavor_expected[:ephemeral].gigabyte
       )
       disk = vm.hardware.disks.find_by_device_name("Swap disk")
-      disk.should have_attributes(
+      expect(disk).to have_attributes(
         :device_name => "Swap disk",
         :device_type => "disk",
         :size        => flavor_expected[:swap].megabytes
@@ -639,12 +639,12 @@ module Openstack
       # when clud network models are merged in and used for refresh
       expect(vm.hardware.networks.size).to eq 2
       network_public = vm.hardware.networks.where(:description => "public").first
-      network_public.should have_attributes(
+      expect(network_public).to have_attributes(
         :description => "public",
       )
 
       network_private = vm.hardware.networks.where(:description => "private").first
-      network_private.should have_attributes(
+      expect(network_private).to have_attributes(
         :description => "private",
       )
     end
@@ -653,17 +653,17 @@ module Openstack
     def assert_specific_template_created_from_vm
       @snap = ManageIQ::Providers::Openstack::CloudManager::Template.where(
         :name => "EmsRefreshSpec-PoweredOn-SnapShot").first
-      @snap.should_not be_nil
+      expect(@snap).not_to be_nil
       # FIXME: @snap.parent.should == @vm
     end
 
     def assert_specific_vm_created_from_snapshot_template
       t = ManageIQ::Providers::Openstack::CloudManager::Vm.where(:name => "EmsRefreshSpec-PoweredOn-FromSnapshot").first
-      t.parent.should == @snap
+      expect(t.parent).to eq(@snap)
     end
 
     def assert_relationship_tree
-      @ems.descendants_arranged.should match_relationship_tree({})
+      expect(@ems.descendants_arranged).to match_relationship_tree({})
     end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_matchers.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_matchers.rb
@@ -36,7 +36,7 @@ module Openstack
                                                          key_translate_table,
                                                          value_translate_table,
                                                          key_blacklist)
-      comparable_hashes[0].should match_array(comparable_hashes[1])
+      expect(comparable_hashes[0]).to match_array(comparable_hashes[1])
     end
 
     private

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_grizzly_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_grizzly_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
 
   context "when configured with skips" do
     before(:each) do
-      VMDB::Config.any_instance.stub(:config).and_return(
+      allow_any_instance_of(VMDB::Config).to receive(:config).and_return(
         :ems_refresh => {:openstack => {:inventory_ignore => [:cloud_volumes, :cloud_volume_snapshots]}}
       )
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
@@ -26,7 +26,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   end
 
   def refresh_ems(ems, error)
-    allow(ManageIQ::Providers::Openstack::CloudManager::RefreshParser).to receive(:ems_inv_to_hashes).and_raise(Excon::Errors::BadRequest.new(error))
+    allow(ManageIQ::Providers::Openstack::CloudManager::RefreshParser)
+      .to receive(:ems_inv_to_hashes).and_raise(Excon::Errors::BadRequest.new(error))
     EmsRefresh.refresh(ems)
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
@@ -21,12 +21,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   end
 
   def assert_failed_refresh(error)
-    @ems.last_refresh_status.should == "error"
-    @ems.last_refresh_error.should == error
+    expect(@ems.last_refresh_status).to eq("error")
+    expect(@ems.last_refresh_error).to eq(error)
   end
 
   def refresh_ems(ems, error)
-    ManageIQ::Providers::Openstack::CloudManager::RefreshParser.stub(:ems_inv_to_hashes).and_raise(Excon::Errors::BadRequest.new(error))
+    allow(ManageIQ::Providers::Openstack::CloudManager::RefreshParser).to receive(:ems_inv_to_hashes).and_raise(Excon::Errors::BadRequest.new(error))
     EmsRefresh.refresh(ems)
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -58,8 +58,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     it "sets the raw_power_state and not state" do
       expect(vm).to receive(:with_provider_object).and_yield(provider_object)
       vm.raw_destroy
-      vm.raw_power_state.should == "DELETED"
-      vm.state.should == "archived"
+      expect(vm.raw_power_state).to eq("DELETED")
+      expect(vm.state).to eq("archived")
     end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -6,11 +6,11 @@ describe ManageIQ::Providers::Openstack::CloudManager do
   end
 
   it ".ems_type" do
-    described_class.ems_type.should == 'openstack'
+    expect(described_class.ems_type).to eq('openstack')
   end
 
   it ".description" do
-    described_class.description.should == 'OpenStack'
+    expect(described_class.description).to eq('OpenStack')
   end
 
   describe ".metrics_collector_queue_name" do
@@ -32,23 +32,23 @@ describe ManageIQ::Providers::Openstack::CloudManager do
       creds = {}
       creds[:amqp] = {:userid => "amqp_user", :password => "amqp_password"}
       @ems.update_authentication(creds, :save => false)
-      @ems.verify_credentials(:amqp).should be_true
+      expect(@ems.verify_credentials(:amqp)).to be_truthy
     end
 
     it "indicates that an event monitor is available" do
-      OpenstackEventMonitor.stub(:available?).and_return(true)
-      @ems.event_monitor_available?.should be_true
+      allow(OpenstackEventMonitor).to receive(:available?).and_return(true)
+      expect(@ems.event_monitor_available?).to be_truthy
     end
 
     it "indicates that an event monitor is not available" do
-      OpenstackEventMonitor.stub(:available?).and_return(false)
-      @ems.event_monitor_available?.should be_false
+      allow(OpenstackEventMonitor).to receive(:available?).and_return(false)
+      expect(@ems.event_monitor_available?).to be_falsey
     end
 
     it "logs an error and indicates that an event monitor is not available when there's an error checking for an event monitor" do
-      OpenstackEventMonitor.stub(:available?).and_raise(StandardError)
-      $log.should_receive(:error).with(/Exeption trying to find openstack event monitor/)
-      @ems.event_monitor_available?.should be_false
+      allow(OpenstackEventMonitor).to receive(:available?).and_raise(StandardError)
+      expect($log).to receive(:error).with(/Exeption trying to find openstack event monitor/)
+      expect(@ems.event_monitor_available?).to be_falsey
     end
   end
 
@@ -57,7 +57,7 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     @ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
     require 'openstack/openstack_event_monitor'
 
-    @ems.event_monitor_options.should == {:hostname => "host", :port => 1234}
+    expect(@ems.event_monitor_options).to eq({:hostname => "host", :port => 1234})
   end
 
   context "translate_exception" do
@@ -67,9 +67,9 @@ describe ManageIQ::Providers::Openstack::CloudManager do
       creds = {:default => {:userid => "fake_user", :password => "fake_password"}}
       ems.update_authentication(creds, :save => false)
 
-      ems.stub(:with_provider_connection).and_raise(StandardError, "unlikely")
+      allow(ems).to receive(:with_provider_connection).and_raise(StandardError, "unlikely")
 
-      $log.should_receive(:error).with(/unlikely/)
+      expect($log).to receive(:error).with(/unlikely/)
       expect { ems.verify_credentials }.to raise_error(MiqException::MiqEVMLoginError, /Unexpected.*unlikely/)
     end
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -57,7 +57,8 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     @ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
     require 'openstack/openstack_event_monitor'
 
-    expect(@ems.event_monitor_options).to eq({:hostname => "host", :port => 1234})
+    expect(@ems.event_monitor_options)
+      .to eq(:hostname => "host", :port => 1234)
   end
 
   context "translate_exception" do

--- a/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
@@ -3,19 +3,19 @@ require "spec_helper"
 describe ManageIQ::Providers::Openstack::InfraManager::EventCatcher do
   before do
     @ems = FactoryGirl.create(:ems_openstack_infra)
-    @ems.stub(:authentication_status_ok?).and_return(true)
-    ManageIQ::Providers::Openstack::InfraManager::EventCatcher.stub(:all_ems_in_zone).and_return([@ems])
+    allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+    allow(ManageIQ::Providers::Openstack::InfraManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 
   it "logs info about EMS that do not have Event Monitors available" do
-    @ems.stub(:event_monitor_available?).and_return(false)
-    $log.should_receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone.should_not include @ems
+    allow(@ems).to receive(:event_monitor_available?).and_return(false)
+    expect($log).to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
+    expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).not_to include @ems
   end
 
   it "does not log info about unavailable Event Monitors when EMS can provide an event monitor" do
-    @ems.stub(:event_monitor_available?).and_return(true)
-    $log.should_not_receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone.should include @ems
+    allow(@ems).to receive(:event_monitor_available?).and_return(true)
+    expect($log).not_to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
+    expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).to include @ems
   end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/event_parser_spec.rb
@@ -14,10 +14,10 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
         :message      => "Success"
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should    be_instance_of Hash
-      data[:host_ems_ref].should be_instance_of String
+      expect(data[:full_data]).to    be_instance_of Hash
+      expect(data[:host_ems_ref]).to be_instance_of String
     end
 
     it "with a compute.instance.create.error event" do
@@ -34,10 +34,10 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
                          " baremetal_2."
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should    be_instance_of Hash
-      data[:host_ems_ref].should be_instance_of String
+      expect(data[:full_data]).to    be_instance_of Hash
+      expect(data[:host_ems_ref]).to be_instance_of String
     end
 
     it "with an orchestration.stack.create.end event" do
@@ -49,9 +49,9 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
         :timestamp  => "2015-05-12 07:24:45.026776"
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should be_instance_of Hash
+      expect(data[:full_data]).to be_instance_of Hash
     end
 
     it "with an orchestration.stack.update.end event" do
@@ -63,9 +63,9 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
         :timestamp  => "2015-05-12 07:33:57.772136"
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should be_instance_of Hash
+      expect(data[:full_data]).to be_instance_of Hash
     end
 
     it "with a port.create.end event" do
@@ -77,9 +77,9 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
         :timestamp  => "2015-05-12 07:22:37.008738"
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should be_instance_of Hash
+      expect(data[:full_data]).to be_instance_of Hash
     end
 
     it "with a port.update.end event" do
@@ -91,9 +91,9 @@ describe ManageIQ::Providers::Openstack::InfraManager::EventParser do
         :timestamp  => "2015-05-12 07:22:43.948145"
       )
 
-      data.should have_attributes(expected_attributes)
+      expect(data).to have_attributes(expected_attributes)
 
-      data[:full_data].should be_instance_of Hash
+      expect(data[:full_data]).to be_instance_of Hash
     end
   end
 

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -22,13 +22,13 @@ openstack-keystone:                     active
 
     let(:ssu) do
       double('ssu').tap do |ssu|
-        ssu.should_receive(:shell_exec).with("openstack-status").and_return(openstack_status_text)
+        expect(ssu).to receive(:shell_exec).with("openstack-status").and_return(openstack_status_text)
       end
     end
 
     let(:host) do
       FactoryGirl.create(:host_openstack_infra).tap do |host|
-        host.stub(:connect_ssh).and_yield(ssu)
+        allow(host).to receive(:connect_ssh).and_yield(ssu)
 
         # create generic SystemService
         host.system_services << FactoryGirl.create(:system_service)
@@ -72,7 +72,7 @@ openstack-keystone:                     active
     context "with stubbed MiqLinux::Utils" do
       it "makes proper utils calls" do
         miq_linux_utils_double = double('MiqLinux::Utils')
-        miq_linux_utils_double.should_receive(:parse_openstack_status).with(openstack_status_text).and_return([])
+        expect(miq_linux_utils_double).to receive(:parse_openstack_status).with(openstack_status_text).and_return([])
         stub_const('MiqLinux::Utils', miq_linux_utils_double)
         host.refresh_openstack_services(ssu)
       end
@@ -98,8 +98,8 @@ openstack-keystone:                     active
         ]
       end
 
-      it { should include(*expected) }
-      it { should_not include(*unexpected) }
+      it { is_expected.to include(*expected) }
+      it { is_expected.not_to include(*unexpected) }
     end
 
     describe "system_services names" do
@@ -123,8 +123,8 @@ openstack-keystone:                     active
         ]
       end
 
-      it { should include(*expected) }
-      it { should_not include(*unexpected) }
+      it { is_expected.to include(*expected) }
+      it { is_expected.not_to include(*unexpected) }
     end
 
     describe "filesystems names" do
@@ -142,7 +142,7 @@ openstack-keystone:                     active
         ]
       end
 
-      it { should include(*expected) }
+      it { is_expected.to include(*expected) }
     end
 
     describe "existing HostServiceGroupOpenstack gets updated" do
@@ -171,8 +171,8 @@ openstack-keystone:                     active
           ]
         end
 
-        it { should include(*expected) }
-        it { should_not include(*unexpected) }
+        it { is_expected.to include(*expected) }
+        it { is_expected.not_to include(*unexpected) }
       end
 
       describe "filesystem names" do
@@ -194,8 +194,8 @@ openstack-keystone:                     active
           ]
         end
 
-        it { should include(*expected) }
-        it { should_not include(*unexpected) }
+        it { is_expected.to include(*expected) }
+        it { is_expected.not_to include(*unexpected) }
       end
     end
 
@@ -203,14 +203,14 @@ openstack-keystone:                     active
       host.refresh_openstack_services(ssu)
       # we test if SystemServices with associated HostServiceGroupOpenstacks from current Host
       # are included among all SystemServices of that host
-      host.system_services.should include(*(host.host_service_group_openstacks.flat_map(&:system_services)))
+      expect(host.system_services).to include(*(host.host_service_group_openstacks.flat_map(&:system_services)))
     end
 
     it "creates association with existing Filesystems" do
       host.refresh_openstack_services(ssu)
       # we test if Filesystems with associated HostServiceGroupOpenstacks from current Host
       # are included among all Filesystems of that host
-      host.filesystems.should include(*(host.host_service_group_openstacks.flat_map(&:filesystems)))
+      expect(host.filesystems).to include(*(host.host_service_group_openstacks.flat_map(&:filesystems)))
     end
   end
 
@@ -232,7 +232,7 @@ openstack-keystone:                     active
     end
 
     before :each do
-      Authentication.any_instance.stub(:raise_event)
+      allow_any_instance_of(Authentication).to receive(:raise_event)
     end
 
     it "#get_parent_keypair returns parent provider auth" do
@@ -413,7 +413,7 @@ openstack-keystone:                     active
     context "#update_ssh_auth_status!" do
       context "when ssh connection causes exception," do
         before :each do
-          host.stub(:verify_credentials_with_ssh) { raise "some error" }
+          allow(host).to receive(:verify_credentials_with_ssh) { raise "some error" }
         end
 
         it "sets auth to 'Error' state if credentials exists" do
@@ -437,7 +437,7 @@ openstack-keystone:                     active
 
       context "when ssh connection succeeds and verification returns true," do
         before :each do
-          host.stub(:verify_credentials_with_ssh).and_return(true)
+          allow(host).to receive(:verify_credentials_with_ssh).and_return(true)
         end
 
         it "sets auth to valid, when credentials verification succeeds" do

--- a/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
@@ -11,18 +11,18 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
     @mock_stats_data = OpenstackMetricStatsData.new
 
     @metering = double(:metering)
-    @metering.stub(:list_meters).and_return(
+    allow(@metering).to receive(:list_meters).and_return(
       OpenstackApiResult.new(@mock_meter_list.list_meters("metadata_counters")))
 
     @ems_openstack = FactoryGirl.create(:ems_openstack_infra, :zone => @zone)
-    @ems_openstack.stub(:connect).with(:service => "Metering").and_return(@metering)
+    allow(@ems_openstack).to receive(:connect).with(:service => "Metering").and_return(@metering)
 
     @host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems_openstack)
   end
 
   context "with standard interval data" do
     before :each do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         OpenstackApiResult.new(@mock_stats_data.get_statistics(name))
       end
     end
@@ -32,7 +32,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       _counters, values_by_id_and_ts = @host.perf_collect_metrics("realtime")
       ts = Time.parse(values_by_id_and_ts[@host.ems_ref].keys.max)
 
-      ts_as_utc.should eq ts
+      expect(ts_as_utc).to eq ts
     end
 
     it "translates cumulative meters into discrete values" do
@@ -92,14 +92,14 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       read_ts1_period = api_time_as_utc(read_bytes1)
       read_ts2_period = api_time_as_utc(read_bytes2)
-      result[read_ts1_period.iso8601]["disk_usage_rate_average"].should eq disk_val1
-      result[read_ts2_period.iso8601]["disk_usage_rate_average"].should eq disk_val2
+      expect(result[read_ts1_period.iso8601]["disk_usage_rate_average"]).to eq disk_val1
+      expect(result[read_ts2_period.iso8601]["disk_usage_rate_average"]).to eq disk_val2
     end
   end
 
   context "with irregular interval data" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         OpenstackApiResult.new(@mock_stats_data.get_statistics(name, "irregular_interval"))
       end
 
@@ -157,15 +157,15 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       # First 3 stats are nil, cause hardware.system_stats.io.outgoing.blocks starts at "2013-08-28T11:00:20". All
       # the stats are collected together by capturing algorithm.
-      (0..2).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq nil }
+      (0..2).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq nil }
       # ensure that the next three statistics match avg_stat1
-      (3..5).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat1 }
+      (3..5).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next three statistics match avg_stat2
-      (6..8).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat2 }
+      (6..8).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next three statistics match avg_stat3
-      (9..11).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat3 }
+      (9..11).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 4 statistics match avg_stat4
-      (12..15).each { |i| @values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"].should eq avg_stat4 }
+      (12..15).each { |i| expect(@values_by_ts[@ts_keys[i]]["cpu_usage_rate_average"]).to eq avg_stat4 }
     end
 
     it "makes sure cpu_usage_rate_average stats continuous block of 20s is correct" do
@@ -176,12 +176,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 28
+      expect(stats_counter).to eq 28
     end
 
     ###################################################################################################################
@@ -273,12 +273,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
                                    "hardware.system_stats.io.outgoing.blocks", @write_bytes, @read_bytes, 3, 4)
 
       # ensure computations are equal
-      avg_stat1_manual.should eq avg_stat1_computed_elsewhere
-      avg_stat4_manual.should eq avg_stat4_computed_elsewhere
-      avg_stat1.should eq avg_stat1_computed_elsewhere
-      avg_stat2.should eq avg_stat2_computed_elsewhere
-      avg_stat3.should eq avg_stat3_computed_elsewhere
-      avg_stat4.should eq avg_stat4_computed_elsewhere
+      expect(avg_stat1_manual).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat4_manual).to eq avg_stat4_computed_elsewhere
+      expect(avg_stat1).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat2).to eq avg_stat2_computed_elsewhere
+      expect(avg_stat3).to eq avg_stat3_computed_elsewhere
+      expect(avg_stat4).to eq avg_stat4_computed_elsewhere
     end
 
     it "aligns not aligned data of the disk_usage_rate_average counters and computes stats correctly" do
@@ -299,24 +299,24 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
                                    "hardware.system_stats.io.outgoing.blocks", @write_bytes, @read_bytes, 6, 7)
 
       # ensure that the first 6 statistics match avg_stat1
-      (0..5).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat1 }
+      (0..5).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 6 statistics match avg_stat2
-      (6..11).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat2 }
+      (6..11).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 6 statistics match avg_stat3
-      (12..17).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat3 }
+      (12..17).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 7 statistics match avg_stat4
-      (18..24).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat4 }
+      (18..24).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat4 }
       # ensure that the next 6 statistics match avg_stat5
-      (25..30).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat5 }
+      (25..30).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat5 }
       # ensure that the next 6 statistics match avg_stat6
-      (31..36).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat6 }
+      (31..36).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat6 }
       # ensure that the next 6 statistics match avg_stat7
-      (37..42).each { |i| @values_by_ts[@ts_keys[i]]["disk_usage_rate_average"].should eq avg_stat7 }
+      (37..42).each { |i| expect(@values_by_ts[@ts_keys[i]]["disk_usage_rate_average"]).to eq avg_stat7 }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct
-      @ts_keys.count.should eq 43
+      expect(@ts_keys.count).to eq 43
     end
 
     it "makes sure disk_usage_rate_average stats continuous block of 20s is correct" do
@@ -327,12 +327,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "disk_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 43
+      expect(stats_counter).to eq 43
     end
 
     it "makes sure start time and end time of collection periods are correct" do
@@ -344,8 +344,8 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       expected_stats_period_start = parse_datetime('2013-08-28 11:00:20')
       expected_stats_period_end   = parse_datetime('2013-08-28 11:14:40Z')
 
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should   eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to   eq expected_stats_period_end
     end
   end
 
@@ -361,7 +361,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
   context "1. collection period from 2 collection periods total of net_usage_rate_average, end of this period has "\
           "incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         first_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                     "multiple_collection_periods"),
                                                     '<=',
@@ -451,26 +451,26 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
                                    "hardware.network.ip.outgoing.datagrams", @write_bytes, @read_bytes, 4, 5)
 
       # ensure that the first 30 statistics match avg_stat1
-      (0..29).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (30..59).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (30..59).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (60..89).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (60..89).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 31 statistics match avg_stat4
-      (90..120).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (90..120).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
       # ensure that the next 30 statistics match avg_stat5
-      (121..150).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat5 }
+      (121..150).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat5 }
     end
 
     it "checks that the net_usage_rate_average should have last incomplete stat not saved" do
       # Ensure that the last 30 statistics match nil. This happens because net usage stat has been incomplete, so we s
       # tore nil values, these nil values should be rewritten in next collection period.
-      (151..180).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq nil }
+      (151..180).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 151 data stats and 30 nil stats
-      @ts_keys.count.should eq 181
+      expect(@ts_keys.count).to eq 181
     end
 
     it "tests that last computed statistic has the right value" do
@@ -479,7 +479,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       # Test that last value of 1. collection period is this. This test continues in 2. collection period test. This
       # value has to be different to first value of 2.collection period
-      avg_stat5.should eq NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat5).to eq NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "make sure disk_usage_rate_average stats continuos block of 20s is correct" do
@@ -490,12 +490,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 151
+      expect(stats_counter).to eq 151
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -507,15 +507,15 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime('2013-08-28 11:01:20')
       expected_stats_period_end = parse_datetime(NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
   context "2. collection period from 2 collection periods total of net_usage_rate_average, start and middle of "\
           "this period has one incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         second_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                      "multiple_collection_periods"),
                                                      '>',
@@ -578,14 +578,14 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
                                    "hardware.network.ip.outgoing.datagrams", @write_bytes, @read_bytes, 3, 4)
 
       # ensure that the next 30 statistics match avg_stat1
-      (21..50).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat1 }
+      (21..50).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (51..80).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat2 }
+      (51..80).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (81..110).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat3 }
+      (81..110).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat3 }
       # ensure that the next 60 statistics match avg_stat4
       # This test assures us that this value fills the empty space caused by corrupted data with missing stat.
-      (111..170).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq avg_stat4 }
+      (111..170).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq avg_stat4 }
     end
 
     it "checks that the net_usage_rate_average should have last incomplete stat not saved" do
@@ -593,12 +593,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # hardware.system_stats.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
       # values has been filled with the right value in previous collection period.
       # !!!!!!! It's up to saving mechanism to not overwrite the old values with nil. !!!!!!!!!!!
-      (0..20).each { |i| @values_by_ts[@ts_keys[i]]["net_usage_rate_average"].should eq nil }
+      (0..20).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 150 data stats and 21 nil stats
-      @ts_keys.count.should eq 171
+      expect(@ts_keys.count).to eq 171
     end
 
     it "checks that last sample of 1. collection period is different to first sample of 2. collection period" do
@@ -606,12 +606,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       avg_stat1 = make_calculation(@counter_info, "hardware.network.ip.incoming.datagrams",
                                    "hardware.network.ip.outgoing.datagrams", @write_bytes, @read_bytes, 0, 1)
 
-      avg_stat1.should_not eq NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat1).not_to eq NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "there is missing stat in the middle of the period, make sure we log warning of corrupted data exactly once" do
       # should fail twice for mem_usage and net_usage
-      $log.should_receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:twice)
+      expect($log).to receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:twice)
       @host.perf_collect_metrics("realtime")
     end
 
@@ -622,12 +622,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "net_usage_rate_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 150
+      expect(stats_counter).to eq 150
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -639,8 +639,8 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime(NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
       expected_stats_period_end = parse_datetime('2013-08-28 12:41:40Z')
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
@@ -653,7 +653,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
   context "1. collection period from 2 collection periods total of the mem_usage_absolute_average, end of this "\
           "period has incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         first_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                     "multiple_collection_periods"),
                                                     '<=',
@@ -721,12 +721,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 4)
 
       # ensure computations are equal
-      avg_stat1_manual.should eq avg_stat1_computed_elsewhere
-      avg_stat4_manual.should eq avg_stat4_computed_elsewhere
-      avg_stat1.should eq avg_stat1_computed_elsewhere
-      avg_stat2.should eq avg_stat2_computed_elsewhere
-      avg_stat3.should eq avg_stat3_computed_elsewhere
-      avg_stat4.should eq avg_stat4_computed_elsewhere
+      expect(avg_stat1_manual).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat4_manual).to eq avg_stat4_computed_elsewhere
+      expect(avg_stat1).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat2).to eq avg_stat2_computed_elsewhere
+      expect(avg_stat3).to eq avg_stat3_computed_elsewhere
+      expect(avg_stat4).to eq avg_stat4_computed_elsewhere
     end
 
     it "computes first 4 values of mem_swapped_absolute_average values correctly" do
@@ -744,12 +744,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       avg_stat4 = make_memory_swapped_calculation(@counter_info_swap, @swap_avail, @swap_total, 4)
 
       # ensure computations are equal
-      avg_stat1_manual.should eq avg_stat1_computed_elsewhere
-      avg_stat4_manual.should eq avg_stat4_computed_elsewhere
-      avg_stat1.should eq avg_stat1_computed_elsewhere
-      avg_stat2.should eq avg_stat2_computed_elsewhere
-      avg_stat3.should eq avg_stat3_computed_elsewhere
-      avg_stat4.should eq avg_stat4_computed_elsewhere
+      expect(avg_stat1_manual).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat4_manual).to eq avg_stat4_computed_elsewhere
+      expect(avg_stat1).to eq avg_stat1_computed_elsewhere
+      expect(avg_stat2).to eq avg_stat2_computed_elsewhere
+      expect(avg_stat3).to eq avg_stat3_computed_elsewhere
+      expect(avg_stat4).to eq avg_stat4_computed_elsewhere
     end
 
     it "checks that the mem_usage_absolute_average has aligned data and computed stats correctly" do
@@ -761,26 +761,26 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       avg_stat5 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 5)
 
       # ensure that the first 30 statistics match avg_stat1
-      (0..29).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat1 }
+      (0..29).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (30..59).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat2 }
+      (30..59).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (60..89).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat3 }
+      (60..89).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat3 }
       # ensure that the next 31 statistics match avg_stat4
-      (90..120).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat4 }
+      (90..120).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat4 }
       # ensure that the next 30 statistics match avg_stat5
-      (121..150).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat5 }
+      (121..150).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat5 }
     end
 
     it "checks that the mem_usage_absolute_average should have last incomplete stat not saved" do
       # Ensure that the last 30 statistics match nil. This happens because net usage stat has been incomplete, so we s
       # tore nil values, these nil values should be rewritten in next collection period.
-      (151..180).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq nil }
+      (151..180).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 151 data stats and 30 nil stats
-      @ts_keys.count.should eq 181
+      expect(@ts_keys.count).to eq 181
     end
 
     it "tests that last computed statistic has the right value" do
@@ -788,7 +788,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
       # Test that last value of 1. collection period is this. This test continues in 2. collection period test. This
       # value has to be different to first value of 2.collection period
-      avg_stat5.should eq MEM_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat5).to eq MEM_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "make sure disk_usage_rate_average stats continuos block of 20s is correct" do
@@ -799,12 +799,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "mem_usage_absolute_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "mem_usage_absolute_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 151
+      expect(stats_counter).to eq 151
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -816,15 +816,15 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime('2013-08-28 11:01:20')
       expected_stats_period_end = parse_datetime(NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 
   context "2. collection period from 2 collection periods total of the mem_usage_absolute_average, start and "\
           "middle of this period has one incomplete stat" do
     before do
-      @metering.stub(:get_statistics) do |name, _options|
+      allow(@metering).to receive(:get_statistics) do |name, _options|
         second_collection_period = filter_statistics(@mock_stats_data.get_statistics(name,
                                                                                      "multiple_collection_periods"),
                                                      '>',
@@ -883,14 +883,14 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       avg_stat4 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 4)
 
       # ensure that the next 30 statistics match avg_stat1
-      (21..50).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat1 }
+      (21..50).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat1 }
       # ensure that the next 30 statistics match avg_stat2
-      (51..80).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat2 }
+      (51..80).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat2 }
       # ensure that the next 30 statistics match avg_stat3
-      (81..110).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat3 }
+      (81..110).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat3 }
       # ensure that the next 60 statistics match avg_stat4
       # This test assures us that this value fills the empty space caused by corrupted data with missing stat.
-      (111..170).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq avg_stat4 }
+      (111..170).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq avg_stat4 }
     end
 
     it "checks that the mem_usage_absolute_average should have last incomplete stat not saved" do
@@ -898,24 +898,24 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # hardware.system_stats.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
       # values has been filled with the right value in previous collection period.
       # !!!!!!! It's up to saving mechanism to not overwrite the old values with nil. !!!!!!!!!!!
-      (0..20).each { |i| @values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"].should eq nil }
+      (0..20).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq nil }
     end
 
     it "checks this collection period has right count of samples saved" do
       # ensure total number of stats is correct, 150 data stats and 21 nil stats
-      @ts_keys.count.should eq 171
+      expect(@ts_keys.count).to eq 171
     end
 
     it "checks that last sample of 1. collection period is different to first sample of 2. collection period" do
       # make computation of stats for comparison
       avg_stat1 = make_memory_util_calculation(@counter_info, @memory_used, @memory_total, 1)
 
-      avg_stat1.should_not eq MEM_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
+      expect(avg_stat1).not_to eq MEM_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD
     end
 
     it "there is missing stat in the middle of the period, make sure we log warning of corrupted data exactly once" do
       # should fail twice for mem_usage and net_usage
-      $log.should_receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:twice)
+      expect($log).to receive(:warn).with(/Distance of the multiple streams of data is invalid/).exactly(:twice)
       @host.perf_collect_metrics("realtime")
     end
 
@@ -926,12 +926,12 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check that 20s block is not interrupted between start and end time, and that count of 20s block is correct
       stats_counter = 0
       (expected_stats_period_start + 20.seconds..expected_stats_period_end).step_value(20.seconds).each do |timestamp|
-        @values_by_ts[timestamp.iso8601].try(:[], "mem_usage_absolute_average").should_not eq nil
+        expect(@values_by_ts[timestamp.iso8601].try(:[], "mem_usage_absolute_average")).not_to eq nil
         stats_counter += 1
       end
 
       # check total number of 20s blocks
-      stats_counter.should eq 150
+      expect(stats_counter).to eq 150
     end
 
     it "makes sure start time and end time of collection period are correct" do
@@ -943,8 +943,8 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
       # check start and end date are as expected
       expected_stats_period_start = parse_datetime(NET_LAST_VALUE_OF_FIRST_COLLECTING_PERIOD_TIMESTAMP)
       expected_stats_period_end = parse_datetime('2013-08-28 12:41:40Z')
-      stats_period_start.should eq expected_stats_period_start
-      stats_period_end.should eq expected_stats_period_end
+      expect(stats_period_start).to eq expected_stats_period_start
+      expect(stats_period_end).to eq expected_stats_period_end
     end
   end
 

--- a/spec/models/manageiq/providers/openstack/infra_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/orchestration_stack_spec.rb
@@ -71,14 +71,14 @@ describe ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack do
 
         # TODO(lsmola) convert status to Status object
         # orchestration_stack.raw_exists?.should be_true
-        orchestration_stack.update_ready?.should be_true
+        expect(orchestration_stack.update_ready?).to be_truthy
       end
 
       it 'determines stack not exist' do
         allow(raw_stacks).to receive(:get).with(orchestration_stack.name, orchestration_stack.ems_ref).and_return(nil)
         expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
 
-        orchestration_stack.raw_exists?.should be_false
+        expect(orchestration_stack.raw_exists?).to be_falsey
       end
 
       it 'catches errors from provider' do

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -181,8 +181,8 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     )
     expect(template.ems_ref).to be_guid
 
-    expect(template.ext_management_system).to  eq @ems
-    expect(template.operating_system).to           be_nil # TODO: This should probably not be nil
+    expect(template.ext_management_system).to eq @ems
+    expect(template.operating_system).to be_nil # TODO: This should probably not be nil
     expect(template.custom_attributes.size).to eq 0
     expect(template.snapshots.size).to         eq 0
     expect(template.hardware).not_to               be_nil

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -69,7 +69,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => nil,
       :uid_ems     => nil
     )
@@ -90,13 +90,13 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
   def assert_specific_host
     @host = ManageIQ::Providers::Openstack::InfraManager::Host.all.detect { |x| x.name.include?('(Controller)') }
 
-    @host.ems_ref.should_not be nil
-    @host.ems_ref_obj.should_not be nil
-    @host.mac_address.should_not be nil
-    @host.ipaddress.should_not be nil
-    @host.ems_cluster.should_not be nil
+    expect(@host.ems_ref).not_to be nil
+    expect(@host.ems_ref_obj).not_to be nil
+    expect(@host.mac_address).not_to be nil
+    expect(@host.ipaddress).not_to be nil
+    expect(@host.ems_cluster).not_to be nil
 
-    @host.should have_attributes(
+    expect(@host).to have_attributes(
       :ipmi_address     => nil,
       :vmm_vendor       => "RedHat",
       :vmm_version      => nil,
@@ -111,11 +111,11 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     expect(@host.network_ports.count).to    be > 0
     expect(@host.network_ports.first).to    be_kind_of(ManageIQ::Providers::Openstack::InfraManager::NetworkPort)
 
-    @host.operating_system.should have_attributes(
+    expect(@host.operating_system).to have_attributes(
       :product_name     => "linux"
     )
 
-    @host.hardware.should have_attributes(
+    expect(@host.hardware).to have_attributes(
       :cpu_speed            => 2000,
       :cpu_type             => "RHEL 7.1.0 PC (i440FX + PIIX, 1996)",
       :manufacturer         => "Red Hat",
@@ -138,7 +138,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
   end
 
   def assert_specific_disk(disk)
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => 'sda',
       :device_type     => 'disk',
       :controller_type => 'scsi',
@@ -156,7 +156,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
 
   def assert_specific_template(name, is_public = false)
     template = ManageIQ::Providers::Openstack::InfraManager::Template.where(:name => name).first
-    template.should have_attributes(
+    expect(template).to have_attributes(
       :template              => true,
       :publicly_available    => is_public,
       :ems_ref_obj           => nil,
@@ -179,14 +179,14 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       :cpu_shares            => nil,
       :cpu_shares_level      => nil
     )
-    template.ems_ref.should be_guid
+    expect(template.ems_ref).to be_guid
 
     expect(template.ext_management_system).to  eq @ems
-    template.operating_system.should           be_nil # TODO: This should probably not be nil
+    expect(template.operating_system).to           be_nil # TODO: This should probably not be nil
     expect(template.custom_attributes.size).to eq 0
     expect(template.snapshots.size).to         eq 0
-    template.hardware.should_not               be_nil
-    template.parent.should                     be_nil
+    expect(template.hardware).not_to               be_nil
+    expect(template.parent).to                     be_nil
     template
   end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Openstack::InfraManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'openstack_infra'
+    expect(described_class.ems_type).to eq('openstack_infra')
   end
 
   it ".description" do
-    described_class.description.should == 'OpenStack Platform Director'
+    expect(described_class.description).to eq('OpenStack Platform Director')
   end
 
   describe ".metrics_collector_queue_name" do
@@ -28,23 +28,23 @@ describe ManageIQ::Providers::Openstack::InfraManager do
       creds = {}
       creds[:amqp] = {:userid => "amqp_user", :password => "amqp_password"}
       @ems.update_authentication(creds, :save => false)
-      @ems.verify_credentials(:amqp).should be_true
+      expect(@ems.verify_credentials(:amqp)).to be_truthy
     end
 
     it "indicates that an event monitor is available" do
-      OpenstackEventMonitor.stub(:available?).and_return(true)
-      @ems.event_monitor_available?.should be_true
+      allow(OpenstackEventMonitor).to receive(:available?).and_return(true)
+      expect(@ems.event_monitor_available?).to be_truthy
     end
 
     it "indicates that an event monitor is not available" do
-      OpenstackEventMonitor.stub(:available?).and_return(false)
-      @ems.event_monitor_available?.should be_false
+      allow(OpenstackEventMonitor).to receive(:available?).and_return(false)
+      expect(@ems.event_monitor_available?).to be_falsey
     end
 
     it "logs an error and indicates that an event monitor is not available when there's an error checking for an event monitor" do
-      OpenstackEventMonitor.stub(:available?).and_raise(StandardError)
-      $log.should_receive(:error).with(/Exeption trying to find openstack event monitor/)
-      @ems.event_monitor_available?.should be_false
+      allow(OpenstackEventMonitor).to receive(:available?).and_raise(StandardError)
+      expect($log).to receive(:error).with(/Exeption trying to find openstack event monitor/)
+      expect(@ems.event_monitor_available?).to be_falsey
     end
   end
 
@@ -54,15 +54,15 @@ describe ManageIQ::Providers::Openstack::InfraManager do
     end
 
     it "creates related ProviderOpenstack after creating EmsOpenstackInfra" do
-      @ems.provider.name.should eq @ems.name
-      @ems.provider.zone.should == @ems.zone
-      ManageIQ::Providers::Openstack::Provider.count.should eq 1
+      expect(@ems.provider.name).to eq @ems.name
+      expect(@ems.provider.zone).to eq(@ems.zone)
+      expect(ManageIQ::Providers::Openstack::Provider.count).to eq 1
     end
 
     it "destroys related ProviderOpenstack after destroying EmsOpenstackInfra" do
-      ManageIQ::Providers::Openstack::Provider.count.should eq 1
+      expect(ManageIQ::Providers::Openstack::Provider.count).to eq 1
       @ems.destroy
-      ManageIQ::Providers::Openstack::Provider.count.should eq 0
+      expect(ManageIQ::Providers::Openstack::Provider.count).to eq 0
     end
 
     it "related EmsOpenstack nullifies relation to ProviderOpenstack on EmsOpenstackInfra destroy" do
@@ -71,12 +71,12 @@ describe ManageIQ::Providers::Openstack::InfraManager do
       @ems.provider.cloud_ems << @ems_cloud
 
       # compare they both use the same provider
-      @ems_cloud.provider.should == @ems.provider
+      expect(@ems_cloud.provider).to eq(@ems.provider)
 
       # destroy ems and see the relation of ems_cloud to provider nullified
       @ems.destroy
-      ManageIQ::Providers::Openstack::Provider.count.should eq 0
-      @ems_cloud.reload.provider.should be_nil
+      expect(ManageIQ::Providers::Openstack::Provider.count).to eq 0
+      expect(@ems_cloud.reload.provider).to be_nil
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner do
 
     before do
       ManageIQ::Providers::Redhat::InfraManager.any_instance.stub(:authentication_check => [true, ""])
-      MiqWorker::Runner.any_instance.stub(:worker_initialization)
+      allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
     end
 
     it "numeric port" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -39,8 +39,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
 
       it "first NIC from dialog" do
         set_vlan
-        rhevm_nic1.should_receive(:apply_options!)
-        rhevm_nic2.should_receive(:apply_options!)
+        expect(rhevm_nic1).to receive(:apply_options!)
+        expect(rhevm_nic2).to receive(:apply_options!)
 
         @task.configure_network_adapters
 
@@ -51,8 +51,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
       end
 
       it "no NIC from dialog" do
-        rhevm_nic1.should_receive(:destroy)
-        rhevm_nic2.should_receive(:apply_options!)
+        expect(rhevm_nic1).to receive(:destroy)
+        expect(rhevm_nic2).to receive(:apply_options!)
 
         @task.configure_network_adapters
       end
@@ -61,8 +61,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
     it "dialog NIC only" do
       set_vlan
 
-      rhevm_nic1.should_receive(:apply_options!)
-      rhevm_nic2.should_receive(:destroy)
+      expect(rhevm_nic1).to receive(:apply_options!)
+      expect(rhevm_nic2).to receive(:destroy)
 
       @task.configure_network_adapters
     end
@@ -75,8 +75,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
       it "should update an existing adapter's network" do
         @task.options[:networks] = [{:network => network_name}]
 
-        rhevm_vm.should_receive(:nics).and_return([rhevm_nic1])
-        rhevm_nic1.should_receive(:apply_options!).with(:name => "nic1", :network_id => network_id)
+        expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
+        expect(rhevm_nic1).to receive(:apply_options!).with(:name => "nic1", :network_id => network_id)
 
         @task.configure_network_adapters
       end
@@ -84,8 +84,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
       it "should update an existing adapter's MAC address" do
         @task.options[:networks] = [{:mac_address => mac_address}]
 
-        rhevm_vm.should_receive(:nics).and_return([rhevm_nic1])
-        rhevm_nic1.should_receive(:apply_options!).with(
+        expect(rhevm_vm).to receive(:nics).and_return([rhevm_nic1])
+        expect(rhevm_nic1).to receive(:apply_options!).with(
           :name        => "nic1",
           :network_id  => network_id,
           :mac_address => mac_address
@@ -98,8 +98,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
     it "should create a new adapter with an optional MAC address" do
       @task.options[:networks] = [{:network => network_name, :mac_address => mac_address}]
 
-      rhevm_vm.should_receive(:nics).and_return([])
-      rhevm_vm.should_receive(:create_nic).with(
+      expect(rhevm_vm).to receive(:nics).and_return([])
+      expect(rhevm_vm).to receive(:create_nic).with(
         :name        => 'nic1',
         :network_id  => network_id,
         :mac_address => mac_address

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/placement_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/placement_spec.rb
@@ -28,21 +28,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
     end
 
     it "#automatic_placement" do
-      @task.should_receive(:get_placement_via_automate).and_return(:cluster => @cluster)
+      expect(@task).to receive(:get_placement_via_automate).and_return(:cluster => @cluster)
       @task.options[:placement_auto]         = true
       check
     end
 
     it "automate returns nothing" do
       @task.options[:placement_cluster_name] = @cluster.id
-      @task.should_receive(:get_placement_via_automate).and_return({})
+      expect(@task).to receive(:get_placement_via_automate).and_return({})
       @task.options[:placement_auto]         = true
       check
     end
 
     def check
       @task.send(:placement)
-      @task.options[:dest_cluster].should eql([@cluster.id, @cluster.name])
+      expect(@task.options[:dest_cluster]).to eql([@cluster.id, @cluster.name])
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -14,60 +14,60 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
     end
 
     it "#create_destination" do
-      @task.should_receive(:determine_placement)
+      expect(@task).to receive(:determine_placement)
 
       @task.create_destination
     end
 
     it "#determine_placement" do
-      @task.stub(:placement)
+      allow(@task).to receive(:placement)
 
-      @task.should_receive(:prepare_provision)
+      expect(@task).to receive(:prepare_provision)
 
       @task.determine_placement
     end
 
     it "#start_clone_task" do
-      @task.stub(:update_and_notify_parent)
-      @task.stub(:log_clone_options)
-      @task.stub(:start_clone)
+      allow(@task).to receive(:update_and_notify_parent)
+      allow(@task).to receive(:log_clone_options)
+      allow(@task).to receive(:start_clone)
 
-      @task.should_receive(:poll_clone_complete)
+      expect(@task).to receive(:poll_clone_complete)
 
       @task.start_clone_task
     end
 
     context "#poll_clone_complete" do
       it "cloning" do
-        @task.should_receive(:clone_complete?).and_return(false)
-        @task.should_receive(:requeue_phase)
+        expect(@task).to receive(:clone_complete?).and_return(false)
+        expect(@task).to receive(:requeue_phase)
 
         @task.poll_clone_complete
       end
 
       it "clone complete" do
-        @task.should_receive(:clone_complete?).and_return(true)
-        EmsRefresh.should_receive(:queue_refresh)
-        @task.should_receive(:poll_destination_in_vmdb)
+        expect(@task).to receive(:clone_complete?).and_return(true)
+        expect(EmsRefresh).to receive(:queue_refresh)
+        expect(@task).to receive(:poll_destination_in_vmdb)
 
         @task.poll_clone_complete
       end
     end
 
     it "#customize_destination" do
-      @task.stub(:get_provider_destination).and_return(nil)
-      @task.stub(:update_and_notify_parent)
+      allow(@task).to receive(:get_provider_destination).and_return(nil)
+      allow(@task).to receive(:update_and_notify_parent)
 
-      @task.should_receive(:configure_container)
-      @task.should_receive(:configure_cloud_init)
-      @task.should_receive(:poll_destination_powered_off_in_provider)
+      expect(@task).to receive(:configure_container)
+      expect(@task).to receive(:configure_cloud_init)
+      expect(@task).to receive(:poll_destination_powered_off_in_provider)
 
       @task.customize_destination
     end
 
     it "#poll_destination_powered_off_in_provider" do
-      ManageIQ::Providers::Redhat::InfraManager::Vm.any_instance.should_receive(:with_provider_object).and_return(:state => "up")
-      @task.should_receive(:requeue_phase)
+      expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Vm).to receive(:with_provider_object).and_return(:state => "up")
+      expect(@task).to receive(:requeue_phase)
 
       @task.poll_destination_powered_off_in_provider
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -66,7 +66,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
     end
 
     it "#poll_destination_powered_off_in_provider" do
-      expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Vm).to receive(:with_provider_object).and_return(:state => "up")
+      expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Vm)
+        .to receive(:with_provider_object).and_return(:state => "up")
       expect(@task).to receive(:requeue_phase)
 
       @task.poll_destination_powered_off_in_provider

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
@@ -12,11 +12,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
     end
 
     it "#customize_destination" do
-      @task.stub(:update_and_notify_parent)
+      allow(@task).to receive(:update_and_notify_parent)
 
-      @task.should_receive(:configure_container)
-      @task.should_receive(:attach_floppy_payload)
-      @task.should_receive(:boot_from_cdrom)
+      expect(@task).to receive(:configure_container)
+      expect(@task).to receive(:attach_floppy_payload)
+      expect(@task).to receive(:boot_from_cdrom)
 
       @task.customize_destination
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso_spec.rb
@@ -30,24 +30,24 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
       context "#prepare_for_clone_task" do
         before do
           @ems_cluster = FactoryGirl.create(:ems_cluster, :ems_ref => "test_ref")
-          @vm_prov.stub(:dest_cluster).and_return(@ems_cluster)
+          allow(@vm_prov).to receive(:dest_cluster).and_return(@ems_cluster)
         end
 
         it "with default options" do
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
 
         it "with linked-clone true" do
           @vm_prov.options[:linked_clone] = true
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
 
         it "with linked-clone false" do
           @vm_prov.options[:linked_clone] = false
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
       end
 
@@ -59,19 +59,19 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
         it "when phase is poll_destination_powered_off_in_vmdb" do
           @vm_prov.phase = "poll_destination_powered_off_in_vmdb"
 
-          @vm.should_receive(:stop)
+          expect(@vm).to receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == "poll_destination_powered_off_in_vmdb"
+          expect(@vm_prov.phase).to eq("poll_destination_powered_off_in_vmdb")
         end
 
         it "when phase is not poll_destination_powered_off_in_vmdb" do
           @vm_prov.phase = "post_provision"
 
-          @vm.should_not_receive(:stop)
+          expect(@vm).not_to receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == "post_provision"
+          expect(@vm_prov.phase).to eq("post_provision")
         end
       end
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe_spec.rb
@@ -30,24 +30,24 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe do
       context "#prepare_for_clone_task" do
         before do
           @ems_cluster = FactoryGirl.create(:ems_cluster, :ems_ref => "test_ref")
-          @vm_prov.stub(:dest_cluster).and_return(@ems_cluster)
+          allow(@vm_prov).to receive(:dest_cluster).and_return(@ems_cluster)
         end
 
         it "with default options" do
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
 
         it "with linked-clone true" do
           @vm_prov.options[:linked_clone] = true
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
 
         it "with linked-clone false" do
           @vm_prov.options[:linked_clone] = false
           clone_options = @vm_prov.prepare_for_clone_task
-          clone_options[:clone_type].should == :skeletal
+          expect(clone_options[:clone_type]).to eq(:skeletal)
         end
       end
 
@@ -59,19 +59,19 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe do
         it "when phase is poll_destination_powered_off_in_vmdb" do
           @vm_prov.phase = "poll_destination_powered_off_in_vmdb"
 
-          @vm.should_receive(:stop)
+          expect(@vm).to receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == "poll_destination_powered_off_in_vmdb"
+          expect(@vm_prov.phase).to eq("poll_destination_powered_off_in_vmdb")
         end
 
         it "when phase is not poll_destination_powered_off_in_vmdb" do
           @vm_prov.phase = "post_provision"
 
-          @vm.should_not_receive(:stop)
+          expect(@vm).not_to receive(:stop)
           @vm_prov.provision_completed
 
-          @vm_prov.phase.should == "post_provision"
+          expect(@vm_prov.phase).to eq("post_provision")
         end
       end
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_workflow_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
 
   before do
     stub_dialog(:get_dialogs)
-    described_class.any_instance.stub(:update_field_visibility)
+    allow_any_instance_of(described_class).to receive(:update_field_visibility)
   end
 
   it "pass platform attributes to automate" do
@@ -27,26 +27,26 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
         host.storages << FactoryGirl.create(:storage, :storage_domain_type => domain_type)
       end
       host.reload
-      workflow.stub(:process_filter).and_return(host.storages.to_a)
-      workflow.stub(:allowed_hosts_obj).and_return([host])
+      allow(workflow).to receive(:process_filter).and_return(host.storages.to_a)
+      allow(workflow).to receive(:allowed_hosts_obj).and_return([host])
     end
 
     it "for ISO and PXE provisioning" do
       result = workflow.allowed_storages
-      result.length.should == 2
-      result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
-      result.each { |storage| storage.storage_domain_type.should == "data" }
+      expect(result.length).to eq(2)
+      result.each { |storage| expect(storage).to be_kind_of(MiqHashStruct) }
+      result.each { |storage| expect(storage.storage_domain_type).to eq("data") }
     end
 
     it "for linked-clone provisioning" do
-      workflow.stub(:supports_linked_clone?).and_return(true)
+      allow(workflow).to receive(:supports_linked_clone?).and_return(true)
       template.storage = Storage.where(:storage_domain_type => "data").first
       template.save
 
       result = workflow.allowed_storages
-      result.length.should == 1
-      result.each { |storage| storage.should be_kind_of(MiqHashStruct) }
-      result.each { |storage| storage.storage_domain_type.should == "data" }
+      expect(result.length).to eq(1)
+      result.each { |storage| expect(storage).to be_kind_of(MiqHashStruct) }
+      result.each { |storage| expect(storage.storage_domain_type).to eq("data") }
     end
   end
 
@@ -54,13 +54,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     let(:workflow) { described_class.new({:src_vm_id => template.id, :linked_clone => true}, admin) }
 
     it "when supports_native_clone? is true" do
-      workflow.stub(:supports_native_clone?).and_return(true)
-      workflow.supports_linked_clone?.should be_true
+      allow(workflow).to receive(:supports_native_clone?).and_return(true)
+      expect(workflow.supports_linked_clone?).to be_truthy
     end
 
     it "when supports_native_clone? is false " do
-      workflow.stub(:supports_native_clone?).and_return(false)
-      workflow.supports_linked_clone?.should be_false
+      allow(workflow).to receive(:supports_native_clone?).and_return(false)
+      expect(workflow.supports_linked_clone?).to be_falsey
     end
   end
 
@@ -68,7 +68,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
     let(:workflow) { described_class.new({:src_vm_id => template.id}, admin) }
 
     it "should support cloud-init" do
-      workflow.supports_cloud_init?.should == true
+      expect(workflow.supports_cloud_init?).to eq(true)
     end
   end
 
@@ -77,8 +77,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
 
     it "should retrieve cloud-init templates when cloning" do
       options = {'key' => 'value'}
-      workflow.stub(:supports_native_clone?).and_return(true)
-      workflow.should_receive(:allowed_cloud_init_customization_templates).with(options)
+      allow(workflow).to receive(:supports_native_clone?).and_return(true)
+      expect(workflow).to receive(:allowed_cloud_init_customization_templates).with(options)
       workflow.allowed_customization_templates(options)
     end
 
@@ -92,8 +92,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow do
       workflow.extend(SuperAllowedCustomizationTemplates)
 
       options = {'key' => 'value'}
-      workflow.stub(:supports_native_clone?).and_return(false)
-      workflow.should_receive(:super_allowed_customization_templates).with(options)
+      allow(workflow).to receive(:supports_native_clone?).and_return(false)
+      expect(workflow).to receive(:super_allowed_customization_templates).with(options)
       workflow.allowed_customization_templates(options)
     end
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
@@ -31,7 +31,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::RefreshParser do
       ]}
 
       result = ManageIQ::Providers::Redhat::InfraManager::RefreshParser.vm_inv_to_disk_hashes(disk_inv, {})
-      result.collect { |d| {:interface => d[:controller_type], :location => d[:location], :device_name => d[:device_name]} }.should == [
+      expect(result.collect { |d| {:interface => d[:controller_type], :location => d[:location], :device_name => d[:device_name]} }).to eq([
         {
           :interface   => 'virtio',
           :location    => '0',
@@ -52,7 +52,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::RefreshParser do
           :location    => '0',
           :device_name => 'abc'
         }
-      ]
+      ])
     end
   end
 
@@ -65,14 +65,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::RefreshParser do
         ]
       }
       result = ManageIQ::Providers::Redhat::InfraManager::RefreshParser.vm_inv_to_custom_attribute_hashes(inv)
-      result.should == [
+      expect(result).to eq([
         {
           :section => "custom_field",
           :name    => "custom_attribute",
           :value   => "#{"0" * 252}...",
           :source  => "VC"
         }
-      ]
+      ])
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
@@ -31,7 +31,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::RefreshParser do
       ]}
 
       result = ManageIQ::Providers::Redhat::InfraManager::RefreshParser.vm_inv_to_disk_hashes(disk_inv, {})
-      expect(result.collect { |d| {:interface => d[:controller_type], :location => d[:location], :device_name => d[:device_name]} }).to eq([
+      hashes = result.collect do |d|
+        {:interface   => d[:controller_type],
+         :location    => d[:location],
+         :device_name => d[:device_name]}
+      end
+
+      expect(hashes).to eq([
         {
           :interface   => 'virtio',
           :location    => '0',

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -25,55 +25,55 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    EmsFolder.count.should == 10
-    EmsCluster.count.should == 5
-    Host.count.should == 1
-    ResourcePool.count.should == 5
-    VmOrTemplate.count.should == 35
-    Vm.count.should == 21
-    MiqTemplate.count.should == 14
-    Storage.count.should == 6
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsFolder.count).to eq(10)
+    expect(EmsCluster.count).to eq(5)
+    expect(Host.count).to eq(1)
+    expect(ResourcePool.count).to eq(5)
+    expect(VmOrTemplate.count).to eq(35)
+    expect(Vm.count).to eq(21)
+    expect(MiqTemplate.count).to eq(14)
+    expect(Storage.count).to eq(6)
 
-    CustomAttribute.count.should == 3
-    CustomizationSpec.count.should == 0
-    Disk.count.should == 124
-    GuestDevice.count.should == 26
-    Hardware.count.should == 36
-    Lan.count.should == 2
-    MiqScsiLun.count.should == 0
-    MiqScsiTarget.count.should == 0
-    Network.count.should == 2
-    OperatingSystem.count.should == 36
-    Snapshot.count.should == 41
-    Switch.count.should == 2
-    SystemService.count.should == 0
+    expect(CustomAttribute.count).to eq(3)
+    expect(CustomizationSpec.count).to eq(0)
+    expect(Disk.count).to eq(124)
+    expect(GuestDevice.count).to eq(26)
+    expect(Hardware.count).to eq(36)
+    expect(Lan.count).to eq(2)
+    expect(MiqScsiLun.count).to eq(0)
+    expect(MiqScsiTarget.count).to eq(0)
+    expect(Network.count).to eq(2)
+    expect(OperatingSystem.count).to eq(36)
+    expect(Snapshot.count).to eq(41)
+    expect(Switch.count).to eq(2)
+    expect(SystemService.count).to eq(0)
 
-    Relationship.count.should == 77
+    expect(Relationship.count).to eq(77)
     # MiqQueue.count.should            == 35 #PENDING: Some timing issue keeps flipping this between 35 and 36
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => "3.0.0.0",
       :uid_ems     => nil
     )
 
-    @ems.ems_folders.size.should == 10
-    @ems.ems_clusters.size.should == 5
-    @ems.resource_pools.size.should == 5
-    @ems.storages.size.should == 2 # TODO: The table count is 6, but this is 4 ??
-    @ems.hosts.size.should == 1
-    @ems.vms_and_templates.size.should == 35
-    @ems.vms.size.should == 21
-    @ems.miq_templates.size.should == 14
+    expect(@ems.ems_folders.size).to eq(10)
+    expect(@ems.ems_clusters.size).to eq(5)
+    expect(@ems.resource_pools.size).to eq(5)
+    expect(@ems.storages.size).to eq(2) # TODO: The table count is 6, but this is 4 ??
+    expect(@ems.hosts.size).to eq(1)
+    expect(@ems.vms_and_templates.size).to eq(35)
+    expect(@ems.vms.size).to eq(21)
+    expect(@ems.miq_templates.size).to eq(14)
 
-    @ems.customization_specs.size.should == 0
+    expect(@ems.customization_specs.size).to eq(0)
   end
 
   def assert_specific_cluster
     @cluster = EmsCluster.find_by_name("Cluster2")
-    @cluster.should have_attributes(
+    expect(@cluster).to have_attributes(
       :ems_ref                 => "/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085",
       :ems_ref_obj             => "/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085",
       :uid_ems                 => "40c1c666-e919-11e0-9c6b-005056af0085",
@@ -86,9 +86,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :drs_migration_threshold => nil
     )
 
-    @cluster.all_resource_pools_with_default.size.should == 1
+    expect(@cluster.all_resource_pools_with_default.size).to eq(1)
     @default_rp = @cluster.default_resource_pool
-    @default_rp.should have_attributes(
+    expect(@default_rp).to have_attributes(
       :ems_ref               => nil,
       :ems_ref_obj           => nil,
       :uid_ems               => "40c1c666-e919-11e0-9c6b-005056af0085_respool",
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_storage
     @storage = Storage.find_by_name("HostNFS")
-    @storage.should have_attributes(
+    expect(@storage).to have_attributes(
       :ems_ref                       => "/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4",
       :ems_ref_obj                   => "/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4",
       :name                          => "HostNFS",
@@ -128,7 +128,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_host
     @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by_name("rhelvirt.manageiq.com")
-    @host.should have_attributes(
+    expect(@host).to have_attributes(
       :ems_ref          => "/api/hosts/ca389dbc-2054-11e1-9241-005056af0085",
       :ems_ref_obj      => "/api/hosts/ca389dbc-2054-11e1-9241-005056af0085",
       :name             => "rhelvirt.manageiq.com",
@@ -143,11 +143,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :connection_state => "connected"
     )
 
-    @host.ems_cluster.should == @cluster
-    @host.storages.size.should == 2
-    @host.storages.should      include(@storage)
+    expect(@host.ems_cluster).to eq(@cluster)
+    expect(@host.storages.size).to eq(2)
+    expect(@host.storages).to      include(@storage)
 
-    @host.operating_system.should have_attributes(
+    expect(@host.operating_system).to have_attributes(
       :name         => "192.168.252.119", # TODO: ?????
       :product_name => "linux",
       :version      => nil,
@@ -155,11 +155,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :product_type => nil
     )
 
-    @host.system_services.size.should == 0
+    expect(@host.system_services.size).to eq(0)
 
-    @host.switches.size.should == 2
+    expect(@host.switches.size).to eq(2)
     switch = @host.switches.find_by_name("rhevm")
-    switch.should have_attributes(
+    expect(switch).to have_attributes(
       :uid_ems           => "00000000-0000-0000-0000-000000000009",
       :name              => "rhevm",
       :ports             => nil,
@@ -168,9 +168,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :mac_changes       => nil
     )
 
-    switch.lans.size.should == 1
+    expect(switch.lans.size).to eq(1)
     @lan = switch.lans.find_by_name("rhevm")
-    @lan.should have_attributes(
+    expect(@lan).to have_attributes(
       :uid_ems                    => "00000000-0000-0000-0000-000000000009",
       :name                       => "rhevm",
       :tag                        => nil,
@@ -182,7 +182,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :computed_mac_changes       => nil
     )
 
-    @host.hardware.should have_attributes(
+    expect(@host.hardware).to have_attributes(
       :cpu_speed            => 2394,
       :cpu_type             => "Intel(R) Core(TM)2 Quad CPU    Q6600  @ 2.40GHz",
       :manufacturer         => "",
@@ -200,20 +200,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_usage         => nil
     )
 
-    @host.hardware.networks.size.should == 2
+    expect(@host.hardware.networks.size).to eq(2)
     network = @host.hardware.networks.find_by_description("eth0")
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description  => "eth0",
       :dhcp_enabled => nil,
       :ipaddress    => "192.168.252.119",
       :subnet_mask  => "255.255.254.0"
     )
 
-    @host.hardware.guest_devices.size.should == 2 # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    expect(@host.hardware.guest_devices.size).to eq(2) # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
 
-    @host.hardware.nics.size.should == 2
+    expect(@host.hardware.nics.size).to eq(2)
     nic = @host.hardware.nics.find_by_device_name("eth0")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "dc7bc21d-f0e6-4b1d-a627-adb82dfe9777",
       :device_name     => "eth0",
       :device_type     => "ethernet",
@@ -221,15 +221,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :present         => true,
       :controller_type => "ethernet"
     )
-    nic.switch.should == switch
-    nic.network.should == network
+    expect(nic.switch).to eq(switch)
+    expect(nic.network).to eq(network)
 
-    @host.hardware.storage_adapters.size.should == 0 # TODO: See @host.hardware.guest_devices TODO
+    expect(@host.hardware.storage_adapters.size).to eq(0) # TODO: See @host.hardware.guest_devices TODO
   end
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by_name("EmsRefreshSpec-PoweredOn")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
       :ems_ref_obj           => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
@@ -255,22 +255,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should == @default_rp
-    v.host.should.nil?
-    v.storages.should == [@storage]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to eq(@default_rp)
+    expect(v.host).to be_nil
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
 
-    v.snapshots.size.should == 2
+    expect(v.snapshots.size).to eq(2)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "b5557722-d376-4201-b869-538204f67c01",
       :parent_uid  => "cf999f1f-aa72-4a0b-8fac-b208ce1de882",
       :uid_ems     => "b5557722-d376-4201-b869-538204f67c01",
@@ -281,7 +281,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :filename    => nil
     )
     snapshot = snapshot.parent
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "cf999f1f-aa72-4a0b-8fac-b208ce1de882",
       :parent_uid  => nil,
       :uid_ems     => "cf999f1f-aa72-4a0b-8fac-b208ce1de882",
@@ -289,9 +289,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :description => "_ActiveImage_EmsRefreshSpec-PoweredOn_Wed Sep 26 14:49:58 EDT 2012",
       :current     => 0
     )
-    snapshot.parent.should be_nil
+    expect(snapshot.parent).to be_nil
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -300,9 +300,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb          => 1024
     )
 
-    v.hardware.disks.size.should == 2
+    expect(v.hardware.disks.size).to eq(2)
     disk = v.hardware.disks.find_by_device_name("Disk 1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "Disk 1",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -314,12 +314,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
-    v.hardware.guest_devices.size.should == 3
-    v.hardware.nics.size.should == 3
+    expect(v.hardware.guest_devices.size).to eq(3)
+    expect(v.hardware.nics.size).to eq(3)
     nic = v.hardware.nics.find_by_device_name("nic1")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "82a2b96c-b17d-4d22-9445-31da58f8b24a",
       :device_name     => "nic1",
       :device_type     => "ethernet",
@@ -330,12 +330,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
     # nic.lan.should == @lan # TODO: Hook up this connection
 
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.networks.size).to eq(0)
     network = v.hardware.networks.first
-    network.should be_nil
+    expect(network).to be_nil
     # nic.network.should == network # TODO: Hook up this connection
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :ems_ref_obj   => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085",
@@ -345,7 +345,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -355,7 +355,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085_vm",
@@ -368,7 +368,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_vm_powered_off
     v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by_name("EmsRefreshSpec-PoweredOff")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
       :ems_ref_obj           => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
@@ -394,22 +394,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should == @default_rp
-    v.host.should                  be_nil
-    v.storages.should == [@storage]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to eq(@default_rp)
+    expect(v.host).to                  be_nil
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
 
-    v.snapshots.size.should == 4
+    expect(v.snapshots.size).to eq(4)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "4ecc2f4c-2932-4eea-8597-e6aad5da305a",
       :parent_uid  => "abf6f7aa-cd46-426e-83be-9f7a492a073b",
       :uid_ems     => "4ecc2f4c-2932-4eea-8597-e6aad5da305a",
@@ -420,7 +420,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :filename    => nil
     )
     snapshot = snapshot.parent
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "abf6f7aa-cd46-426e-83be-9f7a492a073b",
       :parent_uid  => "123c6a56-7998-4275-bb8d-0f232f5d19a5",
       :uid_ems     => "abf6f7aa-cd46-426e-83be-9f7a492a073b",
@@ -429,7 +429,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :current     => 0
     )
     snapshot = snapshot.parent
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "123c6a56-7998-4275-bb8d-0f232f5d19a5",
       :parent_uid  => "1eaef769-fea8-4177-9f94-b78ef8f7a992",
       :uid_ems     => "123c6a56-7998-4275-bb8d-0f232f5d19a5",
@@ -438,7 +438,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :current     => 0
     )
     snapshot = snapshot.parent # TODO: This doesn't seem right. Also check powered on and template.
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "1eaef769-fea8-4177-9f94-b78ef8f7a992",
       :parent_uid  => nil,
       :uid_ems     => "1eaef769-fea8-4177-9f94-b78ef8f7a992",
@@ -446,9 +446,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :description => "Snapshot1",
       :current     => 0
     )
-    snapshot.parent.should be_nil
+    expect(snapshot.parent).to be_nil
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -457,9 +457,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb          => 1024
     )
 
-    v.hardware.disks.size.should == 2
+    expect(v.hardware.disks.size).to eq(2)
     disk = v.hardware.disks.find_by_device_name("Disk 1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "Disk 1",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -471,12 +471,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
-    v.hardware.guest_devices.size.should == 3
-    v.hardware.nics.size.should == 3
+    expect(v.hardware.guest_devices.size).to eq(3)
+    expect(v.hardware.nics.size).to eq(3)
     nic = v.hardware.nics.find_by_device_name("nic1")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "c586cd90-fc74-4b17-9fad-f5a559b40bf2",
       :device_name     => "nic1",
       :device_type     => "ethernet",
@@ -485,12 +485,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :start_connected => true,
       :address         => "00:1a:4a:a8:fc:0c"
     )
-    nic.lan.should     be_nil
-    nic.network.should be_nil
+    expect(nic.lan).to     be_nil
+    expect(nic.network).to be_nil
 
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.networks.size).to eq(0)
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :ems_ref_obj   => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085",
@@ -500,7 +500,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -510,7 +510,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085_vm",
@@ -523,7 +523,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_template
     v = ManageIQ::Providers::Redhat::InfraManager::Template.find_by_name("EmsRefreshSpec")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => true,
       :ems_ref               => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
       :ems_ref_obj           => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
@@ -548,21 +548,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should  be_nil
-    v.host.should                  be_nil
-    v.storages.should == [@storage]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to  be_nil
+    expect(v.host).to                  be_nil
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os             => "rhel_6x64",
       :guest_os_full_name   => nil,
       :bios                 => nil,
@@ -573,9 +573,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb            => 1024
     )
 
-    v.hardware.disks.size.should == 2
+    expect(v.hardware.disks.size).to eq(2)
     disk = v.hardware.disks.find_by_device_name("Disk 1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "Disk 1",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -587,13 +587,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
-    v.hardware.guest_devices.size.should == 0 # TODO: Should this be 3 like the other tests?
-    v.hardware.nics.size.should == 0
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.guest_devices.size).to eq(0) # TODO: Should this be 3 like the other tests?
+    expect(v.hardware.nics.size).to eq(0)
+    expect(v.hardware.networks.size).to eq(0)
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :ems_ref_obj   => "/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085",
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085",
@@ -603,7 +603,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -613,7 +613,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "eb5592d2-ce76-11e0-a703-005056af0085_vm",
@@ -625,7 +625,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree(
+    expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
         [EmsFolder, "DC-iSCSI", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -209,7 +209,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :subnet_mask  => "255.255.254.0"
     )
 
-    expect(@host.hardware.guest_devices.size).to eq(2) # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    expect(@host.hardware.guest_devices.size).to eq(2)
 
     expect(@host.hardware.nics.size).to eq(2)
     nic = @host.hardware.nics.find_by_device_name("eth0")
@@ -397,7 +398,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(v.ext_management_system).to eq(@ems)
     expect(v.ems_cluster).to eq(@cluster)
     expect(v.parent_resource_pool).to eq(@default_rp)
-    expect(v.host).to                  be_nil
+    expect(v.host).to be_nil
     expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -225,7 +225,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :subnet_mask  => "255.255.254.0"
     )
 
-    expect(@host.hardware.guest_devices.size).to eq(2) # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    expect(@host.hardware.guest_devices.size).to eq(2)
 
     expect(@host.hardware.nics.size).to eq(2)
     nic = @host.hardware.nics.find_by_device_name("em1")
@@ -426,7 +427,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(v.ext_management_system).to eq(@ems)
     expect(v.ems_cluster).to eq(@cluster)
     expect(v.parent_resource_pool).to eq(@default_rp)
-    expect(v.host).to                  be_nil
+    expect(v.host).to be_nil
     expect(v.storages).to eq([@storage2])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -25,55 +25,55 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    EmsFolder.count.should == 7
-    EmsCluster.count.should == 4
-    Host.count.should == 2
-    ResourcePool.count.should == 4
-    VmOrTemplate.count.should == 38
-    Vm.count.should == 27
-    MiqTemplate.count.should == 11
-    Storage.count.should == 7
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsFolder.count).to eq(7)
+    expect(EmsCluster.count).to eq(4)
+    expect(Host.count).to eq(2)
+    expect(ResourcePool.count).to eq(4)
+    expect(VmOrTemplate.count).to eq(38)
+    expect(Vm.count).to eq(27)
+    expect(MiqTemplate.count).to eq(11)
+    expect(Storage.count).to eq(7)
 
-    CustomAttribute.count.should == 0 # TODO: 3.0 spec has values for this
-    CustomizationSpec.count.should == 0
-    Disk.count.should == 66
-    GuestDevice.count.should == 29
-    Hardware.count.should == 40
-    Lan.count.should == 3
-    MiqScsiLun.count.should == 0
-    MiqScsiTarget.count.should == 0
-    Network.count.should == 5
-    OperatingSystem.count.should == 40
-    Snapshot.count.should == 32
-    Switch.count.should == 3
-    SystemService.count.should == 0
+    expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
+    expect(CustomizationSpec.count).to eq(0)
+    expect(Disk.count).to eq(66)
+    expect(GuestDevice.count).to eq(29)
+    expect(Hardware.count).to eq(40)
+    expect(Lan.count).to eq(3)
+    expect(MiqScsiLun.count).to eq(0)
+    expect(MiqScsiTarget.count).to eq(0)
+    expect(Network.count).to eq(5)
+    expect(OperatingSystem.count).to eq(40)
+    expect(Snapshot.count).to eq(32)
+    expect(Switch.count).to eq(3)
+    expect(SystemService.count).to eq(0)
 
-    Relationship.count.should == 81
-    MiqQueue.count.should == 41
+    expect(Relationship.count).to eq(81)
+    expect(MiqQueue.count).to eq(41)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => "3.1.0.0",
       :uid_ems     => nil
     )
 
-    @ems.ems_folders.size.should == 7
-    @ems.ems_clusters.size.should == 4
-    @ems.resource_pools.size.should == 4
-    @ems.storages.size.should == 7
-    @ems.hosts.size.should == 2
-    @ems.vms_and_templates.size.should == 38
-    @ems.vms.size.should == 27
-    @ems.miq_templates.size.should == 11
+    expect(@ems.ems_folders.size).to eq(7)
+    expect(@ems.ems_clusters.size).to eq(4)
+    expect(@ems.resource_pools.size).to eq(4)
+    expect(@ems.storages.size).to eq(7)
+    expect(@ems.hosts.size).to eq(2)
+    expect(@ems.vms_and_templates.size).to eq(38)
+    expect(@ems.vms.size).to eq(27)
+    expect(@ems.miq_templates.size).to eq(11)
 
-    @ems.customization_specs.size.should == 0
+    expect(@ems.customization_specs.size).to eq(0)
   end
 
   def assert_specific_cluster
     @cluster = EmsCluster.find_by_name("iSCSI")
-    @cluster.should have_attributes(
+    expect(@cluster).to have_attributes(
       :ems_ref                 => "/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95",
       :ems_ref_obj             => "/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95",
       :uid_ems                 => "99408929-82cf-4dc7-a532-9d998063fa95",
@@ -86,9 +86,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :drs_migration_threshold => nil
     )
 
-    @cluster.all_resource_pools_with_default.size.should == 1
+    expect(@cluster.all_resource_pools_with_default.size).to eq(1)
     @default_rp = @cluster.default_resource_pool
-    @default_rp.should have_attributes(
+    expect(@default_rp).to have_attributes(
       :ems_ref               => nil,
       :ems_ref_obj           => nil,
       :uid_ems               => "99408929-82cf-4dc7-a532-9d998063fa95_respool",
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_storage
     @storage = Storage.find_by_name("NetApp01Lun2")
-    @storage.should have_attributes(
+    expect(@storage).to have_attributes(
       :ems_ref                       => "/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f",
       :ems_ref_obj                   => "/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f",
       :name                          => "NetApp01Lun2",
@@ -126,7 +126,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
 
     @storage2 = Storage.find_by_name("RHEVM31-1")
-    @storage2.should have_attributes(
+    expect(@storage2).to have_attributes(
       :ems_ref                       => "/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96",
       :ems_ref_obj                   => "/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96",
       :name                          => "RHEVM31-1",
@@ -144,7 +144,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_host
     @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by_name("per410-rh1")
-    @host.should have_attributes(
+    expect(@host).to have_attributes(
       :ems_ref          => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
       :ems_ref_obj      => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
       :name             => "per410-rh1",
@@ -159,11 +159,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :connection_state => "connected"
     )
 
-    @host.ems_cluster.should == @cluster
-    @host.storages.size.should == 4
-    @host.storages.should      include(@storage)
+    expect(@host.ems_cluster).to eq(@cluster)
+    expect(@host.storages.size).to eq(4)
+    expect(@host.storages).to      include(@storage)
 
-    @host.operating_system.should have_attributes(
+    expect(@host.operating_system).to have_attributes(
       :name         => "192.168.252.232", # TODO: ?????
       :product_name => "linux",
       :version      => nil,
@@ -171,11 +171,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :product_type => nil
     )
 
-    @host.system_services.size.should == 0
+    expect(@host.system_services.size).to eq(0)
 
-    @host.switches.size.should == 2
+    expect(@host.switches.size).to eq(2)
     switch = @host.switches.find_by_name("rhevm")
-    switch.should have_attributes(
+    expect(switch).to have_attributes(
       :uid_ems           => "00000000-0000-0000-0000-000000000009",
       :name              => "rhevm",
       :ports             => nil,
@@ -184,9 +184,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :mac_changes       => nil
     )
 
-    switch.lans.size.should == 1
+    expect(switch.lans.size).to eq(1)
     @lan = switch.lans.find_by_name("rhevm")
-    @lan.should have_attributes(
+    expect(@lan).to have_attributes(
       :uid_ems                    => "00000000-0000-0000-0000-000000000009",
       :name                       => "rhevm",
       :tag                        => nil,
@@ -198,7 +198,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :computed_mac_changes       => nil
     )
 
-    @host.hardware.should have_attributes(
+    expect(@host.hardware).to have_attributes(
       :cpu_speed            => 1995,
       :cpu_type             => "Intel(R) Xeon(R) CPU           E5504  @ 2.00GHz",
       :manufacturer         => "",
@@ -216,20 +216,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_usage         => nil
     )
 
-    @host.hardware.networks.size.should == 2
+    expect(@host.hardware.networks.size).to eq(2)
     network = @host.hardware.networks.find_by_description("em1")
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description  => "em1",
       :dhcp_enabled => nil,
       :ipaddress    => "192.168.252.232",
       :subnet_mask  => "255.255.254.0"
     )
 
-    @host.hardware.guest_devices.size.should == 2 # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
+    expect(@host.hardware.guest_devices.size).to eq(2) # TODO: Verify this host should have 2 nics, 2 cdroms, 1 floppy, any storage adapters?
 
-    @host.hardware.nics.size.should == 2
+    expect(@host.hardware.nics.size).to eq(2)
     nic = @host.hardware.nics.find_by_device_name("em1")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "1e783be8-fe80-456e-9a19-42329b03f28c",
       :device_name     => "em1",
       :device_type     => "ethernet",
@@ -237,15 +237,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :present         => true,
       :controller_type => "ethernet"
     )
-    nic.switch.should == switch
-    nic.network.should == network
+    expect(nic.switch).to eq(switch)
+    expect(nic.network).to eq(network)
 
-    @host.hardware.storage_adapters.size.should == 0 # TODO: See @host.hardware.guest_devices TODO
+    expect(@host.hardware.storage_adapters.size).to eq(0) # TODO: See @host.hardware.guest_devices TODO
   end
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by_name("EmsRefreshSpec-PoweredOn")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
       :ems_ref_obj           => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
@@ -271,22 +271,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should == @default_rp
-    v.host.should == @host
-    v.storages.should == [@storage]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to eq(@default_rp)
+    expect(v.host).to eq(@host)
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
 
-    v.snapshots.size.should == 1
+    expect(v.snapshots.size).to eq(1)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "d7db04c1-9030-4c39-8618-3978787c3278",
       :parent_uid  => nil,
       :uid_ems     => "d7db04c1-9030-4c39-8618-3978787c3278",
@@ -296,9 +296,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :total_size  => nil,
       :filename    => nil
     )
-    snapshot.parent.should be_nil
+    expect(snapshot.parent).to be_nil
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os             => "rhel_6x64",
       :guest_os_full_name   => nil,
       :bios                 => nil,
@@ -309,9 +309,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb            => 1024
     )
 
-    v.hardware.disks.size.should == 3
+    expect(v.hardware.disks.size).to eq(3)
     disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec-PoweredOn_Disk1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "EmsRefreshSpec-PoweredOn_Disk1",
       :device_type     => "disk",
       :controller_type => "ide",
@@ -323,11 +323,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
     # DirectLUN disk
     disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec-PoweredOn_Disk3")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "EmsRefreshSpec-PoweredOn_Disk3",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -339,12 +339,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thick",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
-    v.hardware.guest_devices.size.should == 3
-    v.hardware.nics.size.should == 3
+    expect(v.hardware.guest_devices.size).to eq(3)
+    expect(v.hardware.nics.size).to eq(3)
     nic = v.hardware.nics.find_by_device_name("nic1")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "98610918-86f6-45a9-b96f-b9849ab3ad7d",
       :device_name     => "nic1",
       :device_type     => "ethernet",
@@ -355,16 +355,16 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
     # nic.lan.should == @lan # TODO: Hook up this connection
 
-    v.hardware.networks.size.should == 1
+    expect(v.hardware.networks.size).to eq(1)
     network = v.hardware.networks.first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :hostname    => nil, # TODO: Should be miq-winxpsp3 (or something like that)?
       :ipaddress   => "192.168.253.45",
       :ipv6address => nil
     )
     # nic.network.should == network # TODO: Hook up this connection
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :ems_ref_obj   => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db",
@@ -374,7 +374,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -384,7 +384,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
@@ -397,7 +397,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_vm_powered_off
     v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by_name("EmsRefreshSpec-PoweredOff")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
       :ems_ref_obj           => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
@@ -423,22 +423,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should == @default_rp
-    v.host.should                  be_nil
-    v.storages.should == [@storage2]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to eq(@default_rp)
+    expect(v.host).to                  be_nil
+    expect(v.storages).to eq([@storage2])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
 
-    v.snapshots.size.should == 3
+    expect(v.snapshots.size).to eq(3)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "a49102de-1e2a-45b7-b464-185f959dbfbb",
       :parent_uid  => "edbc4501-23a6-45c9-a736-b378f45a2aec",
       :uid_ems     => "a49102de-1e2a-45b7-b464-185f959dbfbb",
@@ -449,7 +449,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :filename    => nil
     )
     snapshot = snapshot.parent # TODO: THIS IS COMPLETELY WRONG
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "edbc4501-23a6-45c9-a736-b378f45a2aec",
       :parent_uid  => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
       :uid_ems     => "edbc4501-23a6-45c9-a736-b378f45a2aec",
@@ -458,7 +458,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :current     => 0
     )
     snapshot = snapshot.parent
-    snapshot.should have_attributes(
+    expect(snapshot).to have_attributes(
       :uid         => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
       :parent_uid  => nil,
       :uid_ems     => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
@@ -466,9 +466,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :description => "Snapshot2",
       :current     => 0
     )
-    snapshot.parent.should be_nil
+    expect(snapshot.parent).to be_nil
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "rhel_6x64",
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -477,9 +477,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb          => 1024
     )
 
-    v.hardware.disks.size.should == 2
+    expect(v.hardware.disks.size).to eq(2)
     disk = v.hardware.disks.find_by_device_name("Disk 1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "Disk 1",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -491,12 +491,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage2
+    expect(disk.storage).to eq(@storage2)
 
-    v.hardware.guest_devices.size.should == 3
-    v.hardware.nics.size.should == 3
+    expect(v.hardware.guest_devices.size).to eq(3)
+    expect(v.hardware.nics.size).to eq(3)
     nic = v.hardware.nics.find_by_device_name("nic1")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "f2b9d3dc-e948-4ec9-a746-b03c409cfd18",
       :device_name     => "nic1",
       :device_type     => "ethernet",
@@ -505,12 +505,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :start_connected => true,
       :address         => "00:1a:4a:a8:fc:0c"
     )
-    nic.lan.should     be_nil
-    nic.network.should be_nil
+    expect(nic.lan).to     be_nil
+    expect(nic.network).to be_nil
 
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.networks.size).to eq(0)
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :ems_ref_obj   => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db",
@@ -520,7 +520,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -530,7 +530,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
@@ -543,7 +543,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
   def assert_specific_template
     v = ManageIQ::Providers::Redhat::InfraManager::Template.find_by_name("EmsRefreshSpec-Template")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => true,
       :ems_ref               => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
       :ems_ref_obj           => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
@@ -568,21 +568,21 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should  be_nil
-    v.host.should                  be_nil
-    v.storages.should == [@storage2]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to  be_nil
+    expect(v.host).to                  be_nil
+    expect(v.storages).to eq([@storage2])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "rhel_6x64"
     )
 
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os             => "rhel_6x64",
       :guest_os_full_name   => nil,
       :bios                 => nil,
@@ -593,9 +593,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb            => 1024
     )
 
-    v.hardware.disks.size.should == 2
+    expect(v.hardware.disks.size).to eq(2)
     disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec_Disk1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "EmsRefreshSpec_Disk1",
       :device_type     => "disk",
       :controller_type => "virtio",
@@ -607,13 +607,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage2
+    expect(disk.storage).to eq(@storage2)
 
-    v.hardware.guest_devices.size.should == 0 # TODO: Should this be 3 like the other tests?
-    v.hardware.nics.size.should == 0
-    v.hardware.networks.size.should == 0
+    expect(v.hardware.guest_devices.size).to eq(0) # TODO: Should this be 3 like the other tests?
+    expect(v.hardware.nics.size).to eq(0)
+    expect(v.hardware.networks.size).to eq(0)
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :ems_ref_obj   => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db",
@@ -623,7 +623,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters/Default"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "root_dc",
@@ -633,7 +633,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => nil,
       :ems_ref_obj   => nil,
       :uid_ems       => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
@@ -645,7 +645,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree(
+    expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters"] => {
         [EmsFolder, "Default"] => {
           [EmsFolder, "host"] => {

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -75,7 +75,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
     let(:vm) { FactoryGirl.create(:vm_redhat) }
 
     it "#reconfigurable?" do
-      expect(vm.reconfigurable?).to be_true
+      expect(vm.reconfigurable?).to be_truthy
     end
 
     it "#max_total_vcpus" do

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Redhat::InfraManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'rhevm'
+    expect(described_class.ems_type).to eq('rhevm')
   end
 
   it ".description" do
-    described_class.description.should == 'Red Hat Enterprise Virtualization Manager'
+    expect(described_class.description).to eq('Red Hat Enterprise Virtualization Manager')
   end
 
   describe ".metrics_collector_queue_name" do
@@ -18,12 +18,12 @@ describe ManageIQ::Providers::Redhat::InfraManager do
 
   it "rhevm_metrics_connect_options" do
     h = FactoryGirl.create(:ems_redhat, :hostname => "h")
-    h.rhevm_metrics_connect_options[:host].should == "h"
+    expect(h.rhevm_metrics_connect_options[:host]).to eq("h")
   end
 
   it "rhevm_metrics_connect_options overrides" do
     h = FactoryGirl.create(:ems_redhat, :hostname => "h")
-    h.rhevm_metrics_connect_options(:hostname => "i")[:host].should == "i"
+    expect(h.rhevm_metrics_connect_options(:hostname => "i")[:host]).to eq("i")
   end
 
   context "#vm_reconfigure" do
@@ -42,16 +42,16 @@ describe ManageIQ::Providers::Redhat::InfraManager do
                            "numCoresPerSocket" => @cores_per_socket}
 
       @rhevm_vm = double('rhevm_vm').as_null_object
-      @vm.stub(:with_provider_object).and_yield(@rhevm_vm)
+      allow(@vm).to receive(:with_provider_object).and_yield(@rhevm_vm)
     end
 
     it "cpu_topology=" do
-      @rhevm_vm.should_receive(:cpu_topology=).with(:cores => @cores_per_socket, :sockets => @num_of_sockets)
+      expect(@rhevm_vm).to receive(:cpu_topology=).with(:cores => @cores_per_socket, :sockets => @num_of_sockets)
       @ems.vm_reconfigure(@vm, :spec => @spec)
     end
 
     it "memory=" do
-      @rhevm_vm.should_receive(:memory=).with(@total_mem_in_mb.megabytes)
+      expect(@rhevm_vm).to receive(:memory=).with(@total_mem_in_mb.megabytes)
       @ems.vm_reconfigure(@vm, :spec => @spec)
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
       event = YAML.load_file(File.join(EPV_DATA_DIR, 'general_user_event.yml'))
       data = described_class.event_to_hash(event, 12345)
 
-      data.should have_attributes(
+      expect(data).to have_attributes(
         :event_type   => "GeneralUserEvent",
         :chain_id     => "5361104",
         :is_task      => false,
@@ -26,9 +26,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         :host_name    => "yoda.manageiq.com",
       )
 
-      data[:full_data].should    be_instance_of VimHash
-      data[:vm_ems_ref].should   be_instance_of String
-      data[:host_ems_ref].should be_instance_of String
+      expect(data[:full_data]).to    be_instance_of VimHash
+      expect(data[:vm_ems_ref]).to   be_instance_of String
+      expect(data[:host_ems_ref]).to be_instance_of String
     end
 
     context "with an EventEx event" do
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         data = described_class.event_to_hash(event, 12345)
 
         assert_result_fields(data, event)
-        data.should have_attributes(
+        expect(data).to have_attributes(
           :event_type => "vprob.vmfs.resource.corruptondisk",
           :message    => "event.vprob.vmfs.resource.corruptondisk.fullFormat (vprob.vmfs.resource.corruptondisk)"
         )
@@ -48,14 +48,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         data = described_class.event_to_hash(event, 12345)
 
         assert_result_fields(data, event)
-        data.should have_attributes(
+        expect(data).to have_attributes(
           :event_type => "EventEx",
           :message    => ""
         )
       end
 
       def assert_result_fields(data, event)
-        data.should have_attributes(
+        expect(data).to have_attributes(
           :chain_id     => "297179",
           :is_task      => false,
           :source       => "VC",
@@ -71,8 +71,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
           :host_name    => "vi4esx1.galaxy.local",
         )
 
-        data[:full_data].should    be_instance_of VimHash
-        data[:host_ems_ref].should be_instance_of String
+        expect(data[:full_data]).to    be_instance_of VimHash
+        expect(data[:host_ems_ref]).to be_instance_of String
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/host_spec.rb
@@ -15,36 +15,36 @@ describe ManageIQ::Providers::Vmware::InfraManager::Host do
       it "normal case" do
         @host.update_attributes(:next_available_vnc_port => 5901)
 
-        @host.reserve_next_available_vnc_port.should == 5901
-        @host.next_available_vnc_port.should == 5902
+        expect(@host.reserve_next_available_vnc_port).to eq(5901)
+        expect(@host.next_available_vnc_port).to eq(5902)
       end
 
       it "with last value of nil" do
         @host.update_attributes(:next_available_vnc_port => nil)
 
-        @host.reserve_next_available_vnc_port.should == 5900
-        @host.next_available_vnc_port.should == 5901
+        expect(@host.reserve_next_available_vnc_port).to eq(5900)
+        expect(@host.next_available_vnc_port).to eq(5901)
       end
 
       it "with last value at end of range" do
         @host.update_attributes(:next_available_vnc_port => 5999)
 
-        @host.reserve_next_available_vnc_port.should == 5999
-        @host.next_available_vnc_port.should == 5900
+        expect(@host.reserve_next_available_vnc_port).to eq(5999)
+        expect(@host.next_available_vnc_port).to eq(5900)
       end
 
       it "with last value before start of range" do
         @host.update_attributes(:next_available_vnc_port => 5899)
 
-        @host.reserve_next_available_vnc_port.should == 5900
-        @host.next_available_vnc_port.should == 5901
+        expect(@host.reserve_next_available_vnc_port).to eq(5900)
+        expect(@host.next_available_vnc_port).to eq(5901)
       end
 
       it "with last value after end of range" do
         @host.update_attributes(:next_available_vnc_port => 6000)
 
-        @host.reserve_next_available_vnc_port.should == 5900
-        @host.next_available_vnc_port.should == 5901
+        expect(@host.reserve_next_available_vnc_port).to eq(5900)
+        expect(@host.next_available_vnc_port).to eq(5901)
       end
     end
 
@@ -57,36 +57,36 @@ describe ManageIQ::Providers::Vmware::InfraManager::Host do
       it "normal case" do
         @host.update_attributes(:next_available_vnc_port => 5926)
 
-        @host.reserve_next_available_vnc_port.should == 5926
-        @host.next_available_vnc_port.should == 5927
+        expect(@host.reserve_next_available_vnc_port).to eq(5926)
+        expect(@host.next_available_vnc_port).to eq(5927)
       end
 
       it "with last value of nil" do
         @host.update_attributes(:next_available_vnc_port => nil)
 
-        @host.reserve_next_available_vnc_port.should == 5925
-        @host.next_available_vnc_port.should == 5926
+        expect(@host.reserve_next_available_vnc_port).to eq(5925)
+        expect(@host.next_available_vnc_port).to eq(5926)
       end
 
       it "with last value at end of range" do
         @host.update_attributes(:next_available_vnc_port => 5930)
 
-        @host.reserve_next_available_vnc_port.should == 5930
-        @host.next_available_vnc_port.should == 5925
+        expect(@host.reserve_next_available_vnc_port).to eq(5930)
+        expect(@host.next_available_vnc_port).to eq(5925)
       end
 
       it "with last value before start of range" do
         @host.update_attributes(:next_available_vnc_port => 5924)
 
-        @host.reserve_next_available_vnc_port.should == 5925
-        @host.next_available_vnc_port.should == 5926
+        expect(@host.reserve_next_available_vnc_port).to eq(5925)
+        expect(@host.next_available_vnc_port).to eq(5926)
       end
 
       it "with last value after end of range" do
         @host.update_attributes(:next_available_vnc_port => 5931)
 
-        @host.reserve_next_available_vnc_port.should == 5925
-        @host.next_available_vnc_port.should == 5926
+        expect(@host.reserve_next_available_vnc_port).to eq(5925)
+        expect(@host.next_available_vnc_port).to eq(5926)
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/placement_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/placement_spec.rb
@@ -31,7 +31,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
     end
 
     it "#automatic_placement" do
-      @task.should_receive(:get_most_suitable_host_and_storage).and_return([@host, @storage])
+      expect(@task).to receive(:get_most_suitable_host_and_storage).and_return([@host, @storage])
       @task.options[:placement_auto] = true
       check
     end
@@ -39,15 +39,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
     it "automate returns nothing" do
       @task.options[:placement_host_name] = @host.id
       @task.options[:placement_ds_name]   = @storage.id
-      @task.should_receive(:get_most_suitable_host_and_storage).and_return([nil, nil])
+      expect(@task).to receive(:get_most_suitable_host_and_storage).and_return([nil, nil])
       @task.options[:placement_auto] = true
       check
     end
 
     def check
       host, storage = @task.send(:placement)
-      host.should eql(@host)
-      storage.should eql(@storage)
+      expect(host).to eql(@host)
+      expect(storage).to eql(@storage)
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
 
       it "#workflow" do
         workflow_class = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow
-        workflow_class.any_instance.stub(:get_dialogs).and_return(:dialogs => {})
+        allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
 
         expect(@vm_prov.workflow.class).to eq workflow_class
         expect(@vm_prov.workflow_class).to eq workflow_class
@@ -37,49 +37,49 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         @vm_prov.options.merge!(:vm_memory => '1024', :number_of_cpus => 2)
         @vm_prov.phase_context[:new_vm_validation_guid] = "12345"
         @vm_prov.destination = @vm_template
-        @vm_prov.should_receive(:build_config_network_adapters)
+        expect(@vm_prov).to receive(:build_config_network_adapters)
         spec = @vm_prov.build_config_spec
-        spec.should be_kind_of(VimHash)
-        spec.xsiType.should == 'VirtualMachineConfigSpec'
-        spec["memoryMB"].should == 1024
-        spec["numCPUs"].should == 2
-        spec["annotation"].should include(@vm_prov.phase_context[:new_vm_validation_guid])
+        expect(spec).to be_kind_of(VimHash)
+        expect(spec.xsiType).to eq('VirtualMachineConfigSpec')
+        expect(spec["memoryMB"]).to eq(1024)
+        expect(spec["numCPUs"]).to eq(2)
+        expect(spec["annotation"]).to include(@vm_prov.phase_context[:new_vm_validation_guid])
       end
 
       it "should return a transform spec" do
         spec = @vm_prov.build_transform_spec
-        spec.should be_nil
+        expect(spec).to be_nil
         @vm_prov.options.merge!(:disk_format => 'thin')
         spec = @vm_prov.build_transform_spec
-        spec.should be_kind_of(VimString)
-        spec.vimType.should == 'VirtualMachineRelocateTransformation'
+        expect(spec).to be_kind_of(VimString)
+        expect(spec.vimType).to eq('VirtualMachineRelocateTransformation')
       end
 
       it "should detect when a reconfigure_hardware_on_destination call is required" do
         target_vm = FactoryGirl.create(:vm_vmware, :name => "target_vm1", :location => "abc/def.vmx", :cpu_limit => @vm_prov.options[:cpu_limit])
         @vm_prov.destination = target_vm
-        @vm_prov.reconfigure_hardware_on_destination?.should == false
+        expect(@vm_prov.reconfigure_hardware_on_destination?).to eq(false)
         @vm_prov.options[:cpu_limit] = 100
-        @vm_prov.reconfigure_hardware_on_destination?.should == true
+        expect(@vm_prov.reconfigure_hardware_on_destination?).to eq(true)
       end
 
       it "should delete unneeded network cards" do
         requested_networks = [{:network => "Build", :devicetype => "VirtualE1000"}, {:network => "Enterprise", :devicetype => "VirtualE1000"}]
         template_networks  = [{"connectable" => {"startConnected" => "true"}, "unitNumber" => "7", "controllerKey" => "100", "addressType" => "assigned", "macAddress" => "00:50:56:af:00:50", "deviceInfo" => {"label" => "Network adapter 1", "summary" => "VM Network"}, "backing" => {"deviceName" => "VM Network", "network" => "network-658"}, "key" => "4000"}]
 
-        @vm_prov.stub(:normalize_network_adapter_settings).and_return(requested_networks)
-        @vm_prov.stub(:get_network_adapters).and_return(template_networks)
-        @vm_prov.should_receive(:build_config_spec_vlan).twice
+        allow(@vm_prov).to receive(:normalize_network_adapter_settings).and_return(requested_networks)
+        allow(@vm_prov).to receive(:get_network_adapters).and_return(template_networks)
+        expect(@vm_prov).to receive(:build_config_spec_vlan).twice
 
         vmcs = VimHash.new("VirtualMachineConfigSpec")
-        -> { @vm_prov.build_config_network_adapters(vmcs) }.should_not raise_error
+        expect { @vm_prov.build_config_network_adapters(vmcs) }.not_to raise_error
       end
 
       it "eligible_hosts" do
         host = FactoryGirl.create(:host, :ext_management_system => @ems)
         host_struct = [MiqHashStruct.new(:id => host.id, :evm_object_class => host.class.base_class.name.to_sym)]
-        MiqProvisionWorkflow.any_instance.stub(:allowed_hosts).and_return(host_struct)
-        @vm_prov.eligible_resources(:hosts).should == [host]
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_hosts).and_return(host_struct)
+        expect(@vm_prov.eligible_resources(:hosts)).to eq([host])
       end
 
       it "eligible_resources with bad resource" do
@@ -87,43 +87,43 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
       end
 
       it "disable customization_spec" do
-        @vm_prov.should_receive(:disable_customization_spec).once
-        @vm_prov.set_customization_spec(nil).should be_true
+        expect(@vm_prov).to receive(:disable_customization_spec).once
+        expect(@vm_prov.set_customization_spec(nil)).to be_truthy
       end
 
       context "with destination VM" do
         before(:each) do
           @vm_prov.destination = Vm.first
           @vm_prov.destination.ext_management_system = @ems
-          @vm_prov.stub(:my_zone).and_return("default")
+          allow(@vm_prov).to receive(:my_zone).and_return("default")
         end
 
         it "autostart_destination, vm_auto_start disabled" do
-          @vm_prov.destination.should_not_receive(:start)
-          @vm_prov.should_receive(:post_create_destination)
+          expect(@vm_prov.destination).not_to receive(:start)
+          expect(@vm_prov).to receive(:post_create_destination)
           @vm_prov.signal :autostart_destination
         end
 
         it "autostart_destination" do
           @vm_prov.options[:vm_auto_start] = true
-          @vm_prov.destination.should_receive(:start)
-          @vm_prov.should_receive(:post_create_destination)
+          expect(@vm_prov.destination).to receive(:start)
+          expect(@vm_prov).to receive(:post_create_destination)
           @vm_prov.signal :autostart_destination
         end
 
         it "autostart_destination with error" do
           @vm_prov.options[:vm_auto_start] = true
-          @vm_prov.destination.stub(:start).and_raise
-          @vm_prov.destination.should_receive(:start).once
-          @ems.should_receive(:reset_vim_cache).never
+          allow(@vm_prov.destination).to receive(:start).and_raise
+          expect(@vm_prov.destination).to receive(:start).once
+          expect(@ems).to receive(:reset_vim_cache).never
           @vm_prov.signal :autostart_destination
         end
 
         it "autostart_destination with MiqVimResourceNotFound" do
           @vm_prov.options[:vm_auto_start] = true
-          @vm_prov.destination.stub(:start).and_raise(MiqException::MiqVimResourceNotFound)
-          @vm_prov.destination.should_receive(:start).twice
-          @ems.should_receive(:reset_vim_cache).once
+          allow(@vm_prov.destination).to receive(:start).and_raise(MiqException::MiqVimResourceNotFound)
+          expect(@vm_prov.destination).to receive(:start).twice
+          expect(@ems).to receive(:reset_vim_cache).once
           @vm_prov.signal :autostart_destination
         end
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
@@ -21,12 +21,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   def assert_failed_refresh(error)
-    @ems.last_refresh_status.should == "error"
-    @ems.last_refresh_error.should == error
+    expect(@ems.last_refresh_status).to eq("error")
+    expect(@ems.last_refresh_error).to eq(error)
   end
 
   def refresh_ems(ems, error)
-    ManageIQ::Providers::Vmware::InfraManager::Refresher.any_instance.stub(:refresh_targets_for_ems).and_raise(StandardError.new(error))
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh_targets_for_ems).and_raise(StandardError.new(error))
     EmsRefresh.refresh(ems)
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_errors_spec.rb
@@ -26,7 +26,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   def refresh_ems(ems, error)
-    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh_targets_for_ems).and_raise(StandardError.new(error))
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Refresher)
+      .to receive(:refresh_targets_for_ems)
+      .and_raise(StandardError.new(error))
     EmsRefresh.refresh(ems)
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -6,9 +6,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => zone, :name => "VC41Test-Prod", :hostname => "VC41Test-Prod.MIQTEST.LOCAL", :ipaddress => "192.168.252.14")
 
-    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:connect).and_return(FakeMiqVimHandle.new)
-    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:disconnect).and_return(true)
-    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:has_credentials?).and_return(true)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager)
+      .to receive(:connect).and_return(FakeMiqVimHandle.new)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager)
+      .to receive(:disconnect).and_return(true)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager)
+      .to receive(:has_credentials?).and_return(true)
   end
 
   it "will perform a full refresh" do
@@ -78,7 +81,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :last_update_time => Time.parse("2011-05-17T15:54:37Z")
     )
     expect(cspec.spec).to      be_a_kind_of(VimHash)
-    expect(cspec.spec.keys).to match_array(["identity", "encryptionKey", "nicSettingMap", "globalIPSettings", "options"])
+    expect(cspec.spec.keys).to match_array(%w(identity encryptionKey nicSettingMap globalIPSettings options))
   end
 
   def assert_specific_cluster

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -6,9 +6,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => zone, :name => "VC41Test-Prod", :hostname => "VC41Test-Prod.MIQTEST.LOCAL", :ipaddress => "192.168.252.14")
 
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:connect).and_return(FakeMiqVimHandle.new)
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:disconnect).and_return(true)
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:has_credentials?).and_return(true)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:connect).and_return(FakeMiqVimHandle.new)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:disconnect).and_return(true)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:has_credentials?).and_return(true)
   end
 
   it "will perform a full refresh" do
@@ -26,64 +26,64 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should == 1
-    EmsFolder.count.should == 30
-    EmsCluster.count.should == 1
-    Host.count.should == 4
-    ResourcePool.count.should == 17
-    VmOrTemplate.count.should == 101
-    Vm.count.should == 92
-    MiqTemplate.count.should == 9
-    Storage.count.should == 50
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsFolder.count).to eq(30)
+    expect(EmsCluster.count).to eq(1)
+    expect(Host.count).to eq(4)
+    expect(ResourcePool.count).to eq(17)
+    expect(VmOrTemplate.count).to eq(101)
+    expect(Vm.count).to eq(92)
+    expect(MiqTemplate.count).to eq(9)
+    expect(Storage.count).to eq(50)
 
-    CustomAttribute.count.should == 3
-    CustomizationSpec.count.should == 2
-    Disk.count.should == 421
-    GuestDevice.count.should == 135
-    Hardware.count.should == 105
-    Lan.count.should == 14
-    MiqScsiLun.count.should == 73
-    MiqScsiTarget.count.should == 73
-    Network.count.should == 75
-    OperatingSystem.count.should == 105
-    Snapshot.count.should == 29
-    Switch.count.should == 8
-    SystemService.count.should == 29
+    expect(CustomAttribute.count).to eq(3)
+    expect(CustomizationSpec.count).to eq(2)
+    expect(Disk.count).to eq(421)
+    expect(GuestDevice.count).to eq(135)
+    expect(Hardware.count).to eq(105)
+    expect(Lan.count).to eq(14)
+    expect(MiqScsiLun.count).to eq(73)
+    expect(MiqScsiTarget.count).to eq(73)
+    expect(Network.count).to eq(75)
+    expect(OperatingSystem.count).to eq(105)
+    expect(Snapshot.count).to eq(29)
+    expect(Switch.count).to eq(8)
+    expect(SystemService.count).to eq(29)
 
-    Relationship.count.should == 244
-    MiqQueue.count.should == 101
+    expect(Relationship.count).to eq(244)
+    expect(MiqQueue.count).to eq(101)
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :api_version => "4.1",
       :uid_ems     => "EF53782F-6F1A-4471-B338-72B27774AFDD"
     )
 
-    @ems.ems_folders.size.should == 30
-    @ems.ems_clusters.size.should == 1
-    @ems.resource_pools.size.should == 17
-    @ems.storages.size.should == 47
-    @ems.hosts.size.should == 4
-    @ems.vms_and_templates.size.should == 101
-    @ems.vms.size.should == 92
-    @ems.miq_templates.size.should == 9
+    expect(@ems.ems_folders.size).to eq(30)
+    expect(@ems.ems_clusters.size).to eq(1)
+    expect(@ems.resource_pools.size).to eq(17)
+    expect(@ems.storages.size).to eq(47)
+    expect(@ems.hosts.size).to eq(4)
+    expect(@ems.vms_and_templates.size).to eq(101)
+    expect(@ems.vms.size).to eq(92)
+    expect(@ems.miq_templates.size).to eq(9)
 
-    @ems.customization_specs.size.should == 2
+    expect(@ems.customization_specs.size).to eq(2)
     cspec = @ems.customization_specs.find_by_name("Win2k8Template")
-    cspec.should have_attributes(
+    expect(cspec).to have_attributes(
       :name             => "Win2k8Template",
       :typ              => "Windows",
       :description      => "",
       :last_update_time => Time.parse("2011-05-17T15:54:37Z")
     )
-    cspec.spec.should      be_a_kind_of(VimHash)
-    cspec.spec.keys.should match_array(["identity", "encryptionKey", "nicSettingMap", "globalIPSettings", "options"])
+    expect(cspec.spec).to      be_a_kind_of(VimHash)
+    expect(cspec.spec.keys).to match_array(["identity", "encryptionKey", "nicSettingMap", "globalIPSettings", "options"])
   end
 
   def assert_specific_cluster
     @cluster = EmsCluster.find_by_name("Testing-Production Cluster")
-    @cluster.should have_attributes(
+    expect(@cluster).to have_attributes(
       :ems_ref                 => "domain-c871",
       :ems_ref_obj             => VimString.new("domain-c871", :ClusterComputeResource, :ManagedObjectReference),
       :uid_ems                 => "domain-c871",
@@ -97,7 +97,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     )
 
     @default_rp = @cluster.default_resource_pool
-    @default_rp.should have_attributes(
+    expect(@default_rp).to have_attributes(
       :ems_ref               => "resgroup-872",
       :ems_ref_obj           => VimString.new("resgroup-872", :ResourcePool, :ManagedObjectReference),
       :uid_ems               => "resgroup-872",
@@ -117,7 +117,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     )
 
     @rp = ResourcePool.find_by_ems_ref("resgroup-11340")
-    @rp.should have_attributes(
+    expect(@rp).to have_attributes(
       :ems_ref               => "resgroup-11340",
       :ems_ref_obj           => VimString.new("resgroup-11340", :ResourcePool, :ManagedObjectReference),
       :uid_ems               => "resgroup-11340",
@@ -136,16 +136,16 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :is_default            => false
     )
 
-    @cluster.all_resource_pools_with_default.size.should == 15
-    @cluster.all_resource_pools_with_default.should include(@rp)
-    @cluster.all_resource_pools_with_default.should include(@default_rp)
-    @cluster.all_resource_pools.should              include(@rp)
-    @cluster.all_resource_pools.should_not          include(@default_rp)
+    expect(@cluster.all_resource_pools_with_default.size).to eq(15)
+    expect(@cluster.all_resource_pools_with_default).to include(@rp)
+    expect(@cluster.all_resource_pools_with_default).to include(@default_rp)
+    expect(@cluster.all_resource_pools).to              include(@rp)
+    expect(@cluster.all_resource_pools).not_to          include(@default_rp)
   end
 
   def assert_specific_storage
     @storage = Storage.find_by_name("StarM1-Prod1 (1)")
-    @storage.should have_attributes(
+    expect(@storage).to have_attributes(
       :ems_ref                       => "datastore-953",
       :ems_ref_obj                   => VimString.new("datastore-953", :Datastore, :ManagedObjectReference),
       :name                          => "StarM1-Prod1 (1)",
@@ -163,7 +163,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
   def assert_specific_host
     @host = ManageIQ::Providers::Vmware::InfraManager::Host.find_by_name("VI4ESXM1.manageiq.com")
-    @host.should have_attributes(
+    expect(@host).to have_attributes(
       :ems_ref          => "host-9",
       :ems_ref_obj      => VimString.new("host-9", :HostSystem, :ManagedObjectReference),
       :name             => "VI4ESXM1.manageiq.com",
@@ -178,11 +178,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :connection_state => "connected"
     )
 
-    @host.ems_cluster.should == @cluster
-    @host.storages.size.should == 25
-    @host.storages.should      include(@storage)
+    expect(@host.ems_cluster).to eq(@cluster)
+    expect(@host.storages.size).to eq(25)
+    expect(@host.storages).to      include(@storage)
 
-    @host.operating_system.should have_attributes(
+    expect(@host.operating_system).to have_attributes(
       :name         => "VI4ESXM1.manageiq.com",
       :product_name => "ESXi",
       :version      => "4.1.0",
@@ -190,17 +190,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :product_type => "vmnix-x86"
     )
 
-    @host.system_services.size.should == 9
+    expect(@host.system_services.size).to eq(9)
     sys = @host.system_services.find_by_name("DCUI")
-    sys.should have_attributes(
+    expect(sys).to have_attributes(
       :name         => "DCUI",
       :display_name => "Direct Console UI",
       :running      => true
     )
 
-    @host.switches.size.should == 2
+    expect(@host.switches.size).to eq(2)
     switch = @host.switches.find_by_name("vSwitch0")
-    switch.should have_attributes(
+    expect(switch).to have_attributes(
       :uid_ems           => "vSwitch0",
       :name              => "vSwitch0",
       :ports             => 128,
@@ -209,9 +209,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :mac_changes       => true
     )
 
-    switch.lans.size.should == 3
+    expect(switch.lans.size).to eq(3)
     @lan = switch.lans.find_by_name("NetApp PG")
-    @lan.should have_attributes(
+    expect(@lan).to have_attributes(
       :uid_ems                    => "NetApp PG",
       :name                       => "NetApp PG",
       :tag                        => "0",
@@ -223,7 +223,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :computed_mac_changes       => true
     )
 
-    @host.hardware.should have_attributes(
+    expect(@host.hardware).to have_attributes(
       :cpu_speed            => 2127,
       :cpu_type             => "Intel(R) Xeon(R) CPU           E5506  @ 2.13GHz",
       :manufacturer         => "Dell Inc.",
@@ -241,20 +241,20 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :memory_usage         => 36508
     )
 
-    @host.hardware.networks.size.should == 2
+    expect(@host.hardware.networks.size).to eq(2)
     network = @host.hardware.networks.find_by_description("vmnic0")
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :description  => "vmnic0",
       :dhcp_enabled => false,
       :ipaddress    => "192.168.252.13",
       :subnet_mask  => "255.255.254.0"
     )
 
-    @host.hardware.guest_devices.size.should == 9
+    expect(@host.hardware.guest_devices.size).to eq(9)
 
-    @host.hardware.nics.size.should == 4
+    expect(@host.hardware.nics.size).to eq(4)
     nic = @host.hardware.nics.find_by_uid_ems("vmnic0")
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "vmnic0",
       :device_name     => "vmnic0",
       :device_type     => "ethernet",
@@ -262,12 +262,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :present         => true,
       :controller_type => "ethernet"
     )
-    nic.switch.should == switch
-    nic.network.should == network
+    expect(nic.switch).to eq(switch)
+    expect(nic.network).to eq(network)
 
-    @host.hardware.storage_adapters.size.should == 5
+    expect(@host.hardware.storage_adapters.size).to eq(5)
     adapter = @host.hardware.storage_adapters.find_by_uid_ems("vmhba0")
-    adapter.should have_attributes(
+    expect(adapter).to have_attributes(
       :uid_ems         => "vmhba0",
       :device_name     => "vmhba0",
       :device_type     => "storage",
@@ -280,7 +280,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     )
 
     adapter = @host.hardware.storage_adapters.find_by_uid_ems("vmhba34")
-    adapter.should have_attributes(
+    expect(adapter).to have_attributes(
       :uid_ems         => "vmhba34",
       :device_name     => "vmhba34",
       :device_type     => "storage",
@@ -292,9 +292,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :controller_type => "iSCSI"
     )
 
-    adapter.miq_scsi_targets.size.should == 22
+    expect(adapter.miq_scsi_targets.size).to eq(22)
     scsi_target = adapter.miq_scsi_targets.find_by_uid_ems("1")
-    scsi_target.should have_attributes(
+    expect(scsi_target).to have_attributes(
       :uid_ems     => "1",
       :target      => 1,
       :iscsi_name  => "iqn.1992-08.com.netapp:sn.135107242",
@@ -302,9 +302,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :address     => (VimArray.new << VimString.new("10.1.1.210:3260", nil, :"SOAP::SOAPString"))
     )
 
-    scsi_target.miq_scsi_luns.size.should == 1
+    expect(scsi_target.miq_scsi_luns.size).to eq(1)
     scsi_lun = scsi_target.miq_scsi_luns.first
-    scsi_lun.should have_attributes(
+    expect(scsi_lun).to have_attributes(
       :uid_ems        => "020000000060a980005034442f525a2f7437594a584c554e202020",
       :canonical_name => "naa.60a980005034442f525a2f7437594a58",
       :lun_type       => "disk",
@@ -319,7 +319,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
   def assert_specific_vm
     v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by_name("JoeF 4.0.1")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "vm-11342",
       :ems_ref_obj           => VimString.new("vm-11342", :VirtualMachine, :ManagedObjectReference),
@@ -344,21 +344,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :cpu_shares_level      => "normal"
     )
 
-    v.ext_management_system.should == @ems
-    v.ems_cluster.should == @cluster
-    v.parent_resource_pool.should == @rp
-    v.host.should == @host
-    v.storages.should == [@storage]
+    expect(v.ext_management_system).to eq(@ems)
+    expect(v.ems_cluster).to eq(@cluster)
+    expect(v.parent_resource_pool).to eq(@rp)
+    expect(v.host).to eq(@host)
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
-    v.operating_system.should have_attributes(
+    expect(v.operating_system).to have_attributes(
       :product_name => "Red Hat Enterprise Linux 5 (64-bit)"
     )
 
-    v.custom_attributes.size.should == 0
-    v.snapshots.size.should == 0
+    expect(v.custom_attributes.size).to eq(0)
+    expect(v.snapshots.size).to eq(0)
 
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => "rhel5_64",
       :guest_os_full_name => "Red Hat Enterprise Linux 5 (64-bit)",
       :bios               => "422f5d16-c048-19e6-3212-e588fbebf7e0",
@@ -367,9 +367,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :memory_mb          => 4096
     )
 
-    v.hardware.disks.size.should == 5
+    expect(v.hardware.disks.size).to eq(5)
     disk = v.hardware.disks.find_by_device_name("Hard disk 1")
-    disk.should have_attributes(
+    expect(disk).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
       :controller_type => "scsi",
@@ -381,11 +381,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :disk_type       => "thin",
       :start_connected => true
     )
-    disk.storage.should == @storage
+    expect(disk.storage).to eq(@storage)
 
-    v.hardware.guest_devices.size.should == 1
+    expect(v.hardware.guest_devices.size).to eq(1)
     nic = v.hardware.nics.first
-    nic.should have_attributes(
+    expect(nic).to have_attributes(
       :uid_ems         => "00:50:56:af:00:73",
       :device_name     => "Network adapter 1",
       :device_type     => "ethernet",
@@ -394,18 +394,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :start_connected => true,
       :address         => "00:50:56:af:00:73"
     )
-    nic.lan.should == @lan
+    expect(nic.lan).to eq(@lan)
 
-    v.hardware.networks.count.should == 1
+    expect(v.hardware.networks.count).to eq(1)
     network = v.hardware.networks.first
-    network.should have_attributes(
+    expect(network).to have_attributes(
       :hostname    => "joeytester",
       :ipaddress   => "192.168.253.39",
       :ipv6address => nil
     )
-    nic.network.should == network
+    expect(nic.network).to eq(network)
 
-    v.parent_datacenter.should have_attributes(
+    expect(v.parent_datacenter).to have_attributes(
       :ems_ref       => "datacenter-2",
       :ems_ref_obj   => VimString.new("datacenter-2", :Datacenter, :ManagedObjectReference),
       :uid_ems       => "datacenter-2",
@@ -415,7 +415,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :folder_path   => "Datacenters/Prod"
     )
 
-    v.parent_folder.should have_attributes(
+    expect(v.parent_folder).to have_attributes(
       :ems_ref       => "group-d1",
       :ems_ref_obj   => VimString.new("group-d1", :Folder, :ManagedObjectReference),
       :uid_ems       => "group-d1",
@@ -425,7 +425,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :folder_path   => "Datacenters"
     )
 
-    v.parent_blue_folder.should have_attributes(
+    expect(v.parent_blue_folder).to have_attributes(
       :ems_ref       => "group-v11341",
       :ems_ref_obj   => VimString.new("group-v11341", :Folder, :ManagedObjectReference),
       :uid_ems       => "group-v11341",
@@ -439,10 +439,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   def assert_cpu_layout
     # Test a VM that has numCoresPerSocket = 0
     v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by_ems_ref("vm-12443")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :cpu_total_cores => 2,
     )
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :cpu_total_cores      => 2,
       :cpu_cores_per_socket => 1,
       :cpu_sockets          => 2,
@@ -450,10 +450,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
     # Test a VM that has numCoresPerSocket = 2
     v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by_ems_ref("vm-12203")
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :cpu_total_cores => 4,
     )
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :cpu_total_cores      => 4,
       :cpu_cores_per_socket => 2,
       :cpu_sockets          => 2,
@@ -461,7 +461,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   def assert_relationship_tree
-    @ems.descendants_arranged.should match_relationship_tree(
+    expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
         [EmsFolder, "Dev", {:is_datacenter => true}]            => {
           [EmsFolder, "host", {:is_datacenter => false}] => {

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -7,24 +7,24 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
     end
 
     it "with :mks" do
-      @vm.should_receive(:remote_console_mks_acquire_ticket).with(nil)
+      expect(@vm).to receive(:remote_console_mks_acquire_ticket).with(nil)
       @vm.remote_console_acquire_ticket(:mks)
     end
 
     it "with :vmrc" do
-      @vm.should_receive(:remote_console_vmrc_acquire_ticket).with(nil)
+      expect(@vm).to receive(:remote_console_vmrc_acquire_ticket).with(nil)
       @vm.remote_console_acquire_ticket(:vmrc)
     end
 
     context "with :vnc" do
       it "without a proxy" do
-        @vm.should_receive(:remote_console_vnc_acquire_ticket).with(nil)
+        expect(@vm).to receive(:remote_console_vnc_acquire_ticket).with(nil)
         @vm.remote_console_acquire_ticket(:vnc)
       end
 
       it "with a proxy" do
         server = double("MiqServer")
-        @vm.should_receive(:remote_console_vnc_acquire_ticket).with(server)
+        expect(@vm).to receive(:remote_console_vnc_acquire_ticket).with(server)
         @vm.remote_console_acquire_ticket(:vnc, server)
       end
     end
@@ -44,27 +44,27 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
       @vm.remote_console_acquire_ticket_queue(:mks, "admin")
 
       q_all = MiqQueue.all
-      q_all.length.should == 1
-      q_all[0].method_name.should == "remote_console_acquire_ticket"
-      q_all[0].args.should == [:mks, nil]
+      expect(q_all.length).to eq(1)
+      expect(q_all[0].method_name).to eq("remote_console_acquire_ticket")
+      expect(q_all[0].args).to eq([:mks, nil])
     end
 
     it "with :vmrc" do
       @vm.remote_console_acquire_ticket_queue(:vmrc, "admin")
 
       q_all = MiqQueue.all
-      q_all.length.should == 1
-      q_all[0].method_name.should == "remote_console_acquire_ticket"
-      q_all[0].args.should == [:vmrc, nil]
+      expect(q_all.length).to eq(1)
+      expect(q_all[0].method_name).to eq("remote_console_acquire_ticket")
+      expect(q_all[0].args).to eq([:vmrc, nil])
     end
 
     it "with :vnc" do
       @vm.remote_console_acquire_ticket_queue(:vnc, "admin", 1234)
 
       q_all = MiqQueue.all
-      q_all.length.should == 1
-      q_all[0].method_name.should == "remote_console_acquire_ticket"
-      q_all[0].args.should == [:vnc, 1234]
+      expect(q_all.length).to eq(1)
+      expect(q_all[0].method_name).to eq("remote_console_acquire_ticket")
+      expect(q_all[0].args).to eq([:vnc, 1234])
     end
   end
 
@@ -81,18 +81,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
       ticket = VCR.use_cassette(described_class.name.underscore) do
         @vm.remote_console_vmrc_acquire_ticket
       end
-      ticket.should =~ /^[0-9\-A-Z]{40}$/
+      expect(ticket).to match(/^[0-9\-A-Z]{40}$/)
     end
 
     it "with vm off" do
       @vm.update_attribute(:raw_power_state, "poweredOff")
-      -> { @vm.remote_console_vmrc_acquire_ticket }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @vm.remote_console_vmrc_acquire_ticket }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "with vm with no ems" do
       @vm.ext_management_system = nil
       @vm.save!
-      -> { @vm.remote_console_vmrc_acquire_ticket }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @vm.remote_console_vmrc_acquire_ticket }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
   end
 
@@ -103,23 +103,23 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
     end
 
     it "normal case" do
-      @vm.validate_remote_console_vmrc_support.should be_true
+      expect(@vm.validate_remote_console_vmrc_support).to be_truthy
     end
 
     it "with vm with no ems" do
       @vm.ext_management_system = nil
       @vm.save!
-      -> { @vm.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @vm.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "with vm off" do
       @vm.update_attribute(:raw_power_state, "poweredOff")
-      -> { @vm.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @vm.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "on VC 4.0" do
       @ems.update_attribute(:api_version, "4.0")
-      -> { @vm.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @vm.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
   end
 
@@ -132,66 +132,66 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
     it "will set the attributes on the VC side" do
       vim_vm = double("MiqVimVm")
-      vim_vm.should_receive(:setRemoteDisplayVncAttributes) do |args|
-        args[:enabled].should  be_true
-        args[:port].should == 5901
-        args[:password].should =~ /^[A-Za-z0-9+\/]{8}$/
+      expect(vim_vm).to receive(:setRemoteDisplayVncAttributes) do |args|
+        expect(args[:enabled]).to  be_truthy
+        expect(args[:port]).to eq(5901)
+        expect(args[:password]).to match(/^[A-Za-z0-9+\/]{8}$/)
       end
-      @vm.stub(:with_provider_object).and_yield(vim_vm)
+      allow(@vm).to receive(:with_provider_object).and_yield(vim_vm)
 
       @vm.remote_console_vnc_acquire_ticket
     end
 
     it "without a proxy miq_server" do
-      @vm.should_receive(:with_provider_object)
+      expect(@vm).to receive(:with_provider_object)
 
       password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket
 
-      password.should =~ /^[A-Za-z0-9+\/]{8}$/
-      host_address.should == "192.168.252.4"
-      host_port.should == 5901
-      proxy_address.should be_nil
-      proxy_port.should    be_nil
+      expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+      expect(host_address).to eq("192.168.252.4")
+      expect(host_port).to eq(5901)
+      expect(proxy_address).to be_nil
+      expect(proxy_port).to    be_nil
     end
 
     context "with a proxy miq_server" do
       it "with no proxy configured" do
         server = double("MiqServer")
         server.stub_chain(:get_config, :config => {:server => {:vnc_proxy_address => nil, :vnc_proxy_port => nil}})
-        @vm.should_receive(:with_provider_object)
+        expect(@vm).to receive(:with_provider_object)
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)
 
-        password.should =~ /^[A-Za-z0-9+\/]{8}$/
-        host_address.should == "192.168.252.4"
-        host_port.should == 5901
-        proxy_address.should be_nil
-        proxy_port.should    be_nil
+        expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+        expect(host_address).to eq("192.168.252.4")
+        expect(host_port).to eq(5901)
+        expect(proxy_address).to be_nil
+        expect(proxy_port).to    be_nil
       end
 
       it "with a proxy configured" do
         server = double("MiqServer")
         server.stub_chain(:get_config, :config => {:server => {:vnc_proxy_address => "1.2.3.4", :vnc_proxy_port => "5800"}}) # NOTE: Ports are actually stored as a String in the configuration
-        @vm.should_receive(:with_provider_object)
+        expect(@vm).to receive(:with_provider_object)
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)
 
-        password.should =~ /^[A-Za-z0-9+\/]{8}$/
-        host_address.should == @host.guid
-        host_port.should == 5901
-        proxy_address.should == "1.2.3.4"
-        proxy_port.should == 5800
+        expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+        expect(host_address).to eq(@host.guid)
+        expect(host_port).to eq(5901)
+        expect(proxy_address).to eq("1.2.3.4")
+        expect(proxy_port).to eq(5800)
       end
     end
 
     it "will reclaim the port number from old VMs" do
-      ManageIQ::Providers::Vmware::InfraManager::Vm.any_instance.stub(:with_provider_object)
+      allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:with_provider_object)
       vm_old = FactoryGirl.create(:vm_with_ref, :host => @host, :vnc_port => 5901)
 
       @vm.remote_console_vnc_acquire_ticket
 
       vm_old.reload
-      vm_old.vnc_port.should be_nil
+      expect(vm_old.vnc_port).to be_nil
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -133,9 +133,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
     it "will set the attributes on the VC side" do
       vim_vm = double("MiqVimVm")
       expect(vim_vm).to receive(:setRemoteDisplayVncAttributes) do |args|
-        expect(args[:enabled]).to  be_truthy
+        expect(args[:enabled]).to be_truthy
         expect(args[:port]).to eq(5901)
-        expect(args[:password]).to match(/^[A-Za-z0-9+\/]{8}$/)
+        expect(args[:password]).to match(%r{^[A-Za-z0-9+/]{8}$})
       end
       allow(@vm).to receive(:with_provider_object).and_yield(vim_vm)
 
@@ -147,7 +147,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
       password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket
 
-      expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+      expect(password).to match(%r{^[A-Za-z0-9+/]{8}$})
       expect(host_address).to eq("192.168.252.4")
       expect(host_port).to eq(5901)
       expect(proxy_address).to be_nil
@@ -162,7 +162,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)
 
-        expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+        expect(password).to match(%r{^[A-Za-z0-9+/]{8}$})
         expect(host_address).to eq("192.168.252.4")
         expect(host_port).to eq(5901)
         expect(proxy_address).to be_nil
@@ -176,7 +176,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)
 
-        expect(password).to match(/^[A-Za-z0-9+\/]{8}$/)
+        expect(password).to match(%r{^[A-Za-z0-9+/]{8}$})
         expect(host_address).to eq(@host.guid)
         expect(host_port).to eq(5901)
         expect(proxy_address).to eq("1.2.3.4")

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -61,7 +61,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
     let(:vm) { vm = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :virtual_hw_version => "07")) }
 
     it "#reconfigurable?" do
-      expect(vm.reconfigurable?).to be_true
+      expect(vm.reconfigurable?).to be_truthy
     end
 
     context "#max_total_vcpus" do
@@ -114,7 +114,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
       expect(vm).to receive(:with_provider_object).and_yield(provider_object)
       expect(provider_object).to receive(:send).and_return("nada")
 
-      ems.invoke_vim_ws(:do_nothing, vm).should eq("nada")
+      expect(ems.invoke_vim_ws(:do_nothing, vm)).to eq("nada")
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Vmware::InfraManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'vmwarews'
+    expect(described_class.ems_type).to eq('vmwarews')
   end
 
   it ".description" do
-    described_class.description.should == 'VMware vCenter'
+    expect(described_class.description).to eq('VMware vCenter')
   end
 
   describe ".metrics_collector_queue_name" do
@@ -23,22 +23,22 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
     it "not raise for api_version == 5.0" do
       @ems.update_attributes(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      -> { @ems.validate_remote_console_vmrc_support }.should_not raise_error
+      expect { @ems.validate_remote_console_vmrc_support }.not_to raise_error
     end
 
     it "raise for api_version == 4.0" do
       @ems.update_attributes(:api_version => "4.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      -> { @ems.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "raise for api_version == 4.1" do
       @ems.update_attributes(:api_version => "4.1", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      -> { @ems.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "raise for missing/blank values" do
       @ems.update_attributes(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      -> { @ems.validate_remote_console_vmrc_support }.should raise_error MiqException::RemoteConsoleNotSupportedError
+      expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
   end
 
@@ -49,37 +49,37 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
     it "true with nothing missing/blank" do
       @ems.update_attributes(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      @ems.remote_console_vmrc_support_known?.should be_true
+      expect(@ems.remote_console_vmrc_support_known?).to be_truthy
     end
 
     it "false for missing hostname" do
       @ems.update_attributes(:hostname => nil, :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for blank hostname" do
       @ems.update_attributes(:hostname => "", :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for missing api_version" do
       @ems.update_attributes(:api_version => nil, :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for blank api_version" do
       @ems.update_attributes(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for missing uid_ems" do
       @ems.update_attributes(:api_version => "5.0", :uid_ems => nil)
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for blank uid_ems" do
       @ems.update_attributes(:api_version => "5.0", :uid_ems => "")
-      @ems.remote_console_vmrc_support_known?.should_not be_true
+      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
   end
 
@@ -112,7 +112,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
     it "will not restart EventCatcher when name changes" do
       @ems.update_attributes(:name => "something else")
-      MiqQueue.count.should == 0
+      expect(MiqQueue.count).to eq(0)
     end
   end
 
@@ -120,9 +120,9 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
   def assert_event_catcher_restart_queued
     q = MiqQueue.where(:method_name => "stop_event_monitor")
-    q.length.should == 1
-    q[0].class_name.should == "ManageIQ::Providers::Vmware::InfraManager"
-    q[0].instance_id.should == @ems.id
-    q[0].role.should == "event"
+    expect(q.length).to eq(1)
+    expect(q[0].class_name).to eq("ManageIQ::Providers::Vmware::InfraManager")
+    expect(q[0].instance_id).to eq(@ems.id)
+    expect(q[0].role).to eq("event")
   end
 end


### PR DESCRIPTION
Converts most of the provider model specs to `expect` syntax.