### PR TITLE
RSpec 3 - Models A-E conversion

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -7,8 +7,8 @@ describe Account do
   end
 
   it '#accttype_opposite' do
-    @user.class.accttype_opposite('user').should == 'group'
-    @group.accttype_opposite.should == 'user'
+    expect(@user.class.accttype_opposite('user')).to eq('group')
+    expect(@group.accttype_opposite).to eq('user')
   end
 
   it '#users raise an error when called on user model' do
@@ -16,7 +16,7 @@ describe Account do
   end
 
   it '#users return empty array when called on group' do
-    @group.users.should be_empty
+    expect(@group.users).to be_empty
   end
 
   it '#groups raise an error when called on group model' do
@@ -24,13 +24,13 @@ describe Account do
   end
 
   it '#groups returns empty array when called on user model' do
-    @user.groups.should be_empty
+    expect(@user.groups).to be_empty
   end
 
   it '#add_user and #users' do
-    @group.add_user(@user).should_not be_empty
+    expect(@group.add_user(@user)).not_to be_empty
     # should not add new user if the user already exist in @group
-    @group.add_user(@user).should be_empty
-    @group.users.should include(@user)
+    expect(@group.add_user(@user)).to be_empty
+    expect(@group.users).to include(@user)
   end
 end

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -28,51 +28,51 @@ describe AssignedServerRole do
       end
 
       it "should return Server Role name" do
-        @assigned_server_role.name.should == "smartproxy"
+        expect(@assigned_server_role.name).to eq("smartproxy")
       end
 
       it "should toggle Active indicator" do
         @assigned_server_role.deactivate
-        @assigned_server_role.active.should be_false
+        expect(@assigned_server_role.active).to be_falsey
         @assigned_server_role.activate
-        @assigned_server_role.active.should be_true
+        expect(@assigned_server_role.active).to be_truthy
       end
 
       it "should reset priority" do
         @assigned_server_role.reset
-        @assigned_server_role.active.should be_false
-        @assigned_server_role.priority.should == 2
+        expect(@assigned_server_role.active).to be_falsey
+        expect(@assigned_server_role.priority).to eq(2)
       end
 
       it "should check if -master- role is supported" do
-        @assigned_server_role.master_supported?.should be_true
+        expect(@assigned_server_role.master_supported?).to be_truthy
       end
 
       it "should check if Miq Server is set as -master-" do
-        @assigned_server_role.is_master?.should be_false
+        expect(@assigned_server_role.is_master?).to be_falsey
 
         @assigned_server_role.priority = 1
-        @assigned_server_role.is_master?.should be_false
+        expect(@assigned_server_role.is_master?).to be_falsey
       end
 
       it "should set Miq Server as -master-" do
         @assigned_server_role.set_master
-        @assigned_server_role.priority.should == 1
+        expect(@assigned_server_role.priority).to eq(1)
       end
 
       it "should remove Miq Server as -master-" do
         @assigned_server_role.remove_master
-        @assigned_server_role.priority.should == 2
+        expect(@assigned_server_role.priority).to eq(2)
       end
 
       it "should activate Assigned Server Role" do
         @assigned_server_role.active = false
-        @assigned_server_role.activate.should be_true
+        expect(@assigned_server_role.activate).to be_truthy
       end
 
       it "should deactivate Assigned Server Role" do
         @assigned_server_role.active = true
-        @assigned_server_role.activate.should be_false
+        expect(@assigned_server_role.activate).to be_falsey
       end
     end
   end
@@ -80,7 +80,7 @@ describe AssignedServerRole do
   context "and Server Roles seeded for 1 Region and 2 Zones" do
     before(:each) do
       @miq_region = FactoryGirl.create(:miq_region, :region => 1)
-      MiqRegion.stub(:my_region).and_return(@miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(@miq_region)
 
       @miq_zone1 = FactoryGirl.create(:zone, :name => "Zone 1", :description => "Test Zone One")
       @miq_server_11 = FactoryGirl.create(:miq_server, :zone => @miq_zone1)
@@ -259,34 +259,34 @@ describe AssignedServerRole do
 
     it "should set priority for Server Role scope" do
       @assigned_server_role_11_zu.set_priority(AssignedServerRole::HIGH_PRIORITY)
-      @assigned_server_role_11_zu.priority.should == AssignedServerRole::HIGH_PRIORITY
+      expect(@assigned_server_role_11_zu.priority).to eq(AssignedServerRole::HIGH_PRIORITY)
 
       @assigned_server_role_11_zl.set_priority(AssignedServerRole::HIGH_PRIORITY)
-      @assigned_server_role_11_zl.priority.should == AssignedServerRole::HIGH_PRIORITY
+      expect(@assigned_server_role_11_zl.priority).to eq(AssignedServerRole::HIGH_PRIORITY)
     end
 
     it "should activate Server Role for a Region" do
       @assigned_server_role_11_rl.active = false
       @assigned_server_role_11_rl.activate_in_region
-      @assigned_server_role_11_rl.active.should be_true
+      expect(@assigned_server_role_11_rl.active).to be_truthy
     end
 
     it "should deactivate Server Role for a Region" do
       @assigned_server_role_11_rl.active = true
       @assigned_server_role_11_rl.deactivate_in_region
-      @assigned_server_role_11_rl.active.should be_false
+      expect(@assigned_server_role_11_rl.active).to be_falsey
     end
 
     it "should activate Server Role for a Zone" do
       @assigned_server_role_11_zl.active = false
       @assigned_server_role_11_zl.activate_in_zone
-      @assigned_server_role_11_zl.active.should be_true
+      expect(@assigned_server_role_11_zl.active).to be_truthy
     end
 
     it "should deactivate Server Role for a Zone" do
       @assigned_server_role_11_zl.active = true
       @assigned_server_role_11_zl.deactivate_in_zone
-      @assigned_server_role_11_zl.active.should be_false
+      expect(@assigned_server_role_11_zl.active).to be_falsey
     end
   end
 end

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -13,25 +13,25 @@ describe AsyncDeleteMixin do
 
   def self.should_define_destroy_queue_instance_method
     it "should define destroy_queue instance method" do
-      @obj.respond_to?(:destroy_queue).should be_true, "instance method destroy_queue not defined for #{@obj.class.name}"
+      expect(@obj.respond_to?(:destroy_queue)).to be_truthy, "instance method destroy_queue not defined for #{@obj.class.name}"
     end
   end
 
   def self.should_define_destroy_queue_class_method
     it "should define destroy_queue class method" do
-      @obj.class.respond_to?(:destroy_queue).should be_true, "class method destroy_queue not defined for #{@obj.class.name}"
+      expect(@obj.class.respond_to?(:destroy_queue)).to be_truthy, "class method destroy_queue not defined for #{@obj.class.name}"
     end
   end
 
   def self.should_define_delete_queue_instance_method
     it "should define delete_queue instance method" do
-      @obj.respond_to?(:delete_queue).should be_true, "instance method delete_queue not defined for #{@obj.class.name}"
+      expect(@obj.respond_to?(:delete_queue)).to be_truthy, "instance method delete_queue not defined for #{@obj.class.name}"
     end
   end
 
   def self.should_define_delete_queue_class_method
     it "should define delete_queue class method" do
-      @obj.class.respond_to?(:delete_queue).should be_true, "class method delete_queue not defined for #{@obj.class.name}"
+      expect(@obj.class.respond_to?(:delete_queue)).to be_truthy, "class method delete_queue not defined for #{@obj.class.name}"
     end
   end
 
@@ -39,14 +39,14 @@ describe AsyncDeleteMixin do
     it "should queue up destroy on instance" do
       cond = ["class_name = ? AND instance_id = ? AND method_name = ?", @obj.class.name, @obj.id, "destroy"]
 
-      -> { @obj.destroy_queue }.should_not raise_error
-      MiqQueue.where(cond).count.should == 1
-      @obj.class.any_instance.should_receive(:destroy).once
+      expect { @obj.destroy_queue }.not_to raise_error
+      expect(MiqQueue.where(cond).count).to eq(1)
+      expect_any_instance_of(@obj.class).to receive(:destroy).once
 
       queue_message = MiqQueue.where(cond).first
       status, message, result = queue_message.deliver
       queue_message.delivered(status, message, result)
-      queue_message.state.should == "ok"
+      expect(queue_message.state).to eq("ok")
     end
   end
 
@@ -55,17 +55,17 @@ describe AsyncDeleteMixin do
       ids = @objects.collect(&:id)
       cond = ["class_name = ? AND instance_id in (?) AND method_name = ?", @obj.class.name, ids, "destroy"]
 
-      -> { @obj.class.destroy_queue(ids) }.should_not raise_error
-      MiqQueue.where(cond).count.should == ids.length
+      expect { @obj.class.destroy_queue(ids) }.not_to raise_error
+      expect(MiqQueue.where(cond).count).to eq(ids.length)
       count = @obj.class.count
 
       queue_messages = MiqQueue.where(cond)
       queue_messages.each do |queue_message|
         status, message, result = queue_message.deliver
         queue_message.delivered(status, message, result)
-        queue_message.state.should == "ok"
+        expect(queue_message.state).to eq("ok")
       end
-      @obj.class.count.should == (count - ids.length)
+      expect(@obj.class.count).to eq(count - ids.length)
     end
   end
 
@@ -73,14 +73,14 @@ describe AsyncDeleteMixin do
     it "should queue up delete on instance" do
       cond = ["class_name = ? AND instance_id = ? AND method_name = ?", @obj.class.name, @obj.id, "delete"]
 
-      -> { @obj.delete_queue }.should_not raise_error
-      MiqQueue.where(cond).count.should == 1
-      @obj.class.any_instance.should_receive(:delete).once
+      expect { @obj.delete_queue }.not_to raise_error
+      expect(MiqQueue.where(cond).count).to eq(1)
+      expect_any_instance_of(@obj.class).to receive(:delete).once
 
       queue_message = MiqQueue.where(cond).first
       status, message, result = queue_message.deliver
       queue_message.delivered(status, message, result)
-      queue_message.state.should == "ok"
+      expect(queue_message.state).to eq("ok")
     end
   end
 
@@ -89,17 +89,17 @@ describe AsyncDeleteMixin do
       ids = @objects.collect(&:id)
       cond = ["class_name = ? AND instance_id in (?) AND method_name = ?", @obj.class.name, ids, "delete"]
 
-      -> { @obj.class.delete_queue(ids) }.should_not raise_error
-      MiqQueue.where(cond).count.should == ids.length
+      expect { @obj.class.delete_queue(ids) }.not_to raise_error
+      expect(MiqQueue.where(cond).count).to eq(ids.length)
       count = @obj.class.count
 
       queue_messages = MiqQueue.where(cond)
       queue_messages.each do |queue_message|
         status, message, result = queue_message.deliver
         queue_message.delivered(status, message, result)
-        queue_message.state.should == "ok"
+        expect(queue_message.state).to eq("ok")
       end
-      @obj.class.count.should == (count - ids.length)
+      expect(@obj.class.count).to eq(count - ids.length)
     end
   end
 

--- a/spec/models/audit_event_spec.rb
+++ b/spec/models/audit_event_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe AuditEvent do
   it "should be invalid with empty attributes" do
     event = AuditEvent.new
-    event.should_not be_valid
-    event.errors.should include(:event)
-    event.errors.should include(:status)
-    event.errors.should include(:message)
-    event.errors.should include(:severity)
+    expect(event).not_to be_valid
+    expect(event.errors).to include(:event)
+    expect(event.errors).to include(:status)
+    expect(event.errors).to include(:message)
+    expect(event.errors).to include(:severity)
   end
 
   it "should test for valid status" do
@@ -17,13 +17,13 @@ describe AuditEvent do
     ok.each do |status|
       event = AuditEvent.new(:event => "test_valid_status", :message => "test_valid_status - message", :severity => "info")
       event.status = status
-      event.should be_valid
+      expect(event).to be_valid
     end
 
     bad.each do |status|
       event = AuditEvent.new(:event => "test_invalid_status", :message => "test_invalid_status - message", :severity => "info")
       event.status = status
-      event.should_not be_valid
+      expect(event).not_to be_valid
     end
   end
 
@@ -34,13 +34,13 @@ describe AuditEvent do
     ok.each do|sev|
       event = AuditEvent.new(:event => "test_valid_severity", :message => "test_valid_severity - message",   :status => "success")
       event.severity = sev
-      event.should be_valid
+      expect(event).to be_valid
     end
 
     bad.each do|sev|
       event = AuditEvent.new(:event => "test_invalid_severity", :message => "test_invalid_severity - message",   :status => "success")
       event.severity = sev
-      event.should_not be_valid
+      expect(event).not_to be_valid
     end
   end
 
@@ -48,13 +48,13 @@ describe AuditEvent do
     source = "AuditEventSpec.test_valid_source"
 
     event = AuditEvent.success(tmpl)
-    event.source.should == source
+    expect(event.source).to eq(source)
 
     event = AuditEvent.failure(tmpl)
-    event.source.should == source
+    expect(event.source).to eq(source)
 
     event = AuditEvent.generate(tmpl.merge(:status => "success", :severity => "info"))
-    event.source.should == source
+    expect(event.source).to eq(source)
   end
 
   it "should test for valid source" do

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -13,8 +13,8 @@ describe Authentication do
     it "should create the authentication events and event sets" do
       events = %w(ems_auth_changed ems_auth_valid ems_auth_invalid ems_auth_unreachable ems_auth_incomplete ems_auth_error
                   host_auth_changed host_auth_valid host_auth_invalid host_auth_unreachable host_auth_incomplete host_auth_error)
-      events.each { |event| MiqEventDefinition.exists?(:name => event).should be_true }
-      MiqEventDefinitionSet.exists?(:name => 'auth_validation').should be_true
+      events.each { |event| expect(MiqEventDefinition.exists?(:name => event)).to be_truthy }
+      expect(MiqEventDefinitionSet.exists?(:name => 'auth_validation')).to be_truthy
     end
   end
 

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -128,8 +128,9 @@ describe Authenticator::Amazon do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -124,12 +124,12 @@ describe Authenticator::Amazon do
   end
 
   before(:each) do
-    allow_any_instance_of(described_class).to receive(:aws_connect) { |*args| FakeAmazon.new(user_data, *args) }
+    allow_any_instance_of(described_class).to receive(:aws_connect) { |instance, *args| FakeAmazon.new(user_data, *args) }
   end
 
   describe '#uses_stored_password?' do
     it "is false" do
-      expect(subject.uses_stored_password?).to be_false
+      expect(subject.uses_stored_password?).to be_falsey
     end
   end
 
@@ -456,7 +456,7 @@ describe Authenticator::Amazon do
             task_id = authenticate
             task = MiqTask.find(task_id)
             expect(task.status).to eq('Error')
-            expect(MiqTask.status_error?(task.status)).to be_true
+            expect(MiqTask.status_error?(task.status)).to be_truthy
           end
         end
       end

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -127,7 +127,10 @@ describe Authenticator::Amazon do
     allow_any_instance_of(described_class).to receive(:aws_connect) { |*args| FakeAmazon.new(user_data, *args) }
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -6,7 +6,7 @@ describe Authenticator::Database do
 
   describe '#uses_stored_password?' do
     it "is true" do
-      expect(subject.uses_stored_password?).to be_true
+      expect(subject.uses_stored_password?).to be_truthy
     end
   end
 

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -4,7 +4,10 @@ describe Authenticator::Database do
   subject { Authenticator::Database.new({}) }
   let!(:alice) { FactoryGirl.create(:user, :userid => 'alice', :password => 'secret') }
 
-  its(:uses_stored_password?) { should be_true }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_true }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -5,8 +5,9 @@ describe Authenticator::Database do
   let!(:alice) { FactoryGirl.create(:user, :userid => 'alice', :password => 'secret') }
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_true }
+    it "is true" do
+      expect(subject.uses_stored_password?).to be_true
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -27,7 +27,10 @@ describe Authenticator::Httpd do
     )
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -29,7 +29,7 @@ describe Authenticator::Httpd do
 
   describe '#uses_stored_password?' do
     it "is false" do
-      expect(subject.uses_stored_password?).to be_false
+      expect(subject.uses_stored_password?).to be_falsey
     end
   end
 
@@ -290,7 +290,7 @@ describe Authenticator::Httpd do
             task_id = authenticate
             task = MiqTask.find(task_id)
             expect(task.status).to eq('Error')
-            expect(MiqTask.status_error?(task.status)).to be_true
+            expect(MiqTask.status_error?(task.status)).to be_truthy
           end
         end
       end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -28,8 +28,9 @@ describe Authenticator::Httpd do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -98,8 +98,9 @@ describe Authenticator::Ldap do
   end
 
   describe '#uses_stored_password?' do
-    subject { super().uses_stored_password? }
-    it { should be_false }
+    it "is false" do
+      expect(subject.uses_stored_password?).to be_false
+    end
   end
 
   describe '#lookup_by_identity' do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -94,10 +94,13 @@ describe Authenticator::Ldap do
   end
 
   before(:each) do
-    allow(MiqLdap).to receive(:new).and_return { FakeLdap.new(user_data) }
+    allow(MiqLdap).to receive(:new) { FakeLdap.new(user_data) }
   end
 
-  its(:uses_stored_password?) { should be_false }
+  describe '#uses_stored_password?' do
+    subject { super().uses_stored_password? }
+    it { should be_false }
+  end
 
   describe '#lookup_by_identity' do
     it "finds existing users" do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -99,7 +99,7 @@ describe Authenticator::Ldap do
 
   describe '#uses_stored_password?' do
     it "is false" do
-      expect(subject.uses_stored_password?).to be_false
+      expect(subject.uses_stored_password?).to be_falsey
     end
   end
 
@@ -424,7 +424,7 @@ describe Authenticator::Ldap do
             task_id = authenticate
             task = MiqTask.find(task_id)
             expect(task.status).to eq('Error')
-            expect(MiqTask.status_error?(task.status)).to be_true
+            expect(MiqTask.status_error?(task.status)).to be_truthy
           end
         end
       end

--- a/spec/models/automate_import_json_serializer_spec.rb
+++ b/spec/models/automate_import_json_serializer_spec.rb
@@ -44,29 +44,29 @@ describe AutomateImportJsonSerializer do
     end
 
     before do
