### PR TITLE
RSpec 3 conversion: miq_server specs

### DIFF
--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -6,43 +6,43 @@ describe "Server Environment Management" do
     after(:each) { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
 
     it "when ENV['MIQ_SPARTAN'] is not set" do
-      ENV.stub(:[]).with('MIQ_SPARTAN').and_return(nil)
-      MiqServer.spartan_mode.should be_blank
+      allow(ENV).to receive(:[]).with('MIQ_SPARTAN').and_return(nil)
+      expect(MiqServer.spartan_mode).to be_blank
     end
 
     it "when ENV['MIQ_SPARTAN'] is set" do
       spartan = "minimal:foo:bar"
-      ENV.stub(:[]).with('MIQ_SPARTAN').and_return(spartan)
-      MiqServer.spartan_mode.should == spartan
+      allow(ENV).to receive(:[]).with('MIQ_SPARTAN').and_return(spartan)
+      expect(MiqServer.spartan_mode).to eq(spartan)
     end
   end
 
   context ".minimal_env?" do
     it "when spartan_mode is 'minimal'" do
-      MiqServer.stub(:spartan_mode).and_return("minimal")
-      MiqServer.minimal_env?.should be_true
+      allow(MiqServer).to receive(:spartan_mode).and_return("minimal")
+      expect(MiqServer.minimal_env?).to be_truthy
     end
 
     it "when spartan_mode starts with 'minimal'" do
-      MiqServer.stub(:spartan_mode).and_return("minimal:foo:bar")
-      MiqServer.minimal_env?.should be_true
+      allow(MiqServer).to receive(:spartan_mode).and_return("minimal:foo:bar")
+      expect(MiqServer.minimal_env?).to be_truthy
     end
 
     it "when spartan_mode does not start with 'minimal'" do
-      MiqServer.stub(:spartan_mode).and_return("foo:bar")
-      MiqServer.minimal_env?.should be_false
+      allow(MiqServer).to receive(:spartan_mode).and_return("foo:bar")
+      expect(MiqServer.minimal_env?).to be_falsey
     end
   end
 
   context ".normal_env?" do
     it "when minimal_env? is true" do
-      MiqServer.stub(:minimal_env?).and_return(true)
-      MiqServer.normal_env?.should be_false
+      allow(MiqServer).to receive(:minimal_env?).and_return(true)
+      expect(MiqServer.normal_env?).to be_falsey
     end
 
     it "when minimal_env? is false" do
-      MiqServer.stub(:minimal_env?).and_return(false)
-      MiqServer.normal_env?.should be_true
+      allow(MiqServer).to receive(:minimal_env?).and_return(false)
+      expect(MiqServer.normal_env?).to be_truthy
     end
   end
 
@@ -51,45 +51,45 @@ describe "Server Environment Management" do
     after(:each) { MiqServer.class_eval { instance_variable_set :@minimal_env_options, nil } }
 
     it "when spartan_mode is 'minimal'" do
-      MiqServer.stub(:spartan_mode).and_return("minimal")
-      MiqServer.minimal_env_options.should == []
+      allow(MiqServer).to receive(:spartan_mode).and_return("minimal")
+      expect(MiqServer.minimal_env_options).to eq([])
     end
 
     it "when spartan_mode starts with 'minimal' and has various roles" do
-      MiqServer.stub(:spartan_mode).and_return("minimal:foo:bar")
-      MiqServer.minimal_env_options.should == %w(foo bar)
+      allow(MiqServer).to receive(:spartan_mode).and_return("minimal:foo:bar")
+      expect(MiqServer.minimal_env_options).to eq(%w(foo bar))
     end
 
     it "when spartan_mode starts with 'minimal' and has various roles, including netbeans" do
-      MiqServer.stub(:spartan_mode).and_return("minimal:foo:netbeans:bar")
-      MiqServer.minimal_env_options.should == %w(foo schedule reporting noui bar)
+      allow(MiqServer).to receive(:spartan_mode).and_return("minimal:foo:netbeans:bar")
+      expect(MiqServer.minimal_env_options).to eq(%w(foo schedule reporting noui bar))
     end
 
     it "when spartan_mode does not start with 'minimal'" do
-      MiqServer.stub(:spartan_mode).and_return("foo:bar")
-      MiqServer.minimal_env_options.should == []
+      allow(MiqServer).to receive(:spartan_mode).and_return("foo:bar")
+      expect(MiqServer.minimal_env_options).to eq([])
     end
   end
 
   context ".startup_mode" do
     context "when minimal_env? is true" do
-      before(:each) { MiqServer.stub(:minimal_env?).and_return(true) }
+      before(:each) { allow(MiqServer).to receive(:minimal_env?).and_return(true) }
 
       it "when minimal_env_options is empty" do
-        MiqServer.stub(:minimal_env_options).and_return([])
-        MiqServer.startup_mode.should == "Minimal"
+        allow(MiqServer).to receive(:minimal_env_options).and_return([])
+        expect(MiqServer.startup_mode).to eq("Minimal")
       end
 
       it "when minimal_env_options is not empty" do
         minimal_env_options = %w(foo bar)
-        MiqServer.stub(:minimal_env_options).and_return(minimal_env_options)
-        MiqServer.startup_mode.should == "Minimal [#{minimal_env_options.join(', ')}]"
+        allow(MiqServer).to receive(:minimal_env_options).and_return(minimal_env_options)
+        expect(MiqServer.startup_mode).to eq("Minimal [#{minimal_env_options.join(', ')}]")
       end
     end
 
     it "when minimal_env? is false" do
-      MiqServer.stub(:minimal_env?).and_return(false)
-      MiqServer.startup_mode.should == "Normal"
+      allow(MiqServer).to receive(:minimal_env?).and_return(false)
+      expect(MiqServer.startup_mode).to eq("Normal")
     end
   end
 

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -51,14 +51,14 @@ describe MiqServer do
         server_depot = FactoryGirl.create(:file_depot)
         @miq_server.log_file_depot = server_depot
 
-        @miq_server.log_depot.should == server_depot
+        expect(@miq_server.log_depot).to eq(server_depot)
       end
 
       it "zone log_file_depot configured" do
         zone_depot = FactoryGirl.create(:file_depot)
         @zone.log_file_depot = zone_depot
 
-        @miq_server.log_depot.should == zone_depot
+        expect(@miq_server.log_depot).to eq(zone_depot)
       end
 
       it "server and zone log_file_depot configured" do
@@ -67,7 +67,7 @@ describe MiqServer do
         @miq_server.log_file_depot = server_depot
         @zone.log_file_depot = zone_depot
 
-        @miq_server.log_depot.should == server_depot
+        expect(@miq_server.log_depot).to eq(server_depot)
       end
     end
   end

--- a/spec/models/miq_server/rhn_mirror_spec.rb
+++ b/spec/models/miq_server/rhn_mirror_spec.rb
@@ -13,10 +13,10 @@ describe "MiqServer" do
       it "should configure when not hosting content" do
         @server2.assign_role("rhn_mirror")
 
-        FileUtils.should_not_receive(:rm_f)
-        File.should_receive(:read).with("/etc/hosts").and_return("\n #Some Comment\n127.0.0.1\tlocalhost")
-        File.should_receive(:write).with("/etc/hosts", "\n#Some Comment\n127.0.0.1        localhost\n#{@server1.ipaddress}          #{@server1.guid}\n#{@server2.ipaddress}          #{@server2.guid}\n")
-        MiqServer.any_instance.should_receive(:write_yum_repo_file).with([@server2])
+        expect(FileUtils).not_to receive(:rm_f)
+        expect(File).to receive(:read).with("/etc/hosts").and_return("\n #Some Comment\n127.0.0.1\tlocalhost")
+        expect(File).to receive(:write).with("/etc/hosts", "\n#Some Comment\n127.0.0.1        localhost\n#{@server1.ipaddress}          #{@server1.guid}\n#{@server2.ipaddress}          #{@server2.guid}\n")
+        expect_any_instance_of(MiqServer).to receive(:write_yum_repo_file).with([@server2])
 
         @server1.configure_rhn_mirror_client
       end
@@ -24,7 +24,7 @@ describe "MiqServer" do
       it "should not configure when hosting content" do
         @server1.assign_role("rhn_mirror")
 
-        FileUtils.should_receive(:rm_f).once
+        expect(FileUtils).to receive(:rm_f).once
 
         @server1.configure_rhn_mirror_client
       end
@@ -34,15 +34,15 @@ describe "MiqServer" do
       rpm_file_list       = ["/repo/mirror/abc-1.2.3-1.el6_0.2.i686.rpm", "/repo/mirror/abc-4.5.6-7.el6_4.x86_64.rpm", "/repo/mirror/def-B.02abc.1r6-4.el6cf.x86_64.rpm", "/repo/mirror/ghi-2013c-2.el6.noarch.rpm"]
       parsed_package_list = {"abc" => {"1.2.3.1" => "/repo/mirror/abc-1.2.3-1.el6_0.2.i686.rpm", "4.5.6.7" => "/repo/mirror/abc-4.5.6-7.el6_4.x86_64.rpm"}, "def-B" => {"02.1.6.4" => "/repo/mirror/def-B.02abc.1r6-4.el6cf.x86_64.rpm"}, "ghi" => {"2013.2" => "/repo/mirror/ghi-2013c-2.el6.noarch.rpm"}}
 
-      FileUtils.should_receive(:mkdir_p).with("/repo/mirror")
-      MiqApache::Conf.should_receive(:create_conf_file).once.and_return(true)
-      FileUtils.should_receive(:rm).with("/etc/httpd/conf.d/cfme-https-mirror.conf", :force => true)
-      MiqApache::Control.should_receive(:restart).once
-      LinuxAdmin::Yum.should_receive(:download_packages).once.with("/repo/mirror", "cfme-appliance")
-      Dir.should_receive(:glob).with("/repo/mirror/**/*.rpm").and_return(rpm_file_list)
-      @server1.should_receive(:remove_old_versions).with(parsed_package_list).and_call_original
-      FileUtils.should_receive(:rm).with("/repo/mirror/abc-1.2.3-1.el6_0.2.i686.rpm")
-      LinuxAdmin::Yum.should_receive(:create_repo).with("/repo/mirror")
+      expect(FileUtils).to receive(:mkdir_p).with("/repo/mirror")
+      expect(MiqApache::Conf).to receive(:create_conf_file).once.and_return(true)
+      expect(FileUtils).to receive(:rm).with("/etc/httpd/conf.d/cfme-https-mirror.conf", :force => true)
+      expect(MiqApache::Control).to receive(:restart).once
+      expect(LinuxAdmin::Yum).to receive(:download_packages).once.with("/repo/mirror", "cfme-appliance")
+      expect(Dir).to receive(:glob).with("/repo/mirror/**/*.rpm").and_return(rpm_file_list)
+      expect(@server1).to receive(:remove_old_versions).with(parsed_package_list).and_call_original
+      expect(FileUtils).to receive(:rm).with("/repo/mirror/abc-1.2.3-1.el6_0.2.i686.rpm")
+      expect(LinuxAdmin::Yum).to receive(:create_repo).with("/repo/mirror")
 
       @server1.resync_rhn_mirror
 

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -24,7 +24,7 @@ describe "Server Role Management" do
         user_interface,User Interface,0,false,region
         web_services,Web Services,0,false,region
       CSV
-      ServerRole.stub(:seed_data).and_return(@csv)
+      allow(ServerRole).to receive(:seed_data).and_return(@csv)
       MiqRegion.seed
       ServerRole.seed
       @server_roles = ServerRole.all
@@ -35,28 +35,28 @@ describe "Server Role Management" do
     context "#apache_needed?" do
       it "false with neither webservices or user_interface active" do
         @miq_server.stub(:active_role_names => ["reporting"])
-        @miq_server.apache_needed?.should be_false
+        expect(@miq_server.apache_needed?).to be_falsey
       end
 
       it "true with web_services active" do
         @miq_server.stub(:active_role_names => ["web_services"])
-        @miq_server.apache_needed?.should be_true
+        expect(@miq_server.apache_needed?).to be_truthy
       end
 
       it "true with both web_services and user_interface active" do
         @miq_server.stub(:active_role_names => ["web_services", "user_interface"])
-        @miq_server.apache_needed?.should be_true
+        expect(@miq_server.apache_needed?).to be_truthy
       end
     end
 
     context "role=" do
       it "normal case" do
         @miq_server.assign_role('ems_operations', 1)
-        @miq_server.server_role_names.should == ['ems_operations']
+        expect(@miq_server.server_role_names).to eq(['ems_operations'])
 
         desired = 'event,scheduler,user_interface'
         @miq_server.role = desired
-        @miq_server.server_role_names.should == desired.split(",")
+        expect(@miq_server.server_role_names).to eq(desired.split(","))
       end
 
       it "with a duplicate existing role" do
@@ -64,7 +64,7 @@ describe "Server Role Management" do
 
         desired = 'ems_operations,ems_operations,scheduler'
         @miq_server.role = desired
-        @miq_server.server_role_names.should == %w( ems_operations scheduler )
+        expect(@miq_server.server_role_names).to eq(%w( ems_operations scheduler ))
       end
 
       it "with duplicate new roles" do
@@ -72,7 +72,7 @@ describe "Server Role Management" do
 
         desired = 'ems_operations,scheduler,scheduler'
         @miq_server.role = desired
-        @miq_server.server_role_names.should == %w( ems_operations scheduler )
+        expect(@miq_server.server_role_names).to eq(%w( ems_operations scheduler ))
       end
     end
 
@@ -80,8 +80,8 @@ describe "Server Role Management" do
       @roles = [['ems_operations', 1], ['event', 2], ['ems_metrics_coordinator', 1], ['scheduler', 1], ['reporting', 1]]
       @roles.each do |role, priority|
         asr = @miq_server.assign_role(role, priority)
-        asr.priority.should == priority
-        asr.server_role.name.should == role
+        expect(asr.priority).to eq(priority)
+        expect(asr.server_role.name).to eq(role)
       end
     end
   end

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -24,22 +24,22 @@ describe "Server Monitor" do
         user_interface,User Interface,0,false,region
         web_services,Web Services,0,false,region
       CSV
-      ServerRole.stub(:seed_data).and_return(@csv)
+      allow(ServerRole).to receive(:seed_data).and_return(@csv)
       MiqRegion.seed
       ServerRole.seed
 
       # Do this manually, to avoid caching at the class level
-      ServerRole.stub(:database_owner).and_return(ServerRole.find_by_name('database_owner'))
+      allow(ServerRole).to receive(:database_owner).and_return(ServerRole.find_by_name('database_owner'))
 
       @server_roles = ServerRole.all
     end
 
     it "should respond properly to UI helper methods" do
       @server_roles.each do |server_role|
-        server_role.unlimited?.should be_true        if server_role.max_concurrent == 0
-        server_role.master_supported?.should be_true if server_role.max_concurrent == 1
-        ServerRole.to_role(server_role).should == server_role
-        ServerRole.to_role(server_role.name).should == server_role
+        expect(server_role.unlimited?).to be_truthy        if server_role.max_concurrent == 0
+        expect(server_role.master_supported?).to be_truthy if server_role.max_concurrent == 1
+        expect(ServerRole.to_role(server_role)).to eq(server_role)
+        expect(ServerRole.to_role(server_role.name)).to eq(server_role)
       end
     end
 
@@ -53,9 +53,9 @@ describe "Server Monitor" do
       end
 
       it "should have no roles active after start" do
-        @miq_server.server_roles.length.should == 4
-        @miq_server.inactive_roles.length.should == 4
-        @miq_server.active_roles.length.should == 0
+        expect(@miq_server.server_roles.length).to eq(4)
+        expect(@miq_server.inactive_roles.length).to eq(4)
+        expect(@miq_server.active_roles.length).to eq(0)
       end
 
       it "should activate unlimited zone role via activate_in_zone method" do
@@ -65,10 +65,10 @@ describe "Server Monitor" do
           asr.activate_in_zone
         end
         @miq_server.reload
-        @miq_server.inactive_roles.length.should == 3
-        @miq_server.active_role_names.length.should == 1
-        @miq_server.active_role_names.include?(rolename).should be_true
-        @miq_server.inactive_role_names.include?(rolename).should_not be_true
+        expect(@miq_server.inactive_roles.length).to eq(3)
+        expect(@miq_server.active_role_names.length).to eq(1)
+        expect(@miq_server.active_role_names.include?(rolename)).to be_truthy
+        expect(@miq_server.inactive_role_names.include?(rolename)).not_to be_truthy
       end
 
       it "should activate limited zone role via activate_in_zone method" do
@@ -78,10 +78,10 @@ describe "Server Monitor" do
           asr.activate_in_zone
         end
         @miq_server.reload
-        @miq_server.inactive_roles.length.should == 3
-        @miq_server.active_role_names.length.should == 1
-        @miq_server.active_role_names.include?(rolename).should be_true
-        @miq_server.inactive_role_names.include?(rolename).should_not be_true
+        expect(@miq_server.inactive_roles.length).to eq(3)
+        expect(@miq_server.active_role_names.length).to eq(1)
+        expect(@miq_server.active_role_names.include?(rolename)).to be_truthy
+        expect(@miq_server.inactive_role_names.include?(rolename)).not_to be_truthy
       end
 
       it "should activate unlimited region role via activate_in_region method" do
@@ -91,10 +91,10 @@ describe "Server Monitor" do
           asr.activate_in_region
         end
         @miq_server.reload
-        @miq_server.inactive_roles.length.should == 3
-        @miq_server.active_role_names.length.should == 1
-        @miq_server.active_role_names.include?(rolename).should be_true
-        @miq_server.inactive_role_names.include?(rolename).should_not be_true
+        expect(@miq_server.inactive_roles.length).to eq(3)
+        expect(@miq_server.active_role_names.length).to eq(1)
+        expect(@miq_server.active_role_names.include?(rolename)).to be_truthy
+        expect(@miq_server.inactive_role_names.include?(rolename)).not_to be_truthy
       end
 
       it "should activate limited region role via activate_in_region method" do
@@ -104,10 +104,10 @@ describe "Server Monitor" do
           asr.activate_in_region
         end
         @miq_server.reload
-        @miq_server.inactive_roles.length.should == 3
-        @miq_server.active_role_names.length.should == 1
-        @miq_server.active_role_names.include?(rolename).should be_true
-        @miq_server.inactive_role_names.include?(rolename).should_not be_true
+        expect(@miq_server.inactive_roles.length).to eq(3)
+        expect(@miq_server.active_role_names.length).to eq(1)
+        expect(@miq_server.active_role_names.include?(rolename)).to be_truthy
+        expect(@miq_server.inactive_role_names.include?(rolename)).not_to be_truthy
       end
 
       context "after initial monitor_servers" do
@@ -116,11 +116,11 @@ describe "Server Monitor" do
         end
 
         it "should have all roles active after monitor_servers" do
-          @miq_server.active_role_names.length.should == 4
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
+          expect(@miq_server.active_role_names.length).to eq(4)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
         end
 
         it "should deactivate unlimited role via deactivate_in_zone method" do
@@ -130,10 +130,10 @@ describe "Server Monitor" do
             asr.deactivate_in_zone
           end
           @miq_server.reload
-          @miq_server.inactive_roles.length.should == 1
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?(rolename).should_not be_true
-          @miq_server.inactive_role_names.include?(rolename).should be_true
+          expect(@miq_server.inactive_roles.length).to eq(1)
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?(rolename)).not_to be_truthy
+          expect(@miq_server.inactive_role_names.include?(rolename)).to be_truthy
         end
 
         it "should deactivate limited role via deactivate_in_zone method" do
