### PR TITLE
Convert auth->job_proxy model specs to RSpec 2.99.2 syntax

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -128,8 +128,9 @@ describe Authenticator::Amazon do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -127,7 +127,10 @@ describe Authenticator::Amazon do
     allow_any_instance_of(described_class).to receive(:aws_connect) { |*args| FakeAmazon.new(user_data, *args) }
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -4,7 +4,10 @@ describe Authenticator::Database do
   subject { Authenticator::Database.new({}) }
   let!(:alice) { FactoryGirl.create(:user, :userid => 'alice', :password => 'secret') }
 
-  its(:uses_stored_password?) { should be_true }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_true }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -5,8 +5,9 @@ describe Authenticator::Database do
   let!(:alice) { FactoryGirl.create(:user, :userid => 'alice', :password => 'secret') }
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_true }
+    it "is true" do
+      expect(subject.uses_stored_password?).to be_true
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -27,7 +27,10 @@ describe Authenticator::Httpd do
     )
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -28,8 +28,9 @@ describe Authenticator::Httpd do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -98,8 +98,9 @@ describe Authenticator::Ldap do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -94,10 +94,13 @@ describe Authenticator::Ldap do
   end
 
   before(:each) do
-    allow(MiqLdap).to receive(:new).and_return { FakeLdap.new(user_data) }
+    allow(MiqLdap).to receive(:new) { FakeLdap.new(user_data) }
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -35,13 +35,13 @@ describe DriftState do
         described_class.purge_timer
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge"
         )
-        q.first.args[0].should == :date
-        q.first.args[1].should be_same_time_as 6.months.to_i.seconds.ago.utc
+        expect(q.first.args[0]).to eq(:date)
+        expect(q.first.args[1]).to be_same_time_as 6.months.to_i.seconds.ago.utc
       end
     end
 
@@ -53,8 +53,8 @@ describe DriftState do
 
       it "with nothing in the queue" do
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 1]
@@ -65,8 +65,8 @@ describe DriftState do
         described_class.purge_queue(:remaining, 2)
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 2]
@@ -75,36 +75,36 @@ describe DriftState do
     end
 
     it "#purge_ids_for_remaining" do
-      described_class.send(:purge_ids_for_remaining, 1).should == {["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id}
+      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id})
     end
 
     it "#purge_counts_for_remaining" do
-      described_class.send(:purge_counts_for_remaining, 1).should == {["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2}
+      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2})
     end
 
     context "#purge_count" do
       it "by remaining" do
-        described_class.purge_count(:remaining, 1).should == 3
+        expect(described_class.purge_count(:remaining, 1)).to eq(3)
       end
 
       it "by date" do
-        described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc).should == 3
+        expect(described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc)).to eq(3)
       end
     end
 
     context "#purge" do
       it "by remaining" do
         described_class.purge(:remaining, 1)
-        described_class.where(:resource_id => 1).should == [@rr1.last]
-        described_class.where(:resource_id => 2).should == [@rr2.last]
-        described_class.where(:resource_id => nil).should == @rr_orphaned
+        expect(described_class.where(:resource_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:resource_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:resource_id => nil)).to eq(@rr_orphaned)
       end
 
       it "by date" do
         described_class.purge(:date, 6.months.to_i.seconds.ago.utc)
-        described_class.where(:resource_id => 1).should == [@rr1.last]
-        described_class.where(:resource_id => 2).should == [@rr2.last]
-        described_class.where(:resource_id => nil).should == @rr_orphaned
+        expect(described_class.where(:resource_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:resource_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:resource_id => nil)).to eq(@rr_orphaned)
       end
     end
   end

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -75,11 +75,13 @@ describe DriftState do
     end
 
     it "#purge_ids_for_remaining" do
