### PR TITLE
RSpec3 conversion: F-J models

### DIFF
--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -13,44 +13,44 @@ describe FileDepotFtp do
     it "true if file exists" do
       file_depot_ftp.ftp = double(:nlst => ["somefile"])
 
-      expect(file_depot_ftp.file_exists?("somefile")).to be_true
+      expect(file_depot_ftp.file_exists?("somefile")).to be_truthy
     end
 
     it "false if ftp raises on missing file" do
       file_depot_ftp.ftp = double
-      file_depot_ftp.ftp.should_receive(:nlst).and_raise(Net::FTPPermError)
+      expect(file_depot_ftp.ftp).to receive(:nlst).and_raise(Net::FTPPermError)
 
-      expect(file_depot_ftp.file_exists?("somefile")).to be_false
+      expect(file_depot_ftp.file_exists?("somefile")).to be_falsey
     end
 
     it "false if file missing" do
       file_depot_ftp.ftp = double(:nlst => [])
 
-      expect(file_depot_ftp.file_exists?("somefile")).to be_false
+      expect(file_depot_ftp.file_exists?("somefile")).to be_falsey
     end
   end
 
   context "#upload_file" do
     it "does not already exist" do
-      file_depot_ftp.should_receive(:connect).and_return(connection)
-      file_depot_ftp.should_receive(:file_exists?).exactly(4).times.and_return(false)
-      connection.should_receive(:mkdir).with("uploads")
-      connection.should_receive(:mkdir).with("uploads/#{@zone.name}_#{@zone.id}")
-      connection.should_receive(:mkdir).with("uploads/#{@zone.name}_#{@zone.id}/#{@miq_server.name}_#{@miq_server.id}")
-      connection.should_receive(:putbinaryfile)
-      log_file.should_receive(:post_upload_tasks)
-      connection.should_receive(:close)
+      expect(file_depot_ftp).to receive(:connect).and_return(connection)
+      expect(file_depot_ftp).to receive(:file_exists?).exactly(4).times.and_return(false)
+      expect(connection).to receive(:mkdir).with("uploads")
+      expect(connection).to receive(:mkdir).with("uploads/#{@zone.name}_#{@zone.id}")
+      expect(connection).to receive(:mkdir).with("uploads/#{@zone.name}_#{@zone.id}/#{@miq_server.name}_#{@miq_server.id}")
+      expect(connection).to receive(:putbinaryfile)
+      expect(log_file).to receive(:post_upload_tasks)
+      expect(connection).to receive(:close)
 
       file_depot_ftp.upload_file(log_file)
     end
 
     it "already exists" do
-      file_depot_ftp.should_receive(:connect).and_return(connection)
-      file_depot_ftp.should_receive(:file_exists?).and_return(true)
-      connection.should_not_receive(:mkdir)
-      connection.should_not_receive(:putbinaryfile)
-      log_file.should_not_receive(:post_upload_tasks)
-      connection.should_receive(:close)
+      expect(file_depot_ftp).to receive(:connect).and_return(connection)
+      expect(file_depot_ftp).to receive(:file_exists?).and_return(true)
+      expect(connection).not_to receive(:mkdir)
+      expect(connection).not_to receive(:putbinaryfile)
+      expect(log_file).not_to receive(:post_upload_tasks)
+      expect(connection).to receive(:close)
 
       file_depot_ftp.upload_file(log_file)
     end

--- a/spec/models/filesystem_spec.rb
+++ b/spec/models/filesystem_spec.rb
@@ -26,49 +26,49 @@ my_ip=192.0.2.13
   context "#contents_displayable?" do
     it "filesystem with missing name is not displayable" do
       filesystem = FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_conf_file_ascii)
-      filesystem.stub(:name).and_return(nil)
+      allow(filesystem).to receive(:name).and_return(nil)
 
-      expect(filesystem.contents_displayable?).to be_false
+      expect(filesystem.contents_displayable?).to be_falsey
     end
 
     it "filesystem content bigger than 20k characters is not displayable" do
       filesystem = FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_conf_file_ascii)
-      filesystem.stub(:size).and_return(40_000)
+      allow(filesystem).to receive(:size).and_return(40_000)
 