@@ -143,90 +143,90 @@ describe "Server Monitor" do
             asr.deactivate_in_zone
           end
           @miq_server.reload
-          @miq_server.inactive_roles.length.should == 1
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?(rolename).should_not be_true
-          @miq_server.inactive_role_names.include?(rolename).should be_true
+          expect(@miq_server.inactive_roles.length).to eq(1)
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?(rolename)).not_to be_truthy
+          expect(@miq_server.inactive_role_names.include?(rolename)).to be_truthy
         end
 
         it "should activate newly assigned unlimited zone role" do
           @miq_server.role = 'event, ems_operations, scheduler, reporting, smartstate'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 5
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
-          @miq_server.active_role_names.include?("smartstate").should be_true
+          expect(@miq_server.active_role_names.length).to eq(5)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server.active_role_names.include?("smartstate")).to be_truthy
         end
 
         it "should activate newly assigned limited zone role" do
           @miq_server.role = 'event, ems_operations, scheduler, reporting, ems_inventory'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 5
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
-          @miq_server.active_role_names.include?("ems_inventory").should be_true
+          expect(@miq_server.active_role_names.length).to eq(5)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server.active_role_names.include?("ems_inventory")).to be_truthy
         end
 
         it "should activate newly assigned unlimited region role" do
           @miq_server.role = 'event, ems_operations, scheduler, reporting, database_operations'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 5
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
-          @miq_server.active_role_names.include?("database_operations").should be_true
+          expect(@miq_server.active_role_names.length).to eq(5)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server.active_role_names.include?("database_operations")).to be_truthy
         end
 
         it "should activate newly assigned limited region role" do
           @miq_server.role = 'event, ems_operations, scheduler, reporting, database_synchronization'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 5
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
-          @miq_server.active_role_names.include?("database_synchronization").should be_true
+          expect(@miq_server.active_role_names.length).to eq(5)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server.active_role_names.include?("database_synchronization")).to be_truthy
         end
 
         it "should deactivate removed unlimited zone role" do
           @miq_server.role = 'event, scheduler, reporting'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
         end
 
         it "should deactivate removed limited zone role" do
           @miq_server.role = 'ems_operations, scheduler, reporting'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
         end
 
         it "should deactivate removed unlimited region role" do
           @miq_server.role = 'event, ems_operations, scheduler'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("scheduler").should be_true
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("scheduler")).to be_truthy
         end
 
         it "should deactivate removed limited region role" do
           @miq_server.role = 'event, ems_operations, reporting'
           @miq_server.monitor_server_roles