-      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id})
+      expect(described_class.send(:purge_ids_for_remaining, 1))
+        .to eq(["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id)
     end
 
     it "#purge_counts_for_remaining" do
-      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2})
+      expect(described_class.send(:purge_counts_for_remaining, 1))
+        .to eq(["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2)
     end
 
     context "#purge_count" do

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EmsCluster::CapacityPlanning do
   before(:each) do
     config = VMDB::Config.new('capacity').config
-    EmsCluster.stub(:capacity_settings).and_return(config.deep_clone)
+    allow(EmsCluster).to receive(:capacity_settings).and_return(config.deep_clone)
     @cluster = FactoryGirl.create(:ems_cluster)
   end
 
@@ -11,86 +11,86 @@ describe EmsCluster::CapacityPlanning do
     EmsCluster::CAPACITY_PROFILES.each do |profile|
       prefix = "capacity_profile_#{profile}"
       EmsCluster::CAPACITY_RESOURCES.each do |resource|
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_method",              :string
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_commitment_ratio",    :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_minimum",             :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_maximum",             :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_method",              :string
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_commitment_ratio",    :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_minimum",             :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_maximum",             :float
 
-        EmsCluster.should have_virtual_column "#{prefix}_available_host_#{resource}",      :float
-        EmsCluster.should have_virtual_column "#{prefix}_remaining_host_#{resource}",      :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_per_vm",              :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_per_vm_with_min_max", :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_available_host_#{resource}",      :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_host_#{resource}",      :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_per_vm",              :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_per_vm_with_min_max", :float
 
-        EmsCluster.should have_virtual_column "#{prefix}_remaining_vm_count_based_on_#{resource}", :integer
-        EmsCluster.should have_virtual_column "#{prefix}_projected_vm_count_based_on_#{resource}", :integer
+        expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_vm_count_based_on_#{resource}", :integer
+        expect(EmsCluster).to have_virtual_column "#{prefix}_projected_vm_count_based_on_#{resource}", :integer
       end
-      EmsCluster.should have_virtual_column "#{prefix}_remaining_vm_count_based_on_all", :integer
-      EmsCluster.should have_virtual_column "#{prefix}_projected_vm_count_based_on_all", :integer
+      expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_vm_count_based_on_all", :integer
+      expect(EmsCluster).to have_virtual_column "#{prefix}_projected_vm_count_based_on_all", :integer
     end
   end
 
   it "#capacity_profile_method_description" do
     settings_path = [:profile, :"1", :vcpu_method_description]
-    @cluster.capacity_profile_method_description(1, :vcpu).should == EmsCluster.capacity_settings.fetch_path(settings_path)
+    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
     EmsCluster.capacity_settings.store_path(settings_path, "Test Description")
-    @cluster.capacity_profile_method_description(1, :vcpu).should == "Test Description"
+    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq("Test Description")
   end
 
   context "#capacity_profile_method" do
     it "with invalid values" do
       EmsCluster.capacity_settings.delete_path(:profile, :"1", :vcpu_method)
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "invalidresource_average")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "vcpu_invalidalgorithm")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "mem_average") # resource does not match profile key
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
     end
 
     it "with valid values" do
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "vcpu_high_norm")
-      @cluster.capacity_profile_method(1, :vcpu).should == :vcpu_high_norm
+      expect(@cluster.capacity_profile_method(1, :vcpu)).to eq(:vcpu_high_norm)
 
       EmsCluster.capacity_settings.store_path(:profile, :"1", :memory_method, "mem_average")
-      @cluster.capacity_profile_method(1, :memory).should == :memory_average
+      expect(@cluster.capacity_profile_method(1, :memory)).to eq(:memory_average)
     end
 
     it "with alternate valid values" do
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "cpu_average")
-      @cluster.capacity_profile_method(1, :vcpu).should == :vcpu_average
+      expect(@cluster.capacity_profile_method(1, :vcpu)).to eq(:vcpu_average)
 
       EmsCluster.capacity_settings.store_path(:profile, :"1", :memory_method, "memory_high_norm")
-      @cluster.capacity_profile_method(1, :memory).should == :memory_high_norm
+      expect(@cluster.capacity_profile_method(1, :memory)).to eq(:memory_high_norm)
     end
   end
 
   it "#capacity_profile_minimum" do
     settings_path = [:profile, :"1", :memory_minimum]
-    @cluster.capacity_profile_minimum(1, :memory).should be_nil
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to be_nil
     EmsCluster.capacity_settings.store_path(settings_path, "123")