-      import_file_upload.stub(:binary_blob).and_return(binary_blob)
-      binary_blob.stub(:binary).and_return("a bunch of junk")
-      MiqAeImport.stub(:new).with("*", "zip_file" => "automate_temporary_zip.zip").and_return(miq_ae_yaml_import_zipfs)
-      miq_ae_yaml_import_zipfs.stub(:domain_entries).with("*").and_return(["Customer/test1.yml", "ManageIQ/test2.yml"])
-      miq_ae_yaml_import_zipfs.stub(:namespace_files).with("Customer").and_return([
+      allow(import_file_upload).to receive(:binary_blob).and_return(binary_blob)
+      allow(binary_blob).to receive(:binary).and_return("a bunch of junk")
+      allow(MiqAeImport).to receive(:new).with("*", "zip_file" => "automate_temporary_zip.zip").and_return(miq_ae_yaml_import_zipfs)
+      allow(miq_ae_yaml_import_zipfs).to receive(:domain_entries).with("*").and_return(["Customer/test1.yml", "ManageIQ/test2.yml"])
+      allow(miq_ae_yaml_import_zipfs).to receive(:namespace_files).with("Customer").and_return([
         "Customer/EVMApplications/test.yml"
       ])
-      miq_ae_yaml_import_zipfs.stub(:namespace_files).with("ManageIQ").and_return([])
-      miq_ae_yaml_import_zipfs.stub(:namespace_files).with("Customer/EVMApplications").and_return([
+      allow(miq_ae_yaml_import_zipfs).to receive(:namespace_files).with("ManageIQ").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:namespace_files).with("Customer/EVMApplications").and_return([
         "Customer/EVMApplications/Operations/test.yml"
       ])
-      miq_ae_yaml_import_zipfs.stub(:namespace_files).with("Customer/EVMApplications/Operations").and_return([
+      allow(miq_ae_yaml_import_zipfs).to receive(:namespace_files).with("Customer/EVMApplications/Operations").and_return([
         "Customer/EVMApplications/Operations/Profile/test.yml"
       ])
-      miq_ae_yaml_import_zipfs.stub(:namespace_files).with("Customer/EVMApplications/Operations/Profile").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:namespace_files).with("Customer/EVMApplications/Operations/Profile").and_return([])
 
-      miq_ae_yaml_import_zipfs.stub(:class_files).with("Customer").and_return([])
-      miq_ae_yaml_import_zipfs.stub(:class_files).with("Customer/EVMApplications").and_return([])
-      miq_ae_yaml_import_zipfs.stub(:class_files).with("Customer/EVMApplications/Operations").and_return([
+      allow(miq_ae_yaml_import_zipfs).to receive(:class_files).with("Customer").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:class_files).with("Customer/EVMApplications").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:class_files).with("Customer/EVMApplications/Operations").and_return([
         "Customer/EVMApplications/Operations/Profile.class/test.yml"
       ])
-      miq_ae_yaml_import_zipfs.stub(:class_files).with("Customer/EVMApplications/Operations/Profile").and_return([])
-      miq_ae_yaml_import_zipfs.stub(:class_files).with("ManageIQ").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:class_files).with("Customer/EVMApplications/Operations/Profile").and_return([])
+      allow(miq_ae_yaml_import_zipfs).to receive(:class_files).with("ManageIQ").and_return([])
     end
 
     it "returns the correct json" do

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AutomationRequest do
   let(:admin) { FactoryGirl.create(:user, :role => "admin") }
   before(:each) do
-    MiqServer.stub(:my_zone).and_return(Zone.seed.name)
+    allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
     @zone        = FactoryGirl.create(:zone, :name => "fred")
     @approver    = FactoryGirl.create(:user_miq_request_approver)
 
@@ -18,26 +18,26 @@ describe AutomationRequest do
   end
 
   it ".request_task_class" do
-    AutomationRequest.request_task_class.should == AutomationTask
+    expect(AutomationRequest.request_task_class).to eq(AutomationTask)
   end
 
   context ".create_from_ws" do
     it "with empty requester string" do
       ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
-      ar.should be_kind_of(AutomationRequest)
+      expect(ar).to be_kind_of(AutomationRequest)
 
-      ar.should == AutomationRequest.first
-      ar.request_state.should == "pending"
-      ar.status.should == "Ok"
-      ar.approval_state.should == "pending_approval"
-      ar.userid.should == admin.userid
-      ar.options[:message].should == @ae_message
-      ar.options[:instance_name].should == @ae_instance
-      ar.options[:user_id].should == admin.id
-      ar.options[:attrs][:var1].should == @ae_var1
-      ar.options[:attrs][:var2].should == @ae_var2
-      ar.options[:attrs][:var3].should == @ae_var3
-      ar.options[:attrs][:userid].should == admin.userid
+      expect(ar).to eq(AutomationRequest.first)
+      expect(ar.request_state).to eq("pending")
+      expect(ar.status).to eq("Ok")
+      expect(ar.approval_state).to eq("pending_approval")
+      expect(ar.userid).to eq(admin.userid)
+      expect(ar.options[:message]).to eq(@ae_message)
+      expect(ar.options[:instance_name]).to eq(@ae_instance)
+      expect(ar.options[:user_id]).to eq(admin.id)
+      expect(ar.options[:attrs][:var1]).to eq(@ae_var1)
+      expect(ar.options[:attrs][:var2]).to eq(@ae_var2)
+      expect(ar.options[:attrs][:var3]).to eq(@ae_var3)
+      expect(ar.options[:attrs][:userid]).to eq(admin.userid)
     end
 
     it "doesnt allow overriding userid who is NOT in the database" do
@@ -53,40 +53,40 @@ describe AutomationRequest do
       ar = AutomationRequest.create_from_ws(@version, admin,
                                             @uri_parts, @parameters,
                                             "user_name" => "#{@approver.userid}")
-      ar.should be_kind_of(AutomationRequest)
+      expect(ar).to be_kind_of(AutomationRequest)
 
-      ar.should == AutomationRequest.first
-      ar.request_state.should == "pending"
-      ar.status.should == "Ok"
-      ar.approval_state.should == "pending_approval"
-      ar.userid.should == @approver.userid
-      ar.options[:message].should == @ae_message
-      ar.options[:instance_name].should == @ae_instance
-      ar.options[:user_id].should == @approver.id
-      ar.options[:attrs][:var1].should == @ae_var1
-      ar.options[:attrs][:var2].should == @ae_var2
-      ar.options[:attrs][:var3].should == @ae_var3
-      ar.options[:attrs][:userid].should == @approver.userid
+      expect(ar).to eq(AutomationRequest.first)
+      expect(ar.request_state).to eq("pending")
+      expect(ar.status).to eq("Ok")
+      expect(ar.approval_state).to eq("pending_approval")
+      expect(ar.userid).to eq(@approver.userid)
+      expect(ar.options[:message]).to eq(@ae_message)
+      expect(ar.options[:instance_name]).to eq(@ae_instance)
+      expect(ar.options[:user_id]).to eq(@approver.id)
+      expect(ar.options[:attrs][:var1]).to eq(@ae_var1)
+      expect(ar.options[:attrs][:var2]).to eq(@ae_var2)
+      expect(ar.options[:attrs][:var3]).to eq(@ae_var3)
+      expect(ar.options[:attrs][:userid]).to eq(@approver.userid)
     end
 
     it "with requester string overriding userid AND auto_approval" do
       ar = AutomationRequest.create_from_ws(@version, admin,
                                             @uri_parts, @parameters,
                                             "user_name" => "#{@approver.userid}", 'auto_approve' => 'true')
-      ar.should be_kind_of(AutomationRequest)
+      expect(ar).to be_kind_of(AutomationRequest)
 
-      ar.should == AutomationRequest.first
-      ar.request_state.should == "pending"
-      ar.status.should == "Ok"
-      ar.approval_state.should == "approved"
-      ar.userid.should == @approver.userid
-      ar.options[:message].should == @ae_message
-      ar.options[:instance_name].should == @ae_instance
-      ar.options[:user_id].should == @approver.id
-      ar.options[:attrs][:var1].should == @ae_var1
-      ar.options[:attrs][:var2].should == @ae_var2
-      ar.options[:attrs][:var3].should == @ae_var3
-      ar.options[:attrs][:userid].should == @approver.userid
+      expect(ar).to eq(AutomationRequest.first)
+      expect(ar.request_state).to eq("pending")
+      expect(ar.status).to eq("Ok")
+      expect(ar.approval_state).to eq("approved")
+      expect(ar.userid).to eq(@approver.userid)
+      expect(ar.options[:message]).to eq(@ae_message)
+      expect(ar.options[:instance_name]).to eq(@ae_instance)
+      expect(ar.options[:user_id]).to eq(@approver.id)
+      expect(ar.options[:attrs][:var1]).to eq(@ae_var1)
+      expect(ar.options[:attrs][:var2]).to eq(@ae_var2)
+      expect(ar.options[:attrs][:var3]).to eq(@ae_var3)
+      expect(ar.options[:attrs][:userid]).to eq(@approver.userid)
     end
   end
 
@@ -99,16 +99,16 @@ describe AutomationRequest do
 
       it "updates approval_state" do
         @ar.approve(@approver, @reason)
-        @ar.reload.approval_state.should == "approved"
+        expect(@ar.reload.approval_state).to eq("approved")
       end
 
       it "calls #call_automate_event_queue('request_approved')" do
-        AutomationRequest.any_instance.should_receive(:call_automate_event_queue).with('request_approved').once
+        expect_any_instance_of(AutomationRequest).to receive(:call_automate_event_queue).with('request_approved').once
         @ar.approve(@approver, @reason)
       end
 
       it "calls #execute" do
-        AutomationRequest.any_instance.should_receive(:execute).once
+        expect_any_instance_of(AutomationRequest).to receive(:execute).once
         @ar.approve(@approver, @reason)
       end
     end
@@ -138,22 +138,22 @@ describe AutomationRequest do
       root = {'ae_result' => 'ok'}
       ws = double('ws')
       ws.stub(:root => root)
-      AutomationRequest.any_instance.stub(:call_automate_event_sync).and_return(ws)
+      allow_any_instance_of(AutomationRequest).to receive(:call_automate_event_sync).and_return(ws)
 
       @ar.create_request_tasks
       @ar.reload
     end
 
     it "should create AutomationTask" do
-      @ar.automation_tasks.length.should == 1
-      AutomationTask.count.should == 1
-      AutomationTask.first.should == @ar.automation_tasks.first
+      expect(@ar.automation_tasks.length).to eq(1)
+      expect(AutomationTask.count).to eq(1)
+      expect(AutomationTask.first).to eq(@ar.automation_tasks.first)
     end
   end
 
   context "validate zone" do
     before do
-      MiqRequest.any_instance.stub(:automate_event_failed?).and_return(false)
+      allow_any_instance_of(MiqRequest).to receive(:automate_event_failed?).and_return(false)
     end
 
     def deliver(zone_name)

--- a/spec/models/automation_task_spec.rb
+++ b/spec/models/automation_task_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe AutomationTask do
   before(:each) do
-    MiqServer.stub(:my_zone).and_return("default")
+    allow(MiqServer).to receive(:my_zone).and_return("default")
     admin         = FactoryGirl.create(:user_admin)
 
     @ae_instance = "IIII"
@@ -20,8 +20,8 @@ describe AutomationTask do
   end
 
   it "#execute" do
-    MiqAeEngine.should_receive(:deliver).once
+    expect(MiqAeEngine).to receive(:deliver).once
     @at.execute
-    @ar.reload.message.should == "#{AutomationRequest::TASK_DESCRIPTION} initiated"
+    expect(@ar.reload.message).to eq("#{AutomationRequest::TASK_DESCRIPTION} initiated")
   end
 end

--- a/spec/models/availability_zone_spec.rb
+++ b/spec/models/availability_zone_spec.rb
@@ -6,13 +6,13 @@ describe AvailabilityZone do
     FactoryGirl.create(:availability_zone_openstack)
     FactoryGirl.create(:availability_zone_openstack_null)
 
-    described_class.available.length.should == 2
-    described_class.available.each { |az| az.class.should_not == ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull }
+    expect(described_class.available.length).to eq(2)
+    described_class.available.each { |az| expect(az.class).not_to eq(ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull) }
   end
 
   it ".event_where_clause" do
     zone = FactoryGirl.create(:availability_zone_amazon)
-    zone.event_where_clause.should_not be nil
-    EmsEvent.where(zone.event_where_clause).length.should be == 0
+    expect(zone.event_where_clause).not_to be nil
+    expect(EmsEvent.where(zone.event_where_clause).length).to eq(0)
   end
 end

--- a/spec/models/binary_blob_part_spec.rb
+++ b/spec/models/binary_blob_part_spec.rb
@@ -17,12 +17,12 @@ describe BinaryBlobPart do
 
     it "without UTF-8 data" do
       @data = "--- Quota - Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it "with UTF-8 data" do
       @data = "--- Quota \xE2\x80\x93 Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
   end
 end

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -15,36 +15,36 @@ describe BinaryBlob do
 
     it "without UTF-8 data" do
       @data = "--- Quota - Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it "with UTF-8 data with bad encoding" do
       @data = "%PDF-1.4\n%\xE2"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it "with UTF-8 data" do
       @data = "--- Quota \xE2\x80\x93 Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it '#binary= with less data than the max parts size' do
       data = "test log data"
       @blob.binary = data.dup # binary= destroys the source data, so dup it
-      @blob.binary.length.should == data.length
+      expect(@blob.binary.length).to eq(data.length)
     end
 
     it '#binary= with more data than the max parts size' do
       data = "test log data"
       data *= ((BinaryBlobPart.default_part_size) / data.length * 2)
       @blob.binary = data.dup # binary= destroys the source data, so dup it
-      @blob.binary.length.should == data.length
+      expect(@blob.binary.length).to eq(data.length)
     end
 
     it '#binary will handle data that is only made up of hex digits' do
       data = "1234567890abcdef"
       @blob.binary = data.dup # binary= destroys the source data, so dup it
-      @blob.binary.length.should == data.length
+      expect(@blob.binary.length).to eq(data.length)
     end
   end
 
@@ -63,17 +63,17 @@ describe BinaryBlob do
 
     it "without UTF-8 data" do
       @data = "--- Quota - Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it "with UTF-8 data" do
       @data = "--- Quota \xE2\x80\x93 Max CPUs\n...\n"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
 
     it "with UTF-8 data with bad encoding" do
       @data = "%PDF-1.4\n%\xE2"
-      subject.bytes.to_a.should == @data.bytes.to_a
+      expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
   end
 

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -38,9 +38,9 @@ describe BlacklistedEvent do
   it '#enabled=' do
     User.current_user = FactoryGirl.create(:user)
     f = FactoryGirl.create(:blacklisted_event, :event_name => 'event_1')
-    expect(f.enabled).to be_true
+    expect(f.enabled).to be_truthy
 
     f.enabled = false
-    expect(f.enabled).to be_false
+    expect(f.enabled).to be_falsey
   end
 end

--- a/spec/models/chargeback_rate_detail_measure_spec.rb
+++ b/spec/models/chargeback_rate_detail_measure_spec.rb
@@ -2,32 +2,32 @@ require 'spec_helper'
 
 describe ChargebackRateDetailMeasure do
   it "has a valid factory" do
-    FactoryGirl.create(:chargeback_rate_detail_measure_bytes).should be_valid
+    expect(FactoryGirl.create(:chargeback_rate_detail_measure_bytes)).to be_valid
   end
 
   it "is invalid without a name" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :name => nil).should_not be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :name => nil)).not_to be_valid
   end
 
   it "is invalid without a step" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => nil).should_not be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => nil)).not_to be_valid
   end
 
   it "is invalid with a step less than 0" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => -9).should_not be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => -9)).not_to be_valid
   end
 
   it "is invalid with a empty array units" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => []).should_not be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => [])).not_to be_valid
   end
 
   it "is invalid with a only one array units" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => ["KB"]).should_not be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => ["KB"])).not_to be_valid
   end
 
   it "is invalid with a units_display lenght diferent that the units lenght" do
-    FactoryGirl.build(:chargeback_rate_detail_measure_bytes,
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes,
                       :units         => %w(Bs KBs GBs),
-                      :units_display => %w(kbps mbps)).should_not be_valid
+                      :units_display => %w(kbps mbps))).not_to be_valid
   end
 end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -12,13 +12,13 @@ describe ChargebackRateDetail do
                              :per_unit => per_unit,
                              :enabled  => true
                             )
-    cbd.cost(cvalue).should == cvalue * cbd.hourly_rate
+    expect(cbd.cost(cvalue)).to eq(cvalue * cbd.hourly_rate)
 
     cbd.group = 'fixed'
-    cbd.cost(cvalue).should == cbd.hourly_rate
+    expect(cbd.cost(cvalue)).to eq(cbd.hourly_rate)
 
     cbd.enabled = false
-    cbd.cost(cvalue).should == 0.0
+    expect(cbd.cost(cvalue)).to eq(0.0)
   end
 
   it "#hourly_rate" do
@@ -28,7 +28,7 @@ describe ChargebackRateDetail do
       '0.00'
     ].each do |rate|
       cbd = FactoryGirl.create(:chargeback_rate_detail, :rate => rate)
-      cbd.hourly_rate.should == 0.0
+      expect(cbd.hourly_rate).to eq(0.0)
     end
     cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
     rate = 8.26
@@ -47,11 +47,11 @@ describe ChargebackRateDetail do
                                :metric                            => 'derived_memory_available',
                                :chargeback_rate_detail_measure_id => cbdm.id
                               )
-      cbd.hourly_rate.should == hourly_rate
+      expect(cbd.hourly_rate).to eq(hourly_rate)
     end
 
     cbd = FactoryGirl.create(:chargeback_rate_detail, :rate => rate, :per_time => 'annually')
-    ->  { cbd.hourly_rate }.should raise_error(RuntimeError, "rate time unit of 'annually' not supported")
+    expect  { cbd.hourly_rate }.to raise_error(RuntimeError, "rate time unit of 'annually' not supported")
   end
 
   it "#rate_adjustment" do
@@ -63,7 +63,7 @@ describe ChargebackRateDetail do
     ].each_slice(2) do |per_unit, rate_adjustment|
       cbd = FactoryGirl.create(:chargeback_rate_detail, :per_unit => per_unit, :metric => 'derived_memory_available',
        :chargeback_rate_detail_measure_id => cbdm.id)
-      cbd.rate_adjustment(value).should == rate_adjustment
+      expect(cbd.rate_adjustment(value)).to eq(rate_adjustment)
     end
   end
 
@@ -71,19 +71,19 @@ describe ChargebackRateDetail do
     source = 'used'
     group  = 'cpu'
     cbd = FactoryGirl.create(:chargeback_rate_detail, :source => source, :group => group)
-    cbd.rate_name.should == "#{group}_#{source}"
+    expect(cbd.rate_name).to eq("#{group}_#{source}")
   end
 
   it "#friendly_rate" do
     friendly_rate = "My Rate"
     cbd = FactoryGirl.create(:chargeback_rate_detail, :friendly_rate => friendly_rate)
-    cbd.friendly_rate.should == friendly_rate
+    expect(cbd.friendly_rate).to eq(friendly_rate)
 
     cbd = FactoryGirl.create(:chargeback_rate_detail, :group => 'fixed', :per_time => 'monthly', :rate => '2.53')
-    cbd.friendly_rate.should == "2.53 Monthly"
+    expect(cbd.friendly_rate).to eq("2.53 Monthly")
 
     cbd = FactoryGirl.create(:chargeback_rate_detail, :per_unit => 'cpu', :per_time => 'monthly', :rate => '2.53')
-    cbd.friendly_rate.should == "Monthly @ 2.53 per Cpu"
+    expect(cbd.friendly_rate).to eq("Monthly @ 2.53 per Cpu")
   end
 
   it "#per_unit_display_without_measurements" do
@@ -92,7 +92,7 @@ describe ChargebackRateDetail do
       'ohms',      'Ohms'
     ].each_slice(2) do |per_unit, per_unit_display|
       cbd = FactoryGirl.create(:chargeback_rate_detail, :per_unit => per_unit)
-      cbd.per_unit_display.should == per_unit_display
+      expect(cbd.per_unit_display).to eq(per_unit_display)
     end
   end
 
@@ -102,17 +102,17 @@ describe ChargebackRateDetail do
                               :per_unit                          => 'megabytes',
                               :chargeback_rate_detail_measure_id => cbdm.id
                              )
-    cbd.per_unit_display.should == 'MB'
+    expect(cbd.per_unit_display).to eq('MB')
   end
 
   it "#rate_type" do
     cbd = FactoryGirl.create(:chargeback_rate_detail)
-    cbd.rate_type.should be_nil
+    expect(cbd.rate_type).to be_nil
 
     rate_type = 'ad-hoc'
     cb = FactoryGirl.create(:chargeback_rate, :rate_type => rate_type)
     cbd.chargeback_rate = cb
-    cbd.rate_type.should == rate_type
+    expect(cbd.rate_type).to eq(rate_type)
   end
 
   it "is valid without per_unit, metric and measure" do
@@ -125,7 +125,7 @@ describe ChargebackRateDetail do
                                  :metric                            => metric,
                                  :chargeback_rate_detail_measure_id => chargeback_rate_detail_measure_id
                                 )
-        cbd.should be_valid
+        expect(cbd).to be_valid
       end
   end
 
@@ -144,6 +144,6 @@ describe ChargebackRateDetail do
                                        :per_time                          => 'monthly',
                                        :chargeback_rate_detail_measure_id => cbdm.id
                                       )
-    cbd_bytes.cost(100).should == cbd_gigabytes.cost(100)
+    expect(cbd_bytes.cost(100)).to eq(cbd_gigabytes.cost(100))
   end
 end

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -4,7 +4,7 @@ describe ChargebackRate do
   context "#validate_rate_type" do
     it "handles valid types" do
       [:compute, :storage, 'compute', 'storage', 'Compute', 'Storage'].each do |type|
-        -> { ChargebackRate.validate_rate_type(type) }.should_not raise_error
+        expect { ChargebackRate.validate_rate_type(type) }.not_to raise_error
       end
     end
 

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -96,13 +96,13 @@ describe Chargeback do
                          :rate               => @count_hourly_rate.to_s,
                         )
 
-      subject.cpu_allocated_metric.should == @cpu_count * @metric_size
-      subject.cpu_used_metric.should == @cpu_usagemhz_rate * @metric_size
-      subject.cpu_metric.should == subject.cpu_allocated_metric + subject.cpu_used_metric
+      expect(subject.cpu_allocated_metric).to eq(@cpu_count * @metric_size)
+      expect(subject.cpu_used_metric).to eq(@cpu_usagemhz_rate * @metric_size)
+      expect(subject.cpu_metric).to eq(subject.cpu_allocated_metric + subject.cpu_used_metric)
 
-      subject.cpu_allocated_cost.should == @cpu_count * @count_hourly_rate * @metric_size
-      subject.cpu_used_cost.should == @cpu_usagemhz_rate * @hourly_rate * @metric_size
-      subject.cpu_cost.should == subject.cpu_allocated_cost + subject.cpu_used_cost
+      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * @metric_size)
+      expect(subject.cpu_used_cost).to eq(@cpu_usagemhz_rate * @hourly_rate * @metric_size)
+      expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
     it "memory" do
@@ -117,13 +117,13 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.memory_allocated_metric.should == @memory_available * @metric_size
-      subject.memory_used_metric.should == @memory_used * @metric_size
-      subject.memory_metric.should == subject.memory_allocated_metric + subject.memory_used_metric
+      expect(subject.memory_allocated_metric).to eq(@memory_available * @metric_size)
+      expect(subject.memory_used_metric).to eq(@memory_used * @metric_size)
+      expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      subject.memory_allocated_cost.should == @memory_available * @hourly_rate * @metric_size
-      subject.memory_used_cost.should == @memory_used * @hourly_rate * @metric_size
-      subject.memory_cost.should == subject.memory_allocated_cost + subject.memory_used_cost
+      expect(subject.memory_allocated_cost).to eq(@memory_available * @hourly_rate * @metric_size)
+      expect(subject.memory_used_cost).to eq(@memory_used * @hourly_rate * @metric_size)
+      expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
     it "disk io" do
