### PR TITLE
Upgrade memoist for fewer object allocations and speed.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -27,7 +27,7 @@ gem "kubeclient",              "=0.8.0",            :require => false
 gem "hawkular-client",         "~>0.1.2",           :require => false
 gem "linux_admin",             "~>0.13.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
-gem "memoist",                 "~>0.11.0",          :require => false
+gem "memoist",                 "~>0.14.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>1.2.0",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false


### PR DESCRIPTION
0.14.0 includes PR 36 and 36 on https://github.com/matthewrudy/memoist

For some reports that utilize memoist through the relationship mixin:
Drops object allocations by ~15%
Saves ~2.5% time

Before (memoist 0.11.0)

Time elapsed | Allocated Objects | Description
------------ | ----------------- | -----------
22.667482 | 15337741 | 33 - Host Summary for VMs
19.53994 | 13192428 | 88 - VM Relationships
45.047883 | 29281970 | 89 - Folder to VMs Relationships

After (memoist 0.14.0):

Time elapsed | Allocated Objects | Description
------------ | ----------------- | -----------
22.067832 | 13198765 | 33 - Host Summary for VMs
19.013875 | 11056350 | 88 - VM Relationships
43.888582 | 25011970 | 89 - Folder to VMs Relationships