### PR TITLE
Change logic of choosing depot for collection log

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -611,6 +611,7 @@ module OpsController::Diagnostics
       add_flash(_("Cannot start log collection, a log collection is already in progress within this scope"), :error)
     else
       begin
+        options[:context] = klass.name
         instance.synchronize_logs(session[:userid], options)
       rescue StandardError => bang
         add_flash(_("Log collection error returned: ") << bang.message, :error)
@@ -1095,7 +1096,7 @@ module OpsController::Diagnostics
   def set_credentials
     creds = {}
     if params[:log_userid]
-      log_password = params[:log_password] ? params[:log_password] : @record.log_depot.authentication_password
+      log_password = params[:log_password] ? params[:log_password] : @record.log_file_depot.authentication_password
       creds[:default] = {:userid => params[:log_userid], :password => log_password}
     end
     creds

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1118,9 +1118,9 @@ class ApplicationHelper::ToolbarBuilder
     when "MiqServer"
       case id
       when "collect_logs", "collect_current_logs"
-        return "Cannot collect current logs unless the #{ui_lookup(:table => "miq_servers")} is started" if @record.status != "started"
+        return "Cannot collect current logs unless the #{ui_lookup(:table => "miq_servers")} is started" unless @record.started?
         return "Log collection is already in progress for this #{ui_lookup(:table => "miq_servers")}" if @record.log_collection_active_recently?
-        return "Log collection requires the Log Depot settings to be configured" unless @record.log_depot
+        return "Log collection requires the Log Depot settings to be configured" unless @record.log_file_depot
       when "delete_server"
         return "Server #{@record.name} [#{@record.id}] can only be deleted if it is stopped or has not responded for a while" unless @record.is_deleteable?
       when "restart_workers"
@@ -1272,9 +1272,9 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Zone"
       case id
-      when "collect_logs", "collect_current_logs"
-        return "Cannot collect current logs unless there are started #{ui_lookup(:tables => "miq_servers")} in the Zone" if @record.miq_servers.collect { |s| s.status == "started" ? true : nil }.compact.length == 0
-        return "This Zone and one or more active #{ui_lookup(:tables => "miq_servers")} in this Zone do not have Log Depot settings configured, collection not allowed" if @record.miq_servers.select(&:log_depot).blank?
+      when "zone_collect_logs", "zone_collect_current_logs"
+        return "Cannot collect current logs unless there are started #{ui_lookup(:tables => "miq_servers")} in the Zone" unless @record.any_started_miq_servers?
+        return "This Zone do not have Log Depot settings configured, collection not allowed" unless @record.log_file_depot
         return "Log collection is already in progress for one or more #{ui_lookup(:tables => "miq_servers")} in this Zone" if @record.log_collection_active_recently?
       when "zone_delete"
         if @selected_zone.name.downcase == "default"
@@ -1434,7 +1434,7 @@ class ApplicationHelper::ToolbarBuilder
                              support_vmdb_choice__zone_collect_current_logs
                           )
 
-    if props[:name].in?(collect_log_buttons) && @record.try(:log_depot).try(:requires_support_case?)
+    if props[:name].in?(collect_log_buttons) && @record.try(:log_file_depot).try(:requires_support_case?)
       props[:prompt] = true
     end
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -7,7 +7,6 @@ class Zone < ActiveRecord::Base
   serialize :settings, Hash
 
   belongs_to      :log_file_depot, :class_name => "FileDepot"
-  alias_attribute :log_depot, :log_file_depot
 
   has_many :miq_servers
   has_many :ext_management_systems
@@ -227,6 +226,10 @@ class Zone < ActiveRecord::Base
 
   def active?
     miq_servers.any?(&:active?)
+  end
+
+  def any_started_miq_servers?
+    miq_servers.any?(&:started?)
   end
 
   protected

--- a/app/views/ops/_logs_selected.html.haml
+++ b/app/views/ops/_logs_selected.html.haml
@@ -1,5 +1,5 @@
 - record               = @selected_server
-- log_depot_uri        = "#{record.log_depot.try(:uri) || "N/A"} #{"(from Zone)" unless record.log_file_depot}"
+- log_depot_uri        = "#{record.log_file_depot.try(:uri) || "N/A"}"
 - last_time            = record.last_log_sync_on
 - last_collection_time = last_time.blank? ? "Never" : format_timezone(last_time.to_time, Time.zone, "gtl")
 

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -38,7 +38,7 @@ shared_examples "logs_collect" do |type|
   context "nothing preventing collection" do
     it "succeeds" do
       expect_any_instance_of(klass).to receive(:log_collection_active_recently?).and_return(false)