@@ -133,11 +133,11 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.disk_io_used_metric.should == @disk_usage_rate * @metric_size
-      subject.disk_io_metric.should == subject.disk_io_metric
+      expect(subject.disk_io_used_metric).to eq(@disk_usage_rate * @metric_size)
+      expect(subject.disk_io_metric).to eq(subject.disk_io_metric)
 
-      subject.disk_io_used_cost.should == @disk_usage_rate * @hourly_rate * @metric_size
-      subject.disk_io_cost.should == subject.disk_io_used_cost
+      expect(subject.disk_io_used_cost).to eq(@disk_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.disk_io_cost).to eq(subject.disk_io_used_cost)
     end
 
     it "net io" do
@@ -147,11 +147,11 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.net_io_used_metric.should == @net_usage_rate * @metric_size
-      subject.net_io_metric.should == subject.net_io_metric
+      expect(subject.net_io_used_metric).to eq(@net_usage_rate * @metric_size)
+      expect(subject.net_io_metric).to eq(subject.net_io_metric)
 
-      subject.net_io_used_cost.should == @net_usage_rate * @hourly_rate * @metric_size
-      subject.net_io_cost.should == subject.net_io_used_cost
+      expect(subject.net_io_used_cost).to eq(@net_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.net_io_cost).to eq(subject.net_io_used_cost)
     end
 
     it "storage" do
@@ -173,13 +173,13 @@ describe Chargeback do
                          :chargeback_rate_detail_measure_id => cbdm.id
                         )
 
-      subject.storage_allocated_metric.should == @vm_allocated_disk_storage.gigabytes * @metric_size
-      subject.storage_used_metric.should == @vm_used_disk_storage.gigabytes * @metric_size
-      subject.storage_metric.should == subject.storage_allocated_metric + subject.storage_used_metric
+      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes * @metric_size)
+      expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
+      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      subject.storage_allocated_cost.should == @vm_allocated_disk_storage * @count_hourly_rate * @metric_size
-      subject.storage_used_cost.should == @vm_used_disk_storage * @count_hourly_rate * @metric_size
-      subject.storage_cost.should == subject.storage_allocated_cost + subject.storage_used_cost
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
   end
 
@@ -229,13 +229,13 @@ describe Chargeback do
                          :rate               => @count_hourly_rate.to_s,
                         )
 
-      subject.cpu_allocated_metric.should == @cpu_count * @metric_size
-      subject.cpu_used_metric.should == @cpu_usagemhz_rate * @metric_size
-      subject.cpu_metric.should == subject.cpu_allocated_metric + subject.cpu_used_metric
+      expect(subject.cpu_allocated_metric).to eq(@cpu_count * @metric_size)
+      expect(subject.cpu_used_metric).to eq(@cpu_usagemhz_rate * @metric_size)
+      expect(subject.cpu_metric).to eq(subject.cpu_allocated_metric + subject.cpu_used_metric)
 
-      subject.cpu_allocated_cost.should == @cpu_count * @count_hourly_rate * @metric_size
-      subject.cpu_used_cost.should == @cpu_usagemhz_rate * @hourly_rate * @metric_size
-      subject.cpu_cost.should == subject.cpu_allocated_cost + subject.cpu_used_cost
+      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * @metric_size)
+      expect(subject.cpu_used_cost).to eq(@cpu_usagemhz_rate * @hourly_rate * @metric_size)
+      expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
     it "memory" do
@@ -250,13 +250,13 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.memory_allocated_metric.should == @memory_available * @metric_size
-      subject.memory_used_metric.should == @memory_used * @metric_size
-      subject.memory_metric.should == subject.memory_allocated_metric + subject.memory_used_metric
+      expect(subject.memory_allocated_metric).to eq(@memory_available * @metric_size)
+      expect(subject.memory_used_metric).to eq(@memory_used * @metric_size)
+      expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      subject.memory_allocated_cost.should == @memory_available * @hourly_rate * @metric_size
-      subject.memory_used_cost.should == @memory_used * @hourly_rate * @metric_size
-      subject.memory_cost.should == subject.memory_allocated_cost + subject.memory_used_cost
+      expect(subject.memory_allocated_cost).to eq(@memory_available * @hourly_rate * @metric_size)
+      expect(subject.memory_used_cost).to eq(@memory_used * @hourly_rate * @metric_size)
+      expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
     it "disk io" do
@@ -266,11 +266,11 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.disk_io_used_metric.should == @disk_usage_rate * @metric_size
-      subject.disk_io_metric.should == subject.disk_io_metric
+      expect(subject.disk_io_used_metric).to eq(@disk_usage_rate * @metric_size)
+      expect(subject.disk_io_metric).to eq(subject.disk_io_metric)
 
-      subject.disk_io_used_cost.should == @disk_usage_rate * @hourly_rate * @metric_size
-      subject.disk_io_cost.should == subject.disk_io_used_cost
+      expect(subject.disk_io_used_cost).to eq(@disk_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.disk_io_cost).to eq(subject.disk_io_used_cost)
     end
 
     it "net io" do
@@ -280,11 +280,11 @@ describe Chargeback do
                          :rate               => @hourly_rate.to_s,
                         )
 
-      subject.net_io_used_metric.should == @net_usage_rate * @metric_size
-      subject.net_io_metric.should == subject.net_io_metric
+      expect(subject.net_io_used_metric).to eq(@net_usage_rate * @metric_size)
+      expect(subject.net_io_metric).to eq(subject.net_io_metric)
 
-      subject.net_io_used_cost.should == @net_usage_rate * @hourly_rate * @metric_size
-      subject.net_io_cost.should == subject.net_io_used_cost
+      expect(subject.net_io_used_cost).to eq(@net_usage_rate * @hourly_rate * @metric_size)
+      expect(subject.net_io_cost).to eq(subject.net_io_used_cost)
     end
 
     it "storage" do
@@ -302,13 +302,13 @@ describe Chargeback do
                          :chargeback_rate_detail_measure_id => cbdm.id
                         )
 
-      subject.storage_allocated_metric.should == @vm_allocated_disk_storage.gigabytes * @metric_size
-      subject.storage_used_metric.should == @vm_used_disk_storage.gigabytes * @metric_size
-      subject.storage_metric.should == subject.storage_allocated_metric + subject.storage_used_metric
+      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes * @metric_size)
+      expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
+      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      subject.storage_allocated_cost.should == @vm_allocated_disk_storage * @count_hourly_rate * @metric_size
-      subject.storage_used_cost.should == @vm_used_disk_storage * @count_hourly_rate * @metric_size
-      subject.storage_cost.should == subject.storage_allocated_cost + subject.storage_used_cost
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
 
     context "by owner" do
@@ -323,12 +323,12 @@ describe Chargeback do
       end
 
       it "valid" do
-        subject.owner_name.should == @user.name
+        expect(subject.owner_name).to eq(@user.name)
       end
 
       it "not exist" do
         @user.delete
-        -> { subject }.should raise_error(MiqException::Error, "Unable to find user '#{@user.userid}'")
+        expect { subject }.to raise_error(MiqException::Error, "Unable to find user '#{@user.userid}'")
       end
     end
   end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -25,14 +25,14 @@ describe Classification do
     let(:tag) { FactoryGirl.build(:classification_tag, :parent => FactoryGirl.build(:classification)) }
 
     it "enforce_policy on sub-classed vm" do
-      MiqEvent.stub(:raise_evm_event).and_return(true)
+      allow(MiqEvent).to receive(:raise_evm_event).and_return(true)
 
       vm = FactoryGirl.build(:vm_vmware, :name => "VM1")
       tag.enforce_policy(vm, "fake_event")
     end
 
     it "enforce_policy on sub-classed host" do
-      MiqEvent.stub(:raise_evm_event).and_return(true)
+      allow(MiqEvent).to receive(:raise_evm_event).and_return(true)
 
       host = FactoryGirl.build(:host_vmware_esx)
       tag.enforce_policy(host, "fake_event")
@@ -115,7 +115,7 @@ describe Classification do
       cat.name = "test_update_entry"
 
       expect(cat).to      be_valid
-      expect(cat.save).to be_true
+      expect(cat.save).to be_truthy
     end
 
     it "should test add duplicate entry" do
@@ -134,7 +134,7 @@ describe Classification do
       ent.name = "test_update_entry"
 
       expect(ent).to      be_valid
-      expect(ent.save).to be_true
+      expect(ent.save).to be_truthy
     end
 
     it "should test update entry to duplicate" do
@@ -278,7 +278,7 @@ describe Classification do
       end
 
       it "with some errors" do
-        MiqEvent.stub(:raise_evm_event).and_raise
+        allow(MiqEvent).to receive(:raise_evm_event).and_raise
 
         expect { Classification.bulk_reassignment(@options) }.to raise_error
 
@@ -301,7 +301,7 @@ describe Classification do
 
   describe ".seed" do
     before do
-      YAML.stub(:load_file).and_return([
+      allow(YAML).to receive(:load_file).and_return([
         {:name         => "cc",
          :description  => "Cost Center",
          :example_text => "Cost Center",

--- a/spec/models/cloud_volume_spec.rb
+++ b/spec/models/cloud_volume_spec.rb
@@ -6,6 +6,6 @@ describe CloudVolume do
     cv1 = FactoryGirl.create(:cloud_volume_amazon, :attachments => [disk])
     cv2 = FactoryGirl.create(:cloud_volume_amazon)
 
-    described_class.available.should == [cv2]
+    expect(described_class.available).to eq([cv2])
   end
 end

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -94,14 +94,14 @@ describe Compliance do
 
         it "compliant" do
           expect(MiqEvent).to receive(:raise_evm_event_queue).with(subject, "vm_compliance_passed")
-          expect(Compliance.check_compliance(subject)).to be_true
+          expect(Compliance.check_compliance(subject)).to be_truthy
         end
 
         it "non-compliant" do
           policy.conditions << FactoryGirl.create(:condition, :expression => MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"}))
 
           expect(MiqEvent).to receive(:raise_evm_event_queue).with(subject, "vm_compliance_failed")
-          expect(Compliance.check_compliance(subject)).to be_false
+          expect(Compliance.check_compliance(subject)).to be_falsey
         end
       end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -22,7 +22,7 @@ describe Condition do
 
       it "valid expression" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2</check></find>"
-        Condition.subst(expr, @cluster, nil).should be
+        expect(Condition.subst(expr, @cluster, nil)).to be
       end
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do
@@ -32,27 +32,27 @@ describe Condition do
 
       it "tests all allowed operators in find/check expression clause" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> == 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'false'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> > 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'true'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'true'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'true'</search><check mode=count><count> < 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'false'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> <= 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'false'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('false')
 
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> != 0</check></find>"
-        Condition.subst(expr, @cluster, nil).should == 'true'
+        expect(Condition.subst(expr, @cluster, nil)).to eq('true')
       end
 
       it "rejects and expression with an illegal operator" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> !! 0</check></find>"
-        expect { Condition.subst(expr, @cluster, nil).should == 'false' }.to raise_error(RuntimeError, "Illegal operator, '!!'")
+        expect { expect(Condition.subst(expr, @cluster, nil)).to eq('false') }.to raise_error(RuntimeError, "Illegal operator, '!!'")
       end
     end
 
@@ -65,12 +65,12 @@ describe Condition do
 
       it "string type registry key data is single quoted" do
         expr = "<registry>#{@reg_string.name}</registry>"
-        Condition.subst(expr, @vm, nil).should == '"y"'
+        expect(Condition.subst(expr, @vm, nil)).to eq('"y"')
       end
 
       it "numerical type registry key data is single quoted" do
         expr = "<registry>#{@reg_num.name}</registry>"
-        Condition.subst(expr, @vm, nil).should == '"0"'
+        expect(Condition.subst(expr, @vm, nil)).to eq('"0"')
       end
     end
   end

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -16,10 +16,10 @@ describe CustomButtonSet do
       button_set3.save!
 
       button_sets = CustomButtonSet.find_all_by_class_name("ServiceTemplate", 1)
-      button_sets.count.should == 2
+      expect(button_sets.count).to eq(2)
 
       all_button_sets = CustomButtonSet.all
-      all_button_sets.count.should == 3
+      expect(all_button_sets.count).to eq(3)
     end
   end
 end

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -5,12 +5,12 @@ describe CustomButton do
     before(:each) do
       @miq_server = EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
 
-      User.any_instance.stub(:role).and_return("admin")
+      allow_any_instance_of(User).to receive(:role).and_return("admin")
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
     end
 
     it "should validate there are no buttons" do
-      described_class.count.should == 0
+      expect(described_class.count).to eq(0)
     end
 
     context "when I create a button via save_as_button class method" do
@@ -39,15 +39,15 @@ describe CustomButton do
       end
 
       it "creates the proper button" do
-        described_class.count.should == 1
-        @button.uri_path.should eq('/System/Process/Automation')
-        @button.applies_to_id.should eq(@target_id)
-        @button.uri_object_name.should == @ae_name
-        @ae_attributes.each { |key, value| @button.uri_attributes[key].should == value.to_s }
+        expect(described_class.count).to eq(1)
+        expect(@button.uri_path).to eq('/System/Process/Automation')
+        expect(@button.applies_to_id).to eq(@target_id)
+        expect(@button.uri_object_name).to eq(@ae_name)
+        @ae_attributes.each { |key, value| expect(@button.uri_attributes[key]).to eq(value.to_s) }
 
         # These attributes are not longer stored with the button
-        @button.uri_attributes['User::user'].should be_nil
-        @button.uri_attributes['MiqServer::miq_server'].should be_nil
+        expect(@button.uri_attributes['User::user']).to be_nil
+        expect(@button.uri_attributes['MiqServer::miq_server']).to be_nil
       end
 
       context "when invoking for a particular VM" do
@@ -59,22 +59,22 @@ describe CustomButton do
         it "calls automate without saved User and MiqServer" do
           User.with_user(@user2) { @button.invoke(@vm) }
 
-          MiqQueue.count.should == 1
+          expect(MiqQueue.count).to eq(1)
           q = MiqQueue.first
-          q.class_name.should == "MiqAeEngine"
-          q.method_name.should == "deliver"
-          q.role.should == "automate"
-          q.zone.should eq("default")
-          q.priority.should == MiqQueue::HIGH_PRIORITY
+          expect(q.class_name).to eq("MiqAeEngine")
+          expect(q.method_name).to eq("deliver")
+          expect(q.role).to eq("automate")
+          expect(q.zone).to eq("default")
+          expect(q.priority).to eq(MiqQueue::HIGH_PRIORITY)
           a = q.args
-          a.should be_kind_of(Array)
+          expect(a).to be_kind_of(Array)
           h = a.first
-          h.should be_kind_of(Hash)
-          h[:user_id].should == @user2.id
-          h[:object_type].should == @vm.class.base_class.name
-          h[:object_id].should == @vm.id
+          expect(h).to be_kind_of(Hash)
+          expect(h[:user_id]).to eq(@user2.id)
+          expect(h[:object_type]).to eq(@vm.class.base_class.name)
+          expect(h[:object_id]).to eq(@vm.id)
           expect(h[:attrs]).to include(@ae_attributes)
-          h[:instance_name].should == @ae_name
+          expect(h[:instance_name]).to eq(@ae_name)
         end
       end
     end
@@ -98,10 +98,10 @@ describe CustomButton do
                                     :name        => "foo",
                                     :description => "foo foo")
 
-    described_class.buttons_for(Host).should == []
-    described_class.buttons_for(Vm).should == [button1all]
-    described_class.buttons_for(vm).should  match_array([button1vm, button2vm])
-    described_class.buttons_for(vm_other).should == []
+    expect(described_class.buttons_for(Host)).to eq([])
+    expect(described_class.buttons_for(Vm)).to eq([button1all])
+    expect(described_class.buttons_for(vm)).to  match_array([button1vm, button2vm])
+    expect(described_class.buttons_for(vm_other)).to eq([])
   end
 
   it "#save" do
@@ -112,7 +112,7 @@ describe CustomButton do
     ra.ae_message = "new message"
     button.save
 
-    button.reload.resource_action.ae_message.should == 'new message'
+    expect(button.reload.resource_action.ae_message).to eq('new message')
   end
 
   context "validates uniqueness" do
@@ -126,37 +126,37 @@ describe CustomButton do
                                               :applies_to_class => 'Vm',
                                               :name             => @default_name,
                                               :description      => @default_description)
-      button_for_all_vms.should be_valid
+      expect(button_for_all_vms).to be_valid
 
       new_host_button = described_class.new(
         :applies_to_class => 'Host',
         :name             => @default_name,
         :description      => @default_description)
-      new_host_button.should be_valid
+      expect(new_host_button).to be_valid
 
       dup_vm_button = described_class.new(
         :applies_to_class => 'Vm',
         :name             => @default_name,
         :description      => @default_description)
-      dup_vm_button.should_not be_valid
+      expect(dup_vm_button).not_to be_valid
 
       dup_vm_name_button = described_class.new(
         :applies_to_class => 'Vm',
         :name             => @default_name,
         :description      => "hello world")
-      dup_vm_name_button.should_not be_valid
+      expect(dup_vm_name_button).not_to be_valid
 
       dup_vm_desc_button = described_class.new(
         :applies_to_class => 'Vm',
         :name             => "hello",
         :description      => @default_description)
-      dup_vm_desc_button.should_not be_valid
+      expect(dup_vm_desc_button).not_to be_valid
 
       new_vm_button = described_class.new(
         :applies_to_class => 'Vm',
         :name             => "hello",
         :description      => "hello world")
-      new_vm_button.should be_valid
+      expect(new_vm_button).to be_valid
     end
 
     it "applies_to_instance" do
@@ -168,57 +168,57 @@ describe CustomButton do
                                                 :applies_to  => @vm,
                                                 :name        => @default_name,
                                                 :description => @default_description)
-      button_for_single_vm.should be_valid
+      expect(button_for_single_vm).to be_valid
 
       # For same VM
       dup_vm_button = described_class.new(
         :applies_to  => @vm,
         :name        => @default_name,
         :description => @default_description)
-      dup_vm_button.should_not be_valid
+      expect(dup_vm_button).not_to be_valid
 
       dup_vm_name_button = described_class.new(
         :applies_to  => @vm,
         :name        => @default_name,
         :description => "hello world")
-      dup_vm_name_button.should_not be_valid
+      expect(dup_vm_name_button).not_to be_valid
 
       dup_vm_desc_button = described_class.new(
         :applies_to  => @vm,
         :name        => "hello",
         :description => @default_description)
-      dup_vm_desc_button.should_not be_valid
+      expect(dup_vm_desc_button).not_to be_valid
 
       new_vm_button = described_class.new(
         :applies_to  => @vm,
         :name        => "hello",
         :description => "hello world")
-      new_vm_button.should be_valid
+      expect(new_vm_button).to be_valid
 
       # For other VM
       dup_vm_button = described_class.new(
         :applies_to  => vm_other,
         :name        => @default_name,
         :description => @default_description)
-      dup_vm_button.should be_valid
+      expect(dup_vm_button).to be_valid
 
       dup_vm_name_button = described_class.new(
         :applies_to  => vm_other,
         :name        => @default_name,
         :description => "hello world")
-      dup_vm_name_button.should be_valid
+      expect(dup_vm_name_button).to be_valid
 
       dup_vm_desc_button = described_class.new(
         :applies_to  => vm_other,
         :name        => "hello",
         :description => @default_description)
-      dup_vm_desc_button.should be_valid
+      expect(dup_vm_desc_button).to be_valid
 
       new_vm_button = described_class.new(
         :applies_to  => vm_other,
         :name        => "hello",
         :description => "hello world")
-      new_vm_button.should be_valid
+      expect(new_vm_button).to be_valid
     end
   end
 end

--- a/spec/models/customization_template_cloud_init_spec.rb
+++ b/spec/models/customization_template_cloud_init_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe CustomizationTemplateCloudInit do
   context "#default_filename" do
     it "should be user-data.txt" do
-      described_class.new.default_filename.should == 'user-data.txt'
+      expect(described_class.new.default_filename).to eq('user-data.txt')
     end
   end
 end

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -9,26 +9,26 @@ describe DatabaseBackup do
 
     it "should support backup with internal pg" do
       @db_opts[:name] = "internal"
-      MiqDbConfig.any_instance.stub(:options).and_return(@db_opts)
-      DatabaseBackup.backup_supported?.should be_true
+      allow_any_instance_of(MiqDbConfig).to receive(:options).and_return(@db_opts)
+      expect(DatabaseBackup.backup_supported?).to be_truthy
     end
 
     it "should support backup with pg" do
       @db_opts[:name] = "postgresql"
-      MiqDbConfig.any_instance.stub(:options).and_return(@db_opts)
-      DatabaseBackup.backup_supported?.should be_true
+      allow_any_instance_of(MiqDbConfig).to receive(:options).and_return(@db_opts)
+      expect(DatabaseBackup.backup_supported?).to be_truthy
     end
 
     it "should support backup with external pg" do
       @db_opts[:name] = "external_evm"
-      MiqDbConfig.any_instance.stub(:options).and_return(@db_opts)
-      DatabaseBackup.backup_supported?.should be_true
+      allow_any_instance_of(MiqDbConfig).to receive(:options).and_return(@db_opts)
+      expect(DatabaseBackup.backup_supported?).to be_truthy
     end
 
     it "should not support backup with mysql" do
       @db_opts[:name] = "mysql"
-      MiqDbConfig.any_instance.stub(:options).and_return(@db_opts)
-      DatabaseBackup.backup_supported?.should_not be_true
+      allow_any_instance_of(MiqDbConfig).to receive(:options).and_return(@db_opts)
+      expect(DatabaseBackup.backup_supported?).not_to be_truthy
     end
   end
 
@@ -40,18 +40,18 @@ describe DatabaseBackup do
 
     it "should set region_name based on my_region_number if database backup has a region" do
       backup = FactoryGirl.create(:database_backup)
-      backup.region_name.should == "region_#{@region.region}"
+      expect(backup.region_name).to eq("region_#{@region.region}")
     end
 
     it "should set region_name to region_0 if region is unknown" do
       # my_region_number => 0 if REGION file is missing or empty
       described_class.stub(:my_region_number => 0)
       backup = FactoryGirl.create(:database_backup)
-      backup.region_name.should == "region_0"
+      expect(backup.region_name).to eq("region_0")
     end
 
     it "should set class method region_name to MiqRegion.my_region.region" do
-      DatabaseBackup.region_name.should == "region_#{@region.region}"
+      expect(DatabaseBackup.region_name).to eq("region_#{@region.region}")
     end
   end
 
@@ -67,13 +67,13 @@ describe DatabaseBackup do
     it "should set schedule_name to schedule_unknown if database backup was not passed a valid schedule id" do
       backup = FactoryGirl.create(:database_backup)
       backup.instance_variable_set(:@schedule, nil)
-      backup.schedule_name.should == "schedule_unknown"
+      expect(backup.schedule_name).to eq("schedule_unknown")
     end
 
     it "should set schedule_name to a sanitized version of the schedule's name if database backup was passed a valid schedule id" do
       backup = FactoryGirl.create(:database_backup)
       backup.instance_variable_set(:@sch, @schedule)
-      backup.schedule_name.should == @sanitized_name
+      expect(backup.schedule_name).to eq(@sanitized_name)
     end
   end
 end

--- a/spec/models/dialog_field_check_box_spec.rb
+++ b/spec/models/dialog_field_check_box_spec.rb
@@ -11,7 +11,7 @@ describe DialogFieldCheckBox do
         let(:value) { "" }
 
         before do
-          DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("processor")
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("processor")
         end
 
         it "returns the values from the value processor" do
@@ -45,7 +45,7 @@ describe DialogFieldCheckBox do
       let(:value) { "t" }
 
       it "returns true" do
-        expect(dialog_field.checked?).to be_true
+        expect(dialog_field.checked?).to be_truthy
       end
     end
 
@@ -53,7 +53,7 @@ describe DialogFieldCheckBox do
       let(:value) { "1" }
 
       it "returns false" do
-        expect(dialog_field.checked?).to be_false
+        expect(dialog_field.checked?).to be_falsey
       end
     end
   end
@@ -62,7 +62,7 @@ describe DialogFieldCheckBox do
     let(:dialog_field) { described_class.new }
 
     it "returns false" do
-      expect(dialog_field.initial_values).to be_false
+      expect(dialog_field.initial_values).to be_falsey
     end
   end
 
@@ -90,11 +90,11 @@ describe DialogFieldCheckBox do
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to be_true
+        expect(dialog_field.required).to be_truthy
       end
 
       it "sets the read_only" do
-        expect(dialog_field.read_only).to be_true
+        expect(dialog_field.read_only).to be_truthy
       end
     end
 
@@ -136,7 +136,7 @@ describe DialogFieldCheckBox do
 
     shared_examples_for "DialogFieldCheckBox#validate that returns nil" do
       it "returns nil" do
-        dialog_field_check_box.validate(dialog_tab, dialog_group).should be_nil
+        expect(dialog_field_check_box.validate(dialog_tab, dialog_group)).to be_nil
       end
     end
 
@@ -153,7 +153,7 @@ describe DialogFieldCheckBox do
         let(:value) { "f" }
 
         it "returns error message" do
-          dialog_field_check_box.validate(dialog_tab, dialog_group).should eq(
+          expect(dialog_field_check_box.validate(dialog_tab, dialog_group)).to eq(
             "tab/group/dialog_field_check_box is required"
           )
         end
@@ -181,7 +181,7 @@ describe DialogFieldCheckBox do
     let(:dialog_field) { described_class.new }
 
     before do
-      DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("f")
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("f")
     end
 
     it "returns the checked value in a hash" do

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -31,7 +31,7 @@ describe DialogFieldDateControl do
         let(:dynamic) { true }
 
         before do
-          DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("2015-01-02")
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("2015-01-02")
         end
 
         it "returns the values from the value processor" do
@@ -43,7 +43,7 @@ describe DialogFieldDateControl do
         let(:dynamic) { false }
 
         before do
-          described_class.stub(:server_timezone).and_return("UTC")
+          allow(described_class).to receive(:server_timezone).and_return("UTC")
         end
 
         it "returns tomorrow's date" do
@@ -66,7 +66,7 @@ describe DialogFieldDateControl do
     end
 
     before do
-      described_class.stub(:server_timezone).and_return("UTC")
+      allow(described_class).to receive(:server_timezone).and_return("UTC")
     end
 
     shared_examples_for "DialogFieldDateControl#normalize_automate_values" do
@@ -75,11 +75,11 @@ describe DialogFieldDateControl do
       end
 
       it "sets the show_past_dates" do
-        expect(dialog_field.show_past_dates).to be_true
+        expect(dialog_field.show_past_dates).to be_truthy
       end
 
       it "sets the read_only" do
-        expect(dialog_field.read_only).to be_true
+        expect(dialog_field.read_only).to be_truthy
       end
     end
 
@@ -132,7 +132,7 @@ describe DialogFieldDateControl do
     let(:dialog_field) { described_class.new }
 
     before do
-      DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("2015-01-02")
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("2015-01-02")
     end
 
     it "returns the values from the value processor" do
@@ -177,19 +177,19 @@ describe DialogFieldDateControl do
 
   context "#show_past_dates" do
     it "default" do
-      subject.show_past_dates.should == false
+      expect(subject.show_past_dates).to eq(false)
     end
 
     it "when true" do
       subject.show_past_dates = true
-      subject.options[:show_past_dates].should be_true
-      subject.show_past_dates.should be_true
+      expect(subject.options[:show_past_dates]).to be_truthy
+      expect(subject.show_past_dates).to be_truthy
     end
 
     it "when false" do
       subject.show_past_dates = false
-      subject.options[:show_past_dates].should be_false
-      subject.show_past_dates.should be_false
+      expect(subject.options[:show_past_dates]).to be_falsey
+      expect(subject.show_past_dates).to be_falsey
     end
   end
 end

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -8,43 +8,43 @@ describe DialogFieldDateTimeControl do
 
     context "with UTC timezone" do
       before(:each) do
-        user.stub(:get_timezone).and_return("UTC")
+        allow(user).to receive(:get_timezone).and_return("UTC")
       end
 
       it "#automate_output_value with UTC timezone" do
         subject.value = "07/20/2013 16:26"
-        subject.automate_output_value.should == "2013-07-20T16:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-20T16:26:00Z")
       end
 
       it "#automate_output_value in ISO format" do
         subject.value = "2013-07-20T16:26:00-05:00"
-        subject.automate_output_value.should == "2013-07-20T21:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-20T21:26:00Z")
       end
 
       it "#automate_output_value in ISO format and UTC timezone" do
         subject.value = "2013-07-20T21:26:00Z"
-        subject.automate_output_value.should == "2013-07-20T21:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-20T21:26:00Z")
       end
     end
 
     context "with HST timezone" do
       before(:each) do
-        user.stub(:get_timezone).and_return("HST")
+        allow(user).to receive(:get_timezone).and_return("HST")
       end
 
       it "#automate_output_value" do
         subject.value = "07/20/2013 16:26"
-        subject.automate_output_value.should == "2013-07-21T02:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-21T02:26:00Z")
       end
 
       it "#automate_output_value in ISO format" do
         subject.value = "2013-07-20T16:26:00-10:00"
