### PR TITLE
Inventory: Use associations vs parent.send(type)

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -183,7 +183,7 @@ module EmsRefresh::SaveInventory
     end
 
     deletes = hardware.guest_devices.where(:device_type => ["ethernet", "storage"]).to_a.dup
-    save_inventory_multi(:guest_devices, hardware, hashes, deletes, [:device_type, :uid_ems], [:network, :miq_scsi_targets], [:switch, :lan])
+    save_inventory_multi(hardware.guest_devices, hashes, deletes, [:device_type, :uid_ems], [:network, :miq_scsi_targets], [:switch, :lan])
     store_ids_for_new_records(hardware.guest_devices, hashes, [:device_type, :uid_ems])
   end
 
@@ -197,7 +197,7 @@ module EmsRefresh::SaveInventory
     end
 
     deletes = hardware.disks(true).dup
-    save_inventory_multi(:disks, hardware, hashes, deletes, [:controller_type, :location], nil, [:storage, :backing])
+    save_inventory_multi(hardware.disks, hashes, deletes, [:controller_type, :location], nil, [:storage, :backing])
   end
 
   def save_network_inventory(guest_device, hash)
@@ -220,9 +220,9 @@ module EmsRefresh::SaveInventory
       saved_hashes, new_hashes = hashes.partition { |h| h[:id] }
       saved_hashes.each { |h| deletes.delete_if { |d| d.id == h[:id] } } unless deletes.empty? || saved_hashes.empty?
 
-      save_inventory_multi(:networks, hardware, new_hashes, deletes, [:ipaddress], nil, :guest_device)
+      save_inventory_multi(hardware.networks, new_hashes, deletes, [:ipaddress], nil, :guest_device)
     when :scan
-      save_inventory_multi(:networks, hardware, hashes, deletes, [:description, :guid])
+      save_inventory_multi(hardware.networks, hashes, deletes, [:description, :guid])
     end
   end
 
@@ -234,27 +234,27 @@ module EmsRefresh::SaveInventory
               when :scan    then parent.system_services(true).dup
               end
 
-    save_inventory_multi(:system_services, parent, hashes, deletes, [:typename, :name])
+    save_inventory_multi(parent.system_services, hashes, deletes, [:typename, :name])
   end
 
   def save_guest_applications_inventory(parent, hashes)
     deletes = parent.guest_applications(true).dup
-    save_inventory_multi(:guest_applications, parent, hashes, deletes, [:arch, :typename, :name, :version])
+    save_inventory_multi(parent.guest_applications, hashes, deletes, [:arch, :typename, :name, :version])
   end
 
   def save_advanced_settings_inventory(parent, hashes)
     deletes = parent.advanced_settings(true).dup
-    save_inventory_multi(:advanced_settings, parent, hashes, deletes, [:name])
+    save_inventory_multi(parent.advanced_settings, hashes, deletes, [:name])
   end
 
   def save_patches_inventory(parent, hashes)
     deletes = parent.patches(true).dup
-    save_inventory_multi(:patches, parent, hashes, deletes, [:name])
+    save_inventory_multi(parent.patches, hashes, deletes, [:name])
   end
 
   def save_os_processes_inventory(os, hashes)
     deletes = os.processes(true).dup
-    save_inventory_multi(:processes, os, hashes, deletes, [:pid])
+    save_inventory_multi(os.processes, hashes, deletes, [:pid])
   end
 
   def save_custom_attributes_inventory(parent, hashes, mode = :refresh)
@@ -265,18 +265,18 @@ module EmsRefresh::SaveInventory
               when :scan    then parent.custom_attributes(true).dup
               end
 
-    save_inventory_multi(:custom_attributes, parent, hashes, deletes, [:name, :section])
+    save_inventory_multi(parent.custom_attributes, hashes, deletes, [:name, :section])
   end
 
   def save_ems_custom_attributes_inventory(parent, hashes)
     return if hashes.nil?
     deletes = parent.ems_custom_attributes(true).dup
