### PR TITLE
Use ruby 2.2 parser until 2.3 is supported in ruby_parser.

### DIFF
--- a/config/initializers/ruby_parser_ruby23_bridge.rb
+++ b/config/initializers/ruby_parser_ruby23_bridge.rb
@@ -1,0 +1,18 @@
+require 'ruby_parser'
+
+module RubyParserRuby23Bridge
+  def for_current_ruby
+    result = super
+  rescue => e
+    if e.message.include?("unrecognized RUBY_VERSION 2.3")
+      Ruby22Parser.new
+    else
+      raise
+    end
+  else
+    warn "Remove me: #{__FILE__}:#{__LINE__}.  RubyParser now supports ruby 2.3+" if RUBY_VERSION.match(/^2.3/)
+    result
+  end
+end
+
+RubyParser.singleton_class.prepend RubyParserRuby23Bridge


### PR DESCRIPTION
Fixes errors on ruby 2.3.0-preview2 of the variety:
```
  1) ManageIQ::Providers::Kubernetes::ContainerManager::Refresher will perform a full refresh on k8s
     Failure/Error: @ems = FactoryGirl.create(:ems_kubernetes, :hostname => "10.35.0.169",
     RuntimeError:
       unrecognized RUBY_VERSION 2.3.0
      ./lib/extensions/descendant_loader.rb:74:in `classes_in'
      ./lib/extensions/descendant_loader.rb:193:in `classes_in'
      ./lib/extensions/descendant_loader.rb:205:in `block in class_inheritance_relationships'
      ./lib/extensions/descendant_loader.rb:204:in `glob'
      ./lib/extensions/descendant_loader.rb:204:in `class_inheritance_relationships'
      ./lib/extensions/descendant_loader.rb:228:in `load_subclasses'
      ./lib/extensions/descendant_loader.rb:250:in `descendants'
      ./spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb:7:in `block (2 levels) in <top (required)>'
```

See the request to support 2.3 features such as &. "safe navigation operator"
https://github.com/seattlerb/ruby_parser, issue: 201