-          @miq_server.active_role_names.length.should == 3
-          @miq_server.active_role_names.include?("event").should be_true
-          @miq_server.active_role_names.include?("ems_operations").should be_true
-          @miq_server.active_role_names.include?("reporting").should be_true
+          expect(@miq_server.active_role_names.length).to eq(3)
+          expect(@miq_server.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server.active_role_names.include?("reporting")).to be_truthy
         end
       end
     end
@@ -243,13 +243,13 @@ describe "Server Monitor" do
       end
 
       it "should have no roles active after start" do
-        @miq_server1.server_roles.length.should == 4
-        @miq_server1.inactive_roles.length.should == 4
-        @miq_server1.active_roles.length.should == 0
+        expect(@miq_server1.server_roles.length).to eq(4)
+        expect(@miq_server1.inactive_roles.length).to eq(4)
+        expect(@miq_server1.active_roles.length).to eq(0)
 
-        @miq_server2.server_roles.length.should == 4
-        @miq_server2.inactive_roles.length.should == 4
-        @miq_server2.active_roles.length.should == 0
+        expect(@miq_server2.server_roles.length).to eq(4)
+        expect(@miq_server2.inactive_roles.length).to eq(4)
+        expect(@miq_server2.active_roles.length).to eq(0)
       end
 
       it "should activate unlimited role via activate_in_zone method" do
@@ -262,13 +262,13 @@ describe "Server Monitor" do
         end
         @miq_server1.reload
         @miq_server2.reload
-        @miq_server1.inactive_roles.length.should == 3
-        @miq_server1.active_role_names.length.should == 1
-        @miq_server1.active_role_names.include?(rolename).should be_true
+        expect(@miq_server1.inactive_roles.length).to eq(3)
+        expect(@miq_server1.active_role_names.length).to eq(1)
+        expect(@miq_server1.active_role_names.include?(rolename)).to be_truthy
 
-        @miq_server2.inactive_roles.length.should == 3
-        @miq_server2.active_role_names.length.should == 1
-        @miq_server2.active_role_names.include?(rolename).should be_true
+        expect(@miq_server2.inactive_roles.length).to eq(3)
+        expect(@miq_server2.active_role_names.length).to eq(1)
+        expect(@miq_server2.active_role_names.include?(rolename)).to be_truthy
       end
 
       context "after monitor_servers" do
@@ -278,10 +278,10 @@ describe "Server Monitor" do
         end
 
         it "should have all roles active after sync between them" do
-          (@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).should be_true
-          (@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).should be_true
-          (@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).should be_true
-          (@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).to be_truthy
         end
       end
 
@@ -292,8 +292,8 @@ describe "Server Monitor" do
         end
 
         it "should have all roles on the desired servers" do
-          (@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).should be_true
-          (@miq_server1.inactive_role_names.include?("event") && @miq_server2.active_role_names.include?("event")).should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.inactive_role_names.include?("event") && @miq_server2.active_role_names.include?("event")).to be_truthy
         end
 
         context "where Non-Master shuts down cleanly" do
@@ -310,9 +310,9 @@ describe "Server Monitor" do
           end
 
           it "should migrate roles to Master" do
-            @miq_server1.active_role_names.include?("ems_operations").should be_true
-            @miq_server1.active_role_names.include?("event").should be_true
-            @miq_server2.active_role_names.should be_empty
+            expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+            expect(@miq_server2.active_role_names).to be_empty
           end
         end
 
@@ -325,25 +325,25 @@ describe "Server Monitor" do
           end
 
           it "should mark server as not responding" do
-            @miq_server2.reload.status.should == "not responding"
+            expect(@miq_server2.reload.status).to eq("not responding")
           end
 
           it "should migrate roles to Master" do
             @miq_server1.monitor_server_roles
             @miq_server2.reload
 
-            @miq_server2.server_roles.length.should == 4
-            @miq_server2.inactive_roles.length.should == 4
-            @miq_server2.active_roles.length.should == 0
+            expect(@miq_server2.server_roles.length).to eq(4)
+            expect(@miq_server2.inactive_roles.length).to eq(4)
+            expect(@miq_server2.active_roles.length).to eq(0)
 
-            @miq_server1.server_roles.length.should == 4
-            @miq_server1.inactive_roles.length.should == 0
-            @miq_server1.active_roles.length.should == 4
+            expect(@miq_server1.server_roles.length).to eq(4)
+            expect(@miq_server1.inactive_roles.length).to eq(0)
+            expect(@miq_server1.active_roles.length).to eq(4)
 
-            @miq_server1.active_role_names.include?("ems_operations").should be_true
-            @miq_server1.active_role_names.include?("event").should be_true
-            @miq_server1.active_role_names.include?("reporting").should be_true
-            @miq_server1.active_role_names.include?("scheduler").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("reporting")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("scheduler")).to be_truthy
           end
         end
       end
@@ -369,10 +369,10 @@ describe "Server Monitor" do
       end
 
       it "should have all roles active after sync between them" do
-        (@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).should be_true
-        (@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).should be_true
-        (@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).should be_true
-        (@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).should be_true
+        expect(@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+        expect(@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).to be_truthy
+        expect(@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).to be_truthy
+        expect(@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).to be_truthy
       end
 
       context "where Master shuts down cleanly" do
@@ -386,19 +386,19 @@ describe "Server Monitor" do
         end
 
         it "should takeover as Master" do
-          @miq_server1.is_master?.should be_true
+          expect(@miq_server1.is_master?).to be_truthy
           @miq_server2.reload
-          @miq_server2.is_master?.should_not be_true
+          expect(@miq_server2.is_master?).not_to be_truthy
         end
 
         it "should migrate roles to Master" do
           @miq_server1.monitor_server_roles if @miq_server1.is_master?
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server1.active_role_names.include?("event").should be_true
-          @miq_server1.active_role_names.include?("reporting").should be_true
-          @miq_server1.active_role_names.include?("scheduler").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("scheduler")).to be_truthy
           @miq_server2.reload