-      expect(filesystem.contents_displayable?).to be_false
+      expect(filesystem.contents_displayable?).to be_falsey
     end
 
     it "non MIME .conf ascii file is displayable" do
       filesystem = FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_conf_file_ascii)
 
-      expect(filesystem.contents_displayable?).to be_true
+      expect(filesystem.contents_displayable?).to be_truthy
     end
 
     it "non MIME .conf file, with non ascii characters is not displayable" do
       filesystem = FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_conf_file_non_ascii)
       filesystem.name = "DOES NOT EXIST"
 
-      expect(filesystem.contents_displayable?).to be_false
+      expect(filesystem.contents_displayable?).to be_falsey
     end
 
     it "non MIME .conf file, without content is not displayable" do
       filesystem = FactoryGirl.create(:filesystem_openstack_conf, :contents => filesystem_conf_file_ascii)
       filesystem.name = "DOES NOT EXIST"
-      filesystem.stub(:has_contents?).and_return(false)
+      allow(filesystem).to receive(:has_contents?).and_return(false)
 
-      expect(filesystem.contents_displayable?).to be_false
+      expect(filesystem.contents_displayable?).to be_falsey
     end
 
     it "MIME .exe binary file is not displayable" do
       filesystem = FactoryGirl.create(:filesystem_binary_file)
 
-      expect(filesystem.contents_displayable?).to be_false
+      expect(filesystem.contents_displayable?).to be_falsey
     end
 
     it "MIME .txt non binary file is displayable" do
       filesystem = FactoryGirl.create(:filesystem_txt_file)
 
-      expect(filesystem.contents_displayable?).to be_true
+      expect(filesystem.contents_displayable?).to be_truthy
     end
   end
 end

--- a/spec/models/firewall_rule_spec.rb
+++ b/spec/models/firewall_rule_spec.rb
@@ -8,14 +8,14 @@ describe FirewallRule do
       os = FactoryGirl.create(:operating_system)
       firewall_rule.update_attributes(:resource_type => "OperatingSystem", :resource_id => os.id)
 
-      firewall_rule.operating_system.should == os
+      expect(firewall_rule.operating_system).to eq(os)
     end
 
     it "with a non-OperatingSystem" do
       sg = FactoryGirl.create(:security_group)
       firewall_rule.update_attributes(:resource_type => "SecurityGroup", :resource_id => sg.id)
 
-      firewall_rule.operating_system.should be_nil
+      expect(firewall_rule.operating_system).to be_nil
     end
   end
 
@@ -25,7 +25,7 @@ describe FirewallRule do
 
       firewall_rule.operating_system = os
 
