### PR TITLE
RBAC no count

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -280,6 +280,7 @@ module MiqReport::Generator
           :filter           => conditions,
           :include_for_find => includes,
           :where_clause     => where_clause,
+          :skip_count       => true,
         )
       )
       results = Metric::Helper.remove_duplicate_timestamps(results)


### PR DESCRIPTION
This is part of #5833 - reducing the queries in RBAC and the view screen

- ~~`:results_type => :count` tells RBAC to return a count of the rows. This has potential to remove some larger core queries.~~
- `:skip_count => true` skips RBAC counts before and after rows are fetched. This lets RBAC know that the calling function is just going to throw away these counts.

---

This is more of a future focused feature, but it does remove 2 minor queries and one larger query
I included notes when the queries are uses on the initial list page and the second list page.

name|second page too?|ms before|ms after
---|---|---|---|---
ems count                       |  |0.4|:no_pedestrians:
ems order name                  |  |0.3|0.3
ems count                       |  |0.3|:no_pedestrians:
ems (id)                        |  |0.2|0.2
ems ((id))                      |  |0.2|0.2
vms in ()                       |  |83|83
vms in ()count                  |  |38|:no_pedestrians:
vms (in)                        |  |87|87
vms archived                    |  |0.3|0.3
vms archived templates          |  |0.3|0.3
vms orphaned                       |  |0.3|0.3
vms orphaned templates             |  |0.3|0.3
vms count distinct                 |Y  |28|28
vms distinct id,name order limit 20|Y|53|53
vms details in (20) order          |Y|6.8|6.8
openstack|Y|0.3|0.3

/cc @matthewd @dmetzger57 @gtanzillo 