### PR TITLE
Reset request task status when task is finished.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
@@ -17,7 +17,7 @@ module MiqAeMethodService
     end
 
     def finished(msg)
-      object_send(:update_and_notify_parent, :state => 'finished', :message => msg)
+      object_send(:update_and_notify_parent, :state => 'finished', :message => msg, :status => 'Ok')
     end
 
     def status

--- a/spec/automation/unit/method_validation/task_finished_spec.rb
+++ b/spec/automation/unit/method_validation/task_finished_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'task_finished method' do
+  let(:miq_server)       { EvmSpecHelper.local_miq_server }
+  let(:user)             { FactoryGirl.create(:user_with_email_and_group) }
+  let(:miq_request_task) { FactoryGirl.create(:miq_request_task, :miq_request => request, :source => vm) }
+  let(:request)          { FactoryGirl.create(:vm_migrate_request, :requester => user) }
+
+  let(:ems)              { FactoryGirl.create(:ems_vmware, :tenant => Tenant.root_tenant) }
+  let(:vm)               { FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :evm_owner => user) }
+
+  it 'resets task status' do
+    miq_request_task.update_attributes(:state => 'finished', :status => 'Error', :message => 'timed out after 600.282732 seconds.  Timeout threshold [600]')
+    attrs = ["MiqServer::miq_server=#{miq_server.id}"]
+    attrs << "MiqRequestTask::vm_migrate_task=#{miq_request_task.id}"
+    MiqAeEngine.instantiate("/System/CommonMethods/StateMachineMethods/vm_migrate_finished?#{attrs.join('&')}", user)
+    expect(miq_request_task.reload.status).to eq('Ok')
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
@@ -133,7 +133,7 @@ module MiqAeServiceMiqRequestTaskSpec
       message = 'message1'
       method   = "$evm.root['miq_request_task'].finished('#{message}')"
       @ae_method.update_attributes(:data => method)
-      MiqRequestTask.any_instance.should_receive(:update_and_notify_parent).with(:state => 'finished', :message => message).once
+      MiqRequestTask.any_instance.should_receive(:update_and_notify_parent).with(:state => 'finished', :message => message, :status => 'Ok').once
       invoke_ae
     end
   end


### PR DESCRIPTION
When VM migration takes a long time, the Queue message would timeout after 10 minutes by default
and the request task is updated with :state => 'finished', :status => 'Error', :message => 'Error: timed out after 600.008431 seconds.  Timeout threshold [600].'

Later on when VM migration is finished, the request task is updated with :state => 'finished', :message => 'VM Migrated Successfully' while its status is still left in 'Error'.

https://bugzilla.redhat.com/show_bug.cgi?id=1256903