-    @cluster.capacity_profile_minimum(1, :memory).should == 123
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to eq(123)
     EmsCluster.capacity_settings.store_path(settings_path, "1.gigabytes")
-    @cluster.capacity_profile_minimum(1, :memory).should == 1.gigabytes.to_i
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to eq(1.gigabytes.to_i)
   end
 
   it "#capacity_profile_maximum" do
     settings_path = [:profile, :"1", :memory_maximum]
-    @cluster.capacity_profile_maximum(1, :memory).should be_nil
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to be_nil
     EmsCluster.capacity_settings.store_path(settings_path, "123")
-    @cluster.capacity_profile_maximum(1, :memory).should == 123
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to eq(123)
     EmsCluster.capacity_settings.store_path(settings_path, "1.gigabytes")
-    @cluster.capacity_profile_maximum(1, :memory).should == 1.gigabytes.to_i
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to eq(1.gigabytes.to_i)
   end
 
   context "#capacity_commitment_ratio" do
     it "with default settings" do
-      @cluster.capacity_commitment_ratio(1, :vcpu).should == 2.0
-      @cluster.capacity_commitment_ratio(1, :memory).should == 1.2
-      @cluster.capacity_commitment_ratio(2, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :memory).should == 1.0
+      expect(@cluster.capacity_commitment_ratio(1, :vcpu)).to eq(2.0)
+      expect(@cluster.capacity_commitment_ratio(1, :memory)).to eq(1.2)
+      expect(@cluster.capacity_commitment_ratio(2, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :memory)).to eq(1.0)
     end
 
     it "with missing settings" do
@@ -99,95 +99,95 @@ describe EmsCluster::CapacityPlanning do
       EmsCluster.capacity_settings.delete_path(:profile, :"2", :vcpu_commitment_ratio)
       EmsCluster.capacity_settings.delete_path(:profile, :"2", :memory_commitment_ratio)
 
-      @cluster.capacity_commitment_ratio(1, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(1, :memory).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :memory).should == 1.0
+      expect(@cluster.capacity_commitment_ratio(1, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(1, :memory)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :memory)).to eq(1.0)
     end
   end
 
   context "#capacity_failover_rule" do
     it "with normal settings" do
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
 
     it "with overridden settings" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "none")
-      @cluster.capacity_failover_rule.should == "none"
+      expect(@cluster.capacity_failover_rule).to eq("none")
     end
 
     it "with missing settings" do
       EmsCluster.capacity_settings.delete_path(:failover, :rule)
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
 
     it "with invalid settings" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "xxx")
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
   end
 
   context "#capacity_average_resources_per_vm" do
     it "with normal data" do
-      @cluster.stub(:total_vms).and_return(15)
-      @cluster.capacity_average_resources_per_vm(35.5).should be_within(0.001).of(2.366)
+      allow(@cluster).to receive(:total_vms).and_return(15)
+      expect(@cluster.capacity_average_resources_per_vm(35.5)).to be_within(0.001).of(2.366)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_vms).and_return(0)
-      @cluster.capacity_average_resources_per_vm(35.5).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(0)
+      expect(@cluster.capacity_average_resources_per_vm(35.5)).to eq(0.0)
     end
   end
 
   context "#capacity_average_resources_per_host" do
     it "with normal data" do
-      @cluster.stub(:total_hosts).and_return(15)
-      @cluster.capacity_average_resources_per_host(35.5).should be_within(0.001).of(2.366)
+      allow(@cluster).to receive(:total_hosts).and_return(15)
+      expect(@cluster.capacity_average_resources_per_host(35.5)).to be_within(0.001).of(2.366)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_hosts).and_return(0)
-      @cluster.capacity_average_resources_per_host(35.5).should == 0.0
+      allow(@cluster).to receive(:total_hosts).and_return(0)
+      expect(@cluster.capacity_average_resources_per_host(35.5)).to eq(0.0)
     end
   end
 
   context "#capacity_peak_usage_percentage" do
     it "with normal data" do
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_peak_usage_percentage(:vcpu).should == 11.32
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(11.32)
 