-          @miq_server2.active_role_names.should be_empty
+          expect(@miq_server2.active_role_names).to be_empty
         end
       end
 
@@ -413,28 +413,28 @@ describe "Server Monitor" do
         end
 
         it "should takeover as Master" do
-          @miq_server1.is_master?.should be_true
+          expect(@miq_server1.is_master?).to be_truthy
           @miq_server2.reload
-          @miq_server2.is_master?.should_not be_true
+          expect(@miq_server2.is_master?).not_to be_truthy
         end
 
         it "should migrate roles to Master" do
           @miq_server1.monitor_server_roles if @miq_server1.is_master?
           @miq_server2.reload
 
-          @miq_server2.status.should == "not responding"
-          @miq_server2.server_roles.length.should == 4
-          @miq_server2.inactive_roles.length.should == 4
-          @miq_server2.active_roles.length.should == 0
+          expect(@miq_server2.status).to eq("not responding")
+          expect(@miq_server2.server_roles.length).to eq(4)
+          expect(@miq_server2.inactive_roles.length).to eq(4)
+          expect(@miq_server2.active_roles.length).to eq(0)
 
-          @miq_server1.inactive_roles.length.should == 0
-          @miq_server1.active_roles.length.should == 4
-          @miq_server1.active_role_names.include?("database_owner").should be_false
+          expect(@miq_server1.inactive_roles.length).to eq(0)
+          expect(@miq_server1.active_roles.length).to eq(4)
+          expect(@miq_server1.active_role_names.include?("database_owner")).to be_falsey
 
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server1.active_role_names.include?("event").should be_true
-          @miq_server1.active_role_names.include?("reporting").should be_true
-          @miq_server1.active_role_names.include?("scheduler").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("scheduler")).to be_truthy
         end
       end
     end
@@ -463,39 +463,39 @@ describe "Server Monitor" do
       end
 
       it "should have all roles active after sync between them" do
-        @miq_server1.active_role_names.include?("ems_operations").should be_true
-        @miq_server2.active_role_names.include?("ems_operations").should be_true
-        @miq_server3.active_role_names.include?("ems_operations").should be_true
+        expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+        expect(@miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+        expect(@miq_server3.active_role_names.include?("ems_operations")).to be_truthy
 
-        @miq_server1.active_role_names.include?("event").should_not be_true
-        @miq_server2.active_role_names.include?("event").should be_true
-        @miq_server3.active_role_names.include?("event").should_not be_true
+        expect(@miq_server1.active_role_names.include?("event")).not_to be_truthy
+        expect(@miq_server2.active_role_names.include?("event")).to be_truthy
+        expect(@miq_server3.active_role_names.include?("event")).not_to be_truthy
 
-        @miq_server1.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-        @miq_server2.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-        @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+        expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+        expect(@miq_server2.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+        expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
 
-        @miq_server1.active_role_names.include?("ems_inventory").should_not be_true
-        @miq_server2.active_role_names.include?("ems_inventory").should_not be_true
-        @miq_server3.active_role_names.include?("ems_inventory").should be_true
+        expect(@miq_server1.active_role_names.include?("ems_inventory")).not_to be_truthy
+        expect(@miq_server2.active_role_names.include?("ems_inventory")).not_to be_truthy
+        expect(@miq_server3.active_role_names.include?("ems_inventory")).to be_truthy
       end
 
       it "should respond to helper methods for UI" do
-        @miq_server1.is_master_for_role?("ems_operations").should_not be_true
-        @miq_server2.is_master_for_role?("ems_operations").should be_true
-        @miq_server3.is_master_for_role?("ems_operations").should_not be_true
+        expect(@miq_server1.is_master_for_role?("ems_operations")).not_to be_truthy
+        expect(@miq_server2.is_master_for_role?("ems_operations")).to be_truthy
+        expect(@miq_server3.is_master_for_role?("ems_operations")).not_to be_truthy
 
-        @miq_server1.is_master_for_role?("event").should_not be_true
-        @miq_server2.is_master_for_role?("event").should be_true
-        @miq_server3.is_master_for_role?("event").should_not be_true
+        expect(@miq_server1.is_master_for_role?("event")).not_to be_truthy
+        expect(@miq_server2.is_master_for_role?("event")).to be_truthy
+        expect(@miq_server3.is_master_for_role?("event")).not_to be_truthy
 
-        @miq_server1.is_master_for_role?("ems_inventory").should_not be_true
-        @miq_server2.is_master_for_role?("ems_inventory").should_not be_true
-        @miq_server3.is_master_for_role?("ems_inventory").should be_true
+        expect(@miq_server1.is_master_for_role?("ems_inventory")).not_to be_truthy
+        expect(@miq_server2.is_master_for_role?("ems_inventory")).not_to be_truthy
+        expect(@miq_server3.is_master_for_role?("ems_inventory")).to be_truthy
 
-        @miq_server1.is_master_for_role?("ems_metrics_coordinator").should_not be_true
-        @miq_server2.is_master_for_role?("ems_metrics_coordinator").should_not be_true
-        @miq_server3.is_master_for_role?("ems_metrics_coordinator").should be_true
+        expect(@miq_server1.is_master_for_role?("ems_metrics_coordinator")).not_to be_truthy
+        expect(@miq_server2.is_master_for_role?("ems_metrics_coordinator")).not_to be_truthy
+        expect(@miq_server3.is_master_for_role?("ems_metrics_coordinator")).to be_truthy
       end
 
       context "when Server3 is stopped" do
@@ -513,19 +513,19 @@ describe "Server Monitor" do
         end
 
         it "should migrate all roles properly" do
-          @miq_server3.active_role_names.should be_empty
+          expect(@miq_server3.active_role_names).to be_empty
 
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server2.active_role_names.include?("ems_operations").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server2.active_role_names.include?("ems_operations")).to be_truthy
 
-          @miq_server1.active_role_names.include?("event").should_not be_true
-          @miq_server2.active_role_names.include?("event").should be_true
+          expect(@miq_server1.active_role_names.include?("event")).not_to be_truthy
+          expect(@miq_server2.active_role_names.include?("event")).to be_truthy
 
-          @miq_server1.active_role_names.include?("ems_metrics_coordinator").should be_true
-          @miq_server2.active_role_names.include?("ems_metrics_coordinator").should_not be_true
+          expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
+          expect(@miq_server2.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
 
-          @miq_server1.active_role_names.include?("ems_inventory").should_not be_true
-          @miq_server2.active_role_names.include?("ems_inventory").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_inventory")).not_to be_truthy
+          expect(@miq_server2.active_role_names.include?("ems_inventory")).to be_truthy
         end
 
         context "and then restarted" do
@@ -540,21 +540,21 @@ describe "Server Monitor" do
           end
 
           it "should have all roles active after sync between them" do
-            @miq_server1.active_role_names.include?("ems_operations").should be_true
-            @miq_server2.active_role_names.include?("ems_operations").should be_true
-            @miq_server3.active_role_names.include?("ems_operations").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_operations")).to be_truthy
 
-            @miq_server1.active_role_names.include?("event").should_not be_true
-            @miq_server2.active_role_names.include?("event").should be_true
-            @miq_server3.active_role_names.include?("event").should_not be_true
+            expect(@miq_server1.active_role_names.include?("event")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("event")).to be_truthy
+            expect(@miq_server3.active_role_names.include?("event")).not_to be_truthy
 
-            @miq_server1.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-            @miq_server2.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-            @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
 
-            @miq_server1.active_role_names.include?("ems_inventory").should_not be_true
-            @miq_server2.active_role_names.include?("ems_inventory").should_not be_true
-            @miq_server3.active_role_names.include?("ems_inventory").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_inventory")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_inventory")).not_to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_inventory")).to be_truthy
           end
         end
       end
@@ -574,19 +574,19 @@ describe "Server Monitor" do
         end
 
         it "should have migrate all roles properly" do
-          @miq_server2.active_role_names.should be_empty
+          expect(@miq_server2.active_role_names).to be_empty
 
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server3.active_role_names.include?("ems_operations").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server3.active_role_names.include?("ems_operations")).to be_truthy
 
-          @miq_server1.active_role_names.include?("event").should be_true
-          @miq_server3.active_role_names.include?("event").should_not be_true
+          expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server3.active_role_names.include?("event")).not_to be_truthy
 
-          @miq_server1.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-          @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+          expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
 
-          @miq_server1.active_role_names.include?("ems_inventory").should_not be_true
-          @miq_server3.active_role_names.include?("ems_inventory").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_inventory")).not_to be_truthy
+          expect(@miq_server3.active_role_names.include?("ems_inventory")).to be_truthy
         end
 
         context "and then restarted" do
@@ -601,21 +601,21 @@ describe "Server Monitor" do
           end
 
           it "should have all roles active after sync between them" do
-            @miq_server1.active_role_names.include?("ems_operations").should be_true
-            @miq_server2.active_role_names.include?("ems_operations").should be_true
-            @miq_server3.active_role_names.include?("ems_operations").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_operations")).to be_truthy
 
-            @miq_server1.active_role_names.include?("event").should_not be_true
-            @miq_server2.active_role_names.include?("event").should be_true
-            @miq_server3.active_role_names.include?("event").should_not be_true
+            expect(@miq_server1.active_role_names.include?("event")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("event")).to be_truthy
+            expect(@miq_server3.active_role_names.include?("event")).not_to be_truthy
 