-        subject.automate_output_value.should == "2013-07-21T02:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-21T02:26:00Z")
       end
 
       it "#automate_output_value in ISO format and UTC timezone" do
         subject.value = "2013-07-20T21:26:00Z"
-        subject.automate_output_value.should == "2013-07-20T21:26:00Z"
+        expect(subject.automate_output_value).to eq("2013-07-20T21:26:00Z")
       end
     end
   end
@@ -79,7 +79,7 @@ describe DialogFieldDateTimeControl do
         let(:dynamic) { true }
 
         before do
-          DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("2015-01-02")
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("2015-01-02")
         end
 
         it "returns the values from the value processor" do
@@ -91,7 +91,7 @@ describe DialogFieldDateTimeControl do
         let(:dynamic) { false }
 
         before do
-          described_class.stub(:server_timezone).and_return("UTC")
+          allow(described_class).to receive(:server_timezone).and_return("UTC")
         end
 
         it "returns tomorrow's date" do
@@ -107,8 +107,8 @@ describe DialogFieldDateTimeControl do
     let(:dialog_field) { described_class.new }
 
     before do
-      described_class.stub(:server_timezone).and_return("UTC")
-      DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("2015-02-03T18:50:00Z")
+      allow(described_class).to receive(:server_timezone).and_return("UTC")
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("2015-02-03T18:50:00Z")
     end
 
     it "returns the default value in a hash" do

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -7,41 +7,41 @@ describe DialogFieldDropDownList do
     end
 
     it "sort_by" do
-      @df.sort_by.should == :description
+      expect(@df.sort_by).to eq(:description)
       @df.sort_by = :none
-      @df.sort_by.should == :none
+      expect(@df.sort_by).to eq(:none)
       @df.sort_by = :value
-      @df.sort_by.should == :value
-      -> { @df.sort_by = :data }.should raise_error(RuntimeError)
-      @df.sort_by.should == :value
+      expect(@df.sort_by).to eq(:value)
+      expect { @df.sort_by = :data }.to raise_error(RuntimeError)
+      expect(@df.sort_by).to eq(:value)
     end
 
     it "sort_order" do
-      @df.sort_order.should == :ascending
+      expect(@df.sort_order).to eq(:ascending)
       @df.sort_order = :descending
-      @df.sort_order.should == :descending
-      -> { @df.sort_order = :mixed }.should raise_error(RuntimeError)
-      @df.sort_order.should == :descending
+      expect(@df.sort_order).to eq(:descending)
+      expect { @df.sort_order = :mixed }.to raise_error(RuntimeError)
+      expect(@df.sort_order).to eq(:descending)
     end
 
     it "return sorted values array as strings" do
       @df.data_type = "string"
       @df.values = [["2", "Y"], ["1", "Z"], ["3", "X"]]
-      @df.values.should == [["3", "X"], ["2", "Y"], ["1", "Z"]]
+      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
       @df.sort_order = :descending
-      @df.values.should == [["1", "Z"], ["2", "Y"], ["3", "X"]]
+      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      @df.values.should == [["1", "Z"], ["2", "Y"], ["3", "X"]]
+      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
       @df.sort_order = :descending
-      @df.values.should == [["3", "X"], ["2", "Y"], ["1", "Z"]]
+      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      @df.values.should == [["2", "Y"], ["1", "Z"], ["3", "X"]]
+      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
       @df.sort_order = :descending
-      @df.values.should == [["2", "Y"], ["1", "Z"], ["3", "X"]]
+      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
     end
 
     it "return sorted values array as integers" do
@@ -50,15 +50,15 @@ describe DialogFieldDropDownList do
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      @df.values.should == [["2", "Y"], ["3", "X"], ["10", "Z"]]
+      expect(@df.values).to eq([["2", "Y"], ["3", "X"], ["10", "Z"]])
       @df.sort_order = :descending
-      @df.values.should == [["10", "Z"], ["3", "X"], ["2", "Y"]]
+      expect(@df.values).to eq([["10", "Z"], ["3", "X"], ["2", "Y"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      @df.values.should == [["2", "Y"], ["10", "Z"], ["3", "X"]]
+      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
       @df.sort_order = :descending
-      @df.values.should == [["2", "Y"], ["10", "Z"], ["3", "X"]]
+      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
     end
 
     context "#initialize_with_values" do
@@ -69,24 +69,24 @@ describe DialogFieldDropDownList do
       it "no default value" do
         @df.default_value = nil
         @df.initialize_with_values({})
-        @df.value.should.nil?
+        expect(@df.value).to.nil?
       end
 
       it "with default value" do
         @df.default_value = "1"
         @df.initialize_with_values({})
-        @df.value.should == "1"
+        expect(@df.value).to eq("1")
       end
 
       it "with non-matching default value" do
         @df.default_value = "4"
         @df.initialize_with_values({})
-        @df.value.should.nil?
+        expect(@df.value).to.nil?
       end
     end
 
     it "#automate_key_name" do
-      @df.automate_key_name.should == "dialog_drop_down_list"
+      expect(@df.automate_key_name).to eq("dialog_drop_down_list")
     end
   end
 
@@ -97,7 +97,7 @@ describe DialogFieldDropDownList do
       let(:dynamic) { true }
 
       before do
-        DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return(
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
           [["123", 456], ["789", 101]]
         )
         dialog_field.value = "123"
@@ -145,7 +145,7 @@ describe DialogFieldDropDownList do
       let(:dynamic) { true }
 
       before do
-        DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return(%w(automate values))
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(%w(automate values))
       end
 
       context "when the raw values are already set" do

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -37,7 +37,7 @@ describe DialogFieldImporter do
       end
 
       it "creates a DialogFieldDropDownList with dynamic true" do
-        expect(DialogFieldDropDownList.first.dynamic).to be_true
+        expect(DialogFieldDropDownList.first.dynamic).to be_truthy
       end
 
       it "creates a ResourceAction with the given attributes" do
@@ -54,12 +54,12 @@ describe DialogFieldImporter do
 
       it "creates a DialogFieldTextBox with the correct name" do
         dialog_field_importer.import_field(dialog_field)
-        DialogFieldTextBox.first.name.should == "Something"
+        expect(DialogFieldTextBox.first.name).to eq("Something")
       end
 
       it "creates a DialogFieldTextBox with the correct label" do
         dialog_field_importer.import_field(dialog_field)
-        DialogFieldTextBox.first.label.should == "Something else"
+        expect(DialogFieldTextBox.first.label).to eq("Something else")
       end
 
       it "creates a ResourceAction with the given attributes" do
@@ -69,7 +69,7 @@ describe DialogFieldImporter do
 
       it "returns the created object of that type" do
         result = dialog_field_importer.import_field(dialog_field)
-        result.should == DialogFieldTextBox.first
+        expect(result).to eq(DialogFieldTextBox.first)
       end
     end
 
@@ -78,17 +78,17 @@ describe DialogFieldImporter do
 
       it "creates a DialogField with the correct name" do
         dialog_field_importer.import_field(dialog_field)
-        DialogField.first.name.should == "Something"
+        expect(DialogField.first.name).to eq("Something")
       end
 
       it "creates a DialogField with the correct label" do
         dialog_field_importer.import_field(dialog_field)
-        DialogField.first.label.should == "Something else"
+        expect(DialogField.first.label).to eq("Something else")
       end
 
       it "returns the created DialogField object" do
         result = dialog_field_importer.import_field(dialog_field)
-        result.should == DialogField.first
+        expect(result).to eq(DialogField.first)
       end
     end
 

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -26,7 +26,7 @@ describe DialogFieldRadioButton do
           before do
             dialog_field_radio_button.dynamic = true
             dialog_field_radio_button.default_value = "test"
-            DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field_radio_button).and_return(
+            allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field_radio_button).and_return(
               [["processor", 123]]
             )
 
@@ -75,7 +75,7 @@ describe DialogFieldRadioButton do
       context "when the dialog field is dynamic" do
         before do
           dialog_field_radio_button.dynamic = true
-          DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field_radio_button).and_return(
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field_radio_button).and_return(
             [["processor", 123]]
           )
 
@@ -137,7 +137,7 @@ describe DialogFieldRadioButton do
     before do
       dialog_field_radio_button.dynamic = true
       dialog_field_radio_button.default_value = "123"
-      DynamicDialogFieldValueProcessor.stub(:values_from_automate).and_return(refreshed_values_from_automate)
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).and_return(refreshed_values_from_automate)
     end
 
     context "when the checked value is in the list of refreshed values" do

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -41,13 +41,13 @@ describe DialogFieldSerializer do
     end
 
     before do
-      resource_action_serializer.stub(:serialize).with(resource_action).and_return("serialized resource action")
+      allow(resource_action_serializer).to receive(:serialize).with(resource_action).and_return("serialized resource action")
     end
 
     it "serializes the dialog_field" do
-      dialog_field_serializer.serialize(dialog_field).should == expected_serialized_values.merge(
+      expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
         "resource_action" => "serialized resource action"
-      )
+      ))
     end
   end
 end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -6,12 +6,12 @@ describe DialogFieldSortedItem do
   describe "#get_default_value" do
     it "returns the first value when no default and only a single value is available" do
       df.values = [%w(value1 text1)]
-      df.get_default_value.should == "value1"
+      expect(df.get_default_value).to eq("value1")
     end
 
     it "returns nil when no default and multiple values are available" do
       df.values = [%w(value1 text1), %w(value2 text2)]
-      df.get_default_value.should be_nil
+      expect(df.get_default_value).to be_nil
     end
   end
 
@@ -57,11 +57,11 @@ describe DialogFieldSortedItem do
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to be_true
+        expect(dialog_field.required).to be_truthy
       end
 
       it "sets the read_only" do
-        expect(dialog_field.read_only).to be_true
+        expect(dialog_field.read_only).to be_truthy
       end
     end
 

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -7,16 +7,16 @@ describe DialogField do
     end
 
     it "sets default value for required attribute" do
-      @df.required.should == false
+      expect(@df.required).to eq(false)
     end
 
     it "fields named 'action' or 'controller' are invalid" do
       action_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'action')
-      action_field.should_not be_valid
+      expect(action_field).not_to be_valid
       controller_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'controller')
-      controller_field.should_not be_valid
+      expect(controller_field).not_to be_valid
       foo_field = FactoryGirl.build(:dialog_field, :label => 'dialog_field', :name => 'foo')
-      foo_field.should be_valid
+      expect(foo_field).to be_valid
     end
 
     it "supports more than 255 characters within default_value" do
@@ -24,7 +24,7 @@ describe DialogField do
       @df.default_value = str
       expect { @df.save }.to_not raise_error
       @df.reload
-      @df.default_value.should == str
+      expect(@df.default_value).to eq(str)
     end
 
     describe "#validate" do
@@ -39,7 +39,7 @@ describe DialogField do
 
       shared_examples_for "DialogField#validate that returns nil" do
         it "returns nil" do
-          dialog_field.validate(dialog_tab, dialog_group).should be_nil
+          expect(dialog_field.validate(dialog_tab, dialog_group)).to be_nil
         end
       end
 
@@ -50,7 +50,7 @@ describe DialogField do
           let(:value) { "" }
 
           it "returns error message" do
-            dialog_field.validate(dialog_tab, dialog_group).should eq("tab/group/dialog_field is required")
+            expect(dialog_field.validate(dialog_tab, dialog_group)).to eq("tab/group/dialog_field is required")
           end
         end
 
@@ -82,33 +82,33 @@ describe DialogField do
       it "uses #automate_key_name for extracting initial dialog values" do
         dialog_value = "dummy dialog value"
         @df.initialize_with_values(@df.automate_key_name => dialog_value)
-        @df.value.should == dialog_value
+        expect(@df.value).to eq(dialog_value)
       end
 
       it "initializes to nil with no initial value and no default value" do
         initial_dialog_values = {}
         @df.initialize_with_values(initial_dialog_values)
-        @df.value.should be_nil
+        expect(@df.value).to be_nil
       end
 
       it "initializes to the default value with no initial value and a default value" do
         initial_dialog_values = {}
         @df.default_value = "default_test"
         @df.initialize_with_values(initial_dialog_values)
-        @df.value.should == "default_test"
+        expect(@df.value).to eq("default_test")
       end
 
       it "initializes to the dialog value with a dialog value and no default value" do
         initial_dialog_values = {@df.automate_key_name => "test"}
         @df.initialize_with_values(initial_dialog_values)
-        @df.value.should == "test"
+        expect(@df.value).to eq("test")
       end
 
       it "initializes to the dialog value with a dialog value and a default value" do
         initial_dialog_values = {@df.automate_key_name => "test"}
         @df.default_value = "default_test"
         @df.initialize_with_values(initial_dialog_values)
-        @df.value.should == "test"
+        expect(@df.value).to eq("test")
       end
     end
   end

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -16,42 +16,42 @@ describe DialogFieldTagControl do
 
     it "#category=" do
       @df.category = 1
-      @df.options[:category_id].should == 1
+      expect(@df.options[:category_id]).to eq(1)
     end
 
     it "#category" do
-      @df.category.should be_nil
+      expect(@df.category).to be_nil
     end
 
     it "#category_name" do
-      @df.category_name.should be_nil
+      expect(@df.category_name).to be_nil
     end
 
     it "#category_description" do