-      expect_any_instance_of(klass).to receive(:synchronize_logs).with(user.userid, {})
+      expect_any_instance_of(klass).to receive(:synchronize_logs).with(user.userid, :context => klass.name)
       expect(controller).to receive(:replace_right_cell).with(active_node)
 
       controller.send(:logs_collect)
@@ -115,7 +115,7 @@ describe OpsController do
 
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       file_depot = FileDepotSmb.create(:name => "abc", :uri => "smb://abc")
-      expect(@miq_server).to receive(:log_depot).and_return(file_depot)
+      expect(@miq_server).to receive(:log_file_depot).and_return(file_depot)
       expect(file_depot).to receive(:authentication_password).and_return('default_password')
       controller.instance_variable_set(:@record, @miq_server)
       controller.instance_variable_set(:@_params,

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -1,7 +1,89 @@
 require "spec_helper"
 
+def stub_vmdb_util_methods_for_collection_log
+  VMDB::Util.stub(:zip_logs)
+  VMDB::Util.stub(:compressed_log_patterns).and_return(["log/evm.1122.gz"])
+  VMDB::Util.stub(:get_evm_log_for_date).and_return("20151209_141429_20151217_140845")
+  VMDB::Util.stub(:get_log_start_end_times).and_return([Time.zone.now, Time.zone.now])
+end
+
+shared_examples "post_[type_of_log]_logs" do |type, type_of_log|
+  it "uses #{type} file_depot in LogFile for upload" do
+    @zone.log_file_depot = zone_depot
+    @miq_server.log_file_depot = server_depot
+
+    stub_vmdb_util_methods_for_collection_log
+    allow_any_instance_of(LogFile).to receive(:upload)
+    allow_any_instance_of(MiqServer).to receive(:current_log_patterns)
+
+    method = "post_#{type_of_log}_logs".to_sym
+    @miq_server.send(method, miq_task.id, @miq_server.log_depot(type))
+    log_file_depot = LogFile.first.file_depot
+
+    if type == "Zone"
+      expect(log_file_depot).to eq(zone_depot)
+      expect(log_file_depot).not_to eq(server_depot)
+    else
+      expect(log_file_depot).not_to eq(zone_depot)
+      expect(log_file_depot).to eq(server_depot)
+    end
+
+    expect(LogFile.first.miq_task).to eq(miq_task)
+  end
+end
+
+shared_examples "post_logs_uses_depot" do |is_zone_depot, is_server_depot, context|
+  it "uses #{context} depot" do
+    if is_zone_depot
+      @zone.log_file_depot = zone_depot
+    end
+
+    if is_server_depot
+      @miq_server.log_file_depot = server_depot
+    end
+
+    stub_vmdb_util_methods_for_collection_log
+    allow_any_instance_of(LogFile).to receive(:upload)
+    allow_any_instance_of(MiqServer).to receive(:current_log_patterns)
+
+    @miq_server.post_logs(:taskid => miq_task.id, :context => context)
+
+    log_file_depot = LogFile.first.file_depot
+
+    if context == "Zone"
+      expect(log_file_depot).to eq(zone_depot)
+    else
+      expect(log_file_depot).to eq(server_depot)
+    end
+  end
+end
+
+shared_examples "post_logs_fails" do |is_zone_depot, is_server_depot, context|
+  it "raises error 'Log depot settings not configured'" do
+    if is_zone_depot
+      @zone.log_file_depot = zone_depot
+    end
+
+    if is_server_depot
+      @miq_server.log_file_depot = server_depot
+    end
+
+    stub_vmdb_util_methods_for_collection_log
+    allow_any_instance_of(LogFile).to receive(:upload)
+    allow_any_instance_of(MiqServer).to receive(:current_log_patterns)
+
+    expect do
+      @miq_server.post_logs(:taskid => miq_task.id, :context => context)
+    end.to raise_error(RuntimeError, "Log depot settings not configured")
+  end
+end
+
 describe MiqServer do
   context "LogManagement" do
+    let(:server_depot) { FactoryGirl.create(:file_depot) }
+    let(:zone_depot) { FactoryGirl.create(:file_depot) }
+    let(:miq_task) { FactoryGirl.create(:miq_task) }
+
     before do
       _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
       @miq_server2          = FactoryGirl.create(:miq_server, :zone => @zone)
@@ -46,28 +128,89 @@ describe MiqServer do
       end
     end
 
-    context "#log_depot" do
+    describe "#log_depot" do
       it "server log_file_depot configured" do
-        server_depot = FactoryGirl.create(:file_depot)
         @miq_server.log_file_depot = server_depot
-
-        expect(@miq_server.log_depot).to eq(server_depot)
+        expect(@miq_server.log_depot("MiqServer")).to eq(server_depot)
       end
 
       it "zone log_file_depot configured" do
-        zone_depot = FactoryGirl.create(:file_depot)
         @zone.log_file_depot = zone_depot
-
-        expect(@miq_server.log_depot).to eq(zone_depot)
+        expect(@miq_server.log_depot("Zone")).to eq(zone_depot)
       end
 
       it "server and zone log_file_depot configured" do
-        server_depot = FactoryGirl.create(:file_depot)
-        zone_depot   = FactoryGirl.create(:file_depot)
         @miq_server.log_file_depot = server_depot
         @zone.log_file_depot = zone_depot
+        expect(@miq_server.log_depot("Zone")).to eq(zone_depot)
+        expect(@miq_server.log_depot("MiqServer")).to eq(server_depot)
+      end
+    end
 
-        expect(@miq_server.log_depot).to eq(server_depot)
+    describe "#post_historical_logs" do
+      context "Server" do
+        include_examples "post_[type_of_log]_logs", "MiqServer", :historical
+      end
+
+      context "Zone" do
+        include_examples "post_[type_of_log]_logs", "Zone", :historical
+      end
+    end
+
+    describe "#post_current_logs" do
+      context "Server" do
+        include_examples "post_[type_of_log]_logs", "MiqServer", :current
+      end
+
+      context "Zone" do
+        include_examples "post_[type_of_log]_logs", "Zone", :current
+      end
+    end
+    def post_logs(options)
+      taskid = options[:taskid]
+      task = MiqTask.find(taskid)
+      context_log_depot = log_depot(options[:context])
+
+      # the current queue item and task must be errored out on exceptions so re-raise any caught errors
+      raise "Log depot settings not configured" unless context_log_depot
+      context_log_depot.update_attributes(:support_case => options[:support_case].presence)
+
+      post_historical_logs(taskid, context_log_depot) unless options[:only_current]
+      post_current_logs(taskid, context_log_depot)
+      task.update_status("Finished", "Ok", "Log files were successfully collected")
+    end
+
+    describe "#post_logs" do
+      context "Zone collection log requested, Zone depot is defined, MiqServer is defined" do
+        include_examples "post_logs_uses_depot", true, true, "Zone"
+      end
+
+      context "Zone collection log requested, Zone depot is defined, MiqServer is not defined" do
+        include_examples "post_logs_uses_depot", true, false, "Zone"
+      end
+
+      context "Zone collection log requested, zone depot is not defined, MiqServer defined" do
+        include_examples "post_logs_fails", false, true, "Zone"
+      end
+
+      context "Zone collection log requested, zone depot is not defined, MiqServer is not defined" do
+        include_examples "post_logs_fails", false, false, "Zone"
+      end
+
+      context "MiqServer collection log requested, Zone depot is defined, MiqServer is defined" do
+        include_examples "post_logs_uses_depot", true, true, "MiqServer"
+      end
+
+      context "MiqServer collection log requested, Zone depot is defined, MiqServer is not defined" do
+        include_examples "post_logs_fails", true, false, "MiqServer"
+      end
+
+      context "MiqServer collection log requested, zone depot is not defined, server defined" do
+        include_examples "post_logs_uses_depot", false, true, "MiqServer"
+      end
+
+      context "MiqServer collection log requested, zone depot is not defined, MiqServer is not defined" do
+        include_examples "post_logs_fails", false, false, "MiqServer"
       end
     end
   end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/1962

If log collection is requested in Zone - zone's depot is taken and if it is not defined in the zone the toolbar button "Collect..Logs" is disabled with explanation in title ( Is this ok ? In https://github.com/ManageIQ/manageiq/issues/1962 is that it should fails) 

If log collection is requested in MiqServer - MiqServer's depot is taken and  if it is not defined for the MiqServer the toolbar button "Collect..Logs" is disabled with explanation in title

There is also small UI change for displaying URI (we are not taking depot from zone if for miq_server is not defined)

before
![log_before](https://cloud.githubusercontent.com/assets/14937244/11844258/100cfa5e-a40e-11e5-8958-e83987451f88.png)
after
![log_after](https://cloud.githubusercontent.com/assets/14937244/11844260/139bc3c6-a40e-11e5-8d7d-ff4a67ef8082.png)

Question1: Are we still supporting prompting for Support Case ? Should we leave related code here ?
It seems that it is disable: https://github.com/ManageIQ/manageiq/blob/master/app/models/file_depot.rb#L29 (if it would be enable and when you are clicking on the log collection button then - it prompts you for 'Support Case' and this information stores in file_log depot https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_server/log_management.rb#L130)

I can add more specs after review.

@jrafanie please review, thank you