-      firewall_rule.should have_attributes(
+      expect(firewall_rule).to have_attributes(
         :resource_type => "OperatingSystem",
         :resource_id   => os.id
       )
@@ -34,7 +34,7 @@ describe FirewallRule do
     it "with a non-OperatingSystem" do
       sg = FactoryGirl.create(:security_group)
 
-      -> { firewall_rule.operating_system = sg }.should raise_error(ArgumentError)
+      expect { firewall_rule.operating_system = sg }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/models/floating_ip_spec.rb
+++ b/spec/models/floating_ip_spec.rb
@@ -6,6 +6,6 @@ describe FloatingIp do
     ip1 = FactoryGirl.create(:floating_ip_amazon, :vm => vm)
     ip2 = FactoryGirl.create(:floating_ip_amazon)
 
-    described_class.available.should == [ip2]
+    expect(described_class.available).to eq([ip2])
   end
 end

--- a/spec/models/guest_device_spec.rb
+++ b/spec/models/guest_device_spec.rb
@@ -13,26 +13,26 @@ describe GuestDevice do
   end
 
   it "#vm_or_template" do
-    @vm_gd.vm_or_template.should == @vm
-    @template_gd.vm_or_template.should == @template
-    @host_gd.vm_or_template.should     be_nil
+    expect(@vm_gd.vm_or_template).to eq(@vm)
+    expect(@template_gd.vm_or_template).to eq(@template)
+    expect(@host_gd.vm_or_template).to     be_nil
   end
 
   it "#vm" do
-    @vm_gd.vm.should == @vm
-    @template_gd.vm.should be_nil
-    @host_gd.vm.should     be_nil
+    expect(@vm_gd.vm).to eq(@vm)
+    expect(@template_gd.vm).to be_nil
+    expect(@host_gd.vm).to     be_nil
   end
 
   it "#miq_template" do
-    @vm_gd.miq_template.should       be_nil
-    @template_gd.miq_template.should == @template
-    @host_gd.miq_template.should     be_nil
+    expect(@vm_gd.miq_template).to       be_nil
+    expect(@template_gd.miq_template).to eq(@template)
+    expect(@host_gd.miq_template).to     be_nil
   end
 
   it "#host" do
-    @vm_gd.host.should       be_nil
-    @template_gd.host.should be_nil
-    @host_gd.host.should == @host
+    expect(@vm_gd.host).to       be_nil
+    expect(@template_gd.host).to be_nil
+    expect(@host_gd.host).to eq(@host)
   end
 end

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -13,26 +13,26 @@ describe Hardware do
   end
 
   it "#vm_or_template" do
-    @vm_hw.vm_or_template.should == @vm
-    @template_hw.vm_or_template.should == @template
-    @host_hw.vm_or_template.should     be_nil
+    expect(@vm_hw.vm_or_template).to eq(@vm)
+    expect(@template_hw.vm_or_template).to eq(@template)
+    expect(@host_hw.vm_or_template).to     be_nil
   end
 
   it "#vm" do
-    @vm_hw.vm.should == @vm
-    @template_hw.vm.should be_nil
-    @host_hw.vm.should     be_nil
+    expect(@vm_hw.vm).to eq(@vm)
+    expect(@template_hw.vm).to be_nil
+    expect(@host_hw.vm).to     be_nil
   end
 
   it "#miq_template" do
-    @vm_hw.miq_template.should       be_nil
-    @template_hw.miq_template.should == @template
-    @host_hw.miq_template.should     be_nil
+    expect(@vm_hw.miq_template).to       be_nil
+    expect(@template_hw.miq_template).to eq(@template)
+    expect(@host_hw.miq_template).to     be_nil
   end
 
   it "#host" do
-    @vm_hw.host.should       be_nil
-    @template_hw.host.should be_nil
-    @host_hw.host.should == @host
+    expect(@vm_hw.host).to       be_nil
+    expect(@template_hw.host).to be_nil
+    expect(@host_hw.host).to eq(@host)
   end
 end

--- a/spec/models/import_file_upload_spec.rb
+++ b/spec/models/import_file_upload_spec.rb
@@ -8,19 +8,19 @@ describe ImportFileUpload do
 
     before do
       import_file_upload.create_binary_blob(:binary => "---\n- :file: contents\n")
-      MiqPolicy.stub(:import_from_array).with([{:file => "contents"}], :preview => true).and_return(policy_array)
+      allow(MiqPolicy).to receive(:import_from_array).with([{:file => "contents"}], :preview => true).and_return(policy_array)
     end
 
     it "returns the imported policy array" do
-      import_file_upload.policy_import_data.should == "policy array"
+      expect(import_file_upload.policy_import_data).to eq("policy array")
     end
   end
 
   describe "#service_dialog_json" do
     before do
       import_file_upload.create_binary_blob(:binary => "---\n- label: Dialog2\n- label: dialog\n  not_label: test\n")
-      Dialog.stub(:exists?).with(:label => "dialog").and_return(exists?)
-      Dialog.stub(:exists?).with(:label => "Dialog2").and_return(exists?)
+      allow(Dialog).to receive(:exists?).with(:label => "dialog").and_return(exists?)
+      allow(Dialog).to receive(:exists?).with(:label => "Dialog2").and_return(exists?)
     end
 
     context "when a given dialog exists" do
@@ -39,7 +39,7 @@ describe ImportFileUpload do
           :status      => "This object already exists in the database with the same name"
         }].to_json
 
-        import_file_upload.service_dialog_json.should == expected_json
+        expect(import_file_upload.service_dialog_json).to eq(expected_json)
       end
     end
 