-      @df.category_description.should be_nil
+      expect(@df.category_description).to be_nil
     end
 
     it "#single_value?" do
-      @df.single_value?.should be_false
+      expect(@df.single_value?).to be_falsey
 
       @df.force_single_value = true
-      @df.single_value?.should be_true
+      expect(@df.single_value?).to be_truthy
     end
 
     it "#automate_key_name" do
-      @df.automate_key_name.should == "Array::dialog_#{@df.name}"
+      expect(@df.automate_key_name).to eq("Array::dialog_#{@df.name}")
     end
 
     describe "#initialize_with_values" do
       it "uses #automate_key_name for extracting initial dialog values" do
         dialog_value = "dummy dialog value"
         @df.initialize_with_values(@df.automate_key_name => dialog_value)
-        @df.value.should == dialog_value
+        expect(@df.value).to eq(dialog_value)
       end
 
       it "converts automate dialog value to Classification ids" do
         @df.initialize_with_values(@df.automate_key_name => "Classification::123,Classification::234")
-        @df.value.should == "123,234"
+        expect(@df.value).to eq("123,234")
       end
     end
   end
@@ -64,19 +64,19 @@ describe DialogFieldTagControl do
     end
 
     it "#category" do
-      @df.category.should == 1
+      expect(@df.category).to eq(1)
     end
 
     it "#category_name" do
-      @df.category_name.should == 'category'
+      expect(@df.category_name).to eq('category')
     end
 
     it "#category_description" do
-      @df.category_description.should == 'description'
+      expect(@df.category_description).to eq('description')
     end
 
     it "#single_value?" do
-      @df.single_value?.should be_true
+      expect(@df.single_value?).to be_truthy
     end
   end
 
@@ -89,14 +89,14 @@ describe DialogFieldTagControl do
     end
 
     it "#single_value?" do
-      @df.single_value?.should be_true
+      expect(@df.single_value?).to be_truthy
 
       cat = FactoryGirl.create(:classification, :description => "Auto Approve - Max Memory", :name => "prov_max_memory", :single_value => 0)
       df  = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag category', :name => 'test tag category',
             :options => {:category_id => cat.id, :category_name => 'category', :category_description => 'description'}
                               )
 
-      df.single_value?.should be_false
+      expect(df.single_value?).to be_falsey
     end
   end
 
@@ -118,13 +118,13 @@ describe DialogFieldTagControl do
         {:id => cat.id, :description => cat.description, :single_value => cat.single_value}
       end.sort_by { |cat| cat[:description] }
 
-      DialogFieldTagControl.allowed_tag_categories.should match_array(expected_array)
+      expect(DialogFieldTagControl.allowed_tag_categories).to match_array(expected_array)
     end
 
     it ".category_tags" do
       category = Classification.where(:description => "Environment", :parent_id => 0).first
       expected_array = category.entries.collect { |t| {:id => t.id, :name => t.name, :description => t.description} }
-      DialogFieldTagControl.category_tags(category.id).should match_array(expected_array)
+      expect(DialogFieldTagControl.category_tags(category.id)).to match_array(expected_array)
     end
 
     context "with dialog field tag control without options hash" do
@@ -137,23 +137,23 @@ describe DialogFieldTagControl do
         @df.options[:category_id] = cat.id
 
         expected_array = cat.entries.collect { |c| {:id => c.id, :name => c.name, :description => c.description} }.sort_by { |cat| cat[:description] }
-        @df.values.should match_array(expected_array)
+        expect(@df.values).to match_array(expected_array)
       end
 
       it "automate_output_value with an empty value" do
-        @df.automate_output_value.should == ""
+        expect(@df.automate_output_value).to eq("")
       end
 
       it "automate_output_value with an single value" do
         tag = Classification.first
         @df.value = tag.id.to_s
-        @df.automate_output_value.should == "#{tag.class.name}::#{tag.id}"
+        expect(@df.automate_output_value).to eq("#{tag.class.name}::#{tag.id}")
       end
 
       it "automate_output_value with multiple values" do
         tags = [Classification.first, Classification.last]
         @df.value = tags.collect(&:id).join(",")
-        @df.automate_output_value.split(",").should match_array tags.collect { |tag| "#{tag.class.name}::#{tag.id}" }
+        expect(@df.automate_output_value.split(",")).to match_array tags.collect { |tag| "#{tag.class.name}::#{tag.id}" }
       end
     end
   end

--- a/spec/models/dialog_field_text_area_box_spec.rb
+++ b/spec/models/dialog_field_text_area_box_spec.rb
@@ -22,7 +22,7 @@ describe DialogFieldTextAreaBox do
       end
 
       it "does not set the protected" do
-        expect(dialog_field.protected?).to be_false
+        expect(dialog_field.protected?).to be_falsey
       end
 
       it "does not set the validator type" do
@@ -34,11 +34,11 @@ describe DialogFieldTextAreaBox do
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to be_true
+        expect(dialog_field.required).to be_truthy
       end
 
       it "sets the read_only" do
-        expect(dialog_field.read_only).to be_true
+        expect(dialog_field.read_only).to be_truthy
       end
     end
 

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -7,12 +7,12 @@ describe DialogFieldTextBox do
     end
 
     it "#protected?" do
-      @df.should_not be_protected
+      expect(@df).not_to be_protected
     end
 
     it "#protected=" do
       @df.protected = true
-      @df.should be_protected
+      expect(@df).to be_protected
     end
 
     describe "#initialize_with_values" do
@@ -20,7 +20,7 @@ describe DialogFieldTextBox do
         password = "test"
         @df.protected = true
         @df.initialize_with_values(@df.automate_key_name => MiqPassword.encrypt(password))
-        @df.value.should == password
+        expect(@df.value).to eq(password)
       end
     end
   end
@@ -36,11 +36,11 @@ describe DialogFieldTextBox do
     end
 
     it "#protected?" do
-      @df.should_not be_protected
+      expect(@df).not_to be_protected
     end
 
     it "#automate_key_name" do
-      @df.automate_key_name.should == "dialog_test field"
+      expect(@df.automate_key_name).to eq("dialog_test field")
     end
   end
 
@@ -55,7 +55,7 @@ describe DialogFieldTextBox do
     end
 
     it "#protected?" do
-      @df.should be_protected
+      expect(@df).to be_protected
     end
 
     it "#automate_output_value" do
@@ -68,12 +68,12 @@ describe DialogFieldTextBox do
       @df.value = "test string"
 
       @df.options[:protected] = false
-      @df.should_not be_protected
-      @df.automate_output_value.should == "test string"
+      expect(@df).not_to be_protected
+      expect(@df.automate_output_value).to eq("test string")
     end
 
     it "#automate_key_name" do
-      @df.automate_key_name.should == "password::dialog_test field"
+      expect(@df.automate_key_name).to eq("password::dialog_test field")
     end
   end
 
@@ -92,24 +92,24 @@ describe DialogFieldTextBox do
 
       it "should return nil when no error is detected" do
         df.value = 'Abc'
-        df.validate(dt, dg).should be_nil
+        expect(df.validate(dt, dg)).to be_nil
       end
 
       it "should return an error when the value doesn't match the regex rule" do
         df.value = '123'
-        df.validate(dt, dg).should == 'tab/group/test field is invalid'
+        expect(df.validate(dt, dg)).to eq('tab/group/test field is invalid')
       end
 
       it "should return an error when a required value is not provided" do
         df.value = ''
         df.validator_rule = ''
-        df.validate(dt, dg).should == 'tab/group/test field is required'
+        expect(df.validate(dt, dg)).to eq('tab/group/test field is required')
       end
 
       it "should return an error when a required value is nil" do
         df.value = nil
         df.validator_rule = nil
-        df.validate(dt, dg).should == 'tab/group/test field is required'
+        expect(df.validate(dt, dg)).to eq('tab/group/test field is required')
       end
     end
   end
@@ -132,7 +132,7 @@ describe DialogFieldTextBox do
         let(:value) { "" }
 
         before do
-          DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("processor")
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("processor")
         end
 
         it "returns the values from the value processor" do
@@ -179,15 +179,15 @@ describe DialogFieldTextBox do
       end
 
       it "sets the protected" do
-        expect(dialog_field.protected?).to be_true
+        expect(dialog_field.protected?).to be_truthy
       end
 
       it "sets the required" do
-        expect(dialog_field.required).to be_true
+        expect(dialog_field.required).to be_truthy
       end
 
       it "sets the read_only" do
-        expect(dialog_field.read_only).to be_true
+        expect(dialog_field.read_only).to be_truthy
       end
 
       it "sets the validator type" do
@@ -257,7 +257,7 @@ describe DialogFieldTextBox do
     let(:dialog_field) { described_class.new(:value => "test") }
 
     before do
-      DynamicDialogFieldValueProcessor.stub(:values_from_automate).with(dialog_field).and_return("processor")
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("processor")
     end
 
     it "returns the values from the value processor" do

--- a/spec/models/dialog_group_serializer_spec.rb
+++ b/spec/models/dialog_group_serializer_spec.rb
@@ -30,11 +30,11 @@ describe DialogGroupSerializer do
     end
 
     before do
-      dialog_field_serializer.stub(:serialize).with(dialog_field).and_return("serialized_dialog_fields")
+      allow(dialog_field_serializer).to receive(:serialize).with(dialog_field).and_return("serialized_dialog_fields")
     end
 
     it "serializes the dialog_group" do
-      dialog_group_serializer.serialize(dialog_group).should == expected_serialized_values
+      expect(dialog_group_serializer.serialize(dialog_group)).to eq(expected_serialized_values)
     end
   end
 end

--- a/spec/models/dialog_serializer_spec.rb
+++ b/spec/models/dialog_serializer_spec.rb
@@ -32,12 +32,12 @@ describe DialogSerializer do
     end
 
     before do
-      dialog_tab_serializer.stub(:serialize).with(dialog_tab1).and_return("serialized_dialog1")
-      dialog_tab_serializer.stub(:serialize).with(dialog_tab2).and_return("serialized_dialog2")
+      allow(dialog_tab_serializer).to receive(:serialize).with(dialog_tab1).and_return("serialized_dialog1")
+      allow(dialog_tab_serializer).to receive(:serialize).with(dialog_tab2).and_return("serialized_dialog2")
     end
 
     it "serializes the dialog" do
-      dialog_serializer.serialize(dialogs).should == expected_data
+      expect(dialog_serializer.serialize(dialogs)).to eq(expected_data)
     end
   end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -7,15 +7,15 @@ describe Dialog do
     let(:all_yaml_files) { test_file_path.join("{,*/**/}*.{yaml,yml}") }
 
     before do
-      DialogImportService.stub(:new).and_return(dialog_import_service)
-      dialog_import_service.stub(:import_all_service_dialogs_from_yaml_file)
+      allow(DialogImportService).to receive(:new).and_return(dialog_import_service)
+      allow(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file)
     end
 
     it "delegates to the dialog import service with a file in the default directory" do
       Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("seed_test.yaml").to_path)
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("seed_test.yml").to_path)
         Dialog.seed
       end
@@ -23,9 +23,9 @@ describe Dialog do
 
     it "delegates to the dialog import service with a file in a sub directory" do
       Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("service_dialogs/service_seed_test.yaml").to_path)
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("service_dialogs/service_seed_test.yml").to_path)
         Dialog.seed
       end
@@ -33,9 +33,9 @@ describe Dialog do
 
     it "delegates to the dialog import service with a symlinked file" do
       Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("service_dialog_symlink/service_seed_test.yaml").to_path)
-        dialog_import_service.should_receive(:import_all_service_dialogs_from_yaml_file).with(
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           test_file_path.join("service_dialog_symlink/service_seed_test.yml").to_path)
         Dialog.seed
       end
@@ -44,7 +44,7 @@ describe Dialog do
 
   it "#name" do
     dialog = FactoryGirl.create(:dialog, :label => 'dialog')
-    dialog.label.should == dialog.name
+    expect(dialog.label).to eq(dialog.name)
   end
 
   context "validate label uniqueness" do
@@ -61,14 +61,14 @@ describe Dialog do
 
   context "#create" do
     it "validates_presence_of name" do
-      -> { FactoryGirl.create(:dialog) }.should raise_error
-      -> { FactoryGirl.create(:dialog, :label => 'dialog') }.should_not raise_error
+      expect { FactoryGirl.create(:dialog) }.to raise_error
+      expect { FactoryGirl.create(:dialog, :label => 'dialog') }.not_to raise_error
 
-      -> { FactoryGirl.create(:dialog_tab) }.should raise_error
-      -> { FactoryGirl.create(:dialog_tab, :label => 'tab') }.should_not raise_error
+      expect { FactoryGirl.create(:dialog_tab) }.to raise_error
+      expect { FactoryGirl.create(:dialog_tab, :label => 'tab') }.not_to raise_error
 
-      -> { FactoryGirl.create(:dialog_group) }.should raise_error
-      -> { FactoryGirl.create(:dialog_group, :label => 'group') }.should_not raise_error
+      expect { FactoryGirl.create(:dialog_group) }.to raise_error
+      expect { FactoryGirl.create(:dialog_group, :label => 'group') }.not_to raise_error
     end
   end
 
@@ -78,14 +78,14 @@ describe Dialog do
     end
 
     it "destroy without resource_action association" do
-      @dialog.destroy.should be_true
-      Dialog.count.should == 0
+      expect(@dialog.destroy).to be_truthy
+      expect(Dialog.count).to eq(0)
     end
 
     it "destroy with resource_action association" do
       resource_action = FactoryGirl.create(:resource_action, :action => "Provision", :dialog => @dialog)
       expect { @dialog.destroy }.to raise_error
-      Dialog.count.should == 1
+      expect(Dialog.count).to eq(1)
     end
   end
 
@@ -100,19 +100,19 @@ describe Dialog do
     it "dialog contain tabs" do
       @dialog.add_resource(@dialog_tab)
       @dialog.save
-      @dialog.dialog_tabs.should have(1).thing
+      expect(@dialog.dialog_tabs.size).to eq(1)
     end
 
     it "tabs contain groups" do
       @dialog_tab.add_resource(@dialog_group)
       @dialog_tab.save
-      @dialog_tab.dialog_groups.should have(1).thing
+      expect(@dialog_tab.dialog_groups.size).to eq(1)
     end
 
     it "groups contain fields" do
       @dialog_group.add_resource(@dialog_field)
       @dialog_group.save
-      @dialog_group.dialog_fields.should have(1).thing
+      expect(@dialog_group.dialog_fields.size).to eq(1)
     end
   end
 
@@ -126,43 +126,43 @@ describe Dialog do
 
     it "dialogs contain tabs" do
       @dialog.add_resource!(@dialog_tab)
-      @dialog.dialog_tabs.should have(1).thing
+      expect(@dialog.dialog_tabs.size).to eq(1)
     end
 
     it "tabs contain groups" do
       @dialog_tab.add_resource!(@dialog_group)
-      @dialog_tab.dialog_groups.should have(1).thing
+      expect(@dialog_tab.dialog_groups.size).to eq(1)
     end
 
     it "groups contain fields" do
       @dialog_group.add_resource!(@dialog_field)
-      @dialog_group.dialog_fields.should have(1).thing
+      expect(@dialog_group.dialog_fields.size).to eq(1)
     end
 
     it "add controls" do
       text_box = FactoryGirl.create(:dialog_field_text_box, :label => 'text box', :name => 'text_box')
       @dialog_group.add_resource!(text_box)
-      @dialog_group.dialog_fields.should have(1).thing
+      expect(@dialog_group.dialog_fields.size).to eq(1)
 
       tags = FactoryGirl.create(:dialog_field_tag_control, :label => 'tags', :name => 'tags')
       @dialog_group.add_resource!(tags)
       @dialog_group.reload
-      @dialog_group.dialog_fields.should have(2).things
+      expect(@dialog_group.dialog_fields.size).to eq(2)
 
       button = FactoryGirl.create(:dialog_field_button, :label => 'button', :name => 'button')
       @dialog_group.add_resource!(button)
       @dialog_group.reload
-      @dialog_group.dialog_fields.should have(3).things
+      expect(@dialog_group.dialog_fields.size).to eq(3)
 
       check_box = FactoryGirl.create(:dialog_field_text_box, :label => 'check box', :name => "check_box")
       @dialog_group.add_resource!(check_box)
       @dialog_group.reload
-      @dialog_group.dialog_fields.should have(4).things
+      expect(@dialog_group.dialog_fields.size).to eq(4)
 
       drop_down_list = FactoryGirl.create(:dialog_field_drop_down_list, :label => 'drop down list', :name => "drop_down_1")
       @dialog_group.add_resource!(drop_down_list)
       @dialog_group.reload
-      @dialog_group.dialog_fields.should have(5).things
+      expect(@dialog_group.dialog_fields.size).to eq(5)
     end
   end
 
@@ -176,23 +176,23 @@ describe Dialog do
 
     it "dialogs contain tabs" do
       @dialog.add_resource(@dialog_tab)
-      @dialog.dialog_resources.should have(1).thing
+      expect(@dialog.dialog_resources.size).to eq(1)
       @dialog.remove_all_resources
-      @dialog.dialog_resources.should have(0).things
+      expect(@dialog.dialog_resources.size).to eq(0)
     end
 
     it "tabs contain groups" do
       @dialog_tab.add_resource(@dialog_group)
-      @dialog_tab.dialog_resources.should have(1).thing
+      expect(@dialog_tab.dialog_resources.size).to eq(1)
       @dialog_tab.remove_all_resources
-      @dialog_tab.dialog_resources.should have(0).things
+      expect(@dialog_tab.dialog_resources.size).to eq(0)
     end
 
     it "groups contain fields" do
       @dialog_group.add_resource(@dialog_field)
-      @dialog_group.dialog_resources.should have(1).thing
+      expect(@dialog_group.dialog_resources.size).to eq(1)
       @dialog_group.remove_all_resources
-      @dialog_group.dialog_resources.should have(0).things
+      expect(@dialog_group.dialog_resources.size).to eq(0)
     end
   end
 
@@ -214,30 +214,30 @@ describe Dialog do
 
     it "dialog" do
       @dialog.destroy
-      Dialog.count.should == 0
-      DialogTab.count.should == 0
-      DialogGroup.count.should == 0
-      DialogField.count.should == 0
+      expect(Dialog.count).to eq(0)
+      expect(DialogTab.count).to eq(0)
+      expect(DialogGroup.count).to eq(0)
+      expect(DialogField.count).to eq(0)
     end
 
     it "dialog_tab" do
       @dialog_tab.destroy
-      Dialog.count.should == 1
-      DialogTab.count.should == 0
-      DialogGroup.count.should == 0
-      DialogField.count.should == 0
+      expect(Dialog.count).to eq(1)
+      expect(DialogTab.count).to eq(0)
+      expect(DialogGroup.count).to eq(0)
+      expect(DialogField.count).to eq(0)
     end
 
     it "dialog_group" do
       @dialog_group.destroy
-      Dialog.count.should == 1
-      DialogTab.count.should == 1
-      DialogGroup.count.should == 0
-      DialogField.count.should == 0
+      expect(Dialog.count).to eq(1)
+      expect(DialogTab.count).to eq(1)
+      expect(DialogGroup.count).to eq(0)
+      expect(DialogField.count).to eq(0)
 
       @dialog_tab.destroy
-      Dialog.count.should == 1
-      DialogTab.count.should == 0
+      expect(Dialog.count).to eq(1)
+      expect(DialogTab.count).to eq(0)
     end
   end
 
@@ -262,19 +262,19 @@ describe Dialog do
     it "dialog_group" do
       count = 0
       @dialog_group.each_dialog_field { |_df| count += 1 }
-      count.should == 2
+      expect(count).to eq(2)
     end
 
     it "dialog_tab" do
       count = 0
       @dialog_tab.each_dialog_field { |_df| count += 1 }
-      count.should == 2
+      expect(count).to eq(2)
     end
 
     it "dialog" do
       count = 0
       @dialog.each_dialog_field { |_df| count += 1 }
-      count.should == 2
+      expect(count).to eq(2)
     end
   end
 
@@ -297,15 +297,15 @@ describe Dialog do
     end
 
     it "dialog_group" do
-      @dialog_group.dialog_fields.count.should == 2
+      expect(@dialog_group.dialog_fields.count).to eq(2)
     end
 
     it "dialog_tab" do
-      @dialog_tab.dialog_fields.count.should == 2
+      expect(@dialog_tab.dialog_fields.count).to eq(2)
     end
 
     it "dialog" do
-      @dialog.dialog_fields.count.should == 2
+      expect(@dialog.dialog_fields.count).to eq(2)
     end
   end
 end

--- a/spec/models/dialog_tab_serializer_spec.rb
+++ b/spec/models/dialog_tab_serializer_spec.rb
@@ -31,11 +31,11 @@ describe DialogTabSerializer do
     end
 
     before do
-      dialog_group_serializer.stub(:serialize).with(dialog_group).and_return("serialized dialog group")
+      allow(dialog_group_serializer).to receive(:serialize).with(dialog_group).and_return("serialized dialog group")
     end
 
     it "serializes the dialog tab" do
-      dialog_tab_serializer.serialize(dialog_tab).should == expected_serialized_values
+      expect(dialog_tab_serializer.serialize(dialog_tab)).to eq(expected_serialized_values)
     end
   end
 end