-            @miq_server1.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-            @miq_server2.active_role_names.include?("ems_metrics_coordinator").should_not be_true
-            @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_metrics_coordinator")).not_to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
 
-            @miq_server1.active_role_names.include?("ems_inventory").should_not be_true
-            @miq_server2.active_role_names.include?("ems_inventory").should_not be_true
-            @miq_server3.active_role_names.include?("ems_inventory").should be_true
+            expect(@miq_server1.active_role_names.include?("ems_inventory")).not_to be_truthy
+            expect(@miq_server2.active_role_names.include?("ems_inventory")).not_to be_truthy
+            expect(@miq_server3.active_role_names.include?("ems_inventory")).to be_truthy
           end
         end
       end
@@ -642,19 +642,19 @@ describe "Server Monitor" do
       end
 
       it "should have the master on Server 2" do
-        @miq_server1.is_master?.should_not be_true
-        @miq_server2.is_master?.should be_true
-        @miq_server3.is_master?.should_not be_true
+        expect(@miq_server1.is_master?).not_to be_truthy
+        expect(@miq_server2.is_master?).to be_truthy
+        expect(@miq_server3.is_master?).not_to be_truthy
       end
 
       it "should have all roles active after sync between them" do
-        @miq_server1.active_role_names.include?("ems_operations").should be_true
-        @miq_server2.active_role_names.include?("ems_operations").should be_true
-        @miq_server3.active_role_names.include?("ems_operations").should be_true
+        expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+        expect(@miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+        expect(@miq_server3.active_role_names.include?("ems_operations")).to be_truthy
 
-        (@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).should be_true
-        (@miq_server2.active_role_names.include?("ems_metrics_coordinator") ^ @miq_server3.active_role_names.include?("ems_metrics_coordinator")).should be_true
-        (@miq_server1.active_role_names.include?("ems_inventory") ^ @miq_server3.active_role_names.include?("ems_inventory")).should be_true
+        expect(@miq_server1.active_role_names.include?("event") ^ @miq_server2.active_role_names.include?("event")).to be_truthy
+        expect(@miq_server2.active_role_names.include?("ems_metrics_coordinator") ^ @miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
+        expect(@miq_server1.active_role_names.include?("ems_inventory") ^ @miq_server3.active_role_names.include?("ems_inventory")).to be_truthy
       end
 
       context "where Master shuts down cleanly" do
@@ -671,9 +671,9 @@ describe "Server Monitor" do
         it "should takeover as Master" do
           @miq_server2.reload
           @miq_server3.reload
-          @miq_server1.is_master?.should be_true
-          @miq_server2.is_master?.should_not be_true
-          @miq_server3.is_master?.should_not be_true
+          expect(@miq_server1.is_master?).to be_truthy
+          expect(@miq_server2.is_master?).not_to be_truthy
+          expect(@miq_server3.is_master?).not_to be_truthy
         end
 
         it "should migrate roles to Master" do
@@ -681,21 +681,21 @@ describe "Server Monitor" do
           @miq_server2.reload
           @miq_server3.reload
 
-          @miq_server1.inactive_roles.length.should == 0
-          @miq_server1.active_roles.length.should == 3
+          expect(@miq_server1.inactive_roles.length).to eq(0)
+          expect(@miq_server1.active_roles.length).to eq(3)
 
-          @miq_server2.server_roles.length.should == 3
-          @miq_server2.inactive_roles.length.should == 3
-          @miq_server2.active_roles.length.should == 0
+          expect(@miq_server2.server_roles.length).to eq(3)
+          expect(@miq_server2.inactive_roles.length).to eq(3)
+          expect(@miq_server2.active_roles.length).to eq(0)
 
-          @miq_server3.server_roles.length.should == 3
-          @miq_server3.inactive_roles.length.should == 1
-          @miq_server3.active_roles.length.should == 2
+          expect(@miq_server3.server_roles.length).to eq(3)
+          expect(@miq_server3.inactive_roles.length).to eq(1)
+          expect(@miq_server3.active_roles.length).to eq(2)
 
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server1.active_role_names.include?("event").should be_true
-          @miq_server1.active_role_names.include?("ems_inventory").should be_true
-          @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("ems_inventory")).to be_truthy
+          expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
         end
       end
 
@@ -713,9 +713,9 @@ describe "Server Monitor" do
           @miq_server2.reload
           @miq_server3.reload
 
-          @miq_server1.is_master?.should be_true
-          @miq_server2.is_master?.should_not be_true
-          @miq_server3.is_master?.should_not be_true
+          expect(@miq_server1.is_master?).to be_truthy
+          expect(@miq_server2.is_master?).not_to be_truthy
+          expect(@miq_server3.is_master?).not_to be_truthy
         end
 
         it "should migrate roles to Master" do
@@ -723,18 +723,18 @@ describe "Server Monitor" do
           @miq_server2.reload
           @miq_server3.reload
 
-          @miq_server2.status.should == "not responding"
-          @miq_server2.server_roles.length.should == 3
-          @miq_server2.inactive_roles.length.should == 3
-          @miq_server2.active_roles.length.should == 0
+          expect(@miq_server2.status).to eq("not responding")
+          expect(@miq_server2.server_roles.length).to eq(3)
+          expect(@miq_server2.inactive_roles.length).to eq(3)
+          expect(@miq_server2.active_roles.length).to eq(0)
 
-          @miq_server1.inactive_roles.length.should == 0
-          @miq_server1.active_roles.length.should == 3
+          expect(@miq_server1.inactive_roles.length).to eq(0)
+          expect(@miq_server1.active_roles.length).to eq(3)
 
-          @miq_server1.active_role_names.include?("ems_operations").should be_true
-          @miq_server1.active_role_names.include?("event").should be_true
-          @miq_server1.active_role_names.include?("ems_inventory").should be_true
-          @miq_server3.active_role_names.include?("ems_metrics_coordinator").should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("ems_inventory")).to be_truthy
+          expect(@miq_server3.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
         end
       end
     end
@@ -757,13 +757,13 @@ describe "Server Monitor" do
         it "should allow only 1 Master in the Region" do
           @miq_server1.monitor_servers
           @miq_server2.reload
-          @miq_server1.is_master.should be_true
-          @miq_server2.is_master.should be_false
+          expect(@miq_server1.is_master).to be_truthy
+          expect(@miq_server2.is_master).to be_falsey
 
           @miq_server2.monitor_servers
           @miq_server2.reload
-          @miq_server1.is_master.should be_true
-          @miq_server2.is_master.should be_false
+          expect(@miq_server1.is_master).to be_truthy
+          expect(@miq_server2.is_master).to be_falsey
         end
 
         it "should allow only 1 Limited Regional Role in the Region" do
@@ -773,8 +773,8 @@ describe "Server Monitor" do
           @miq_server1.monitor_server_roles
           @miq_server2.reload
 
-          (@miq_server1.active_role_names.include?("scheduler") && @miq_server2.active_role_names.include?("scheduler")).should be_false
-          (@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).should be_true
+          expect(@miq_server1.active_role_names.include?("scheduler") && @miq_server2.active_role_names.include?("scheduler")).to be_falsey
+          expect(@miq_server1.active_role_names.include?("scheduler") ^ @miq_server2.active_role_names.include?("scheduler")).to be_truthy
         end
       end
 
@@ -794,19 +794,19 @@ describe "Server Monitor" do
         end
 
         it "should have proper roles active after start" do
-          @miq_server1.server_roles.length.should == 5
-          @miq_server1.inactive_roles.length.should == 0
-          @miq_server1.active_roles.length.should == 5
+          expect(@miq_server1.server_roles.length).to eq(5)
+          expect(@miq_server1.inactive_roles.length).to eq(0)
+          expect(@miq_server1.active_roles.length).to eq(5)
 
-          @miq_server2.server_roles.length.should == 5
-          @miq_server2.inactive_roles.length.should == 1
-          @miq_server2.active_roles.length.should == 4
+          expect(@miq_server2.server_roles.length).to eq(5)
+          expect(@miq_server2.inactive_roles.length).to eq(1)
+          expect(@miq_server2.active_roles.length).to eq(4)
 
-          (@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).should be_true
-          (@miq_server1.active_role_names.include?("event") && @miq_server2.active_role_names.include?("event")).should be_true
-          (@miq_server1.active_role_names.include?("ems_metrics_coordinator") && @miq_server2.active_role_names.include?("ems_metrics_coordinator")).should be_true
-          (@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).should be_true
-          (@miq_server1.active_role_names.include?("scheduler") && !@miq_server2.active_role_names.include?("scheduler")).should be_true
+          expect(@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("event") && @miq_server2.active_role_names.include?("event")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("ems_metrics_coordinator") && @miq_server2.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).to be_truthy
+          expect(@miq_server1.active_role_names.include?("scheduler") && !@miq_server2.active_role_names.include?("scheduler")).to be_truthy
         end
 
         context "Server2 moved into zone of Server 1" do
@@ -818,18 +818,18 @@ describe "Server Monitor" do
           it "should resolve 1 Master in the Zone" do
             @miq_server1.monitor_servers
             @miq_server2.reload
-            @miq_server1.is_master?.should be_true
-            @miq_server2.is_master?.should_not be_true
+            expect(@miq_server1.is_master?).to be_truthy
+            expect(@miq_server2.is_master?).not_to be_truthy
           end
 
           it "should have proper roles after rezoning" do
             @miq_server1.monitor_server_roles
             @miq_server2.reload
-            (@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).should be_true
-            (@miq_server1.active_role_names.include?("event") && !@miq_server2.active_role_names.include?("event")).should be_true
-            (!@miq_server1.active_role_names.include?("ems_metrics_coordinator") && @miq_server2.active_role_names.include?("ems_metrics_coordinator")).should be_true
-            (@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).should be_true
-            (@miq_server1.active_role_names.include?("scheduler") && !@miq_server2.active_role_names.include?("scheduler")).should be_true
+            expect(@miq_server1.active_role_names.include?("ems_operations") && @miq_server2.active_role_names.include?("ems_operations")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("event") && !@miq_server2.active_role_names.include?("event")).to be_truthy
+            expect(!@miq_server1.active_role_names.include?("ems_metrics_coordinator") && @miq_server2.active_role_names.include?("ems_metrics_coordinator")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("reporting") && @miq_server2.active_role_names.include?("reporting")).to be_truthy
+            expect(@miq_server1.active_role_names.include?("scheduler") && !@miq_server2.active_role_names.include?("scheduler")).to be_truthy
           end
         end
       end

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -7,7 +7,7 @@ describe "StatusManagement" do
 
   # for now, just making sure there are no syntax errors
   it ".log_status" do
-    MiqServer.should_receive(:log_system_status).once
+    expect(MiqServer).to receive(:log_system_status).once
     MiqServer.log_status
   end
 end

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -57,13 +57,13 @@ describe MiqServer do
   context "#update_registration_status" do
     it "rhn_client" do
       @server.update_attribute(:rhn_mirror, true)
-      @server.should_receive(:check_updates).once
+      expect(@server).to receive(:check_updates).once
 
       @server.update_registration_status
     end
     it "not rhn_client" do
-      @server.should_receive(:attempt_registration).once
-      @server.should_receive(:check_updates).once
+      expect(@server).to receive(:attempt_registration).once
+      expect(@server).to receive(:check_updates).once
 
       @server.update_registration_status
     end
@@ -71,26 +71,26 @@ describe MiqServer do
 
   context "#attempt_registration" do
     it "does not continue if registration fails" do
-      @server.should_receive(:register).and_return(false)
-      @server.should_not_receive(:attach_products)
+      expect(@server).to receive(:register).and_return(false)
+      expect(@server).not_to receive(:attach_products)
 
       @server.attempt_registration
     end
 
     it "should not try to enable the repo if already enabled" do
-      @server.should_receive(:register).and_return(true)
-      @server.should_receive(:attach_products)
-      @server.should_receive(:repos_enabled?).and_return(true)
-      @server.should_not_receive(:enable_repos)
+      expect(@server).to receive(:register).and_return(true)
+      expect(@server).to receive(:attach_products)
+      expect(@server).to receive(:repos_enabled?).and_return(true)
+      expect(@server).not_to receive(:enable_repos)
 
       @server.attempt_registration
     end
 
     it "should enable the repo if not enabled" do
-      @server.should_receive(:register).and_return(true)
-      @server.should_receive(:attach_products)
-      reg_system.should_receive(:enabled_repos).and_return([], [], database.update_repo_name.split)
-      @server.should_receive(:enable_repos).twice
+      expect(@server).to receive(:register).and_return(true)
+      expect(@server).to receive(:attach_products)
+      expect(reg_system).to receive(:enabled_repos).and_return([], [], database.update_repo_name.split)
+      expect(@server).to receive(:enable_repos).twice
 
       @server.attempt_registration
     end
@@ -98,9 +98,9 @@ describe MiqServer do
     it "rhn should not call #attach_products" do
       database.update_attributes!(:registration_type => "rhn_satellite", :registration_server => "https://server.example.com/XMLRPC")
 
-      @server.should_receive(:register).and_return(true)
-      @server.should_not_receive(:attach_products)
-      @server.should_receive(:repos_enabled?).and_return(true)
+      expect(@server).to receive(:register).and_return(true)
+      expect(@server).not_to receive(:attach_products)
+      expect(@server).to receive(:repos_enabled?).and_return(true)
 
       @server.attempt_registration
     end
@@ -109,7 +109,7 @@ describe MiqServer do
   context "#register" do
     let(:default_params) { {:server_url => "subscription.rhn.redhat.com"} }
     it "already registered" do
-      reg_system.stub(:registered?).and_return(true)
+      allow(reg_system).to receive(:registered?).and_return(true)
 
       @server.register
 
@@ -118,10 +118,10 @@ describe MiqServer do
     end
 
     it "unregistered should use subscription-manager" do
-      reg_system.stub(:registered?).once.and_return(false, true)
-      LinuxAdmin::SubscriptionManager.should_receive(:register).once.with(default_params).and_return(true)
-      File.should_receive(:exist?).once.and_return(true)
-      reg_system.should_receive(:registration_type).once
+      allow(reg_system).to receive(:registered?).once.and_return(false, true)
+      expect(LinuxAdmin::SubscriptionManager).to receive(:register).once.with(default_params).and_return(true)
+      expect(File).to receive(:exist?).once.and_return(true)
+      expect(reg_system).to receive(:registration_type).once
 
       @server.register
 
@@ -135,10 +135,10 @@ describe MiqServer do
       database.update_attribute(:registration_type, "rhn_satellite6")
       database.update_attribute(:registration_server, expected_params[:server_url])
 
-      reg_system.stub(:registered?).once.and_return(false, true)
-      LinuxAdmin::SubscriptionManager.should_receive(:register).once.with(expected_params).and_return(true)
-      File.should_receive(:exist?).once.and_return(true)
-      reg_system.should_receive(:registration_type).once
+      allow(reg_system).to receive(:registered?).once.and_return(false, true)
+      expect(LinuxAdmin::SubscriptionManager).to receive(:register).once.with(expected_params).and_return(true)
+      expect(File).to receive(:exist?).once.and_return(true)
+      expect(reg_system).to receive(:registration_type).once
 
       @server.register
 
@@ -149,21 +149,21 @@ describe MiqServer do
     it "unregistered should use rhn" do
       database.update_attribute(:registration_type, "rhn_satellite")
 
-      reg_system.stub(:registered?).once.and_return(false, true)
-      LinuxAdmin::Rhn.should_receive(:register).once.with(default_params).and_return(true)
-      File.should_receive(:exist?).twice.and_return(false, true)
-      reg_system.should_receive(:registration_type).once
+      allow(reg_system).to receive(:registered?).once.and_return(false, true)
+      expect(LinuxAdmin::Rhn).to receive(:register).once.with(default_params).and_return(true)
+      expect(File).to receive(:exist?).twice.and_return(false, true)
+      expect(reg_system).to receive(:registration_type).once
 
       @server.register
 
-      expect(@server.reload.rh_registered).to be_true
+      expect(@server.reload.rh_registered).to be_truthy
       expect(@server.upgrade_message).to eq("registration successful")
     end
   end
 
   context "#attach_products" do
     it "attaches products for SubscriptionManager" do
-      reg_system.should_receive(:subscribe)
+      expect(reg_system).to receive(:subscribe)
 
       @server.attach_products
       expect(@server.upgrade_message).to eq("attaching products")
@@ -172,29 +172,29 @@ describe MiqServer do
 
   context "#repo_enabled?" do
     it "true" do
-      reg_system.should_receive(:enabled_repos).and_return(["abc", database.update_repo_names].flatten)
+      expect(reg_system).to receive(:enabled_repos).and_return(["abc", database.update_repo_names].flatten)
 
-      expect(@server.repos_enabled?).to be_true
+      expect(@server.repos_enabled?).to be_truthy
       expect(@server.upgrade_message).to eq("registered")
     end
 
     it "false" do
-      reg_system.should_receive(:enabled_repos).and_return(["abc", "def"])
+      expect(reg_system).to receive(:enabled_repos).and_return(["abc", "def"])
 
-      expect(@server.repos_enabled?).to be_false
+      expect(@server.repos_enabled?).to be_falsey
     end
   end
 
   it "#enable_repos" do
-    reg_system.should_receive(:enable_repo).twice
+    expect(reg_system).to receive(:enable_repo).twice
 
     @server.enable_repos
     expect(@server.upgrade_message).to eq("enabling rhel-server-rhscl-7-rpms")
   end
 
   it "#check_updates" do
-    yum.should_receive(:updates_available?).twice.and_return(true)
-    yum.should_receive(:version_available).with("cfme-appliance").once.and_return({"cfme-appliance" => "3.1"})
+    expect(yum).to receive(:updates_available?).twice.and_return(true)
+    expect(yum).to receive(:version_available).with("cfme-appliance").once.and_return({"cfme-appliance" => "3.1"})
     MiqDatabase.stub(:postgres_package_name => "postgresql-server")
 
     @server.check_updates
@@ -208,31 +208,31 @@ describe MiqServer do
     end
 
     it "will apply cfme updates only with local database" do
-      yum.should_receive(:updates_available?).twice.and_return(true)
-      yum.should_receive(:version_available).once.and_return({})
-      Dir.should_receive(:glob).and_return(["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"])
-      LinuxAdmin::Rpm.should_receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
-      LinuxAdmin::Rpm.should_receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta").and_return(true)
-      EvmDatabase.should_receive(:local?).and_return(true)
-      yum.should_receive(:update).once.with("cfme-appliance")
+      expect(yum).to receive(:updates_available?).twice.and_return(true)
+      expect(yum).to receive(:version_available).once.and_return({})
+      expect(Dir).to receive(:glob).and_return(["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"])
+      expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
+      expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta").and_return(true)
+      expect(EvmDatabase).to receive(:local?).and_return(true)
+      expect(yum).to receive(:update).once.with("cfme-appliance")
 
       @server.apply_updates
     end
 
     it "will apply all updates with remote database" do
-      yum.should_receive(:updates_available?).twice.and_return(true)
-      yum.should_receive(:version_available).once.and_return({})
-      Dir.should_receive(:glob).and_return(["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"])
-      LinuxAdmin::Rpm.should_receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
-      EvmDatabase.should_receive(:local?).and_return(false)
-      yum.should_receive(:update).once.with(no_args)
+      expect(yum).to receive(:updates_available?).twice.and_return(true)
+      expect(yum).to receive(:version_available).once.and_return({})
+      expect(Dir).to receive(:glob).and_return(["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"])
+      expect(LinuxAdmin::Rpm).to receive(:import_key).with("/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release").and_return(true)
+      expect(EvmDatabase).to receive(:local?).and_return(false)
+      expect(yum).to receive(:update).once.with(no_args)
 
       @server.apply_updates
     end
 
     it "does not have updates to apply" do
-      yum.should_receive(:updates_available?).twice.and_return(false)
-      yum.should_receive(:version_available).once.and_return({})
+      expect(yum).to receive(:updates_available?).twice.and_return(false)
+      expect(yum).to receive(:version_available).once.and_return({})
       MiqDatabase.stub(:postgres_package_name => "postgresql-server")
 
       @server.apply_updates

--- a/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
@@ -23,12 +23,12 @@ describe MiqServer do
       context "#enough_resource_to_start_worker?" do
         it "70% swap used" do
           MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
-          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_false
+          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_falsey
         end
 
         it "30% swap used" do
           MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
-          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_true
+          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_truthy
         end
 
         it "child_worker_settings overrides worker_monitor_settings" do
@@ -42,19 +42,19 @@ describe MiqServer do
           @server.stub(:child_worker_settings => child)
 
           MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
-          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_false
+          expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_falsey
         end
       end
 
       context "#kill_workers_due_to_resources_exhausted?" do
         it "90% swap used" do
           MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 1.gigabytes))