@@ -59,7 +59,7 @@ describe ImportFileUpload do
           :status      => "New object"
         }].to_json
 
-        import_file_upload.service_dialog_json.should == expected_json
+        expect(import_file_upload.service_dialog_json).to eq(expected_json)
       end
     end
   end
@@ -76,8 +76,8 @@ describe ImportFileUpload do
     not_name: test
         BINARY
       )
-      MiqWidget.stub(:exists?).with(:title => "widget").and_return(exists?)
-      MiqWidget.stub(:exists?).with(:title => "Widget1").and_return(exists?)
+      allow(MiqWidget).to receive(:exists?).with(:title => "widget").and_return(exists?)
+      allow(MiqWidget).to receive(:exists?).with(:title => "Widget1").and_return(exists?)
     end
 
     context "when a given widget exists" do
@@ -127,15 +127,15 @@ describe ImportFileUpload do
     end
 
     it "stores the binary blob binary data" do
-      import_file_upload.binary_blob.binary.should == "123"
+      expect(import_file_upload.binary_blob.binary).to eq("123")
     end
 
     it "stores the binary blob name" do
-      import_file_upload.binary_blob.name.should == "the name"
+      expect(import_file_upload.binary_blob.name).to eq("the name")
     end
 
     it "stores the binary blob data type" do
-      import_file_upload.binary_blob.data_type.should == "yml"
+      expect(import_file_upload.binary_blob.data_type).to eq("yml")
     end
   end
 
@@ -145,7 +145,7 @@ describe ImportFileUpload do
     end
 
     it "returns the binary_blob binary data" do
-      import_file_upload.uploaded_content.should == "binary data"
+      expect(import_file_upload.uploaded_content).to eq("binary data")
     end
   end
 
@@ -155,7 +155,7 @@ describe ImportFileUpload do
     end
 
     it "returns the binary_blob data parsed as yaml" do
-      import_file_upload.uploaded_yaml_content.should == [{:file => "contents"}]
+      expect(import_file_upload.uploaded_yaml_content).to eq([{:file => "contents"}])
     end
   end
 end

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -13,7 +13,7 @@ module JobProxyDispatcherEmbeddedScanSpec
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
       vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"]).select("target_id").collect(&:target_id).compact.uniq
-      vms_in_embedded_scanning.length.should > 0
+      expect(vms_in_embedded_scanning.length).to be > 0
 
       method = case y_resource
                when :ems then 'ems_id'
@@ -36,8 +36,8 @@ module JobProxyDispatcherEmbeddedScanSpec
         end
       end
 
-      resource_hsh.values.detect { |count| count > 0 }.should be_true, "Expected at least one #{y_resource} resource with more than 0 scan jobs. resource_hash: #{resource_hsh.inspect}"
-      resource_hsh.values.detect { |count| count > x_scans }.should be_nil, "Expected no #{y_resource} resource with more than #{x_scans} scan jobs. resource_hash: #{resource_hsh.inspect}"
+      expect(resource_hsh.values.detect { |count| count > 0 }).to be_truthy, "Expected at least one #{y_resource} resource with more than 0 scan jobs. resource_hash: #{resource_hsh.inspect}"
+      expect(resource_hsh.values.detect { |count| count > x_scans }).to be_nil, "Expected no #{y_resource} resource with more than #{x_scans} scan jobs. resource_hash: #{resource_hsh.inspect}"
     end
 
     context "With a zone, server, ems, hosts, vmware vms" do
@@ -59,7 +59,7 @@ module JobProxyDispatcherEmbeddedScanSpec
 
       context "and a scan job for each vm" do
         before(:each) do
-          MiqVimBrokerWorker.stub(:available_in_zone?).and_return(true)
+          allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
           # JobProxyDispatcher.stub(:start_job_on_proxy).and_return(nil)
 
           @jobs = @vms.collect(&:scan)
@@ -67,13 +67,13 @@ module JobProxyDispatcherEmbeddedScanSpec
 
         context "and embedded scans on ems" do
           before(:each) do