-      @cluster.stub(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
-      @cluster.capacity_peak_usage_percentage(:memory).should == 35.23
+      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
+      expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(35.23)
     end
 
     it "with missing data" do
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_peak_usage_percentage(:vcpu).should == 100.0
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(100.0)
 
-      @cluster.stub(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_peak_usage_percentage(:memory).should == 100.0
+      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(100.0)
     end
   end
 
   context "#capacity_effective_host_resources" do
     it "with effective_resource set" do
-      @cluster.stub(:effective_cpu).and_return(31000)
-      @cluster.capacity_effective_host_resources(2, :vcpu).should == 31000
+      allow(@cluster).to receive(:effective_cpu).and_return(31000)
+      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31000)
     end
 
     context "with effective_resource not set" do
       before(:each) do
-        @cluster.stub(:effective_cpu).and_return(nil)
+        allow(@cluster).to receive(:effective_cpu).and_return(nil)
       end
 
       it "and normal data" do
-        @cluster.stub(:aggregate_cpu_speed).and_return(12345)
-        @cluster.capacity_effective_host_resources(2, :vcpu).should == 12345
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12345)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12345)
       end
 
       it "and missing data" do
-        @cluster.stub(:aggregate_cpu_speed).and_return(0)
-        @cluster.capacity_effective_host_resources(2, :vcpu).should == 0
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(0)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(0)
       end
     end
   end
@@ -195,13 +195,13 @@ describe EmsCluster::CapacityPlanning do
   context "#capacity_failover_host_resources" do
     it "with failover rule 'none'" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "none")
-      @cluster.capacity_failover_host_resources(2, :vcpu).should == 0
+      expect(@cluster.capacity_failover_host_resources(2, :vcpu)).to eq(0)
     end
 
     context "with failover rule 'discovered'" do
       it "and HA disabled" do
         @cluster.update_attribute(:ha_enabled, false)
-        @cluster.capacity_failover_host_resources(2, :vcpu).should == 0
+        expect(@cluster.capacity_failover_host_resources(2, :vcpu)).to eq(0)
       end
 
       context "and HA enabled" do
@@ -210,14 +210,14 @@ describe EmsCluster::CapacityPlanning do
         end
 
         it "and no failover hosts" do
-          @cluster.stub(:failover_hosts).and_return([])
-          @cluster.should_receive(:capacity_failover_host_resources_without_failover_hosts)
+          allow(@cluster).to receive(:failover_hosts).and_return([])
+          expect(@cluster).to receive(:capacity_failover_host_resources_without_failover_hosts)
           @cluster.capacity_failover_host_resources(2, :vcpu)
         end
 
         it "and failover hosts" do
-          @cluster.stub(:failover_hosts).and_return([1, 2])
-          @cluster.should_receive(:capacity_failover_host_resources_with_failover_hosts)
+          allow(@cluster).to receive(:failover_hosts).and_return([1, 2])
+          expect(@cluster).to receive(:capacity_failover_host_resources_with_failover_hosts)
           @cluster.capacity_failover_host_resources(2, :vcpu)
         end
       end
@@ -231,7 +231,7 @@ describe EmsCluster::CapacityPlanning do
       FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :cpu_total_cores => 1), :failover => false)
     ]
     @cluster.hosts << hosts
-    @cluster.capacity_failover_host_resources_with_failover_hosts(1, :vcpu).should == 6.0
+    expect(@cluster.capacity_failover_host_resources_with_failover_hosts(1, :vcpu)).to eq(6.0)
   end
 
   it "#capacity_failover_host_resources_without_failover_hosts" do
@@ -240,78 +240,78 @@ describe EmsCluster::CapacityPlanning do
       FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :cpu_total_cores => 2), :failover => false)
     ]
     @cluster.hosts << hosts
-    @cluster.capacity_failover_host_resources_without_failover_hosts(1, :vcpu).should == 3.0
+    expect(@cluster.capacity_failover_host_resources_without_failover_hosts(1, :vcpu)).to eq(3.0)
   end
 
   context "#capacity_used_host_resources" do
     it "with normal data" do
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_used_host_resources(2, :vcpu).should be_within(0.001).of(3509.200)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3509.200)
     end
 
     it "with missing data" do
