### PR TITLE
Containers: disable Timelines button when there are no events

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1346,9 +1346,10 @@ class ApplicationHelper::ToolbarBuilder
       record.class.base_class.name
     else
       klass = case record
-              when Host, ExtManagementSystem then record.class.base_class
-              when VmOrTemplate then              record.class.base_model
-              else                            record.class
+              when ContainerNode, ContainerGroup, Container then record.class.base_class
+              when Host, ExtManagementSystem                then record.class.base_class
+              when VmOrTemplate                             then record.class.base_model
+              else                                               record.class
               end
       klass.name
     end


### PR DESCRIPTION
Currently, disabling Timelines button isn't working for Containers, Pods and Nodes.

before:
![before_disable_timelines](https://cloud.githubusercontent.com/assets/6347577/11868035/b44da410-a4bd-11e5-9218-b202e7605815.png)

after: 
![after_disable_timelines](https://cloud.githubusercontent.com/assets/6347577/11868042/b8eab580-a4bd-11e5-9260-9a7b32f4688f.png)