-    save_inventory_multi(:ems_custom_attributes, parent, hashes, deletes, [:section, :name])
+    save_inventory_multi(parent.ems_custom_attributes, hashes, deletes, [:section, :name])
   end
 
   def save_filesystems_inventory(parent, hashes)
     deletes = parent.filesystems(true).dup
-    save_inventory_multi(:filesystems, parent, hashes, deletes, [:name])
+    save_inventory_multi(parent.filesystems, hashes, deletes, [:name])
   end
 
   def save_snapshots_inventory(vm, hashes)
@@ -285,7 +285,7 @@ module EmsRefresh::SaveInventory
     hashes.each { |h| h[:parent_id] = nil } # Delink all snapshots
 
     deletes = vm.snapshots(true).dup
-    save_inventory_multi(:snapshots, vm, hashes, deletes, [:uid])
+    save_inventory_multi(vm.snapshots, hashes, deletes, [:uid])
 
     # Reset the relationship tree for the snapshots
     vm.snapshots.each do |s|
@@ -298,6 +298,6 @@ module EmsRefresh::SaveInventory
 
   def save_event_logs_inventory(os, hashes)
     deletes = os.event_logs(true).dup
-    save_inventory_multi(:event_logs, os, hashes, deletes, [:uid])
+    save_inventory_multi(os.event_logs, hashes, deletes, [:uid])
   end
 end

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -89,7 +89,7 @@ module EmsRefresh::SaveInventoryCloud
                 []
               end
 
-    save_inventory_multi(:flavors, ems, hashes, deletes, [:ems_ref])
+    save_inventory_multi(ems.flavors, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.flavors, hashes, :ems_ref)
   end
 
@@ -103,7 +103,7 @@ module EmsRefresh::SaveInventoryCloud
                 []
               end
 
-    save_inventory_multi(:availability_zones, ems, hashes, deletes, [:ems_ref])
+    save_inventory_multi(ems.availability_zones, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
   end
 
@@ -117,7 +117,7 @@ module EmsRefresh::SaveInventoryCloud
                 []
               end
 
-    save_inventory_multi(:cloud_tenants, ems, hashes, deletes, [:ems_ref])
+    save_inventory_multi(ems.cloud_tenants, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.cloud_tenants, hashes, :ems_ref)
   end
 
@@ -135,7 +135,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:cloud_tenant, :id)
     end
 
-    save_inventory_multi(:cloud_resource_quotas, ems, hashes, deletes, [:ems_ref, :name], nil, :cloud_tenant)
+    save_inventory_multi(ems.cloud_resource_quotas, hashes, deletes, [:ems_ref, :name], nil, :cloud_tenant)
     store_ids_for_new_records(ems.cloud_resource_quotas, hashes, [:ems_ref, :name])
   end
 
@@ -149,7 +149,7 @@ module EmsRefresh::SaveInventoryCloud
                 []
               end
 
-    save_inventory_multi(:key_pairs, ems, hashes, deletes, [:name])
+    save_inventory_multi(ems.key_pairs, hashes, deletes, [:name])
     store_ids_for_new_records(ems.key_pairs, hashes, :name)
   end
 
@@ -170,7 +170,7 @@ module EmsRefresh::SaveInventoryCloud
       # Defer setting :cloud_volume_snapshot_id until after snapshots are saved.
     end
 
-    save_inventory_multi(:cloud_volumes, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :availability_zone, :base_snapshot])
+    save_inventory_multi(ems.cloud_volumes, hashes, deletes, [:ems_ref], nil, [:tenant, :availability_zone, :base_snapshot])
     store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
@@ -190,7 +190,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_volume_id] = h.fetch_path(:volume, :id)
     end
 
-    save_inventory_multi(:cloud_volume_snapshots, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :volume])
+    save_inventory_multi(ems.cloud_volume_snapshots, hashes, deletes, [:ems_ref], nil, [:tenant, :volume])
     store_ids_for_new_records(ems.cloud_volume_snapshots, hashes, :ems_ref)
   end
 