-      @cluster.stub(:capacity_available_host_resources).and_return(0)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_used_host_resources(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(0)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.capacity_used_host_resources(2, :vcpu).should be_within(0.001).of(31000.000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31000.000)
     end
   end
 
   context "#capacity_resources_per_vm" do
     it "with normal data" do
-      @cluster.stub(:total_vms).and_return(994)
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should be_within(0.001).of(3.530)
+      allow(@cluster).to receive(:total_vms).and_return(994)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(3.530)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_vms).and_return(0)
-      @cluster.stub(:capacity_available_host_resources).and_return(0)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(0)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(0)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:total_vms).and_return(994)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(994)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should be_within(0.001).of(31.187)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(31.187)
     end
   end
 
   context "#capacity_resources_per_vm_with_min_max" do
     before(:each) do
-      @cluster.stub(:capacity_resources_per_vm).and_return(3.530)
+      allow(@cluster).to receive(:capacity_resources_per_vm).and_return(3.530)
     end
 
     it "with neither min nor max" do
-      @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+      expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
     end
 
     context "with min only" do
       it "and min < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
 
       it "and expected < min" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 4.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(4.0)
       end
     end
 
     context "with max only" do
       it "and max < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 1.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(1.0)
       end
 
       it "and expected < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
     end
 
@@ -319,66 +319,66 @@ describe EmsCluster::CapacityPlanning do
       it "and min < max < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 0.1)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 1.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(1.0)
       end
 
       it "and min < expected < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 1.0)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
 
       it "and expected < min < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 4.0)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 5.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 4.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(4.0)
       end
     end
   end
 
   it "#capacity_remaining_vm_count" do
     @cluster.update_attribute(:ha_enabled, false)
-    @cluster.stub(:total_vms).and_return(994)
-    @cluster.stub(:effective_cpu).and_return(31000)
-    @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-    @cluster.capacity_remaining_vm_count(2, :vcpu).should == 7786
+    allow(@cluster).to receive(:total_vms).and_return(994)
+    allow(@cluster).to receive(:effective_cpu).and_return(31000)
+    allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7786)
   end
 
   it "#capacity_remaining_vm_count_based_on_all" do
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(3)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(3)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(3)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(3)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-4)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == -4
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-4)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(-4)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(-4)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == -4
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(-4)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(-4)
   end
 
   it "#capacity_projected_vm_count" do
-    @cluster.stub(:total_vms).and_return(3)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.capacity_projected_vm_count(1, :vcpu).should == 13
+    allow(@cluster).to receive(:total_vms).and_return(3)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    expect(@cluster.capacity_projected_vm_count(1, :vcpu)).to eq(13)
 
-    @cluster.stub(:total_vms).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-3)
-    @cluster.capacity_projected_vm_count(1, :vcpu).should == 7
+    allow(@cluster).to receive(:total_vms).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-3)
+    expect(@cluster.capacity_projected_vm_count(1, :vcpu)).to eq(7)
   end
 
   it "#capacity_projected_vm_count_based_on_all" do
-    @cluster.stub(:capacity_projected_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_projected_vm_count).with(1, :memory).and_return(3)
-    @cluster.capacity_projected_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :memory).and_return(3)
+    expect(@cluster.capacity_projected_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_projected_vm_count).with(1, :vcpu).and_return(3)
-    @cluster.stub(:capacity_projected_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_projected_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :vcpu).and_return(3)
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_projected_vm_count_based_on_all(1)).to eq(3)
   end
 end

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -31,7 +31,8 @@ describe EmsCluster::CapacityPlanning do
 
   it "#capacity_profile_method_description" do
     settings_path = [:profile, :"1", :vcpu_method_description]
-    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
+    expect(@cluster.capacity_profile_method_description(1, :vcpu))
+      .to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
     EmsCluster.capacity_settings.store_path(settings_path, "Test Description")
     expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq("Test Description")
   end
@@ -156,7 +157,9 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
       expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(11.32)
 
-      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
+      allow(@cluster)
+        .to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead)
+        .and_return(35.23)
       expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(35.23)
     end
 
