### PR TITLE
Allow newer bundler since 1.11.1 is released with a bug fix.

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,7 +1,7 @@
 set -v
 
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
-travis_retry gem install bundler -v "~> 1.10.6"
+travis_retry gem install bundler -v ">= 1.11.1"
 
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}


### PR DESCRIPTION
a3371736aa197a840f5e4a837f78b6945ef59b6a prevented 1.11.0 due to a bug,
see Bundler 4149.

1.11.1 is now released with a fix so let's unleash the latest bundler
so travis helps us keep bundler current.