@@ -220,7 +220,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_tenant_id] = h.fetch_path(:tenant, :id)
     end
 
-    save_inventory_multi(:cloud_object_store_containers, ems, hashes, deletes, [:ems_ref], nil, :tenant)
+    save_inventory_multi(ems.cloud_object_store_containers, hashes, deletes, [:ems_ref], nil, :tenant)
     store_ids_for_new_records(ems.cloud_object_store_containers, hashes, :ems_ref)
   end
 
@@ -240,7 +240,7 @@ module EmsRefresh::SaveInventoryCloud
       h[:cloud_object_store_container_id] = h.fetch_path(:container, :id)
     end
 
-    save_inventory_multi(:cloud_object_store_objects, ems, hashes, deletes, [:ems_ref], nil, [:tenant, :container])
+    save_inventory_multi(ems.cloud_object_store_objects, hashes, deletes, [:ems_ref], nil, [:tenant, :container])
     store_ids_for_new_records(ems.cloud_object_store_objects, hashes, :ems_ref)
   end
 
@@ -254,7 +254,7 @@ module EmsRefresh::SaveInventoryCloud
                 []
               end
 
-    save_inventory_multi(:resource_groups, ems, hashes, deletes, [:ems_ref])
+    save_inventory_multi(ems.resource_groups, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.resource_groups, hashes, :ems_ref)
   end
 end

--- a/app/models/ems_refresh/save_inventory_configuration.rb
+++ b/app/models/ems_refresh/save_inventory_configuration.rb
@@ -19,7 +19,7 @@ module EmsRefresh
 
     def save_configuration_profiles_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:configuration_profiles, manager, hashes, delete_missing_records, [:manager_ref])
+      save_inventory_assoc(manager.configuration_profiles, hashes, delete_missing_records, [:manager_ref])
 
       link_children_references(manager.configuration_profiles)
     end
@@ -31,7 +31,7 @@ module EmsRefresh
       hashes.each do |hash|
         hash[:configuration_profile_id] = hash.fetch_path(:configuration_profile, :id)
       end
-      save_inventory_assoc(:configured_systems, manager, hashes, delete_missing_records, [:manager_ref], nil,
+      save_inventory_assoc(manager.configured_systems, hashes, delete_missing_records, [:manager_ref], nil,
                            [:configuration_profile])
     end
   end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -25,7 +25,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_projects, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_projects, hashes, deletes, [:ems_ref],
                          :labels)
     store_ids_for_new_records(ems.container_projects, hashes, :ems_ref)
   end
@@ -41,7 +41,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:persistent_volumes, ems, hashes, deletes, [:ems_ref], [], [:namespace])
+    save_inventory_multi(ems.persistent_volumes, hashes, deletes, [:ems_ref], [], [:namespace])
     store_ids_for_new_records(ems.persistent_volumes, hashes, :ems_ref)
   end
 
@@ -60,7 +60,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(:container_quotas, ems, hashes, deletes, [:ems_ref], :container_quota_items, :project)
+    save_inventory_multi(ems.container_quotas, hashes, deletes, [:ems_ref], :container_quota_items, :project)
     store_ids_for_new_records(ems.container_quotas, hashes, :ems_ref)
   end
 
@@ -72,7 +72,7 @@ module EmsRefresh::SaveInventoryContainer
               else
                 []
               end
-    save_inventory_multi(:container_quota_items, container_quota, hashes, deletes, [:resource])
+    save_inventory_multi(container_quota.container_quota_items, hashes, deletes, [:resource])
     store_ids_for_new_records(container_quota.container_quota_items, hashes, :resource)
   end
 
@@ -90,7 +90,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(:container_limits, ems, hashes, deletes, [:ems_ref], :container_limit_items, :project)
+    save_inventory_multi(ems.container_limits, hashes, deletes, [:ems_ref], :container_limit_items, :project)
     store_ids_for_new_records(ems.container_limits, hashes, :ems_ref)
   end
 