--- a/spec/models/dialog_yaml_serializer_spec.rb
+++ b/spec/models/dialog_yaml_serializer_spec.rb
@@ -32,12 +32,12 @@ describe DialogYamlSerializer do
     end
 
     before do
-      dialog_tab_serializer.stub(:serialize).with(dialog_tab1).and_return("serialized_dialog1")
-      dialog_tab_serializer.stub(:serialize).with(dialog_tab2).and_return("serialized_dialog2")
+      allow(dialog_tab_serializer).to receive(:serialize).with(dialog_tab1).and_return("serialized_dialog1")
+      allow(dialog_tab_serializer).to receive(:serialize).with(dialog_tab2).and_return("serialized_dialog2")
     end
 
     it "serializes the dialog" do
-      YAML.load(dialog_yaml_serializer.serialize(dialogs)).should == expected_data
+      expect(YAML.load(dialog_yaml_serializer.serialize(dialogs))).to eq(expected_data)
     end
   end
 end

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -35,13 +35,13 @@ describe DriftState do
         described_class.purge_timer
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge"
         )
-        q.first.args[0].should == :date
-        q.first.args[1].should be_same_time_as 6.months.to_i.seconds.ago.utc
+        expect(q.first.args[0]).to eq(:date)
+        expect(q.first.args[1]).to be_same_time_as 6.months.to_i.seconds.ago.utc
       end
     end
 
@@ -53,8 +53,8 @@ describe DriftState do
 
       it "with nothing in the queue" do
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 1]
@@ -65,8 +65,8 @@ describe DriftState do
         described_class.purge_queue(:remaining, 2)
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 2]
@@ -75,36 +75,36 @@ describe DriftState do
     end
 
     it "#purge_ids_for_remaining" do
-      described_class.send(:purge_ids_for_remaining, 1).should == {["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id}
+      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id})
     end
 
     it "#purge_counts_for_remaining" do
-      described_class.send(:purge_counts_for_remaining, 1).should == {["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2}
+      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2})
     end
 
     context "#purge_count" do
       it "by remaining" do
-        described_class.purge_count(:remaining, 1).should == 3
+        expect(described_class.purge_count(:remaining, 1)).to eq(3)
       end
 
       it "by date" do
-        described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc).should == 3
+        expect(described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc)).to eq(3)
       end
     end
 
     context "#purge" do
       it "by remaining" do
         described_class.purge(:remaining, 1)
-        described_class.where(:resource_id => 1).should == [@rr1.last]
-        described_class.where(:resource_id => 2).should == [@rr2.last]
-        described_class.where(:resource_id => nil).should == @rr_orphaned
+        expect(described_class.where(:resource_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:resource_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:resource_id => nil)).to eq(@rr_orphaned)
       end
 
       it "by date" do
         described_class.purge(:date, 6.months.to_i.seconds.ago.utc)
-        described_class.where(:resource_id => 1).should == [@rr1.last]
-        described_class.where(:resource_id => 2).should == [@rr2.last]
-        described_class.where(:resource_id => nil).should == @rr_orphaned
+        expect(described_class.where(:resource_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:resource_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:resource_id => nil)).to eq(@rr_orphaned)
       end
     end
   end

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -75,11 +75,13 @@ describe DriftState do
     end
 
     it "#purge_ids_for_remaining" do
-      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id})
+      expect(described_class.send(:purge_ids_for_remaining, 1))
+        .to eq(["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id)
     end
 
     it "#purge_counts_for_remaining" do
-      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2})
+      expect(described_class.send(:purge_counts_for_remaining, 1))
+        .to eq(["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2)
     end
 
     context "#purge_count" do

--- a/spec/models/dynamic_dialog_field_value_processor_spec.rb
+++ b/spec/models/dynamic_dialog_field_value_processor_spec.rb
@@ -23,8 +23,8 @@ describe DynamicDialogFieldValueProcessor do
     let(:resource_action) { active_record_instance_double("ResourceAction") }
 
     before do
-      dialog_field.stub(:dialog).and_return(dialog)
-      dialog_field.stub(:resource_action).and_return(resource_action)
+      allow(dialog_field).to receive(:dialog).and_return(dialog)
+      allow(dialog_field).to receive(:resource_action).and_return(resource_action)
     end
 
     context "when there is no error delivering to automate from dialog field" do
@@ -44,13 +44,13 @@ describe DynamicDialogFieldValueProcessor do
 
       before do
         User.current_user = user
-        resource_action.stub(:deliver_to_automate_from_dialog_field).with(
+        allow(resource_action).to receive(:deliver_to_automate_from_dialog_field).with(
           {:dialog => "automate_values_hash"},
           "target_resource",
           user
         ).and_return(workspace)
-        workspace.stub(:root).and_return(workspace_attributes)
-        dialog_field.stub(:normalize_automate_values).with(workspace_attributes.attributes).and_return(
+        allow(workspace).to receive(:root).and_return(workspace_attributes)
+        allow(dialog_field).to receive(:normalize_automate_values).with(workspace_attributes.attributes).and_return(
           "normalized values"
         )
       end
@@ -62,7 +62,7 @@ describe DynamicDialogFieldValueProcessor do
 
     context "when there is an error delivering to automate from dialog field" do
       before do
-        resource_action.stub(:deliver_to_automate_from_dialog_field).and_raise("O noes")
+        allow(resource_action).to receive(:deliver_to_automate_from_dialog_field).and_raise("O noes")
       end
 
       it "returns the dialog field's script error values" do

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe EmsCluster::CapacityPlanning do
   before(:each) do
     config = VMDB::Config.new('capacity').config
-    EmsCluster.stub(:capacity_settings).and_return(config.deep_clone)
+    allow(EmsCluster).to receive(:capacity_settings).and_return(config.deep_clone)
     @cluster = FactoryGirl.create(:ems_cluster)
   end
 
@@ -11,86 +11,86 @@ describe EmsCluster::CapacityPlanning do
     EmsCluster::CAPACITY_PROFILES.each do |profile|
       prefix = "capacity_profile_#{profile}"
       EmsCluster::CAPACITY_RESOURCES.each do |resource|
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_method",              :string
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_commitment_ratio",    :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_minimum",             :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_maximum",             :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_method",              :string
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_commitment_ratio",    :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_minimum",             :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_maximum",             :float
 
-        EmsCluster.should have_virtual_column "#{prefix}_available_host_#{resource}",      :float
-        EmsCluster.should have_virtual_column "#{prefix}_remaining_host_#{resource}",      :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_per_vm",              :float
-        EmsCluster.should have_virtual_column "#{prefix}_#{resource}_per_vm_with_min_max", :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_available_host_#{resource}",      :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_host_#{resource}",      :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_per_vm",              :float
+        expect(EmsCluster).to have_virtual_column "#{prefix}_#{resource}_per_vm_with_min_max", :float
 
-        EmsCluster.should have_virtual_column "#{prefix}_remaining_vm_count_based_on_#{resource}", :integer
-        EmsCluster.should have_virtual_column "#{prefix}_projected_vm_count_based_on_#{resource}", :integer
+        expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_vm_count_based_on_#{resource}", :integer
+        expect(EmsCluster).to have_virtual_column "#{prefix}_projected_vm_count_based_on_#{resource}", :integer
       end
-      EmsCluster.should have_virtual_column "#{prefix}_remaining_vm_count_based_on_all", :integer
-      EmsCluster.should have_virtual_column "#{prefix}_projected_vm_count_based_on_all", :integer
+      expect(EmsCluster).to have_virtual_column "#{prefix}_remaining_vm_count_based_on_all", :integer
+      expect(EmsCluster).to have_virtual_column "#{prefix}_projected_vm_count_based_on_all", :integer
     end
   end
 
   it "#capacity_profile_method_description" do
     settings_path = [:profile, :"1", :vcpu_method_description]
-    @cluster.capacity_profile_method_description(1, :vcpu).should == EmsCluster.capacity_settings.fetch_path(settings_path)
+    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
     EmsCluster.capacity_settings.store_path(settings_path, "Test Description")
-    @cluster.capacity_profile_method_description(1, :vcpu).should == "Test Description"
+    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq("Test Description")
   end
 
   context "#capacity_profile_method" do
     it "with invalid values" do
       EmsCluster.capacity_settings.delete_path(:profile, :"1", :vcpu_method)
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "invalidresource_average")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "vcpu_invalidalgorithm")
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "mem_average") # resource does not match profile key
-      -> { @cluster.capacity_profile_method(1, :vcpu) }.should raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
     end
 
     it "with valid values" do
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "vcpu_high_norm")
-      @cluster.capacity_profile_method(1, :vcpu).should == :vcpu_high_norm
+      expect(@cluster.capacity_profile_method(1, :vcpu)).to eq(:vcpu_high_norm)
 
       EmsCluster.capacity_settings.store_path(:profile, :"1", :memory_method, "mem_average")
-      @cluster.capacity_profile_method(1, :memory).should == :memory_average
+      expect(@cluster.capacity_profile_method(1, :memory)).to eq(:memory_average)
     end
 
     it "with alternate valid values" do
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "cpu_average")
-      @cluster.capacity_profile_method(1, :vcpu).should == :vcpu_average
+      expect(@cluster.capacity_profile_method(1, :vcpu)).to eq(:vcpu_average)
 
       EmsCluster.capacity_settings.store_path(:profile, :"1", :memory_method, "memory_high_norm")
-      @cluster.capacity_profile_method(1, :memory).should == :memory_high_norm
+      expect(@cluster.capacity_profile_method(1, :memory)).to eq(:memory_high_norm)
     end
   end
 
   it "#capacity_profile_minimum" do
     settings_path = [:profile, :"1", :memory_minimum]
-    @cluster.capacity_profile_minimum(1, :memory).should be_nil
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to be_nil
     EmsCluster.capacity_settings.store_path(settings_path, "123")
-    @cluster.capacity_profile_minimum(1, :memory).should == 123
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to eq(123)
     EmsCluster.capacity_settings.store_path(settings_path, "1.gigabytes")
-    @cluster.capacity_profile_minimum(1, :memory).should == 1.gigabytes.to_i
+    expect(@cluster.capacity_profile_minimum(1, :memory)).to eq(1.gigabytes.to_i)
   end
 
   it "#capacity_profile_maximum" do
     settings_path = [:profile, :"1", :memory_maximum]
-    @cluster.capacity_profile_maximum(1, :memory).should be_nil
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to be_nil
     EmsCluster.capacity_settings.store_path(settings_path, "123")
-    @cluster.capacity_profile_maximum(1, :memory).should == 123
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to eq(123)
     EmsCluster.capacity_settings.store_path(settings_path, "1.gigabytes")
-    @cluster.capacity_profile_maximum(1, :memory).should == 1.gigabytes.to_i
+    expect(@cluster.capacity_profile_maximum(1, :memory)).to eq(1.gigabytes.to_i)
   end
 
   context "#capacity_commitment_ratio" do
     it "with default settings" do
-      @cluster.capacity_commitment_ratio(1, :vcpu).should == 2.0
-      @cluster.capacity_commitment_ratio(1, :memory).should == 1.2
-      @cluster.capacity_commitment_ratio(2, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :memory).should == 1.0
+      expect(@cluster.capacity_commitment_ratio(1, :vcpu)).to eq(2.0)
+      expect(@cluster.capacity_commitment_ratio(1, :memory)).to eq(1.2)
+      expect(@cluster.capacity_commitment_ratio(2, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :memory)).to eq(1.0)
     end
 
     it "with missing settings" do
@@ -99,95 +99,95 @@ describe EmsCluster::CapacityPlanning do
       EmsCluster.capacity_settings.delete_path(:profile, :"2", :vcpu_commitment_ratio)
       EmsCluster.capacity_settings.delete_path(:profile, :"2", :memory_commitment_ratio)
 
-      @cluster.capacity_commitment_ratio(1, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(1, :memory).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :vcpu).should == 1.0
-      @cluster.capacity_commitment_ratio(2, :memory).should == 1.0
+      expect(@cluster.capacity_commitment_ratio(1, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(1, :memory)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :vcpu)).to eq(1.0)
+      expect(@cluster.capacity_commitment_ratio(2, :memory)).to eq(1.0)
     end
   end
 
   context "#capacity_failover_rule" do
     it "with normal settings" do
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
 
     it "with overridden settings" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "none")
-      @cluster.capacity_failover_rule.should == "none"
+      expect(@cluster.capacity_failover_rule).to eq("none")
     end
 
     it "with missing settings" do
       EmsCluster.capacity_settings.delete_path(:failover, :rule)
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
 
     it "with invalid settings" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "xxx")
-      @cluster.capacity_failover_rule.should == "discovered"
+      expect(@cluster.capacity_failover_rule).to eq("discovered")
     end
   end
 
   context "#capacity_average_resources_per_vm" do
     it "with normal data" do
-      @cluster.stub(:total_vms).and_return(15)
-      @cluster.capacity_average_resources_per_vm(35.5).should be_within(0.001).of(2.366)
+      allow(@cluster).to receive(:total_vms).and_return(15)
+      expect(@cluster.capacity_average_resources_per_vm(35.5)).to be_within(0.001).of(2.366)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_vms).and_return(0)
-      @cluster.capacity_average_resources_per_vm(35.5).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(0)
+      expect(@cluster.capacity_average_resources_per_vm(35.5)).to eq(0.0)
     end
   end
 
   context "#capacity_average_resources_per_host" do
     it "with normal data" do
-      @cluster.stub(:total_hosts).and_return(15)
-      @cluster.capacity_average_resources_per_host(35.5).should be_within(0.001).of(2.366)
+      allow(@cluster).to receive(:total_hosts).and_return(15)
+      expect(@cluster.capacity_average_resources_per_host(35.5)).to be_within(0.001).of(2.366)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_hosts).and_return(0)
-      @cluster.capacity_average_resources_per_host(35.5).should == 0.0
+      allow(@cluster).to receive(:total_hosts).and_return(0)
+      expect(@cluster.capacity_average_resources_per_host(35.5)).to eq(0.0)
     end
   end
 
   context "#capacity_peak_usage_percentage" do
     it "with normal data" do
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_peak_usage_percentage(:vcpu).should == 11.32
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(11.32)
 
-      @cluster.stub(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
-      @cluster.capacity_peak_usage_percentage(:memory).should == 35.23
+      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
+      expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(35.23)
     end
 
     it "with missing data" do
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_peak_usage_percentage(:vcpu).should == 100.0
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(100.0)
 
-      @cluster.stub(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_peak_usage_percentage(:memory).should == 100.0
+      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(100.0)
     end
   end
 
   context "#capacity_effective_host_resources" do
     it "with effective_resource set" do
-      @cluster.stub(:effective_cpu).and_return(31000)
-      @cluster.capacity_effective_host_resources(2, :vcpu).should == 31000
+      allow(@cluster).to receive(:effective_cpu).and_return(31000)
+      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31000)
     end
 
     context "with effective_resource not set" do
       before(:each) do
-        @cluster.stub(:effective_cpu).and_return(nil)
+        allow(@cluster).to receive(:effective_cpu).and_return(nil)
       end
 
       it "and normal data" do
-        @cluster.stub(:aggregate_cpu_speed).and_return(12345)
-        @cluster.capacity_effective_host_resources(2, :vcpu).should == 12345
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12345)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12345)
       end
 
       it "and missing data" do
-        @cluster.stub(:aggregate_cpu_speed).and_return(0)
-        @cluster.capacity_effective_host_resources(2, :vcpu).should == 0
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(0)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(0)
       end
     end
   end
@@ -195,13 +195,13 @@ describe EmsCluster::CapacityPlanning do
   context "#capacity_failover_host_resources" do
     it "with failover rule 'none'" do
       EmsCluster.capacity_settings.store_path(:failover, :rule, "none")
-      @cluster.capacity_failover_host_resources(2, :vcpu).should == 0
+      expect(@cluster.capacity_failover_host_resources(2, :vcpu)).to eq(0)
     end
 
     context "with failover rule 'discovered'" do
       it "and HA disabled" do
         @cluster.update_attribute(:ha_enabled, false)
-        @cluster.capacity_failover_host_resources(2, :vcpu).should == 0
+        expect(@cluster.capacity_failover_host_resources(2, :vcpu)).to eq(0)
       end
 
       context "and HA enabled" do
@@ -210,14 +210,14 @@ describe EmsCluster::CapacityPlanning do
         end
 
         it "and no failover hosts" do
-          @cluster.stub(:failover_hosts).and_return([])
-          @cluster.should_receive(:capacity_failover_host_resources_without_failover_hosts)
+          allow(@cluster).to receive(:failover_hosts).and_return([])
+          expect(@cluster).to receive(:capacity_failover_host_resources_without_failover_hosts)
           @cluster.capacity_failover_host_resources(2, :vcpu)
         end
 
         it "and failover hosts" do
-          @cluster.stub(:failover_hosts).and_return([1, 2])
-          @cluster.should_receive(:capacity_failover_host_resources_with_failover_hosts)
+          allow(@cluster).to receive(:failover_hosts).and_return([1, 2])
+          expect(@cluster).to receive(:capacity_failover_host_resources_with_failover_hosts)
           @cluster.capacity_failover_host_resources(2, :vcpu)
         end
       end
@@ -231,7 +231,7 @@ describe EmsCluster::CapacityPlanning do
       FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :cpu_total_cores => 1), :failover => false)
     ]
     @cluster.hosts << hosts
-    @cluster.capacity_failover_host_resources_with_failover_hosts(1, :vcpu).should == 6.0
+    expect(@cluster.capacity_failover_host_resources_with_failover_hosts(1, :vcpu)).to eq(6.0)
   end
 
   it "#capacity_failover_host_resources_without_failover_hosts" do
@@ -240,78 +240,78 @@ describe EmsCluster::CapacityPlanning do
       FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :cpu_total_cores => 2), :failover => false)
     ]
     @cluster.hosts << hosts
-    @cluster.capacity_failover_host_resources_without_failover_hosts(1, :vcpu).should == 3.0
+    expect(@cluster.capacity_failover_host_resources_without_failover_hosts(1, :vcpu)).to eq(3.0)
   end
 
   context "#capacity_used_host_resources" do
     it "with normal data" do
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_used_host_resources(2, :vcpu).should be_within(0.001).of(3509.200)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3509.200)
     end
 
     it "with missing data" do
-      @cluster.stub(:capacity_available_host_resources).and_return(0)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_used_host_resources(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(0)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.capacity_used_host_resources(2, :vcpu).should be_within(0.001).of(31000.000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31000.000)
     end
   end
 
   context "#capacity_resources_per_vm" do
     it "with normal data" do
-      @cluster.stub(:total_vms).and_return(994)
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should be_within(0.001).of(3.530)
+      allow(@cluster).to receive(:total_vms).and_return(994)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(3.530)
     end
 
     it "with missing data" do
-      @cluster.stub(:total_vms).and_return(0)
-      @cluster.stub(:capacity_available_host_resources).and_return(0)
-      @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(0)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(0)
+      allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:total_vms).and_return(994)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should == 0.0
+      allow(@cluster).to receive(:total_vms).and_return(994)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      @cluster.stub(:capacity_available_host_resources).and_return(31000)
-      @cluster.capacity_resources_per_vm(2, :vcpu).should be_within(0.001).of(31.187)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(31.187)
     end
   end
 
   context "#capacity_resources_per_vm_with_min_max" do
     before(:each) do
-      @cluster.stub(:capacity_resources_per_vm).and_return(3.530)
+      allow(@cluster).to receive(:capacity_resources_per_vm).and_return(3.530)
     end
 
     it "with neither min nor max" do
-      @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+      expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
     end
 
     context "with min only" do
       it "and min < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
 
       it "and expected < min" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 4.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(4.0)
       end
     end
 
     context "with max only" do
       it "and max < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 1.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(1.0)
       end
 
       it "and expected < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
     end
 
@@ -319,66 +319,66 @@ describe EmsCluster::CapacityPlanning do
       it "and min < max < expected" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 0.1)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 1.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 1.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(1.0)
       end
 
       it "and min < expected < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 1.0)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 4.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 3.530
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(3.530)
       end
 
       it "and expected < min < max" do
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_minimum, 4.0)
         EmsCluster.capacity_settings.store_path(:profile, :"2", :vcpu_maximum, 5.0)
-        @cluster.capacity_resources_per_vm_with_min_max(2, :vcpu).should == 4.0
+        expect(@cluster.capacity_resources_per_vm_with_min_max(2, :vcpu)).to eq(4.0)
       end
     end
   end
 
   it "#capacity_remaining_vm_count" do
     @cluster.update_attribute(:ha_enabled, false)
-    @cluster.stub(:total_vms).and_return(994)
-    @cluster.stub(:effective_cpu).and_return(31000)
-    @cluster.stub(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-    @cluster.capacity_remaining_vm_count(2, :vcpu).should == 7786
+    allow(@cluster).to receive(:total_vms).and_return(994)
+    allow(@cluster).to receive(:effective_cpu).and_return(31000)
+    allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
+    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7786)
   end
 
   it "#capacity_remaining_vm_count_based_on_all" do
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(3)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(3)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(3)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(3)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-4)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == -4
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-4)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(-4)
 
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :memory).and_return(-4)
-    @cluster.capacity_remaining_vm_count_based_on_all(1).should == -4
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :memory).and_return(-4)
+    expect(@cluster.capacity_remaining_vm_count_based_on_all(1)).to eq(-4)
   end
 
   it "#capacity_projected_vm_count" do