-            ManageIQ::Providers::Vmware::InfraManager::Vm.stub(:scan_via_ems?).and_return(true)
+            allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:scan_via_ems?).and_return(true)
           end
 
           context "and scans against ems limited to 2 and up to 10 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(10)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_ems => 2})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 2})
             end
 
             it "should dispatch only 2 scan jobs per ems"  do
@@ -89,8 +89,8 @@ module JobProxyDispatcherEmbeddedScanSpec
 
           context "and scans against ems limited to 4 and up to 10 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(10)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
             end
 
             it "should dispatch only 4 scan jobs per ems"  do
@@ -101,8 +101,8 @@ module JobProxyDispatcherEmbeddedScanSpec
 
           context "and scans against ems limited to 4 and up to 2 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(2)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(2)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
             end
 
             it "should dispatch up to 4 per ems and 2 per miqserver"  do
@@ -115,13 +115,13 @@ module JobProxyDispatcherEmbeddedScanSpec
 
         context "and embedded scans on hosts" do
           before(:each) do
-            ManageIQ::Providers::Vmware::InfraManager::Vm.stub(:scan_via_ems?).and_return(false)
+            allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:scan_via_ems?).and_return(false)
           end
 
           context "and scans against host limited to 2 and up to 10 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(10)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_host => 2})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 2})
             end
 
             it "should dispatch only 2 scan jobs per host"  do
@@ -132,8 +132,8 @@ module JobProxyDispatcherEmbeddedScanSpec
 
           context "and scans against host limited to 4 and up to 10 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(10)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
             end
 
             it "should dispatch only 4 scan jobs per host"  do
@@ -144,8 +144,8 @@ module JobProxyDispatcherEmbeddedScanSpec
 
           context "and scans against host limited to 4 and up to 2 scans per miqserver" do
             before(:each) do