@@ -102,7 +102,7 @@ module EmsRefresh::SaveInventoryContainer
               else
                 []
               end
-    save_inventory_multi(:container_limit_items, container_limit, hashes, deletes, [:resource, :item_type])
+    save_inventory_multi(container_limit.container_limit_items, hashes, deletes, [:resource, :item_type])
     store_ids_for_new_records(container_limit.container_limit_items, hashes, [:resource, :item_type])
   end
 
@@ -122,7 +122,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_service_id] = h.fetch_path(:container_service, :id)
     end
 
-    save_inventory_multi(:container_routes, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_routes, hashes, deletes, [:ems_ref],
                          :labels, [:container_service, :project, :namespace])
     store_ids_for_new_records(ems.container_routes, hashes, :ems_ref)
   end
@@ -138,7 +138,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_nodes, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_nodes, hashes, deletes, [:ems_ref],
                          [:labels, :computer_system, :container_conditions], [:namespace])
     store_ids_for_new_records(ems.container_nodes, hashes, :ems_ref)
   end
@@ -162,7 +162,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(:container_replicators, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_replicators, hashes, deletes, [:ems_ref],
                          [:labels, :selector_parts], [:project, :namespace])
     store_ids_for_new_records(ems.container_replicators, hashes, :ems_ref)
   end
@@ -183,7 +183,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(:container_services, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_services, hashes, deletes, [:ems_ref],
                          [:labels, :selector_parts, :container_service_port_configs],
                          [:container_groups, :project, :namespace])
 
@@ -207,7 +207,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(:container_groups, ems, hashes, deletes, [:ems_ref],
+    save_inventory_multi(ems.container_groups, hashes, deletes, [:ems_ref],
                          [:container_definitions, :containers, :labels, :node_selector_parts, :container_conditions,
                           :container_volumes], [:container_node, :container_replicator, :project, :namespace])
     store_ids_for_new_records(ems.container_groups, hashes, :ems_ref)
@@ -223,7 +223,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_definitions, container_group, hashes, deletes,
+    save_inventory_multi(container_group.container_definitions, hashes, deletes,
                          [:ems_ref], [:container_port_configs, :container_env_vars, :security_context, :container])
     store_ids_for_new_records(container_group.container_definitions, hashes, :ems_ref)
   end
@@ -238,7 +238,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_port_configs, container_definition, hashes, deletes, [:ems_ref])
+    save_inventory_multi(container_definition.container_port_configs, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_definition.container_port_configs, hashes, :ems_ref)
   end
 
@@ -252,7 +252,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_service_port_configs, container_service, hashes, deletes, [:ems_ref])
+    save_inventory_multi(container_service.container_service_port_configs, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(container_service.container_service_port_configs, hashes, :ems_ref)
   end
 
@@ -264,7 +264,7 @@ module EmsRefresh::SaveInventoryContainer
               else
                 []
               end
-    save_inventory_multi(:container_env_vars, container_definition, hashes, deletes, [:name, :value, :field_path])
+    save_inventory_multi(container_definition.container_env_vars, hashes, deletes, [:name, :value, :field_path])
     store_ids_for_new_records(container_definition.container_env_vars, hashes, [:name, :value, :field_path])
   end
 
@@ -282,7 +282,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_image_registry_id] = h[:container_image_registry][:id] unless h[:container_image_registry].nil?
     end
 
-    save_inventory_multi(:container_images, ems, hashes, deletes, [:image_ref, :container_image_registry_id], [],
+    save_inventory_multi(ems.container_images, hashes, deletes, [:image_ref, :container_image_registry_id], [],
                          :container_image_registry)
     store_ids_for_new_records(ems.container_images, hashes,
                               [:image_ref, :container_image_registry_id])
@@ -299,7 +299,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_image_registries, ems, hashes, deletes, [:host, :port])
+    save_inventory_multi(ems.container_image_registries, hashes, deletes, [:host, :port])
     store_ids_for_new_records(ems.container_image_registries, hashes, [:host, :port])
   end
 