@@ -171,8 +174,8 @@ describe EmsCluster::CapacityPlanning do
 
   context "#capacity_effective_host_resources" do
     it "with effective_resource set" do
-      allow(@cluster).to receive(:effective_cpu).and_return(31000)
-      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31000)
+      allow(@cluster).to receive(:effective_cpu).and_return(31_000)
+      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31_000)
     end
 
     context "with effective_resource not set" do
@@ -181,8 +184,8 @@ describe EmsCluster::CapacityPlanning do
       end
 
       it "and normal data" do
-        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12345)
-        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12345)
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12_345)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12_345)
       end
 
       it "and missing data" do
@@ -245,9 +248,9 @@ describe EmsCluster::CapacityPlanning do
 
   context "#capacity_used_host_resources" do
     it "with normal data" do
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3509.200)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3_509.200)
     end
 
     it "with missing data" do
@@ -255,15 +258,15 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
       expect(@cluster.capacity_used_host_resources(2, :vcpu)).to eq(0.0)
 
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
-      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31000.000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31_000.000)
     end
   end
 
   context "#capacity_resources_per_vm" do
     it "with normal data" do
       allow(@cluster).to receive(:total_vms).and_return(994)
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(3.530)
     end
@@ -277,7 +280,7 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:total_vms).and_return(994)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(31.187)
     end
   end
@@ -339,9 +342,9 @@ describe EmsCluster::CapacityPlanning do
   it "#capacity_remaining_vm_count" do
     @cluster.update_attribute(:ha_enabled, false)
     allow(@cluster).to receive(:total_vms).and_return(994)
-    allow(@cluster).to receive(:effective_cpu).and_return(31000)
+    allow(@cluster).to receive(:effective_cpu).and_return(31_000)
     allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7786)
+    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7_786)
   end
 
   it "#capacity_remaining_vm_count_based_on_all" do

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -20,25 +20,19 @@ describe EmsRefresh::MetadataRelats do
     end
 
     it "with a Vm" do
-      expect(EmsRefresh.vmdb_relats(@vm)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-        :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-        :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@vm)).to eq(:folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
     end
 
     it "with a Host" do
-      expect(EmsRefresh.vmdb_relats(@host)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@host)).to eq(:folders_to_clusters => {@folder.id => [@cluster.id]})
     end
 
     it "with an EMS" do
-      expect(EmsRefresh.vmdb_relats(@ems)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-        :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-        :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@ems)).to eq(:folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                 :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                 :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
     end
 
     context "with an invalid relats tree" do
@@ -52,13 +46,11 @@ describe EmsRefresh::MetadataRelats do
       end
 
       it "with an EMS" do
-        expect(EmsRefresh.vmdb_relats(@ems)).to eq({
-          :folders_to_hosts           => {@folder.id  => [@host.id]},
-          :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-          :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-          :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
-          :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-        })
+        expect(EmsRefresh.vmdb_relats(@ems)).to eq(:folders_to_hosts           => {@folder.id  => [@host.id]},
+                                                   :folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                   :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                   :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
+                                                   :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
       end
     end
   end

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -20,25 +20,25 @@ describe EmsRefresh::MetadataRelats do
     end
 
     it "with a Vm" do
-      EmsRefresh.vmdb_relats(@vm).should == {
+      expect(EmsRefresh.vmdb_relats(@vm)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
         :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
         :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      }
+      })
     end
 
     it "with a Host" do
-      EmsRefresh.vmdb_relats(@host).should == {
+      expect(EmsRefresh.vmdb_relats(@host)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-      }
+      })
     end
 
     it "with an EMS" do
-      EmsRefresh.vmdb_relats(@ems).should == {
+      expect(EmsRefresh.vmdb_relats(@ems)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
         :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
         :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      }
+      })
     end
 
     context "with an invalid relats tree" do
@@ -52,13 +52,13 @@ describe EmsRefresh::MetadataRelats do
       end
 
       it "with an EMS" do
-        EmsRefresh.vmdb_relats(@ems).should == {
+        expect(EmsRefresh.vmdb_relats(@ems)).to eq({
           :folders_to_hosts           => {@folder.id  => [@host.id]},
           :folders_to_clusters        => {@folder.id  => [@cluster.id]},
           :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
           :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
           :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-        }
+        })
       end
     end
   end