-          expect(@server.kill_workers_due_to_resources_exhausted?).to be_true
+          expect(@server.kill_workers_due_to_resources_exhausted?).to be_truthy
         end
 
         it "70% swap used" do
           MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
-          expect(@server.kill_workers_due_to_resources_exhausted?).to be_false
+          expect(@server.kill_workers_due_to_resources_exhausted?).to be_falsey
         end
       end
     end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe "MiqWorker Monitor" do
   context "After Setup," do
     before(:each) do
-      MiqWorker.stub(:nice_increment).and_return("+10")
-      MiqServer.any_instance.stub(:get_time_threshold).and_return(120)
-      MiqServer.any_instance.stub(:get_memory_threshold).and_return(100.megabytes)
-      MiqServer.any_instance.stub(:get_restart_interval).and_return(0)
+      allow(MiqWorker).to receive(:nice_increment).and_return("+10")
+      allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(120)
+      allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(100.megabytes)
+      allow_any_instance_of(MiqServer).to receive(:get_restart_interval).and_return(0)
 
       @miq_server = EvmSpecHelper.local_miq_server
     end
@@ -18,45 +18,45 @@ describe "MiqWorker Monitor" do
 
       it "MiqServer#clean_worker_records" do
         FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
-        @miq_server.stub(:worker_delete)
+        allow(@miq_server).to receive(:worker_delete)
         @worker.update_attributes(:status => MiqWorker::STATUS_STOPPED)
 
