### PR TITLE
Renaming the tab 'All VM Analysis Tasks'

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -30,7 +30,7 @@ class MiqTaskController < ApplicationController
 
     if role_allows(:feature => "job_my_smartproxy")
       @tabs ||= [["1", ""]]
-      @tabs.push(["1", _("My VM Analysis Tasks")])
+      @tabs.push(["1", _("My VM and Container Analysis Tasks")])
     end
     if role_allows(:feature => "miq_task_my_ui")
       @tabs ||= [["2", ""]]
@@ -38,7 +38,7 @@ class MiqTaskController < ApplicationController
     end
     if role_allows(:feature => "job_all_smartproxy")
       @tabs ||= [["3", ""]]
-      @tabs.push(["3", _("All VM Analysis Tasks")])
+      @tabs.push(["3", _("All VM and Container Analysis Tasks")])
     end
     if role_allows(:feature => "miq_task_all_ui")
       @tabs ||= [["4", ""]]
@@ -91,7 +91,7 @@ class MiqTaskController < ApplicationController
     if @tabform == "tasks_1"
       @layout = "my_tasks"
       @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
-      drop_breadcrumb(:name => _("My VM Analysis Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
+      drop_breadcrumb(:name => _("My VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=tasks")
 
     elsif @tabform == "tasks_2"
       # My UI Tasks
@@ -102,7 +102,7 @@ class MiqTaskController < ApplicationController
     elsif @tabform == "tasks_3" || @tabform == "alltasks_1"
       @layout = "all_tasks"
       @view, @pages = get_view(Job, :conditions => conditions)  # Get the records (into a view) and the paginator
-      drop_breadcrumb(:name => _("All VM Analysis Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
+      drop_breadcrumb(:name => _("All VM and Container Analysis Tasks"), :url => "/miq_task/index?jobs_tab=alltasks")
       @user_names = Job.distinct("userid").pluck("userid").delete_if(&:blank?)
 
     elsif @tabform == "tasks_4" || @tabform == "alltasks_2"

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2047,16 +2047,16 @@
     :feature_type: view
     :identifier: tasks_view
     :children:
-    - :name: All VM Analysis Tasks
-      :description: Display Lists of All VM Analysis Tasks
+    - :name: All VM and Container Analysis Tasks
+      :description: Display Lists of All VM and Container Analysis Tasks
       :feature_type: view
       :identifier: job_all_smartproxy
     - :name: All Other Tasks
       :description: Display Lists of All UI Tasks
       :feature_type: view
       :identifier: miq_task_all_ui
-    - :name: VM Analysis Tasks
-      :description: Display Lists of VM Analysis Tasks
+    - :name: VM and Container Analysis Tasks
+      :description: Display Lists of VM and Container Analysis Tasks
       :feature_type: view
       :identifier: job_my_smartproxy
     - :name: Other UI Tasks

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -6,7 +6,7 @@ describe MiqTaskController do
       allow(controller).to receive_messages(:session => user)
     end
 
-    describe "My VM Analysis Tasks" do
+    describe "My VM and Container Analysis Tasks" do
       before do
         controller.instance_variable_set(:@tabform, "tasks_1")
         @opts = {:ok           => true,
@@ -451,7 +451,7 @@ describe MiqTaskController do
       end
     end
 
-    describe "All VM Analysis Tasks" do
+    describe "All VM and Container Analysis Tasks" do
       before do
         controller.instance_variable_set(:@tabform, "tasks_3")
         @opts = {:ok           => true,


### PR DESCRIPTION
Signed-off-by: Erez Freiberger <efreiber@redhat.com>

![change_configure_task_tab_names](https://cloud.githubusercontent.com/assets/3123328/14016103/94cc1da0-f1c6-11e5-8d89-437e15479d3a.png)