--- a/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_spec.rb
@@ -18,14 +18,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -33,24 +33,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).to eq(@vm1.uid_ems)
       end
     end
 
@@ -66,24 +66,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should_not == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).not_to eq(@vm1.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -91,14 +91,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
     end
 
@@ -114,24 +114,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should_not == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).not_to eq(@vm1.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -139,15 +139,15 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
-        v1.ems_id.should_not be_nil
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
+        expect(v1.ems_id).not_to be_nil
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
     end
 
@@ -164,16 +164,16 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
-        v1.ems_id.should == @ems2.id
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
+        expect(v1.ems_id).to eq(@ems2.id)
 
-        v2.id.should_not == @vm1.id
-        v2.uid_ems.should == @vm1.uid_ems
-        v2.ems_id.should == @ems.id
+        expect(v2.id).not_to eq(@vm1.id)
+        expect(v2.uid_ems).to eq(@vm1.uid_ems)
+        expect(v2.ems_id).to eq(@ems.id)
       end
     end
 
@@ -189,11 +189,11 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 1
+        expect(vms.length).to eq(1)
         v = vms.first
 
-        v.id.should == @vm1.id
-        v.uid_ems.should == @vm1.uid_ems
+        expect(v.id).to eq(@vm1.id)
+        expect(v.uid_ems).to eq(@vm1.uid_ems)
       end
     end
 
@@ -217,14 +217,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -234,24 +234,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).to eq(@vm1.uid_ems)
       end
     end
   end

--- a/spec/models/ems_refresh/vc_updates_spec.rb
+++ b/spec/models/ems_refresh/vc_updates_spec.rb
@@ -62,7 +62,8 @@ describe EmsRefresh::VcUpdates do
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_false
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_false
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode"))
+        .to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_true

--- a/spec/models/ems_refresh/vc_updates_spec.rb
+++ b/spec/models/ems_refresh/vc_updates_spec.rb
@@ -39,7 +39,7 @@ describe EmsRefresh::VcUpdates do
       @prop[:changeSet].first["val"] = prop_value
       EmsRefresh.vc_update(@vm.ems_id, @prop)
       @vm = VmOrTemplate.find(@vm.id) # reload will not handle vm <=> template type change, so we must do a real find
-      @vm.send(meth).should == expected
+      expect(@vm.send(meth)).to eq(expected)
     end
   end
 
@@ -54,30 +54,30 @@ describe EmsRefresh::VcUpdates do
         ]
       }
     ) do
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "sum").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter")).to be_false
     end
   end
 end

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -30,28 +30,28 @@ describe Job::StateMachine do
 
   it "should transition from one state to another by a signal" do
     @obj.signal(:initializing)
-    @obj.state.should eq 'waiting'
+    expect(@obj.state).to eq 'waiting'
   end
 
   it "should transition to another by a signal according to its current state" do
     @obj.state = 'waiting'
     @obj.signal(:start)
-    @obj.state.should eq 'doing'
+    expect(@obj.state).to eq 'doing'
 
     @obj.state = 'retrying'
     @obj.signal(:start)
-    @obj.state.should eq 'working'
+    expect(@obj.state).to eq 'working'
   end
 
   it "should transition to some selected state from any state" do
     @obj.signal(:cancel)
-    @obj.state.should eq 'canceling'
+    expect(@obj.state).to eq 'canceling'
   end
 
   it "should leave the state unchanged for some selected signal" do
     @obj.state = 'doing'
     @obj.signal(:error)
-    @obj.state.should eq 'doing'
+    expect(@obj.state).to eq 'doing'
   end
 
   it "should raise an error if the transition is not allowed" do


### PR DESCRIPTION
Converts tests in the follow model dirs:
* authenticator
* drift_state
* ems_cluster
* ems_refresh
* job
* job_proxy_dispatcher

To test these specifically, run `bundle exec rspec spec/models/authenticator spec/models/drift_state spec/models/ems_cluster spec/models/ems_refresh spec/models/job spec/models/job_proxy_dispatcher`