-        @miq_server.miq_workers.length.should == 2
+        expect(@miq_server.miq_workers.length).to eq(2)
         ids = @miq_server.clean_worker_records
-        @miq_server.miq_workers.length.should == 1
-        ids.should == [@worker.id]
+        expect(@miq_server.miq_workers.length).to eq(1)
+        expect(ids).to eq([@worker.id])
       end
 
       it "MiqServer#check_not_responding" do
         w2 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => (@worker.pid + 1))
-        @miq_server.stub(:worker_delete)
-        @miq_server.stub(:worker_get_monitor_status).with(@worker.pid).and_return(:waiting_for_stop)
-        @miq_server.stub(:worker_get_monitor_reason).with(@worker.pid).and_return(:not_responding)
-        @miq_server.stub(:worker_get_monitor_status).with(w2.pid).and_return(nil)
-        @miq_server.stub(:worker_get_monitor_reason).with(w2.pid).and_return(nil)
-        MiqWorker.any_instance.stub(:kill)
+        allow(@miq_server).to receive(:worker_delete)
+        allow(@miq_server).to receive(:worker_get_monitor_status).with(@worker.pid).and_return(:waiting_for_stop)
+        allow(@miq_server).to receive(:worker_get_monitor_reason).with(@worker.pid).and_return(:not_responding)
+        allow(@miq_server).to receive(:worker_get_monitor_status).with(w2.pid).and_return(nil)
+        allow(@miq_server).to receive(:worker_get_monitor_reason).with(w2.pid).and_return(nil)
+        allow_any_instance_of(MiqWorker).to receive(:kill)
         @worker.update_attributes(:status => MiqWorker::STATUS_STOPPING)
 
-        @miq_server.miq_workers.length.should == 2
+        expect(@miq_server.miq_workers.length).to eq(2)
         ids = @miq_server.check_not_responding
-        @miq_server.miq_workers.length.should == 1
-        ids.should == [@worker.id]
+        expect(@miq_server.miq_workers.length).to eq(1)
+        expect(ids).to eq([@worker.id])
       end
 
       context "with no messages" do
         it "should not have any in its relationship" do
-          @worker.messages.should be_empty
+          expect(@worker.messages).to be_empty
         end
       end
 
       it "quiesce time allowance will use message timeout" do
-        @worker.stub(:current_timeout).and_return(2.minutes)
-        @worker.quiesce_time_allowance.should == 2.minutes
+        allow(@worker).to receive(:current_timeout).and_return(2.minutes)
+        expect(@worker.quiesce_time_allowance).to eq(2.minutes)
       end
 
       it "quiesce time allowance will use default of 5 minutes if no message timeout" do
-        @worker.stub(:current_timeout).and_return(nil)
-        @worker.quiesce_time_allowance.should == 5.minutes
+        allow(@worker).to receive(:current_timeout).and_return(nil)
+        expect(@worker.quiesce_time_allowance).to eq(5.minutes)
       end
 
       context "with 1 message" do
@@ -65,8 +65,8 @@ describe "MiqWorker Monitor" do
         end
 
         it "should have one in its relationship" do
-          @worker.messages.should == [@message]
-          @worker.active_messages.should == [@message]
+          expect(@worker.messages).to eq([@message])
+          expect(@worker.active_messages).to eq([@message])
         end
       end
 
@@ -90,45 +90,45 @@ describe "MiqWorker Monitor" do
         end
 
         it "should have them in its relationship" do
-          @worker.messages.should        match_array @messages
-          @worker.active_messages.should match_array @actives
+          expect(@worker.messages).to        match_array @messages
+          expect(@worker.active_messages).to match_array @actives
         end
 
         it "on worker destroy, will destroy its processed messages" do
           @worker.destroy
-          @worker.messages.where("state != ?", "ready").count.should == 0
-          @worker.active_messages.size.should == 0
+          expect(@worker.messages.where("state != ?", "ready").count).to eq(0)
+          expect(@worker.active_messages.size).to eq(0)
         end
 
         it "on worker destroy, will no longer associate the 'ready' message with the worker" do
           @worker.destroy
-          MiqQueue.where(:state => 'ready').count.should == 1
-          @worker.messages(true).size.should == 0
+          expect(MiqQueue.where(:state => 'ready').count).to eq(1)
+          expect(@worker.messages(true).size).to eq(0)
 
           m = @messages.first.reload
-          m.handler_type.should be_nil
-          m.handler_id.should be_nil
+          expect(m.handler_type).to be_nil
+          expect(m.handler_id).to be_nil
         end
 
         it "on worker destroy, will log a warning message for each of its message" do
           log_count = @worker.messages.count
-          $log.should_receive(:warn).exactly(log_count).times
+          expect($log).to receive(:warn).exactly(log_count).times
           @worker.destroy
         end
 
         it "should timeout the expired active messages" do
-          @worker.messages.should        match_array @messages
-          @worker.active_messages.should match_array @actives
+          expect(@worker.messages).to        match_array @messages
+          expect(@worker.active_messages).to match_array @actives
 
           Timecop.travel 5.minutes do
             @worker.validate_active_messages
           end
 
           @worker.reload
-          (@messages - @worker.messages).length.should == 1
-          (@actives - @worker.active_messages).length.should == 1
-          @worker.active_messages.length.should == @actives.length - 1
-          @worker.active_messages.first.msg_timeout.should == 5.minutes
+          expect((@messages - @worker.messages).length).to eq(1)
+          expect((@actives - @worker.active_messages).length).to eq(1)
+          expect(@worker.active_messages.length).to eq(@actives.length - 1)
+          expect(@worker.active_messages.first.msg_timeout).to eq(5.minutes)
         end
       end
     end