-    @cluster.stub(:total_vms).and_return(3)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.capacity_projected_vm_count(1, :vcpu).should == 13
+    allow(@cluster).to receive(:total_vms).and_return(3)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(10)
+    expect(@cluster.capacity_projected_vm_count(1, :vcpu)).to eq(13)
 
-    @cluster.stub(:total_vms).and_return(10)
-    @cluster.stub(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-3)
-    @cluster.capacity_projected_vm_count(1, :vcpu).should == 7
+    allow(@cluster).to receive(:total_vms).and_return(10)
+    allow(@cluster).to receive(:capacity_remaining_vm_count).with(1, :vcpu).and_return(-3)
+    expect(@cluster.capacity_projected_vm_count(1, :vcpu)).to eq(7)
   end
 
   it "#capacity_projected_vm_count_based_on_all" do
-    @cluster.stub(:capacity_projected_vm_count).with(1, :vcpu).and_return(10)
-    @cluster.stub(:capacity_projected_vm_count).with(1, :memory).and_return(3)
-    @cluster.capacity_projected_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :vcpu).and_return(10)
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :memory).and_return(3)
+    expect(@cluster.capacity_projected_vm_count_based_on_all(1)).to eq(3)
 
-    @cluster.stub(:capacity_projected_vm_count).with(1, :vcpu).and_return(3)
-    @cluster.stub(:capacity_projected_vm_count).with(1, :memory).and_return(10)
-    @cluster.capacity_projected_vm_count_based_on_all(1).should == 3
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :vcpu).and_return(3)
+    allow(@cluster).to receive(:capacity_projected_vm_count).with(1, :memory).and_return(10)
+    expect(@cluster.capacity_projected_vm_count_based_on_all(1)).to eq(3)
   end
 end

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -31,7 +31,8 @@ describe EmsCluster::CapacityPlanning do
 
   it "#capacity_profile_method_description" do
     settings_path = [:profile, :"1", :vcpu_method_description]
-    expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
+    expect(@cluster.capacity_profile_method_description(1, :vcpu))
+      .to eq(EmsCluster.capacity_settings.fetch_path(settings_path))
     EmsCluster.capacity_settings.store_path(settings_path, "Test Description")
     expect(@cluster.capacity_profile_method_description(1, :vcpu)).to eq("Test Description")
   end
@@ -156,7 +157,9 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
       expect(@cluster.capacity_peak_usage_percentage(:vcpu)).to eq(11.32)
 
-      allow(@cluster).to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead).and_return(35.23)
+      allow(@cluster)
+        .to receive(:max_mem_usage_absolute_average_high_over_time_period_without_overhead)
+        .and_return(35.23)
       expect(@cluster.capacity_peak_usage_percentage(:memory)).to eq(35.23)
     end
 
@@ -171,8 +174,8 @@ describe EmsCluster::CapacityPlanning do
 
   context "#capacity_effective_host_resources" do
     it "with effective_resource set" do
-      allow(@cluster).to receive(:effective_cpu).and_return(31000)
-      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31000)
+      allow(@cluster).to receive(:effective_cpu).and_return(31_000)
+      expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(31_000)
     end
 
     context "with effective_resource not set" do
@@ -181,8 +184,8 @@ describe EmsCluster::CapacityPlanning do
       end
 
       it "and normal data" do
-        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12345)
-        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12345)
+        allow(@cluster).to receive(:aggregate_cpu_speed).and_return(12_345)
+        expect(@cluster.capacity_effective_host_resources(2, :vcpu)).to eq(12_345)
       end
 
       it "and missing data" do
@@ -245,9 +248,9 @@ describe EmsCluster::CapacityPlanning do
 
   context "#capacity_used_host_resources" do
     it "with normal data" do
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3509.200)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(3_509.200)
     end
 
     it "with missing data" do
@@ -255,15 +258,15 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(nil)
       expect(@cluster.capacity_used_host_resources(2, :vcpu)).to eq(0.0)
 
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
-      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31000.000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
+      expect(@cluster.capacity_used_host_resources(2, :vcpu)).to be_within(0.001).of(31_000.000)
     end
   end
 
   context "#capacity_resources_per_vm" do
     it "with normal data" do
       allow(@cluster).to receive(:total_vms).and_return(994)
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(3.530)
     end
@@ -277,7 +280,7 @@ describe EmsCluster::CapacityPlanning do
       allow(@cluster).to receive(:total_vms).and_return(994)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to eq(0.0)
 
-      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31000)
+      allow(@cluster).to receive(:capacity_available_host_resources).and_return(31_000)
       expect(@cluster.capacity_resources_per_vm(2, :vcpu)).to be_within(0.001).of(31.187)
     end
   end
@@ -339,9 +342,9 @@ describe EmsCluster::CapacityPlanning do
   it "#capacity_remaining_vm_count" do
     @cluster.update_attribute(:ha_enabled, false)
     allow(@cluster).to receive(:total_vms).and_return(994)
-    allow(@cluster).to receive(:effective_cpu).and_return(31000)
+    allow(@cluster).to receive(:effective_cpu).and_return(31_000)
     allow(@cluster).to receive(:max_cpu_usage_rate_average_high_over_time_period_without_overhead).and_return(11.32)
-    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7786)
+    expect(@cluster.capacity_remaining_vm_count(2, :vcpu)).to eq(7_786)
   end
 
   it "#capacity_remaining_vm_count_based_on_all" do

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -21,41 +21,41 @@ describe EmsCluster do
       @template2 = FactoryGirl.create(:template_vmware, :host => @host2, :ems_cluster => @cluster)
     end
 
-    it('#vms_and_templates')              { @cluster.vms_and_templates.should              match_array [@vm1, @vm2, @template1, @template2] }
-    it('#direct_vms_and_templates')       { @cluster.direct_vms_and_templates.should       match_array [@vm1, @template1, @template2] }
-    it('#vm_or_template_ids')             { @cluster.vm_or_template_ids.should             match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
-    it('#direct_vm_or_template_ids')      { @cluster.direct_vm_or_template_ids.should      match_array [@vm1.id, @template1.id, @template2.id] }
-    it('#total_direct_vms_and_templates') { @cluster.total_direct_vms_and_templates.should == 3 }
+    it('#vms_and_templates')              { expect(@cluster.vms_and_templates).to              match_array [@vm1, @vm2, @template1, @template2] }
+    it('#direct_vms_and_templates')       { expect(@cluster.direct_vms_and_templates).to       match_array [@vm1, @template1, @template2] }
+    it('#vm_or_template_ids')             { expect(@cluster.vm_or_template_ids).to             match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
+    it('#direct_vm_or_template_ids')      { expect(@cluster.direct_vm_or_template_ids).to      match_array [@vm1.id, @template1.id, @template2.id] }
+    it('#total_direct_vms_and_templates') { expect(@cluster.total_direct_vms_and_templates).to eq(3) }
 
-    it('#vms')              { @cluster.vms.should              match_array [@vm1, @vm2] }
-    it('#direct_vms')       { @cluster.direct_vms.should       match_array [@vm1] }
-    it('#vm_ids')           { @cluster.vm_ids.should           match_array [@vm1.id, @vm2.id] }
-    it('#direct_vm_ids')    { @cluster.direct_vm_ids.should    match_array [@vm1.id] }
-    it('#total_direct_vms') { @cluster.total_direct_vms.should == 1 }
+    it('#vms')              { expect(@cluster.vms).to              match_array [@vm1, @vm2] }
+    it('#direct_vms')       { expect(@cluster.direct_vms).to       match_array [@vm1] }
+    it('#vm_ids')           { expect(@cluster.vm_ids).to           match_array [@vm1.id, @vm2.id] }
+    it('#direct_vm_ids')    { expect(@cluster.direct_vm_ids).to    match_array [@vm1.id] }
+    it('#total_direct_vms') { expect(@cluster.total_direct_vms).to eq(1) }
 
-    it('#miq_templates')              { @cluster.miq_templates.should              match_array [@template1, @template2] }
-    it('#direct_miq_templates')       { @cluster.direct_miq_templates.should       match_array [@template1, @template2] }
-    it('#miq_template_ids')           { @cluster.miq_template_ids.should           match_array [@template1.id, @template2.id] }
-    it('#direct_miq_template_ids')    { @cluster.direct_miq_template_ids.should    match_array [@template1.id, @template2.id] }
-    it('#total_direct_miq_templates') { @cluster.total_direct_miq_templates.should == 2 }
+    it('#miq_templates')              { expect(@cluster.miq_templates).to              match_array [@template1, @template2] }
+    it('#direct_miq_templates')       { expect(@cluster.direct_miq_templates).to       match_array [@template1, @template2] }
+    it('#miq_template_ids')           { expect(@cluster.miq_template_ids).to           match_array [@template1.id, @template2.id] }
+    it('#direct_miq_template_ids')    { expect(@cluster.direct_miq_template_ids).to    match_array [@template1.id, @template2.id] }
+    it('#total_direct_miq_templates') { expect(@cluster.total_direct_miq_templates).to eq(2) }
 
-    it('#all_vms_and_templates')   { @cluster.all_vms_and_templates.should   match_array [@vm1, @vm2, @template1, @template2] }
-    it('#all_vm_or_template_ids')  { @cluster.all_vm_or_template_ids.should  match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
-    it('#total_vms_and_templates') { @cluster.total_vms_and_templates.should == 4 }
+    it('#all_vms_and_templates')   { expect(@cluster.all_vms_and_templates).to   match_array [@vm1, @vm2, @template1, @template2] }
+    it('#all_vm_or_template_ids')  { expect(@cluster.all_vm_or_template_ids).to  match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
+    it('#total_vms_and_templates') { expect(@cluster.total_vms_and_templates).to eq(4) }
 
-    it('#all_vms')    { @cluster.all_vms.should    match_array [@vm1, @vm2] }
-    it('#all_vm_ids') { @cluster.all_vm_ids.should match_array [@vm1.id, @vm2.id] }
-    it('#total_vms')  { @cluster.total_vms.should == 2 }
+    it('#all_vms')    { expect(@cluster.all_vms).to    match_array [@vm1, @vm2] }
+    it('#all_vm_ids') { expect(@cluster.all_vm_ids).to match_array [@vm1.id, @vm2.id] }
+    it('#total_vms')  { expect(@cluster.total_vms).to eq(2) }
 
-    it('#all_miq_templates')    { @cluster.all_miq_templates.should    match_array [@template1, @template2] }
-    it('#all_miq_template_ids') { @cluster.all_miq_template_ids.should match_array [@template1.id, @template2.id] }
-    it('#total_miq_templates')  { @cluster.total_miq_templates.should == 2 }
+    it('#all_miq_templates')    { expect(@cluster.all_miq_templates).to    match_array [@template1, @template2] }
+    it('#all_miq_template_ids') { expect(@cluster.all_miq_template_ids).to match_array [@template1.id, @template2.id] }
+    it('#total_miq_templates')  { expect(@cluster.total_miq_templates).to eq(2) }
 
-    it('ResourcePool#v_direct_vms') { @rp1.v_direct_vms.should == 1 }
-    it('ResourcePool#v_total_vms')  { @rp1.v_total_vms.should == 2 }
+    it('ResourcePool#v_direct_vms') { expect(@rp1.v_direct_vms).to eq(1) }
+    it('ResourcePool#v_total_vms')  { expect(@rp1.v_total_vms).to eq(2) }
 
-    it('ResourcePool#v_direct_miq_templates') { @rp1.v_direct_vms.should == 1 }
-    it('ResourcePool#v_total_miq_templates')  { @rp1.v_total_vms.should == 2 }
+    it('ResourcePool#v_direct_miq_templates') { expect(@rp1.v_direct_vms).to eq(1) }
+    it('ResourcePool#v_total_miq_templates')  { expect(@rp1.v_total_vms).to eq(2) }
   end
 
   context("RedHat") do
@@ -79,35 +79,35 @@ describe EmsCluster do
       @template2 = FactoryGirl.create(:template_redhat, :ems_cluster => @cluster)
     end
 
-    it('#vms_and_templates')              { @cluster.vms_and_templates.should              match_array [@vm1, @vm2, @template1, @template2] }
-    it('#direct_vms_and_templates')       { @cluster.direct_vms_and_templates.should       match_array [@vm1, @template1, @template2] }
-    it('#vm_or_template_ids')             { @cluster.vm_or_template_ids.should             match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
-    it('#direct_vm_or_template_ids')      { @cluster.direct_vm_or_template_ids.should      match_array [@vm1.id, @template1.id, @template2.id] }
-    it('#total_direct_vms_and_templates') { @cluster.total_direct_vms_and_templates.should == 3 }
+    it('#vms_and_templates')              { expect(@cluster.vms_and_templates).to              match_array [@vm1, @vm2, @template1, @template2] }
+    it('#direct_vms_and_templates')       { expect(@cluster.direct_vms_and_templates).to       match_array [@vm1, @template1, @template2] }
+    it('#vm_or_template_ids')             { expect(@cluster.vm_or_template_ids).to             match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
+    it('#direct_vm_or_template_ids')      { expect(@cluster.direct_vm_or_template_ids).to      match_array [@vm1.id, @template1.id, @template2.id] }
+    it('#total_direct_vms_and_templates') { expect(@cluster.total_direct_vms_and_templates).to eq(3) }
 
-    it('#vms')              { @cluster.vms.should              match_array [@vm1, @vm2] }
-    it('#direct_vms')       { @cluster.direct_vms.should       match_array [@vm1] }
-    it('#vm_ids')           { @cluster.vm_ids.should           match_array [@vm1.id, @vm2.id] }
-    it('#direct_vm_ids')    { @cluster.direct_vm_ids.should    match_array [@vm1.id] }
-    it('#total_direct_vms') { @cluster.total_direct_vms.should == 1 }
+    it('#vms')              { expect(@cluster.vms).to              match_array [@vm1, @vm2] }
+    it('#direct_vms')       { expect(@cluster.direct_vms).to       match_array [@vm1] }
+    it('#vm_ids')           { expect(@cluster.vm_ids).to           match_array [@vm1.id, @vm2.id] }
+    it('#direct_vm_ids')    { expect(@cluster.direct_vm_ids).to    match_array [@vm1.id] }
+    it('#total_direct_vms') { expect(@cluster.total_direct_vms).to eq(1) }
 
-    it('#miq_templates')              { @cluster.miq_templates.should              match_array [@template1, @template2] }
-    it('#direct_miq_templates')       { @cluster.direct_miq_templates.should       match_array [@template1, @template2] }
-    it('#miq_template_ids')           { @cluster.miq_template_ids.should           match_array [@template1.id, @template2.id] }
-    it('#direct_miq_template_ids')    { @cluster.direct_miq_template_ids.should    match_array [@template1.id, @template2.id] }
-    it('#total_direct_miq_templates') { @cluster.total_direct_miq_templates.should == 2 }
+    it('#miq_templates')              { expect(@cluster.miq_templates).to              match_array [@template1, @template2] }
+    it('#direct_miq_templates')       { expect(@cluster.direct_miq_templates).to       match_array [@template1, @template2] }
+    it('#miq_template_ids')           { expect(@cluster.miq_template_ids).to           match_array [@template1.id, @template2.id] }
+    it('#direct_miq_template_ids')    { expect(@cluster.direct_miq_template_ids).to    match_array [@template1.id, @template2.id] }
+    it('#total_direct_miq_templates') { expect(@cluster.total_direct_miq_templates).to eq(2) }
 
-    it('#all_vms_and_templates')   { @cluster.all_vms_and_templates.should   match_array [@vm1, @vm2, @template1, @template2] }
-    it('#all_vm_or_template_ids')  { @cluster.all_vm_or_template_ids.should  match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
-    it('#total_vms_and_templates') { @cluster.total_vms_and_templates.should == 4 }
+    it('#all_vms_and_templates')   { expect(@cluster.all_vms_and_templates).to   match_array [@vm1, @vm2, @template1, @template2] }
+    it('#all_vm_or_template_ids')  { expect(@cluster.all_vm_or_template_ids).to  match_array [@vm1.id, @vm2.id, @template1.id, @template2.id] }
+    it('#total_vms_and_templates') { expect(@cluster.total_vms_and_templates).to eq(4) }
 
-    it('#all_vms')    { @cluster.all_vms.should    match_array [@vm1, @vm2] }
-    it('#all_vm_ids') { @cluster.all_vm_ids.should match_array [@vm1.id, @vm2.id] }
-    it('#total_vms')  { @cluster.total_vms.should == 2 }
+    it('#all_vms')    { expect(@cluster.all_vms).to    match_array [@vm1, @vm2] }
+    it('#all_vm_ids') { expect(@cluster.all_vm_ids).to match_array [@vm1.id, @vm2.id] }
+    it('#total_vms')  { expect(@cluster.total_vms).to eq(2) }
 
-    it('#all_miq_templates')    { @cluster.all_miq_templates.should    match_array [@template1, @template2] }
-    it('#all_miq_template_ids') { @cluster.all_miq_template_ids.should match_array [@template1.id, @template2.id] }
-    it('#total_miq_templates')  { @cluster.total_miq_templates.should == 2 }
+    it('#all_miq_templates')    { expect(@cluster.all_miq_templates).to    match_array [@template1, @template2] }
+    it('#all_miq_template_ids') { expect(@cluster.all_miq_template_ids).to match_array [@template1.id, @template2.id] }
+    it('#total_miq_templates')  { expect(@cluster.total_miq_templates).to eq(2) }
   end
 
   it "#save_drift_state" do
@@ -115,10 +115,10 @@ describe EmsCluster do
     cluster = FactoryGirl.create(:ems_cluster)
     cluster.save_drift_state
 
-    cluster.drift_states.size.should == 1
-    DriftState.count.should == 1
+    expect(cluster.drift_states.size).to eq(1)
+    expect(DriftState.count).to eq(1)
 
-    cluster.drift_states.first.data.should == {
+    expect(cluster.drift_states.first.data).to eq({
       :aggregate_cpu_speed       => 0,
       :aggregate_cpu_total_cores => 0,
       :aggregate_memory          => 0,
@@ -131,44 +131,44 @@ describe EmsCluster do
       :vms                       => [],
       :miq_templates             => [],
       :hosts                     => [],
-    }
+    })
   end
 
   context("#perf_capture_enabled_host_ids=") do
     before do
       @miq_region = FactoryGirl.create(:miq_region, :region => 1)
-      MiqRegion.stub(:my_region).and_return(@miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(@miq_region)
       @cluster = FactoryGirl.create(:ems_cluster)
       @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster)
       @host2 = FactoryGirl.create(:host, :ems_cluster => @cluster)
     end
 
     it "Initially Performance capture for cluster and its hosts should not be set" do
-      @cluster.perf_capture_enabled.should eq(false)
-      @host1.perf_capture_enabled.should eq(false)
-      @host2.perf_capture_enabled.should eq(false)
+      expect(@cluster.perf_capture_enabled).to eq(false)
+      expect(@host1.perf_capture_enabled).to eq(false)
+      expect(@host2.perf_capture_enabled).to eq(false)
     end
 
     it "Performance capture for cluster and its hosts should be set" do
       @cluster.perf_capture_enabled_host_ids = [@host1.id, @host2.id]
-      @cluster.perf_capture_enabled.should eq(true)
-      @host1.perf_capture_enabled.should eq(true)
-      @host2.perf_capture_enabled.should eq(true)
+      expect(@cluster.perf_capture_enabled).to eq(true)
+      expect(@host1.perf_capture_enabled).to eq(true)
+      expect(@host2.perf_capture_enabled).to eq(true)
     end
 
     it "Performance capture for cluster and only 1 hosts should be set" do
       @cluster.perf_capture_enabled_host_ids = [@host2.id]
-      @cluster.perf_capture_enabled.should eq(true)
-      @host1.perf_capture_enabled.should eq(false)
-      @host2.perf_capture_enabled.should eq(true)
+      expect(@cluster.perf_capture_enabled).to eq(true)
+      expect(@host1.perf_capture_enabled).to eq(false)
+      expect(@host2.perf_capture_enabled).to eq(true)
     end
 
     it "Performance capture for cluster and its hosts should get unset" do
       @cluster.perf_capture_enabled_host_ids = [@host2.id]
       @cluster.perf_capture_enabled_host_ids = []
-      @cluster.perf_capture_enabled.should eq(false)
-      @host1.perf_capture_enabled.should eq(false)
-      @host2.perf_capture_enabled.should eq(false)
+      expect(@cluster.perf_capture_enabled).to eq(false)
+      expect(@host1.perf_capture_enabled).to eq(false)
+      expect(@host2.perf_capture_enabled).to eq(false)
     end
   end
 
@@ -183,19 +183,19 @@ describe EmsCluster do
       FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
 
       result = EmsCluster.node_types
-      result.should eq(:mixed_clusters)
+      expect(result).to eq(:mixed_clusters)
     end
 
     it "returns :openstack when there are only openstack clusters in db" do
       FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
       result = EmsCluster.node_types
-      result.should eq(:openstack)
+      expect(result).to eq(:openstack)
     end
 
     it "returns :non_openstack when there are non-openstack clusters in db" do
       FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
       result = EmsCluster.node_types
-      result.should eq(:non_openstack)
+      expect(result).to eq(:non_openstack)
     end
   end
 
@@ -205,14 +205,14 @@ describe EmsCluster do
       cluster = FactoryGirl.create(:ems_cluster, :ems_id => ems.id)
 
       result = cluster.openstack_cluster?
-      result.should be_true
+      expect(result).to be_truthy
     end
 
     it "returns false for non-openstack cluster" do
       ems = FactoryGirl.create(:ems_vmware)
       cluster = FactoryGirl.create(:ems_cluster, :ems_id => ems.id)
       result = cluster.openstack_cluster?
-      result.should be_false
+      expect(result).to be_falsey
     end
   end
 end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -18,10 +18,10 @@ describe EmsEvent do
 
       EmsEvent.add_vc(@ems.id, raw_event)
 
-      EmsEvent.count.should == 1
+      expect(EmsEvent.count).to eq(1)
       event = EmsEvent.first
 
-      event.should have_attributes(
+      expect(event).to have_attributes(
         :event_type        => "GeneralUserEvent",
         :chain_id          => 5361104,
         :is_task           => false,
@@ -46,11 +46,11 @@ describe EmsEvent do
 
         EmsEvent.add_vc(@ems.id, raw_event)
 
-        EmsEvent.count.should == 1
+        expect(EmsEvent.count).to eq(1)
         event = EmsEvent.first
 
         assert_result_fields(event)
-        event.should have_attributes(
+        expect(event).to have_attributes(
           :event_type => "vprob.vmfs.resource.corruptondisk",
           :message    => "event.vprob.vmfs.resource.corruptondisk.fullFormat (vprob.vmfs.resource.corruptondisk)",
         )
@@ -62,18 +62,18 @@ describe EmsEvent do
 
         EmsEvent.add_vc(@ems.id, raw_event)
 
-        EmsEvent.count.should == 1
+        expect(EmsEvent.count).to eq(1)
         event = EmsEvent.first
 
         assert_result_fields(event)
-        event.should have_attributes(
+        expect(event).to have_attributes(
           :event_type => "EventEx",
           :message    => "",
         )
       end
 
       def assert_result_fields(event)
-        event.should have_attributes(
+        expect(event).to have_attributes(
           :chain_id          => 297179,
           :is_task           => false,
           :source            => "VC",
@@ -124,7 +124,7 @@ describe EmsEvent do
 
         it "should use the availability zone from the event" do
           EmsEvent.process_availability_zone_in_event!(@event_hash)
-          @event_hash[:availability_zone_id].should eq @availability_zone.id
+          expect(@event_hash[:availability_zone_id]).to eq @availability_zone.id
         end
       end
 
@@ -137,14 +137,14 @@ describe EmsEvent do
 
           it "should use the VM's availability zone" do
             EmsEvent.process_availability_zone_in_event!(@event_hash)
-            @event_hash[:availability_zone_id].should eq @availability_zone.id
+            expect(@event_hash[:availability_zone_id]).to eq @availability_zone.id
           end
         end
 
         context "and the VM does not have an availability zone" do
           it "should not put an availability zone in the event hash" do
             EmsEvent.process_availability_zone_in_event!(@event_hash)
-            @event_hash[:availability_zone_id].should be_nil
+            expect(@event_hash[:availability_zone_id]).to be_nil
           end
         end
       end
@@ -166,7 +166,7 @@ describe EmsEvent do
           @vm.save
 
           new_event = EmsEvent.add(@vm.ems_id, @event_hash)
-          new_event.availability_zone_id.should eq @availability_zone.id
+          expect(new_event.availability_zone_id).to eq @availability_zone.id
         end
       end
 
@@ -177,7 +177,7 @@ describe EmsEvent do
           @vm.save
 
           new_event = EmsEvent.add(@vm.ems_id, @event_hash)
-          new_event.availability_zone_id.should eq @availability_zone.id
+          expect(new_event.availability_zone_id).to eq @availability_zone.id
         end
       end
     end
@@ -187,12 +187,12 @@ describe EmsEvent do
         described_class.stub(:keep_ems_events => "3.months")
 
         # Exposes 3.months.seconds.ago.utc != 3.months.ago.utc
-        described_class.purge_date.should be_within(2.days).of(3.months.ago.utc)
+        expect(described_class.purge_date).to be_within(2.days).of(3.months.ago.utc)
       end
 
       it "defaults to 6 months" do
         described_class.stub(:keep_ems_events => nil)
-        described_class.purge_date.should be_within(1.day).of(6.months.ago.utc)
+        expect(described_class.purge_date).to be_within(1.day).of(6.months.ago.utc)
       end
     end
 
@@ -206,8 +206,8 @@ describe EmsEvent do
 
       it "with nothing in the queue" do
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [purge_time]
@@ -219,8 +219,8 @@ describe EmsEvent do
         described_class.purge_queue(new_purge_time)
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [new_purge_time]
@@ -238,9 +238,9 @@ describe EmsEvent do
       end
 
       def assert_delete_calls_and_unpurged_ids(options)
-        described_class.should_receive(:delete_all).public_send(options[:delete_calls]).and_call_original
+        expect(described_class).to receive(:delete_all).public_send(options[:delete_calls]).and_call_original
         described_class.purge(purge_date, options[:window], options[:limit])
-        described_class.order(:id).pluck(:id).should == Array(options[:unpurged_ids]).sort
+        expect(described_class.order(:id).pluck(:id)).to eq(Array(options[:unpurged_ids]).sort)
       end
 
       it "purge_date and older" do

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -74,7 +74,7 @@ describe EmsFolder do
         @sib2.id => "root/dc/sib2",
         @leaf.id => "root/dc/sib2/leaf"
       }
-      @root.child_folder_paths.should == expected
+      expect(@root.child_folder_paths).to eq(expected)
     end
   end
 end

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -20,25 +20,19 @@ describe EmsRefresh::MetadataRelats do
     end
 
     it "with a Vm" do
-      expect(EmsRefresh.vmdb_relats(@vm)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-        :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-        :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@vm)).to eq(:folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
     end
 
     it "with a Host" do
-      expect(EmsRefresh.vmdb_relats(@host)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@host)).to eq(:folders_to_clusters => {@folder.id => [@cluster.id]})
     end
 
     it "with an EMS" do
-      expect(EmsRefresh.vmdb_relats(@ems)).to eq({
-        :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-        :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-        :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      })
+      expect(EmsRefresh.vmdb_relats(@ems)).to eq(:folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                 :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                 :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
     end
 
     context "with an invalid relats tree" do
@@ -52,13 +46,11 @@ describe EmsRefresh::MetadataRelats do
       end
 
       it "with an EMS" do
-        expect(EmsRefresh.vmdb_relats(@ems)).to eq({
-          :folders_to_hosts           => {@folder.id  => [@host.id]},
-          :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-          :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
-          :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
-          :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-        })
+        expect(EmsRefresh.vmdb_relats(@ems)).to eq(:folders_to_hosts           => {@folder.id  => [@host.id]},
+                                                   :folders_to_clusters        => {@folder.id  => [@cluster.id]},
+                                                   :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
+                                                   :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
+                                                   :resource_pools_to_vms      => {@rp.id      => [@vm.id]})
       end
     end
   end

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -20,25 +20,25 @@ describe EmsRefresh::MetadataRelats do
     end
 
     it "with a Vm" do
-      EmsRefresh.vmdb_relats(@vm).should == {
+      expect(EmsRefresh.vmdb_relats(@vm)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
         :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
         :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      }
+      })
     end
 
     it "with a Host" do
-      EmsRefresh.vmdb_relats(@host).should == {
+      expect(EmsRefresh.vmdb_relats(@host)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
-      }
+      })
     end
 
     it "with an EMS" do
-      EmsRefresh.vmdb_relats(@ems).should == {
+      expect(EmsRefresh.vmdb_relats(@ems)).to eq({
         :folders_to_clusters        => {@folder.id  => [@cluster.id]},
         :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
         :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-      }
+      })
     end
 
     context "with an invalid relats tree" do
@@ -52,13 +52,13 @@ describe EmsRefresh::MetadataRelats do
       end
 
       it "with an EMS" do
-        EmsRefresh.vmdb_relats(@ems).should == {
+        expect(EmsRefresh.vmdb_relats(@ems)).to eq({
           :folders_to_hosts           => {@folder.id  => [@host.id]},
           :folders_to_clusters        => {@folder.id  => [@cluster.id]},
           :clusters_to_resource_pools => {@cluster.id => [@rp.id]},
           :hosts_to_resource_pools    => {@host.id    => [@rp2.id]},
           :resource_pools_to_vms      => {@rp.id      => [@vm.id]},
-        }
+        })
       end
     end
   end

--- a/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_spec.rb
@@ -18,14 +18,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -33,24 +33,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).to eq(@vm1.uid_ems)
       end
     end
 
@@ -66,24 +66,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should_not == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).not_to eq(@vm1.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -91,14 +91,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
     end
 
@@ -114,24 +114,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should_not == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).not_to eq(@vm1.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -139,15 +139,15 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
-        v1.ems_id.should_not be_nil
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
+        expect(v1.ems_id).not_to be_nil
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
     end
 
@@ -164,16 +164,16 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
-        v1.ems_id.should == @ems2.id
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
+        expect(v1.ems_id).to eq(@ems2.id)
 
-        v2.id.should_not == @vm1.id
-        v2.uid_ems.should == @vm1.uid_ems
-        v2.ems_id.should == @ems.id
+        expect(v2.id).not_to eq(@vm1.id)
+        expect(v2.uid_ems).to eq(@vm1.uid_ems)
+        expect(v2.ems_id).to eq(@ems.id)
       end
     end
 
@@ -189,11 +189,11 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 1
+        expect(vms.length).to eq(1)
         v = vms.first
 
-        v.id.should == @vm1.id
-        v.uid_ems.should == @vm1.uid_ems
+        expect(v.id).to eq(@vm1.id)
+        expect(v.uid_ems).to eq(@vm1.uid_ems)
       end
     end
 
@@ -217,14 +217,14 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 2
+        expect(vms.length).to eq(2)
         v1, v2 = vms.sort_by(&:id)
 
-        v1.id.should == @vm1.id
-        v1.uid_ems.should == @vm1.uid_ems
+        expect(v1.id).to eq(@vm1.id)
+        expect(v1.uid_ems).to eq(@vm1.uid_ems)
 
-        v2.id.should == @vm2.id
-        v2.uid_ems.should == @vm2.uid_ems
+        expect(v2.id).to eq(@vm2.id)
+        expect(v2.uid_ems).to eq(@vm2.uid_ems)
       end
 
       it "should handle dups in the raw data" do
@@ -234,24 +234,24 @@ describe EmsRefresh::SaveInventory do
         EmsRefresh.save_vms_inventory(@ems, data)
 
         vms = Vm.all
-        vms.length.should == 3
+        expect(vms.length).to eq(3)
 
         disconnected, connected = vms.partition { |v| v.ems_id.nil? }
-        disconnected.length.should == 1
-        connected.length.should == 2
+        expect(disconnected.length).to eq(1)
+        expect(connected.length).to eq(2)
 
         d      = disconnected.first
         c1, c2 = connected.sort_by(&:id)
 
-        d.id.should == @vm2.id
-        d.uid_ems.should == @vm2.uid_ems
+        expect(d.id).to eq(@vm2.id)
+        expect(d.uid_ems).to eq(@vm2.uid_ems)
 
-        c1.id.should == @vm1.id
-        c1.uid_ems.should == @vm1.uid_ems
+        expect(c1.id).to eq(@vm1.id)
+        expect(c1.uid_ems).to eq(@vm1.uid_ems)
 
-        c2.id.should_not == @vm1.id
-        c2.id.should_not == @vm2.id
-        c2.uid_ems.should == @vm1.uid_ems
+        expect(c2.id).not_to eq(@vm1.id)
+        expect(c2.id).not_to eq(@vm2.id)
+        expect(c2.uid_ems).to eq(@vm1.uid_ems)
       end
     end
   end

--- a/spec/models/ems_refresh/vc_updates_spec.rb
+++ b/spec/models/ems_refresh/vc_updates_spec.rb
@@ -62,7 +62,8 @@ describe EmsRefresh::VcUpdates do
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_false
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_false
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode"))
+        .to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_true
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_true

--- a/spec/models/ems_refresh/vc_updates_spec.rb
+++ b/spec/models/ems_refresh/vc_updates_spec.rb
@@ -54,31 +54,31 @@ describe EmsRefresh::VcUpdates do
         ]
       }
     ) do
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary")).to be_truthy
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power")).to be_false
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_false
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power")).to be_falsey
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_falsey
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_falsey
 
       expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode"))
-        .to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_true
+        .to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_truthy
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back")).to be_false
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back")).to be_falsey
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev")).to be_falsey
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig")).to be_truthy
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest")).to be_true
-      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest")).to be_truthy
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk")).to be_falsey
 
-      expect(EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter")).to be_falsey
     end
   end
 end

--- a/spec/models/ems_refresh/vc_updates_spec.rb
+++ b/spec/models/ems_refresh/vc_updates_spec.rb
@@ -39,7 +39,7 @@ describe EmsRefresh::VcUpdates do
       @prop[:changeSet].first["val"] = prop_value
       EmsRefresh.vc_update(@vm.ems_id, @prop)
       @vm = VmOrTemplate.find(@vm.id) # reload will not handle vm <=> template type change, so we must do a real find
-      @vm.send(meth).should == expected
+      expect(@vm.send(meth)).to eq(expected)
     end
   end
 
@@ -54,30 +54,30 @@ describe EmsRefresh::VcUpdates do
         ]
       }
     ) do
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.powerState")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "sum").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.runtime.power")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.run")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "sum")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000]")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back").should be_false
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.device[2000].back")).to be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.hardware.dev")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig").should be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "config.extraConfig")).to be_true
 
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest").should be_true
-      EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest")).to be_true
+      expect(EmsRefresh::VcUpdates.selected_property?(:vm, "summary.guest.disk")).to be_false
 
-      EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter").should be_false
+      expect(EmsRefresh::VcUpdates.selected_property?(:other, "does.not.matter")).to be_false
     end
   end
 end

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -44,11 +44,11 @@ describe EmsRefresh do
       described_class.queue_refresh(target)
 
       q_all = MiqQueue.all
-      q_all.length.should == 1
-      q_all[0].args.should == [expected_targets.collect { |t| [t.class.name, t.id] }]
-      q_all[0].class_name.should == described_class.name
-      q_all[0].method_name.should == 'refresh'
-      q_all[0].role.should == "ems_inventory"
+      expect(q_all.length).to eq(1)
+      expect(q_all[0].args).to eq([expected_targets.collect { |t| [t.class.name, t.id] }])
+      expect(q_all[0].class_name).to eq(described_class.name)
+      expect(q_all[0].method_name).to eq('refresh')
+      expect(q_all[0].role).to eq("ems_inventory")
     end
   end
 
@@ -61,7 +61,7 @@ describe EmsRefresh do
         [ems2.class, ems2.id]
       ]
 