@@ -313,7 +313,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_component_statuses, ems, hashes, deletes, [:name])
+    save_inventory_multi(ems.container_component_statuses, hashes, deletes, [:name])
     store_ids_for_new_records(ems.container_component_statuses, hashes, :name)
   end
 
@@ -335,7 +335,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_conditions, container_entity, hashes, deletes, [:name])
+    save_inventory_multi(container_entity.container_conditions, hashes, deletes, [:name])
     store_ids_for_new_records(container_entity.container_conditions, hashes, :name)
   end
 
@@ -353,7 +353,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:container_volumes, container_group, hashes, deletes, [:name])
+    save_inventory_multi(container_group.container_volumes, hashes, deletes, [:name])
     store_ids_for_new_records(container_group.container_volumes, hashes, :name)
   end
 
@@ -367,7 +367,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:labels, entity, hashes, deletes, [:section, :name])
+    save_inventory_multi(entity.labels, hashes, deletes, [:section, :name])
     store_ids_for_new_records(entity.labels, hashes, [:section, :name])
   end
 
@@ -381,7 +381,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:selector_parts, entity, hashes, deletes, [:section, :name])
+    save_inventory_multi(entity.selector_parts, hashes, deletes, [:section, :name])
     store_ids_for_new_records(entity.selector_parts, hashes, [:section, :name])
   end
 
@@ -395,7 +395,7 @@ module EmsRefresh::SaveInventoryContainer
                 []
               end
 
-    save_inventory_multi(:node_selector_parts, entity, hashes, deletes, [:section, :name])
+    save_inventory_multi(entity.node_selector_parts, hashes, deletes, [:section, :name])
     store_ids_for_new_records(entity.node_selector_parts, hashes, [:section, :name])
   end
 end

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -29,22 +29,7 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
-  # first argument is either an association or a symbol and the parent class
-  # save_inventory_multi(hardware.guest_devices, hashes, deletes, [:uid_ems], [:miq_scsi_targets], [:switch, :lan])
-  # save_inventory_multi(:guest_devices, hardware, hashes, deletes, [:uid_ems], [:miq_scsi_targets], [:switch, :lan])
-  def save_inventory_multi(type, parent, hashes, deletes, find_key = [], child_keys = [], extra_keys = [])
-    association = nil
-    if !type.kind_of?(Symbol) && type < ActiveRecord::Associations
-      association = type
-      # shift args left one
-      raise IllegalArgument, "too many parameters" unless extra_keys.blank?
-      hashes, deletes, find_key, child_keys, extra_keys = parent, hashes, deletes, find_key, child_keys
-    else
-      # legacy accessor
-      association = parent.send(type)
-    end
-    raise IllegalArgument, "missing parameter find_key" if find_key.blank?
-
+  def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [])
     deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
@@ -128,19 +113,7 @@ module EmsRefresh::SaveInventoryHelper
 
   # most of the refresh_inventory_multi calls follow the same pattern
   # this pulls it out
-  def save_inventory_assoc(type, parent, hashes, target, find_key = [], child_keys = [], extra_keys = [])
-    association = nil
-    if !type.kind_of?(Symbol) && type < ActiveRecord::Associations
-      association = type
-      # shift args left one
-      raise IllegalArgument, "too many parameters" unless extra_keys.blank?
-      hashes, target, find_key, child_keys, extra_keys = parent, hashes, target, find_key, child_keys
-    else
-      # legacy accessor
-      association = parent.send(type)
-    end
-    raise IllegalArgument, "missing parameter find_key" if find_key.blank?
-
+  def save_inventory_assoc(association, hashes, target, find_key = [], child_keys = [], extra_keys = [])
     deletes = relation_values(association, target)
     save_inventory_multi(association, hashes, deletes, find_key, child_keys, extra_keys)
     store_ids_for_new_records(association, hashes, find_key)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -29,8 +29,22 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
