### PR TITLE
Fix top of the main UI dissapearing behind menus

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -551,6 +551,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def render_flash_and_scroll(*args)
+    render_flash(*args) do |page|
+      page << '$("#main_div").scrollTop(0);'
+    end
+  end
+
   def tagging_explorer_controller?
     false
   end
@@ -2569,7 +2575,7 @@ class ApplicationController < ActionController::Base
     add_flash(_("%{task} does not apply to at least one of the selected %{model}") %
                 {:model => model_type,
                  :task  => type.split.map(&:capitalize).join(' ')}, :error)
-    render_flash { |page| page << '$(\'#main_div\').scrollTop();' } if @explorer
+    render_flash_and_scroll if @explorer
   end
 
   def set_gettext_locale

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -187,7 +187,7 @@ module ApplicationController::CiProcessing
     vms = find_checked_items
     if VmOrTemplate.includes_template?(vms.map(&:to_i).uniq)
       add_flash(_("%{task} does not apply to selected %{model}") % {:model => ui_lookup(:table => "miq_template"), :task => "Set Retirement Dates"}, :error)
-      render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+      render_flash_and_scroll
       return
     end
     # check to see if coming from show_list or drilled into vms from another CI
@@ -326,7 +326,7 @@ module ApplicationController::CiProcessing
     else
       if VmOrTemplate.includes_template?(recs)
         add_flash(_("%{task} does not apply to selected %{model}") % {:model => ui_lookup(:table => "miq_template"), :task => "Right-Size Recommendations"}, :error)
-        render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+        render_flash_and_scroll
         return
       end
     end
@@ -1052,17 +1052,17 @@ module ApplicationController::CiProcessing
     end
     if recs.length < 1
       add_flash(_("One or more %{model} must be selected to %{task}") % {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize, :task => "Reconfigure"}, :error)
-      render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+      render_flash_and_scroll
       return
     else
       if VmOrTemplate.includes_template?(recs)
         add_flash(_("%{task} does not apply because you selected at least one %{model}") % {:model => ui_lookup(:table => "miq_template"), :task => "Reconfigure"}, :error)
-        render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+        render_flash_and_scroll
         return
       end
       unless VmOrTemplate.reconfigurable?(recs)
         add_flash(_("%{task} does not apply because you selected at least one un-reconfigurable VM") % {:task => "Reconfigure"}, :error)
-        render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+        render_flash_and_scroll
         return
       end
       @edit[:reconfigure_items] = recs.collect(&:to_i)
@@ -1171,7 +1171,7 @@ module ApplicationController::CiProcessing
       vms = find_checked_items
       if method == 'retire_now' && VmOrTemplate.includes_template?(vms)
         add_flash(_("%{task} does not apply to selected %{model}") % {:model => ui_lookup(:table => "miq_template"), :task => "Retire"}, :error)
-        render_flash { |page| page << '$(\'#main_div\').scrollTop();' }
+        render_flash_and_scroll
         return
       end
 

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -154,3 +154,7 @@
 - if show_advanced_search?
   :javascript
     #{javascript_show_if_exists("adv_searchbox_div")}
+
+:javascript
+  // a hack to prevent toolbars disappearing behind top menus, see BZ#1291465 for details
+  $('.container-fluid').scrollTop(0);


### PR DESCRIPTION
As far as I can tell, it looks more like a browser bug (except consistent at least between Firefox and Chrome) in that an element with overflow:hidden and height:100% can actually get a non-zero scrollTop value - it seems to happen while rendering, when center_div is taller than the actual available space.
    
(And I've verified we're not setting the non-zero scrollTop ourselves.)
    
The simplest fix is actually to simply trigger a browser resize event (but triggering just the handlers does not work), shifting the window size by a pixel fixes it, but that's not quite portable.
    
Thus, this adds an unconditional `$('.container-fluid').scrollTop(0)` to the content layout, which fixes it.

https://bugzilla.redhat.com/show_bug.cgi?id=1291465

Also piggy-backing an almost-related fix to a prototype->jquery conversion bug - replacing `render_flash { |page| page << '$(\'#main_div\').scrollTop();' }` which does nothing (as opposed to `...scrollTop(0)`) with a `render_flash_and_scroll` helper which does the right thing.