-      described_class.get_ar_objects(pairs).should match_array([ems1, ems2])
+      expect(described_class.get_ar_objects(pairs)).to match_array([ems1, ems2])
     end
   end
 
@@ -70,11 +70,11 @@ describe EmsRefresh do
       ems = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
       vm1 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems)
       vm2 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware2", :ext_management_system => ems)
-      ManageIQ::Providers::Vmware::InfraManager::Refresher.should_receive(:refresh).with do |args|
+      expect(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh).with { |args|
         # Refresh code doesn't care about args order so neither does the test
         # TODO: use array_including in rspec 3
         (args - [vm2, vm1]).empty?
-      end
+      }
 
       EmsRefresh.refresh([
         [vm1.class, vm1.id],
@@ -86,7 +86,7 @@ describe EmsRefresh do
       ems = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
       vm1 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems)
       vm2 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware2", :ext_management_system => nil)
-      ManageIQ::Providers::Vmware::InfraManager::Refresher.should_receive(:refresh).with([vm1])
+      expect(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh).with([vm1])
       EmsRefresh.refresh([
         [vm1.class, vm1.id],
         [vm2.class, vm2.id],

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 describe ExtManagementSystem do
   it ".model_name_from_emstype" do
     described_class.leaf_subclasses.each do |klass|
-      described_class.model_name_from_emstype(klass.ems_type).should == klass.name
+      expect(described_class.model_name_from_emstype(klass.ems_type)).to eq(klass.name)
     end
-    described_class.model_name_from_emstype('foo').should be_nil
+    expect(described_class.model_name_from_emstype('foo')).to be_nil
   end
 
   let(:all_types) do
@@ -29,11 +29,11 @@ describe ExtManagementSystem do
   end
 
   it ".types" do
-    described_class.types.should match_array(all_types)
+    expect(described_class.types).to match_array(all_types)
   end
 
   it ".supported_types" do
-    described_class.supported_types.should match_array(all_types)
+    expect(described_class.supported_types).to match_array(all_types)
   end
 
   it ".ems_infra_discovery_types" do
@@ -59,15 +59,15 @@ describe ExtManagementSystem do
 
     it "refresh_all_ems_timer will refresh for all emses in zone1" do
       @ems1 = @zone1.ext_management_systems.first
-      MiqServer.stub(:my_server).and_return(@zone1.miq_servers.first)
-      described_class.should_receive(:refresh_ems).with([@ems1.id], true)
+      allow(MiqServer).to receive(:my_server).and_return(@zone1.miq_servers.first)
+      expect(described_class).to receive(:refresh_ems).with([@ems1.id], true)
       described_class.refresh_all_ems_timer
     end
 
     it "refresh_all_ems_timer will refresh for all emses in zone2" do
       @ems2 = @zone2.ext_management_systems.first
-      MiqServer.stub(:my_server).and_return(@zone2.miq_servers.first)
-      described_class.should_receive(:refresh_ems).with([@ems2.id], true)
+      allow(MiqServer).to receive(:my_server).and_return(@zone2.miq_servers.first)
+      expect(described_class).to receive(:refresh_ems).with([@ems2.id], true)
       described_class.refresh_all_ems_timer
     end
   end
@@ -79,40 +79,40 @@ describe ExtManagementSystem do
     end
 
     it "#total_vms_on" do
-      @ems.total_vms_on.should == 5
+      expect(@ems.total_vms_on).to eq(5)
     end
 
     it "#total_vms_off" do
-      @ems.total_vms_off.should == 0
+      expect(@ems.total_vms_off).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "poweredOff") }
-      @ems.total_vms_off.should == 5
+      expect(@ems.total_vms_off).to eq(5)
     end
 
     it "#total_vms_unknown" do
-      @ems.total_vms_unknown.should == 0
+      expect(@ems.total_vms_unknown).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "unknown") }
-      @ems.total_vms_unknown.should == 5
+      expect(@ems.total_vms_unknown).to eq(5)
     end
 
     it "#total_vms_never" do
-      @ems.total_vms_never.should == 0
+      expect(@ems.total_vms_never).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "never") }
-      @ems.total_vms_never.should == 5
+      expect(@ems.total_vms_never).to eq(5)
     end
 
     it "#total_vms_suspended" do
-      @ems.total_vms_suspended.should == 0
+      expect(@ems.total_vms_suspended).to eq(0)
 
       @ems.vms.each { |v| v.update_attributes(:raw_power_state => "suspended") }
-      @ems.total_vms_suspended.should == 5
+      expect(@ems.total_vms_suspended).to eq(5)
     end
 
     %w(total_vms_on total_vms_off total_vms_unknown total_vms_never total_vms_suspended).each do |vcol|
       it "should have virtual column #{vcol} " do
-        described_class.should have_virtual_column "#{vcol}", :integer
+        expect(described_class).to have_virtual_column "#{vcol}", :integer
       end
     end
   end

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -30,28 +30,28 @@ describe Job::StateMachine do
 
   it "should transition from one state to another by a signal" do
     @obj.signal(:initializing)
-    @obj.state.should eq 'waiting'
+    expect(@obj.state).to eq 'waiting'
   end
 
   it "should transition to another by a signal according to its current state" do
     @obj.state = 'waiting'
     @obj.signal(:start)
-    @obj.state.should eq 'doing'
+    expect(@obj.state).to eq 'doing'
 
     @obj.state = 'retrying'
     @obj.signal(:start)
-    @obj.state.should eq 'working'
+    expect(@obj.state).to eq 'working'
   end
 
   it "should transition to some selected state from any state" do
     @obj.signal(:cancel)
-    @obj.state.should eq 'canceling'
+    expect(@obj.state).to eq 'canceling'
   end
 
   it "should leave the state unchanged for some selected signal" do
     @obj.state = 'doing'
     @obj.signal(:error)
-    @obj.state.should eq 'doing'
+    expect(@obj.state).to eq 'doing'
   end
 
   it "should raise an error if the transition is not allowed" do


### PR DESCRIPTION
**REQUIRES ~~#5842~~ (EDIT: Merged). Merge that one first.**

Converts model spec under the pattern [a-e]* to newer `expect` syntax.

Note that some models in this pattern have already been converted in #5842