-  def save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys = [], extra_keys = [])
-    association = parent.send(type)
+  # first argument is either an association or a symbol and the parent class
+  # save_inventory_multi(hardware.guest_devices, hashes, deletes, [:uid_ems], [:miq_scsi_targets], [:switch, :lan])
+  # save_inventory_multi(:guest_devices, hardware, hashes, deletes, [:uid_ems], [:miq_scsi_targets], [:switch, :lan])
+  def save_inventory_multi(type, parent, hashes, deletes, find_key = [], child_keys = [], extra_keys = [])
+    association = nil
+    if !type.kind_of?(Symbol) && type < ActiveRecord::Associations
+      association = type
+      # shift args left one
+      raise IllegalArgument, "too many parameters" unless extra_keys.blank?
+      hashes, deletes, find_key, child_keys, extra_keys = parent, hashes, deletes, find_key, child_keys
+    else
+      # legacy accessor
+      association = parent.send(type)
+    end
+    raise IllegalArgument, "missing parameter find_key" if find_key.blank?
+
     deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
@@ -114,11 +128,21 @@ module EmsRefresh::SaveInventoryHelper
 
   # most of the refresh_inventory_multi calls follow the same pattern
   # this pulls it out
-  def save_inventory_assoc(type, parent, hashes, target, find_key, child_keys = [], extra_keys = [])
-    association = parent.send(type)
-    deletes = relation_values(association, target)
+  def save_inventory_assoc(type, parent, hashes, target, find_key = [], child_keys = [], extra_keys = [])
+    association = nil
+    if !type.kind_of?(Symbol) && type < ActiveRecord::Associations
+      association = type
+      # shift args left one
+      raise IllegalArgument, "too many parameters" unless extra_keys.blank?
+      hashes, target, find_key, child_keys, extra_keys = parent, hashes, target, find_key, child_keys
+    else
+      # legacy accessor
+      association = parent.send(type)
+    end
+    raise IllegalArgument, "missing parameter find_key" if find_key.blank?
 
-    save_inventory_multi(type, parent, hashes, deletes, find_key, child_keys, extra_keys)
+    deletes = relation_values(association, target)
+    save_inventory_multi(association, hashes, deletes, find_key, child_keys, extra_keys)
     store_ids_for_new_records(association, hashes, find_key)
   end
 

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -227,7 +227,7 @@ module EmsRefresh::SaveInventoryInfra
                 []
               end
 
