### PR TITLE
Fixed external_httpd_configuration hostname

### DIFF
--- a/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -44,6 +44,7 @@ module ApplianceConsole
         AwesomeSpawn.run!(IPA_INSTALL_COMMAND,
                           :params => [
                             "-N", :force_join, :fixed_primary, :unattended, {
+                              :hostname=  => LinuxAdmin::Hosts.new.hostname,
                               :realm=     => realm,
                               :domain=    => domain,
                               :server=    => server,


### PR DESCRIPTION
Open to suggestions on how to improve this, am a ruby n00b, but essentially, if the hostname passed to the installer is left blank, then the IPA installer uses ```socket.getfqdn()``` in python. This in turn, due to the lack of an arg, will get the hostname for 127.0.0.1, which will be the first hostname with a . in it, as listed in /etc/hosts. On a RHEL based system, this will be localhost.localdomain. This domain name is invalid in ipa and cannot be used with the installer. As the hostname feature uses the ```LinuxAdmin``` module to get the hostname to display, I thought it probably the right call to use it here as well, but may not be putting it in the right place. The code below works, but once again, open to suggestions.