-              MiqServer.any_instance.stub(:concurrent_job_max).and_return(2)
-              JobProxyDispatcher.stub(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
+              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(2)
+              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
             end
 
             it "should dispatch up to 4 per host and 2 per miqserver"  do

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -32,7 +32,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
           end
 
           it "should return an empty array" do
-            @jpd.get_eligible_proxies_for_job(@job).should be_empty
+            expect(@jpd.get_eligible_proxies_for_job(@job)).to be_empty
           end
         end
 
@@ -44,7 +44,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
           end
 
           it "should return an empty array" do
-            @jpd.get_eligible_proxies_for_job(@job).should be_empty
+            expect(@jpd.get_eligible_proxies_for_job(@job)).to be_empty
           end
         end
 
@@ -54,7 +54,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
           end
 
           it "should return an empty array" do
-            @jpd.get_eligible_proxies_for_job(@job).should be_empty
+            expect(@jpd.get_eligible_proxies_for_job(@job)).to be_empty
           end
         end
       end

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -23,9 +23,9 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
 
         it "should return both servers" do
           res = @vm.miq_server_proxies
-          res.length.should == 2
-          res.include?(@server1).should be_true
-          res.include?(@server2).should be_true
+          expect(res.length).to eq(2)
+          expect(res.include?(@server1)).to be_truthy
+          expect(res.include?(@server2)).to be_truthy
         end
       end
 
@@ -35,7 +35,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @server1.save
         end
         it "should return second server" do
-          @vm.miq_server_proxies.should == [@server2]
+          expect(@vm.miq_server_proxies).to eq([@server2])
         end
       end
 
@@ -44,7 +44,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           MiqServer.any_instance.stub(:is_vix_disk? => false)
         end
         it "should return no servers" do
-          @vm.miq_server_proxies.should be_empty
+          expect(@vm.miq_server_proxies).to be_empty
         end
       end
 
@@ -56,7 +56,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @vm.stub(:my_zone => @vms_zone.name)
         end
         it "should return only server2, in same zone" do
-          @vm.miq_server_proxies.should == [@server2]
+          expect(@vm.miq_server_proxies).to eq([@server2])
         end
       end
 
@@ -66,7 +66,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @vm.save
         end
         it "should return no servers" do
-          @vm.miq_server_proxies.should be_empty
+          expect(@vm.miq_server_proxies).to be_empty
         end
       end
 
@@ -76,7 +76,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @vm.save
         end
         it "should return no servers" do
-          @vm.miq_server_proxies.should be_empty
+          expect(@vm.miq_server_proxies).to be_empty
         end
       end
 
@@ -86,7 +86,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @vm.save
         end
         it "should return no servers" do
-          @vm.miq_server_proxies.should be_empty
+          expect(@vm.miq_server_proxies).to be_empty
         end
       end
 
@@ -96,7 +96,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           host.vm_scan_affinity = [@server2]
         end
         it "should return only servers in the host's affinity list" do
-          @vm.miq_server_proxies.should == [@server2]
+          expect(@vm.miq_server_proxies).to eq([@server2])
         end
       end
 
@@ -107,7 +107,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
         end
 
         it "should return only second server (without any scan affinity)" do
-          @vm.miq_server_proxies.should == [@server2]
+          expect(@vm.miq_server_proxies).to eq([@server2])
         end
       end
     end

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -28,7 +28,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
           end
 
           it "should return with message asking for VM's host's creds" do
-            @vm.proxies4job[:message].should == "Provide credentials for this VM's Host to perform SmartState Analysis"
+            expect(@vm.proxies4job[:message]).to eq("Provide credentials for this VM's Host to perform SmartState Analysis")
           end
         end
 
@@ -38,7 +38,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
           end
 
           it "should return with message 'No active SmartProxies'" do
-            @vm.proxies4job[:message].should == "No active SmartProxies found to analyze this VM"
+            expect(@vm.proxies4job[:message]).to eq("No active SmartProxies found to analyze this VM")
           end
         end
       end
@@ -54,7 +54,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
         end
 
         it "should return with message Smarstate Analysis is available through registered Host only" do
-          @vm.proxies4job[:message].should == 'SmartState Analysis is only available through the registered Host for running VM'
+          expect(@vm.proxies4job[:message]).to eq('SmartState Analysis is only available through the registered Host for running VM')
         end
 
         context "with a server in the all proxy list" do
@@ -62,7 +62,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
             @vm.stub(:storage2proxies => [@server1])
           end
           it "should return with message to start a smart proxy or provide Vm's hosts creds" do
-            @vm.proxies4job[:message].should == "Start a SmartProxy or provide credentials for this VM's Host to perform SmartState Analysis"
+            expect(@vm.proxies4job[:message]).to eq("Start a SmartProxy or provide credentials for this VM's Host to perform SmartState Analysis")
           end
         end
       end
@@ -75,13 +75,13 @@ describe "JobProxyDispatcherVmProxies4Job" do
         end
 
         it "should accept an instance of a job and call log proxies with a job" do
-          @vm.should_receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
-          @vm.proxies4job(@job)[:proxies].should be_empty
+          expect(@vm).to receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
+          expect(@vm.proxies4job(@job)[:proxies]).to be_empty
         end
 
         it "should accept a job guid and call log proxies with a job" do
-          @vm.should_receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
-          @vm.proxies4job(@job.guid)[:proxies].should be_empty
+          expect(@vm).to receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
+          expect(@vm.proxies4job(@job.guid)[:proxies]).to be_empty
         end
 
         context "with VmAmazon, " do
@@ -93,7 +93,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
           end
 
           it "should return my_server" do
-            @vm.proxies4job[:proxies].should == [@server1]
+            expect(@vm.proxies4job[:proxies]).to eq([@server1])
           end
         end
       end

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -29,7 +29,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
             vm_storage.save
           end
           it "should return storage's hosts" do
-            @vm.storage2hosts.should == @vm.storage.hosts
+            expect(@vm.storage2hosts).to eq(@vm.storage.hosts)
           end
         end
 
@@ -41,7 +41,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
           end
 
           it "should return repo host" do
-            @vm.storage2hosts.should == [@repo_host]
+            expect(@vm.storage2hosts).to eq([@repo_host])
           end
         end
 
@@ -55,7 +55,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
           end
 
           it "should return storage's hosts" do
-            @vm.storage2hosts.should == @vm.storage.hosts
+            expect(@vm.storage2hosts).to eq(@vm.storage.hosts)
           end
         end
 
@@ -69,7 +69,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
           end
 
           it "should return repo host" do
-            @vm.storage2hosts.should == [@repo_host]
+            expect(@vm.storage2hosts).to eq([@repo_host])
           end
         end
 
@@ -86,7 +86,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
           end
 
           it "should exlude non-vmware hosts" do
-            @vm.storage2hosts.should be_empty
+            expect(@vm.storage2hosts).to be_empty
           end
         end
       end

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -36,7 +36,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           end
 
           it "Vm#storage2proxies will exclude proxy-less hosts" do
-            @vm.storage2proxies.should be_empty
+            expect(@vm.storage2proxies).to be_empty
           end
         end
 
@@ -48,17 +48,17 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           end
           context "repo host's proxy inactive" do
             it "Vm#storage2active_proxies will exclude all proxies" do
-              @vm.storage2active_proxies.should be_empty
+              expect(@vm.storage2active_proxies).to be_empty
             end
           end
 
           context "'smartproxy' server and roles deactivated" do
             before(:each) do
               # Overwrite so that we set our own assigned roles instead of from config file
-              MiqServer.any_instance.stub(:set_assigned_roles).and_return(nil)
-              MiqServer.any_instance.stub(:sync_workers).and_return(nil)
-              MiqServer.any_instance.stub(:sync_log_level).and_return(nil)
-              MiqServer.any_instance.stub(:wait_for_started_workers).and_return(nil)
+              allow_any_instance_of(MiqServer).to receive(:set_assigned_roles).and_return(nil)
+              allow_any_instance_of(MiqServer).to receive(:sync_workers).and_return(nil)
+              allow_any_instance_of(MiqServer).to receive(:sync_log_level).and_return(nil)
+              allow_any_instance_of(MiqServer).to receive(:wait_for_started_workers).and_return(nil)
 
               server_roles = [FactoryGirl.create(:server_role, :name => "smartproxy", :max_concurrent => 0)]
 
@@ -68,27 +68,27 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
             end
 
             it "will have no roles active" do
-              @server1.server_roles.length.should == 1
-              @server1.inactive_roles.length.should == 1
-              @server1.active_roles.length.should == 0
+              expect(@server1.server_roles.length).to eq(1)
+              expect(@server1.inactive_roles.length).to eq(1)
+              expect(@server1.active_roles.length).to eq(0)
             end
 
             it "MiqServer#is_proxy_active? will be false" do
-              @server1.is_proxy_active?.should_not be_true
+              expect(@server1.is_proxy_active?).not_to be_truthy
             end
 
             it "Vm#storage2active_proxies will not be eligible to scan vms" do
               $log.info("XXX @server1.is_proxy_active?: #{@server1.is_proxy_active?}")
               $log.info("XXX @server1.started?: #{@server1.started?}")
               $log.info("XXX @server1.has_active_role?(:SmartProxy): #{@server1.has_active_role?(:SmartProxy)}")
-              @vm.storage2active_proxies.should_not include(@server1)
+              expect(@vm.storage2active_proxies).not_to include(@server1)
             end
           end
 
           context "with server proxies active," do
             before(:each) do
               MiqServer.any_instance.stub(:is_proxy_active? => true)
-              @vm.stub(:my_zone).and_return(@server1.zone.name)
+              allow(@vm).to receive(:my_zone).and_return(@server1.zone.name)
             end
 
             context "a vm template and invalid VC authentication" do
@@ -100,7 +100,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
                 @vm.save
               end
               it "Vm#storage2active_proxies will return an empty list" do
-                @vm.storage2active_proxies.should be_empty
+                expect(@vm.storage2active_proxies).to be_empty
               end
             end
 
@@ -110,7 +110,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
                 @vm.stub(:template? => false)
               end
               it "Vm#storage2active_proxies will return an empty list" do
-                @vm.storage2active_proxies.should be_empty
+                expect(@vm.storage2active_proxies).to be_empty
               end
             end
           end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -53,7 +53,7 @@ describe Job do
       end
 
       it "should not queue a timeout job if one is already on there" do
-        expect { @job.timeout! }.not_to change { MiqQueue.count }.by(1)
+        expect { @job.timeout! }.not_to change { MiqQueue.count }
       end
 
       it "should queue a timeout job if one is there, but it is failed" do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -46,9 +46,9 @@ describe Job do
 
         it "should be timed out after 5 minutes" do
           $log.info("@job: #{@job.inspect}")
-          @job.state.should == "finished"
-          @job.status.should == "error"
-          @job.message.starts_with?("job timed out after").should be_true
+          expect(@job.state).to eq("finished")
+          expect(@job.status).to eq("error")
+          expect(@job.message.starts_with?("job timed out after")).to be_truthy
         end
       end
 
@@ -83,9 +83,9 @@ describe Job do
 
       it "should be timed out after 5 minutes" do
         $log.info("@job: #{@job.inspect}")
-        @job.state.should == "finished"
-        @job.status.should == "error"
-        @job.message.starts_with?("job timed out after").should be_true
+        expect(@job.state).to eq("finished")
+        expect(@job.status).to eq("error")
+        expect(@job.message.starts_with?("job timed out after")).to be_truthy
       end
     end
 
@@ -106,23 +106,23 @@ describe Job do
       end
 
       it "should create proper AR relationships" do
-        @snapshot.vm_or_template.should == @vm
-        @vm.snapshots.first.should == @snapshot
-        @vm.ext_management_system.should == @ems
-        @ems.vms.first.should == @vm
+        expect(@snapshot.vm_or_template).to eq(@vm)
+        expect(@vm.snapshots.first).to eq(@snapshot)
+        expect(@vm.ext_management_system).to eq(@ems)
+        expect(@ems.vms.first).to eq(@vm)
 
-        @snapshot2.vm_or_template.should == @vm2
-        @vm2.snapshots.first.should == @snapshot2
-        @vm2.ext_management_system.should == @ems2
-        @ems2.vms.first.should == @vm2
+        expect(@snapshot2.vm_or_template).to eq(@vm2)
+        expect(@vm2.snapshots.first).to eq(@snapshot2)
+        expect(@vm2.ext_management_system).to eq(@ems2)
+        expect(@ems2.vms.first).to eq(@vm2)
       end
 
       it "should be able to find Job from Evm Snapshot" do
         job_guid, ts = Snapshot.parse_evm_snapshot_description(@snapshot.description)
-        Job.find_by_guid(job_guid).should == @job
+        expect(Job.find_by_guid(job_guid)).to eq(@job)
 
         job_guid, ts = Snapshot.parse_evm_snapshot_description(@snapshot2.description)
-        Job.find_by_guid(job_guid).should == @job2
+        expect(Job.find_by_guid(job_guid)).to eq(@job2)
       end
 
       context "where job is not found and the snapshot timestamp is less than an hour old with default job_not_found_delay" do
@@ -227,17 +227,17 @@ describe Job do
   private
 
   def assert_queue_message
-    MiqQueue.count.should == 1
+    expect(MiqQueue.count).to eq(1)
     q = MiqQueue.first
-    q.instance_id.should == @vm.id
-    q.class_name.should == @vm.class.name
-    q.method_name.should == "remove_evm_snapshot"
-    q.args.should == [@snapshot.id]
-    q.role.should == "ems_operations"
-    q.zone.should == @zone.name
+    expect(q.instance_id).to eq(@vm.id)
+    expect(q.class_name).to eq(@vm.class.name)
+    expect(q.method_name).to eq("remove_evm_snapshot")
+    expect(q.args).to eq([@snapshot.id])
+    expect(q.role).to eq("ems_operations")
+    expect(q.zone).to eq(@zone.name)
   end
 
   def assert_no_queue_message
-    MiqQueue.count.should == 0
+    expect(MiqQueue.count).to eq(0)
   end
 end


### PR DESCRIPTION
* Converts all model specs F-J. Doesn't include changes that were made in previous PRs (namely, #5842 - That was made before I decided converting by patterns like this is a much better approach)

You can run these specs specifically via `bundle exec rspec spec/models/[f-j]*`

Punting any Rubocop warnings; I don't want this conversion to drag out much further and it's becoming too time consuming fixing existing issues that I happened to touch.