@@ -143,14 +143,14 @@ describe "MiqWorker Monitor" do
 
         it "should timeout the right active messages" do
           actives = MiqQueue.where(:state => 'dequeue')
-          actives.length.should == @actives.length
+          expect(actives.length).to eq(@actives.length)
 
           Timecop.travel 5.minutes do
             @miq_server.validate_active_messages
           end
 
           actives = MiqQueue.where(:state => 'dequeue')
-          actives.length.should == @actives.length - 1
+          expect(actives.length).to eq(@actives.length - 1)
         end
       end
 
@@ -168,15 +168,15 @@ describe "MiqWorker Monitor" do
           @actives << FactoryGirl.create(:miq_queue, :state => 'dequeue', :msg_timeout => 4.minutes, :handler => @worker2)
 
           actives = MiqQueue.where(:state => 'dequeue')
-          actives.length.should == @actives.length
+          expect(actives.length).to eq(@actives.length)
 
           Timecop.travel 5.minutes do
             @miq_server.validate_active_messages
           end
 
           actives = MiqQueue.where(:state => 'dequeue')
-          actives.length.should == @actives.length - 1
-          actives.first.handler.should == @worker2
+          expect(actives.length).to eq(@actives.length - 1)
+          expect(actives.first.handler).to eq(@worker2)
 
           @miq_server2.update_attribute(:status, 'stopped')
 
@@ -185,16 +185,16 @@ describe "MiqWorker Monitor" do
           end
 
           actives = MiqQueue.where(:state => 'dequeue')
-          actives.length.should == 0
+          expect(actives.length).to eq(0)
         end
       end
 
       context "with vanilla generic worker" do
         before(:each) do
           @worker1 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => 42, :type => 'MiqGenericWorker')
-          MiqServer.any_instance.stub(:get_time_threshold).and_return(2.minutes)
-          MiqServer.any_instance.stub(:get_memory_threshold).and_return(500.megabytes)
-          MiqServer.any_instance.stub(:get_restart_interval).and_return(0.hours)
+          allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(2.minutes)
+          allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(500.megabytes)
+          allow_any_instance_of(MiqServer).to receive(:get_restart_interval).and_return(0.hours)
           @miq_server.setup_drb_variables
           @miq_server.worker_add(@worker1.pid)
         end
@@ -206,20 +206,20 @@ describe "MiqWorker Monitor" do
             end
 
             it "should delete worker row after clean_worker_records" do
-              MiqWorker.count.should == 1
+              expect(MiqWorker.count).to eq(1)
               MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
-              MiqWorker.count.should == 0
+              expect(MiqWorker.count).to eq(0)
             end
 
             context "but is waiting for restart" do
               before(:each) do
-                @miq_server.stub(:worker_get_monitor_status).with(@worker1.pid).and_return(:pending_restart)
+                allow(@miq_server).to receive(:worker_get_monitor_status).with(@worker1.pid).and_return(:pending_restart)
               end
 
               it "should not delete worker row after clean_worker_records" do
-                MiqWorker.count.should == 1
+                expect(MiqWorker.count).to eq(1)
                 MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
-                MiqWorker.count.should == 1
+                expect(MiqWorker.count).to eq(1)
               end
             end
           end
@@ -230,9 +230,9 @@ describe "MiqWorker Monitor" do
             end
 
             it "should delete worker row after clean_worker_records" do
-              MiqWorker.count.should == 1
+              expect(MiqWorker.count).to eq(1)
               MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
-              MiqWorker.count.should == 0
+              expect(MiqWorker.count).to eq(0)
             end
           end
 
@@ -242,9 +242,9 @@ describe "MiqWorker Monitor" do
             end
 
             it "should delete worker row after clean_worker_records" do
-              MiqWorker.count.should == 1
+              expect(MiqWorker.count).to eq(1)
               MiqServer.monitor_class_names.each { |c| @miq_server.clean_worker_records(c) }
-              MiqWorker.count.should == 0
+              expect(MiqWorker.count).to eq(0)
             end
           end
         end
@@ -257,13 +257,13 @@ describe "MiqWorker Monitor" do
 
           it "should queue up work for the server" do
             q = MiqQueue.first
-            q.class_name.should == "MiqServer"
-            q.instance_id.should == @miq_server.id
-            q.method_name.should == 'message_for_worker'
-            q.args.should == [@worker1.id, 'reconnect_ems', "#{@ems_id}"]
-            q.queue_name.should == 'miq_server'
-            q.zone.should == @miq_server.zone.name
-            q.server_guid.should == @miq_server.guid
+            expect(q.class_name).to eq("MiqServer")
+            expect(q.instance_id).to eq(@miq_server.id)
+            expect(q.method_name).to eq('message_for_worker')
+            expect(q.args).to eq([@worker1.id, 'reconnect_ems', "#{@ems_id}"])
+            expect(q.queue_name).to eq('miq_server')
+            expect(q.zone).to eq(@miq_server.zone.name)
+            expect(q.server_guid).to eq(@miq_server.guid)
           end
         end
 
@@ -273,7 +273,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['foo']]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['foo']])
           end
         end
 
@@ -283,7 +283,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['sync_config', {:config => nil}]]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_config', {:config => nil}]])
           end
         end
 
@@ -293,7 +293,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['sync_active_roles', {:roles => nil}]]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}]])
           end
         end
 
@@ -304,7 +304,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "exit message followed by active_roles and config" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['exit'], ['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['exit'], ['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]])
           end
         end
 
@@ -314,7 +314,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}], ['sync_config', {:config => nil}]])
           end
         end
 
@@ -325,7 +325,7 @@ describe "MiqWorker Monitor" do
           end
 
           it "should return proper message on heartbeat via drb" do
-            @miq_server.worker_heartbeat(@worker1.pid).should == [['reconnect_ems', @ems_id.to_s]]
+            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s]])
           end
 
           context "and an exit message" do
@@ -334,7 +334,7 @@ describe "MiqWorker Monitor" do
             end
 
             it "should return proper message on heartbeat via drb" do
-              @miq_server.worker_heartbeat(@worker1.pid).should == [['reconnect_ems', @ems_id.to_s], ['exit']]
+              expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s], ['exit']])
             end
           end
         end
@@ -343,45 +343,45 @@ describe "MiqWorker Monitor" do
       context "with worker that is using a lot of memory" do
         before(:each) do
           @worker1 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :memory_usage => 2.gigabytes, :pid => 42)
-          MiqServer.any_instance.stub(:get_time_threshold).and_return(2.minutes)
-          MiqServer.any_instance.stub(:get_memory_threshold).and_return(500.megabytes)
-          MiqServer.any_instance.stub(:get_restart_interval).and_return(0.hours)
+          allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(2.minutes)
+          allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(500.megabytes)
+          allow_any_instance_of(MiqServer).to receive(:get_restart_interval).and_return(0.hours)
           @miq_server.setup_drb_variables
         end
 
         it "should not trigger memory threshold if worker is creating" do
           @worker1.status = MiqWorker::STATUS_CREATING
-          @miq_server.validate_worker(@worker1).should be_true
+          expect(@miq_server.validate_worker(@worker1)).to be_truthy
         end
 
         it "should not trigger memory threshold if worker is starting" do
           @worker1.status = MiqWorker::STATUS_STARTING
-          @miq_server.validate_worker(@worker1).should be_true
+          expect(@miq_server.validate_worker(@worker1)).to be_truthy
         end
 
         it "should trigger memory threshold if worker is started" do
           @worker1.status = MiqWorker::STATUS_STARTED
-          @miq_server.should_receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
+          expect(@miq_server).to receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
           @miq_server.validate_worker(@worker1)
         end
 
         it "should trigger memory threshold if worker is ready" do
           @worker1.status = MiqWorker::STATUS_READY
-          @miq_server.should_receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
+          expect(@miq_server).to receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
           @miq_server.validate_worker(@worker1)
         end
 
         it "should trigger memory threshold if worker is working" do
           @worker1.status = MiqWorker::STATUS_WORKING
-          @miq_server.should_receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
+          expect(@miq_server).to receive(:worker_set_monitor_status).with(@worker1.pid, :waiting_for_stop_before_restart).once
           @miq_server.validate_worker(@worker1)
         end
 
         it "should return proper message on heartbeat" do
           @worker1.status = MiqWorker::STATUS_READY
-          @miq_server.worker_heartbeat(@worker1.pid).should == []
+          expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([])
           @miq_server.validate_worker(@worker1) # Validation will populate message
-          @miq_server.worker_heartbeat(@worker1.pid).should == [['exit']]
+          expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['exit']])
         end
       end
     end

--- a/spec/support/vmdb_configuration_helper.rb
+++ b/spec/support/vmdb_configuration_helper.rb
@@ -3,7 +3,7 @@ module VMDBConfigurationHelper
     configuration = double(:config                         => config,
                            :merge_from_template_if_missing => nil,
                            :merge_from_template            => nil)
-    allow(configuration).to receive(:fetch_with_fallback).and_return { |*arg| config.fetch_path(arg) }
-    allow(VMDB::Config).to receive(:new).with(config_name).and_return(configuration)
+    allow(configuration).to receive(:fetch_with_fallback) { |*args| config.fetch_path(args) }
+    allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
   end
 end


### PR DESCRIPTION
Converts miq_server specs to the newer `expect` syntax.

Punting on any Rubocop violations to speed up the conversion process.