-    save_inventory_multi(:ems_folders, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
+    save_inventory_multi(ems.ems_folders, hashes, deletes, [:uid_ems], nil, :ems_children)
     store_ids_for_new_records(ems.ems_folders, hashes, :uid_ems)
   end
   alias_method :save_ems_folders_inventory, :save_folders_inventory
@@ -242,7 +242,7 @@ module EmsRefresh::SaveInventoryInfra
                 []
               end
 
-    save_inventory_multi(:ems_clusters, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
+    save_inventory_multi(ems.ems_clusters, hashes, deletes, [:uid_ems], nil, :ems_children)
     store_ids_for_new_records(ems.ems_clusters, hashes, :uid_ems)
   end
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
@@ -259,28 +259,28 @@ module EmsRefresh::SaveInventoryInfra
                 []
               end
 
-    save_inventory_multi(:resource_pools, ems, hashes, deletes, [:uid_ems], nil, :ems_children)
+    save_inventory_multi(ems.resource_pools, hashes, deletes, [:uid_ems], nil, :ems_children)
     store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)
     deletes = ems.customization_specs(true).dup
-    save_inventory_multi(:customization_specs, ems, hashes, deletes, [:name])
+    save_inventory_multi(ems.customization_specs, hashes, deletes, [:name])
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
     deletes = guest_device.miq_scsi_targets(true).dup
-    save_inventory_multi(:miq_scsi_targets, guest_device, hashes, deletes, [:uid_ems], :miq_scsi_luns)
+    save_inventory_multi(guest_device.miq_scsi_targets, hashes, deletes, [:uid_ems], :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
     deletes = miq_scsi_target.miq_scsi_luns(true).dup
-    save_inventory_multi(:miq_scsi_luns, miq_scsi_target, hashes, deletes, [:uid_ems])
+    save_inventory_multi(miq_scsi_target.miq_scsi_luns, hashes, deletes, [:uid_ems])
   end
 
   def save_switches_inventory(host, hashes)
     deletes = host.switches(true).dup
-    save_inventory_multi(:switches, host, hashes, deletes, [:uid_ems], :lans)
+    save_inventory_multi(host.switches, hashes, deletes, [:uid_ems], :lans)
 
     host.save!
 
@@ -299,11 +299,11 @@ module EmsRefresh::SaveInventoryInfra
 
   def save_lans_inventory(switch, hashes)
     deletes = switch.lans(true).dup
-    save_inventory_multi(:lans, switch, hashes, deletes, [:uid_ems])
+    save_inventory_multi(switch.lans, hashes, deletes, [:uid_ems])
   end
 
   def save_storage_files_inventory(storage, hashes)
     deletes = storage.storage_files(true).dup
-    save_inventory_multi(:storage_files, storage, hashes, deletes, [:name])
+    save_inventory_multi(storage.storage_files, hashes, deletes, [:name])
   end
 end

--- a/app/models/ems_refresh/save_inventory_networks.rb
+++ b/app/models/ems_refresh/save_inventory_networks.rb
@@ -25,8 +25,7 @@ module EmsRefresh
         h[:orchestration_stack_id] = h.fetch_path(:orchestration_stack, :id)
       end
 
-      save_inventory_multi(:cloud_networks,
-                           ems,
+      save_inventory_multi(ems.cloud_networks,
                            hashes,
                            deletes,
                            [:ems_ref],
@@ -42,7 +41,7 @@ module EmsRefresh
         h[:availability_zone_id] = h.fetch_path(:availability_zone, :id)
       end
 
-      save_inventory_multi(:cloud_subnets, cloud_network, hashes, deletes, [:ems_ref], nil, :availability_zone)
+      save_inventory_multi(cloud_network.cloud_subnets, hashes, deletes, [:ems_ref], nil, :availability_zone)
 
       cloud_network.save!
       store_ids_for_new_records(cloud_network.cloud_subnets, hashes, :ems_ref)
@@ -64,8 +63,7 @@ module EmsRefresh
         h[:orchestration_stack_id] = h.fetch_path(:orchestration_stack, :id)
       end
 
-      save_inventory_multi(:security_groups,
-                           ems, hashes,
+      save_inventory_multi(ems.security_groups, hashes,
                            deletes,
                            [:ems_ref],
                            :firewall_rules,
@@ -99,7 +97,7 @@ module EmsRefresh
         end
       end
 
-      save_inventory_multi(:floating_ips, ems, hashes, deletes, [:ems_ref], nil, [:network_port])
+      save_inventory_multi(ems.floating_ips, hashes, deletes, [:ems_ref], nil, [:network_port])
       store_ids_for_new_records(ems.floating_ips, hashes, :ems_ref)
     end
 
@@ -122,7 +120,7 @@ module EmsRefresh
         end
 
       deletes = parent.firewall_rules(true).dup
-      save_inventory_multi(:firewall_rules, parent, hashes, deletes, find_key, nil, [:source_security_group])
+      save_inventory_multi(parent.firewall_rules, hashes, deletes, find_key, nil, [:source_security_group])
 
       parent.save!
       store_ids_for_new_records(parent.firewall_rules, hashes, find_key)
@@ -143,8 +141,7 @@ module EmsRefresh
         h[:cloud_network_id] = h.fetch_path(:cloud_network, :id)
       end
 
-      save_inventory_multi(:network_routers,
-                           ems,
+      save_inventory_multi(ems.network_routers,
                            hashes,
                            deletes,
                            [:ems_ref],
@@ -171,7 +168,7 @@ module EmsRefresh
         h[:security_groups] = h.fetch_path(:security_groups).map { |x| x[:_object] }
       end
 
-      save_inventory_multi(:network_ports, ems, hashes, deletes, [:ems_ref], nil, [])
+      save_inventory_multi(ems.network_ports, hashes, deletes, [:ems_ref], nil, [])
 
       store_ids_for_new_records(ems.network_ports, hashes, :ems_ref)
     end

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -25,8 +25,7 @@ module EmsRefresh
         h[:cloud_tenant_id]           = h.fetch_path(:cloud_tenant, :id)
       end
 
-      stacks = save_inventory_multi(:orchestration_stacks,
-                                    ems,
+      stacks = save_inventory_multi(ems.orchestration_stacks,
                                     hashes,
                                     deletes,
                                     [:ems_ref],
@@ -48,8 +47,7 @@ module EmsRefresh
     def save_parameters_inventory(orchestration_stack, hashes)
       deletes = orchestration_stack.parameters(true).dup
 
-      save_inventory_multi(:parameters,
-                           orchestration_stack,
+      save_inventory_multi(orchestration_stack.parameters,
                            hashes,
                            deletes,
                            [:ems_ref])
@@ -58,8 +56,7 @@ module EmsRefresh
     def save_outputs_inventory(orchestration_stack, hashes)
       deletes = orchestration_stack.outputs(true).dup
 
-      save_inventory_multi(:outputs,
-                           orchestration_stack,
+      save_inventory_multi(orchestration_stack.outputs,
                            hashes,
                            deletes,
                            [:ems_ref])
@@ -68,8 +65,7 @@ module EmsRefresh
     def save_resources_inventory(orchestration_stack, hashes)
       deletes = orchestration_stack.resources(true).dup
 
-      save_inventory_multi(:resources,
-                           orchestration_stack,
+      save_inventory_multi(orchestration_stack.resources,
                            hashes,
                            deletes,
                            [:ems_ref])

--- a/app/models/ems_refresh/save_inventory_provisioning.rb
+++ b/app/models/ems_refresh/save_inventory_provisioning.rb
@@ -21,7 +21,7 @@ module EmsRefresh
 
     def save_customization_scripts_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:customization_scripts, manager, hashes, delete_missing_records, [:type, :manager_ref])
+      save_inventory_assoc(manager.customization_scripts, hashes, delete_missing_records, [:type, :manager_ref])
     end
 
     def save_operating_system_flavors_inventory(manager, hashes, target)
@@ -31,25 +31,25 @@ module EmsRefresh
           hash[:customization_script_ids] = hash[:customization_scripts].map { |cp| cp[:id] }
         end
       end
-      save_inventory_assoc(:operating_system_flavors, manager, hashes, delete_missing_records, [:manager_ref], nil,
+      save_inventory_assoc(manager.operating_system_flavors, hashes, delete_missing_records, [:manager_ref], nil,
                            [:customization_scripts])
     end
 
     def save_configuration_locations_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:configuration_locations, manager, hashes, delete_missing_records, [:manager_ref])
+      save_inventory_assoc(manager.configuration_locations, hashes, delete_missing_records, [:manager_ref])
       link_children_references(manager.configuration_locations)
     end
 
     def save_configuration_organizations_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:configuration_organizations, manager, hashes, delete_missing_records, [:manager_ref])
+      save_inventory_assoc(manager.configuration_organizations, hashes, delete_missing_records, [:manager_ref])
       link_children_references(manager.configuration_organizations)
     end
 
     def save_configuration_tags_inventory(manager, hashes, target)
       delete_missing_records = target.nil? || manager == target
-      save_inventory_assoc(:configuration_tags, manager, hashes, delete_missing_records, [:type, :manager_ref])
+      save_inventory_assoc(manager.configuration_tags, hashes, delete_missing_records, [:type, :manager_ref])
     end
   end
 end


### PR DESCRIPTION
Noticed we are deriving the association all over our inventory_helper code.

Curious if we can move towards just using associations.

/cc @fryguy common trend for me right now. pushing just using associations