### PR TITLE
RSpec 3 conversion: miq_expression model specs

### DIFF
--- a/spec/models/miq_expression/get_col_spec.rb
+++ b/spec/models/miq_expression/get_col_spec.rb
@@ -6,54 +6,54 @@ describe MiqExpression do
 
     it "with model-field__with_pivot_table_suffix" do
       @field = "Vm-name__pv"
-      subject.should == described_class.get_col_type("Vm-name")
+      expect(subject).to eq(described_class.get_col_type("Vm-name"))
     end
 
     it "with managed-field" do
       @field = "managed.location"
-      subject.should == :string
+      expect(subject).to eq(:string)
     end
 
     it "with model.managed-in_field" do
       @field = "Vm.managed-service_level"
-      subject.should == :string
+      expect(subject).to eq(:string)
     end
 
     it "with model.last.managed-in_field" do
       @field = "Vm.host.managed-environment"
-      subject.should == :string
+      expect(subject).to eq(:string)
     end
 
     it "with valid model-in_field" do
       @field = "Vm-cpu_limit"
       described_class.stub(:col_type => :some_type)
-      subject.should == :some_type
+      expect(subject).to eq(:some_type)
     end
 
     it "with invalid model-in_field" do
       @field = "abc-name"
-      subject.should be_nil
+      expect(subject).to be_nil
     end
 
     it "with valid model.association-in_field" do
       @field = "Vm.guest_applications-vendor"
       described_class.stub(:col_type => :some_type)
-      subject.should == :some_type
+      expect(subject).to eq(:some_type)
     end
 
     it "with invalid model.association-in_field" do
       @field = "abc.host-name"
-      subject.should be_nil
+      expect(subject).to be_nil
     end
 
     it "with model-invalid_field" do
       @field = "Vm-abc"
-      subject.should be_nil
+      expect(subject).to be_nil
     end
 
     it "with field without model" do
       @field = "storage"
-      subject.should be_nil
+      expect(subject).to be_nil
     end
   end
 
@@ -62,32 +62,32 @@ describe MiqExpression do
 
     it "with model-field__with_pivot_table_suffix" do
       @field = "Vm-name__pv"
-      subject.should == ["Vm", [], "name"]
+      expect(subject).to eq(["Vm", [], "name"])
     end
 
     it "with managed-field" do
       @field = "managed.location"
-      subject.should == ["managed", ["location"], "managed.location"]
+      expect(subject).to eq(["managed", ["location"], "managed.location"])
     end
 
     it "with model.managed-in_field" do
       @field = "Vm.managed-service_level"
-      subject.should == ["Vm", ["managed"], "service_level"]
+      expect(subject).to eq(["Vm", ["managed"], "service_level"])
     end
 
     it "with model.last.managed-in_field" do
       @field = "Vm.host.managed-environment"
-      subject.should == ["Vm", ["host", "managed"], "environment"]
+      expect(subject).to eq(["Vm", ["host", "managed"], "environment"])
     end
 
     it "with valid model-in_field" do
       @field = "Vm-cpu_limit"
-      subject.should == ["Vm", [], "cpu_limit"]
+      expect(subject).to eq(["Vm", [], "cpu_limit"])
     end
 
     it "with field without model" do
       @field = "storage"
-      subject.should == ["storage", [], "storage"]
+      expect(subject).to eq(["storage", [], "storage"])
     end
   end
 end

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -44,7 +44,7 @@ describe MiqExpression do
         field: Host-enabled_inbound_ports
         value: 22, 427, 5988, 5989, 1..4
     '
-    filter.to_ruby.should == '(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]'
+    expect(filter.to_ruby).to eq('(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -53,7 +53,7 @@ describe MiqExpression do
         value: 22, 427, 5988, 5989, 1..3
     '
 
-    filter.to_ruby.should == '([1,2,3,22,427,5988,5989] - <value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value>) != [1,2,3,22,427,5988,5989]'
+    expect(filter.to_ruby).to eq('([1,2,3,22,427,5988,5989] - <value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value>) != [1,2,3,22,427,5988,5989]')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -61,7 +61,7 @@ describe MiqExpression do
         field: Host-enabled_inbound_ports
         value: 22
     '
-    filter.to_ruby.should == '(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [22]) == []'
+    expect(filter.to_ruby).to eq('(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [22]) == []')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -69,7 +69,7 @@ describe MiqExpression do
         field: Host-enabled_inbound_ports
         value: 22
     '
-    filter.to_ruby.should == '(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [22]) == []'
+    expect(filter.to_ruby).to eq('(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [22]) == []')
   end
 
   it "should test string set expressions" do
@@ -83,7 +83,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "<value ref=host, type=string_set>/virtual/service_names</value> == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+    expect(filter.to_ruby).to eq("<value ref=host, type=string_set>/virtual/service_names</value> == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -95,7 +95,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "(<value ref=host, type=string_set>/virtual/service_names</value> & ['ntpd','sshd','vmware-vpxa','vmware-webAccess']) == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+    expect(filter.to_ruby).to eq("(<value ref=host, type=string_set>/virtual/service_names</value> & ['ntpd','sshd','vmware-vpxa','vmware-webAccess']) == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -107,7 +107,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "(['ntpd','sshd','vmware-vpxa','vmware-webAccess'] - <value ref=host, type=string_set>/virtual/service_names</value>) != ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+    expect(filter.to_ruby).to eq("(['ntpd','sshd','vmware-vpxa','vmware-webAccess'] - <value ref=host, type=string_set>/virtual/service_names</value>) != ['ntpd','sshd','vmware-vpxa','vmware-webAccess']")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -119,7 +119,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []"
+    expect(filter.to_ruby).to eq("(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -131,7 +131,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []"
+    expect(filter.to_ruby).to eq("(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -150,7 +150,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<find><search><value ref=host, type=text>/virtual/filesystems/name</value> == "/etc/passwd"</search><check mode=all><value ref=host, type=string>/virtual/filesystems/permissions</value> == "0644"</check></find>'
+    expect(filter.to_ruby).to eq('<find><search><value ref=host, type=text>/virtual/filesystems/name</value> == "/etc/passwd"</search><check mode=all><value ref=host, type=string>/virtual/filesystems/permissions</value> == "0644"</check></find>')
   end
 
   it "should test regexp" do
@@ -164,7 +164,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/'
+    expect(filter.to_ruby).to eq('<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -176,7 +176,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/'
+    expect(filter.to_ruby).to eq('<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -194,7 +194,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<find><search><value ref=host, type=boolean>/virtual/firewall_rules/enabled</value> == "true"</search><check mode=any><value ref=host, type=string>/virtual/firewall_rules/name</value> =~ /^.*SLP.*$/</check></find>'
+    expect(filter.to_ruby).to eq('<find><search><value ref=host, type=boolean>/virtual/firewall_rules/enabled</value> == "true"</search><check mode=any><value ref=host, type=string>/virtual/firewall_rules/name</value> =~ /^.*SLP.*$/</check></find>')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -212,7 +212,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<find><search><value ref=host, type=boolean>/virtual/firewall_rules/enabled</value> == "true"</search><check mode=any><value ref=host, type=string>/virtual/firewall_rules/name</value> !~ /^.*SLP.*$/</check></find>'
+    expect(filter.to_ruby).to eq('<find><search><value ref=host, type=boolean>/virtual/firewall_rules/enabled</value> == "true"</search><check mode=any><value ref=host, type=string>/virtual/firewall_rules/name</value> !~ /^.*SLP.*$/</check></find>')
   end
 
   it "should test fb7726" do
@@ -226,7 +226,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "<exist ref=host>/virtual/filesystems/name/%2fetc%2fshadow</exist>"
+    expect(filter.to_ruby).to eq("<exist ref=host>/virtual/filesystems/name/%2fetc%2fshadow</exist>")
   end
 
   it "should escape strings" do
@@ -240,10 +240,10 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "<value ref=vm, type=text>/virtual/registry_items/data</value> =~ /\\$foo/"
+    expect(filter.to_ruby).to eq("<value ref=vm, type=text>/virtual/registry_items/data</value> =~ /\\$foo/")
 
     data = {"registry_items.data" => "C:\\Documents and Users\\O'Neill, April\\", "/virtual/registry_items/data" => "C:\\Documents and Users\\O'Neill, April\\"}
-    Condition.subst(filter.to_ruby, data, {}).should == "\"C:\\\\Documents and Users\\\\O'Neill, April\\\\\" =~ /\\$foo/"
+    expect(Condition.subst(filter.to_ruby, data, {})).to eq("\"C:\\\\Documents and Users\\\\O'Neill, April\\\\\" =~ /\\$foo/")
   end
 
   it "should test context hash" do
@@ -260,8 +260,8 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "<value type=string>guest_applications.name</value> == \"VMware Tools\""
-    Condition.subst(filter.to_ruby, data, {}).should == "\"VMware Tools\" == \"VMware Tools\""
+    expect(filter.to_ruby).to eq("<value type=string>guest_applications.name</value> == \"VMware Tools\"")
+    expect(Condition.subst(filter.to_ruby, data, {})).to eq("\"VMware Tools\" == \"VMware Tools\"")
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     exp:
@@ -274,8 +274,8 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == "<value type=string>guest_applications.vendor</value> =~ /^[^.]*ware.*$/"
-    Condition.subst(filter.to_ruby, data, {}).should == '"VMware, Inc." =~ /^[^.]*ware.*$/'
+    expect(filter.to_ruby).to eq("<value type=string>guest_applications.vendor</value> =~ /^[^.]*ware.*$/")
+    expect(Condition.subst(filter.to_ruby, data, {})).to eq('"VMware, Inc." =~ /^[^.]*ware.*$/')
   end
 
   it "should test numbers with methods" do
@@ -290,7 +290,7 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<value ref=vm, type=integer>/virtual/memory_shares</value> >= 25600'
+    expect(filter.to_ruby).to eq('<value ref=vm, type=integer>/virtual/memory_shares</value> >= 25600')
 
     filter = YAML.load '--- !ruby/object:MiqExpression
     context_type:
@@ -303,29 +303,29 @@ describe MiqExpression do
     # puts "Expression in Human: #{filter.to_human}"
     # puts "Expression in Ruby:  #{filter.to_ruby}"
     # puts
-    filter.to_ruby.should == '<value ref=vm, type=integer>/virtual/used_disk_storage</value> >= 1048576000'
+    expect(filter.to_ruby).to eq('<value ref=vm, type=integer>/virtual/used_disk_storage</value> >= 1048576000')
   end
 
   # end to_ruby
 
   describe ".atom_error" do
     it "should test atom error" do
-      MiqExpression.atom_error("Host-xx", "regular expression matches", '123[)').should_not be_false
+      expect(MiqExpression.atom_error("Host-xx", "regular expression matches", '123[)')).not_to be_falsey
 
-      MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '').should_not be_false
-      MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123abc').should_not be_false
-      MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123').should be_false
-      MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123.456').should be_false
-      MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '2,123.456').should be_false
+      expect(MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '')).not_to be_falsey
+      expect(MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123abc')).not_to be_falsey
+      expect(MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123')).to be_falsey
+      expect(MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '123.456')).to be_falsey
+      expect(MiqExpression.atom_error("VmPerformance-cpu_usage_rate_average", "=", '2,123.456')).to be_falsey
 
-      MiqExpression.atom_error("Vm-cpu_limit", "=", '').should_not be_false
-      MiqExpression.atom_error("Vm-cpu_limit", "=", '123.5').should_not be_false
-      MiqExpression.atom_error("Vm-cpu_limit", "=", '123.5.abc').should_not be_false
-      MiqExpression.atom_error("Vm-cpu_limit", "=", '123').should be_false
-      MiqExpression.atom_error("Vm-cpu_limit", "=", '2,123').should be_false
+      expect(MiqExpression.atom_error("Vm-cpu_limit", "=", '')).not_to be_falsey
+      expect(MiqExpression.atom_error("Vm-cpu_limit", "=", '123.5')).not_to be_falsey
+      expect(MiqExpression.atom_error("Vm-cpu_limit", "=", '123.5.abc')).not_to be_falsey
+      expect(MiqExpression.atom_error("Vm-cpu_limit", "=", '123')).to be_falsey
+      expect(MiqExpression.atom_error("Vm-cpu_limit", "=", '2,123')).to be_falsey
 
-      MiqExpression.atom_error("Vm-created_on", "=", Time.now.to_s).should be_false
-      MiqExpression.atom_error("Vm-created_on", "=", "123456").should_not be_false
+      expect(MiqExpression.atom_error("Vm-created_on", "=", Time.now.to_s)).to be_falsey
+      expect(MiqExpression.atom_error("Vm-created_on", "=", "123456")).not_to be_falsey
     end
   end
 
@@ -334,10 +334,10 @@ describe MiqExpression do
       relats  = MiqExpression.get_relats(Vm)
       details = MiqExpression._model_details(relats, {})
       cluster_sorted = details.select { |d| d.first.starts_with?("Cluster") }.sort
-      cluster_sorted.map(&:first).should include("Cluster / Deployment Role : Total Number of Physical CPUs")
-      cluster_sorted.map(&:first).should include("Cluster / Deployment Role : Total Number of Logical CPUs")
+      expect(cluster_sorted.map(&:first)).to include("Cluster / Deployment Role : Total Number of Physical CPUs")
+      expect(cluster_sorted.map(&:first)).to include("Cluster / Deployment Role : Total Number of Logical CPUs")
       hardware_sorted = details.select { |d| d.first.starts_with?("Hardware") }.sort
-      hardware_sorted.map(&:first).should_not include("Hardware : Logical Cpus")
+      expect(hardware_sorted.map(&:first)).not_to include("Hardware : Logical Cpus")
     end
 
     it "should not contain duplicate tag fields" do
@@ -348,24 +348,24 @@ describe MiqExpression do
                                          :include_model   => true,
                                          :include_my_tags => false,
                                          :userid          => 'admin')
-      tags.uniq.length.should eq(tags.length)
+      expect(tags.uniq.length).to eq(tags.length)
     end
   end
 
   context ".build_relats" do
     it "includes reflections from descendant classes of Vm" do
       relats = MiqExpression.get_relats(Vm)
-      relats[:reflections][:cloud_tenant].should_not be_blank
+      expect(relats[:reflections][:cloud_tenant]).not_to be_blank
     end
 
     it "includes reflections from descendant classes of Host" do
       relats = MiqExpression.get_relats(Host)
-      relats[:reflections][:cloud_networks].should_not be_blank
+      expect(relats[:reflections][:cloud_networks]).not_to be_blank
     end
 
     it "excludes reflections from descendant classes of VmOrTemplate " do
       relats = MiqExpression.get_relats(VmOrTemplate)
-      relats[:reflections][:cloud_tenant].should be_blank
+      expect(relats[:reflections][:cloud_tenant]).to be_blank
     end
   end
 
@@ -373,181 +373,181 @@ describe MiqExpression do
     context "Testing expression conversion ruby, sql and human with static dates and times" do
       it "should generate the correct ruby expression with an expression having static dates and times with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
 
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
 
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T08:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T17:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T08:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T17:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T00:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T00:00:00Z'.to_time(:utc)")
       end
 
       it "should generate the correct ruby expression running to_ruby with an expression having static dates and times with a time zone" do
         tz = "Eastern Time (US & Canada)"
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
 
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
 
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T13:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T22:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T13:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T22:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T05:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T05:00:00Z'.to_time(:utc)")
       end
 
       it "should generate the correct SQL query running to_sql with an expression having static dates and times with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > '2011-01-10'"
+        expect(sql).to eq("vms.retires_on > '2011-01-10'")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > '2011-01-10'"
+        expect(sql).to eq("vms.retires_on > '2011-01-10'")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < '2011-01-10'"
+        expect(sql).to eq("vms.retires_on < '2011-01-10'")
 
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < '2011-01-10'"
+        expect(sql).to eq("vms.retires_on < '2011-01-10'")
 
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on >= '2011-01-10'"
+        expect(sql).to eq("vms.retires_on >= '2011-01-10'")
 
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on <= '2011-01-10'"
+        expect(sql).to eq("vms.retires_on <= '2011-01-10'")
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on > '2011-01-10T09:00:00Z'"
+        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
 
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on > '2011-01-10T09:00:00Z'"
+        expect(sql).to eq("vms.last_scan_on > '2011-01-10T09:00:00Z'")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on = '2011-01-10'"
+        expect(sql).to eq("vms.retires_on = '2011-01-10'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'"
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'"
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-09' AND '2011-01-10'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2011-01-10T08:00:00Z' AND '2011-01-10T17:00:00Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T08:00:00Z' AND '2011-01-10T17:00:00Z'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2011-01-10T00:00:00Z' AND '2011-01-10T00:00:00Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-10T00:00:00Z' AND '2011-01-10T00:00:00Z'")
       end
 
       it "should generate the correct human expression with an expression having static dates and times with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On AFTER "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On AFTER "2011-01-10"')
 
         exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On > "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On > "2011-01-10"')
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On BEFORE "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On BEFORE "2011-01-10"')
 
         exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On < "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On < "2011-01-10"')
 
         exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On >= "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On >= "2011-01-10"')
 
         exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On <= "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On <= "2011-01-10"')
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time AFTER "2011-01-10 9:00"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time AFTER "2011-01-10 9:00"')
 
         exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time > "2011-01-10 9:00"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time > "2011-01-10 9:00"')
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        exp.to_human.should == 'VM and Instance : Retires On IS "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On IS "2011-01-10"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-        exp.to_human.should == 'VM and Instance : Retires On FROM "2011-01-09" THROUGH "2011-01-10"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On FROM "2011-01-09" THROUGH "2011-01-10"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-        exp.to_human.should == 'VM and Instance : Retires On FROM "01/09/2011" THROUGH "01/10/2011"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On FROM "01/09/2011" THROUGH "01/10/2011"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time FROM "2011-01-10 8:00" THROUGH "2011-01-10 17:00"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time FROM "2011-01-10 8:00" THROUGH "2011-01-10 17:00"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time FROM "2011-01-10 00:00" THROUGH "2011-01-10 00:00"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time FROM "2011-01-10 00:00" THROUGH "2011-01-10 00:00"')
       end
     end
 
@@ -562,222 +562,222 @@ describe MiqExpression do
 
       it ".normalize_date_time" do
         # Test <value> <interval> Ago
-        MiqExpression.normalize_date_time("3 Hours Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-11 14:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Hours Ago", "UTC").utc.to_s.should == "2011-01-11 14:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Hours Ago", "UTC", "end").utc.to_s.should == "2011-01-11 14:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("3 Hours Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 14:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Hours Ago", "UTC").utc.to_s).to eq("2011-01-11 14:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Hours Ago", "UTC", "end").utc.to_s).to eq("2011-01-11 14:59:59 UTC")
 
-        MiqExpression.normalize_date_time("3 Days Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-08 05:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Days Ago", "UTC").utc.to_s.should == "2011-01-08 00:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Days Ago", "UTC", "end").utc.to_s.should == "2011-01-08 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("3 Days Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-08 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Days Ago", "UTC").utc.to_s).to eq("2011-01-08 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Days Ago", "UTC", "end").utc.to_s).to eq("2011-01-08 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("3 Weeks Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2010-12-20 05:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Weeks Ago", "UTC").utc.to_s.should == "2010-12-20 00:00:00 UTC"
+        expect(MiqExpression.normalize_date_time("3 Weeks Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-12-20 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Weeks Ago", "UTC").utc.to_s).to eq("2010-12-20 00:00:00 UTC")
 
-        MiqExpression.normalize_date_time("4 Months Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2010-09-01 04:00:00 UTC"
-        MiqExpression.normalize_date_time("4 Months Ago", "UTC").utc.to_s.should == "2010-09-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("4 Months Ago", "UTC", "end").utc.to_s.should == "2010-09-30 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("4 Months Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-09-01 04:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("4 Months Ago", "UTC").utc.to_s).to eq("2010-09-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("4 Months Ago", "UTC", "end").utc.to_s).to eq("2010-09-30 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("1 Quarter Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2010-10-01 04:00:00 UTC"
-        MiqExpression.normalize_date_time("1 Quarter Ago", "UTC").utc.to_s.should == "2010-10-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("1 Quarter Ago", "UTC", "end").utc.to_s.should == "2010-12-31 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("1 Quarter Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-10-01 04:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("1 Quarter Ago", "UTC").utc.to_s).to eq("2010-10-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("1 Quarter Ago", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("3 Quarters Ago", "Eastern Time (US & Canada)").utc.to_s.should == "2010-04-01 04:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Quarters Ago", "UTC").utc.to_s.should == "2010-04-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("3 Quarters Ago", "UTC", "end").utc.to_s.should == "2010-06-30 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("3 Quarters Ago", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-04-01 04:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Quarters Ago", "UTC").utc.to_s).to eq("2010-04-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("3 Quarters Ago", "UTC", "end").utc.to_s).to eq("2010-06-30 23:59:59 UTC")
 
         # Test Now, Today, Yesterday
-        MiqExpression.normalize_date_time("Now", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-11 17:00:00 UTC"
-        MiqExpression.normalize_date_time("Now", "UTC").utc.to_s.should == "2011-01-11 17:00:00 UTC"
-        MiqExpression.normalize_date_time("Now", "UTC", "end").utc.to_s.should == "2011-01-11 17:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Now", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Now", "UTC").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Now", "UTC", "end").utc.to_s).to eq("2011-01-11 17:59:59 UTC")
 
-        MiqExpression.normalize_date_time("Today", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-11 05:00:00 UTC"
-        MiqExpression.normalize_date_time("Today", "UTC").utc.to_s.should == "2011-01-11 00:00:00 UTC"
-        MiqExpression.normalize_date_time("Today", "UTC", "end").utc.to_s.should == "2011-01-11 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Today", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Today", "UTC").utc.to_s).to eq("2011-01-11 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Today", "UTC", "end").utc.to_s).to eq("2011-01-11 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("Yesterday", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-10 05:00:00 UTC"
-        MiqExpression.normalize_date_time("Yesterday", "UTC").utc.to_s.should == "2011-01-10 00:00:00 UTC"
-        MiqExpression.normalize_date_time("Yesterday", "UTC", "end").utc.to_s.should == "2011-01-10 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Yesterday", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-10 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Yesterday", "UTC").utc.to_s).to eq("2011-01-10 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Yesterday", "UTC", "end").utc.to_s).to eq("2011-01-10 23:59:59 UTC")
 
         # Test Last ...
-        MiqExpression.normalize_date_time("Last Hour", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-11 16:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Hour", "UTC").utc.to_s.should == "2011-01-11 16:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Hour", "UTC", "end").utc.to_s.should == "2011-01-11 16:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Last Hour", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 16:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Hour", "UTC").utc.to_s).to eq("2011-01-11 16:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Hour", "UTC", "end").utc.to_s).to eq("2011-01-11 16:59:59 UTC")
 
-        MiqExpression.normalize_date_time("Last Week", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-03 05:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Week", "UTC").utc.to_s.should == "2011-01-03 00:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Week", "UTC", "end").utc.to_s.should == "2011-01-09 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Last Week", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-03 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Week", "UTC").utc.to_s).to eq("2011-01-03 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Week", "UTC", "end").utc.to_s).to eq("2011-01-09 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("Last Month", "Eastern Time (US & Canada)").utc.to_s.should == "2010-12-01 05:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Month", "UTC").utc.to_s.should == "2010-12-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Month", "UTC", "end").utc.to_s.should == "2010-12-31 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Last Month", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-12-01 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Month", "UTC").utc.to_s).to eq("2010-12-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Month", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("Last Quarter", "Eastern Time (US & Canada)").utc.to_s.should == "2010-10-01 04:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Quarter", "UTC").utc.to_s.should == "2010-10-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("Last Quarter", "UTC", "end").utc.to_s.should == "2010-12-31 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("Last Quarter", "Eastern Time (US & Canada)").utc.to_s).to eq("2010-10-01 04:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Quarter", "UTC").utc.to_s).to eq("2010-10-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("Last Quarter", "UTC", "end").utc.to_s).to eq("2010-12-31 23:59:59 UTC")
 
         # Test This ...
-        MiqExpression.normalize_date_time("This Hour", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-11 17:00:00 UTC"
-        MiqExpression.normalize_date_time("This Hour", "UTC").utc.to_s.should == "2011-01-11 17:00:00 UTC"
-        MiqExpression.normalize_date_time("This Hour", "UTC", "end").utc.to_s.should == "2011-01-11 17:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("This Hour", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Hour", "UTC").utc.to_s).to eq("2011-01-11 17:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Hour", "UTC", "end").utc.to_s).to eq("2011-01-11 17:59:59 UTC")
 
-        MiqExpression.normalize_date_time("This Week", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-10 05:00:00 UTC"
-        MiqExpression.normalize_date_time("This Week", "UTC").utc.to_s.should == "2011-01-10 00:00:00 UTC"
-        MiqExpression.normalize_date_time("This Week", "UTC", "end").utc.to_s.should == "2011-01-16 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("This Week", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-10 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Week", "UTC").utc.to_s).to eq("2011-01-10 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Week", "UTC", "end").utc.to_s).to eq("2011-01-16 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("This Month", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-01 05:00:00 UTC"
-        MiqExpression.normalize_date_time("This Month", "UTC").utc.to_s.should == "2011-01-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("This Month", "UTC", "end").utc.to_s.should == "2011-01-31 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("This Month", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-01 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Month", "UTC").utc.to_s).to eq("2011-01-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Month", "UTC", "end").utc.to_s).to eq("2011-01-31 23:59:59 UTC")
 
-        MiqExpression.normalize_date_time("This Quarter", "Eastern Time (US & Canada)").utc.to_s.should == "2011-01-01 05:00:00 UTC"
-        MiqExpression.normalize_date_time("This Quarter", "UTC").utc.to_s.should == "2011-01-01 00:00:00 UTC"
-        MiqExpression.normalize_date_time("This Quarter", "UTC", "end").utc.to_s.should == "2011-03-31 23:59:59 UTC"
+        expect(MiqExpression.normalize_date_time("This Quarter", "Eastern Time (US & Canada)").utc.to_s).to eq("2011-01-01 05:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Quarter", "UTC").utc.to_s).to eq("2011-01-01 00:00:00 UTC")
+        expect(MiqExpression.normalize_date_time("This Quarter", "UTC", "end").utc.to_s).to eq("2011-03-31 23:59:59 UTC")
       end
 
       it "should generate the correct ruby expression running to_ruby with an expression having relative dates with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date")
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T00:00:00Z'.to_time(:utc) && val.to_time <= '2010-12-31T23:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T00:00:00Z'.to_time(:utc) && val.to_time <= '2010-12-31T23:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-        exp.to_ruby.should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)")
       end
 
       it "should generate the correct ruby expression running to_ruby with an expression having relative time with a time zone" do
         tz = "Hawaii"
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T16:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T17:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-01T09:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2010-11-01T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-01T09:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-        exp.to_ruby(tz).should == "val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)"
+        expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)")
       end
 
       it "should generate the correct SQL query running to_sql with an expression having relative dates with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on > '2011-01-09'"
+        expect(sql).to eq("vms.retires_on > '2011-01-09'")
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on > '2011-01-09T23:59:59Z'"
+        expect(sql).to eq("vms.last_scan_on > '2011-01-09T23:59:59Z'")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on < '2011-01-09'"
+        expect(sql).to eq("vms.retires_on < '2011-01-09'")
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on < '2011-01-09T00:00:00Z'"
+        expect(sql).to eq("vms.last_scan_on < '2011-01-09T00:00:00Z'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2011-01-11T16:00:00Z' AND '2011-01-11T17:59:59Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T16:00:00Z' AND '2011-01-11T17:59:59Z'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN '2011-01-03' AND '2011-01-09'"
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-03' AND '2011-01-09'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2011-01-03T00:00:00Z' AND '2011-01-09T23:59:59Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-03T00:00:00Z' AND '2011-01-09T23:59:59Z'")
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2010-11-01T00:00:00Z' AND '2010-12-31T23:59:59Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2010-11-01T00:00:00Z' AND '2010-12-31T23:59:59Z'")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'"
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'"
+        expect(sql).to eq("vms.retires_on BETWEEN '2011-01-11' AND '2011-01-11'")
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
         sql, includes, attrs = exp.to_sql
-        sql.should == "vms.last_scan_on BETWEEN '2011-01-11T14:00:00Z' AND '2011-01-11T14:59:59Z'"
+        expect(sql).to eq("vms.last_scan_on BETWEEN '2011-01-11T14:00:00Z' AND '2011-01-11T14:59:59Z'")
       end
 
       it "should generate the correct human expression running to_ruby with an expression having relative dates with no time zone" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-        exp.to_human.should == 'VM and Instance : Retires On AFTER "2 Days Ago"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On AFTER "2 Days Ago"')
 
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time AFTER "2 Days Ago"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time AFTER "2 Days Ago"')
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-        exp.to_human.should == 'VM and Instance : Retires On BEFORE "2 Days Ago"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On BEFORE "2 Days Ago"')
 
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time BEFORE "2 Days Ago"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time BEFORE "2 Days Ago"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time FROM "Last Hour" THROUGH "This Hour"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time FROM "Last Hour" THROUGH "This Hour"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_human.should == 'VM and Instance : Retires On FROM "Last Week" THROUGH "Last Week"'
+        expect(exp.to_human).to eq('VM and Instance : Retires On FROM "Last Week" THROUGH "Last Week"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time FROM "Last Week" THROUGH "Last Week"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time FROM "Last Week" THROUGH "Last Week"')
 
         exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time FROM "2 Months Ago" THROUGH "Last Month"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time FROM "2 Months Ago" THROUGH "Last Month"')
 
         exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-        exp.to_human.should == 'VM and Instance : Last Analysis Time IS "3 Hours Ago"'
+        expect(exp.to_human).to eq('VM and Instance : Last Analysis Time IS "3 Hours Ago"')
       end
     end
   end
@@ -786,26 +786,26 @@ describe MiqExpression do
     context "should handle expression atoms that do/don't have alias keys" do
       it "FIELD type" do
         exp = MiqExpression.new(">" => {"field" => "Vm-allocated_disk_storage", "value" => "5.megabytes"})
-        exp.to_human.should == 'VM and Instance : Allocated Disk Storage > 5 MB'
+        expect(exp.to_human).to eq('VM and Instance : Allocated Disk Storage > 5 MB')
 
         exp = MiqExpression.new(">" => {"field" => "Vm-allocated_disk_storage", "value" => "5.megabytes", "alias" => "Disk"})
-        exp.to_human.should == 'Disk > 5 MB'
+        expect(exp.to_human).to eq('Disk > 5 MB')
       end
 
       it "FIND/CHECK type" do
         exp = MiqExpression.new("FIND" => {"search" => {"STARTS WITH" => {"field" => "Vm.advanced_settings-name", "value" => "X"}}, "checkall" => {"=" => {"field" => "Vm.advanced_settings-read_only", "value" => "true"}}})
-        exp.to_human.should == 'FIND VM and Instance.Advanced Settings : Name STARTS WITH "X" CHECK ALL Read Only = "true"'
+        expect(exp.to_human).to eq('FIND VM and Instance.Advanced Settings : Name STARTS WITH "X" CHECK ALL Read Only = "true"')
 
         exp = MiqExpression.new({"FIND" => {"search" => {"STARTS WITH" => {"field" => "Vm.advanced_settings-name", "value" => "X", "alias" => "Settings Name"}}, "checkall" => {"=" => {"field" => "Vm.advanced_settings-read_only", "value" => "true"}}}})
-        exp.to_human.should == 'FIND Settings Name STARTS WITH "X" CHECK ALL Read Only = "true"'
+        expect(exp.to_human).to eq('FIND Settings Name STARTS WITH "X" CHECK ALL Read Only = "true"')
       end
 
       it "COUNT type" do
         exp = MiqExpression.new({">" => {"count" => "Vm.snapshots", "value" => "1"}})
-        exp.to_human.should == "COUNT OF VM and Instance.Snapshots > 1"
+        expect(exp.to_human).to eq("COUNT OF VM and Instance.Snapshots > 1")
 
         exp = MiqExpression.new(">" => {"count" => "Vm.snapshots", "value" => "1", "alias" => "Snaps"})
-        exp.to_human.should == "COUNT OF Snaps > 1"
+        expect(exp.to_human).to eq("COUNT OF Snaps > 1")
       end
 
       it "TAG type" do
@@ -814,10 +814,10 @@ describe MiqExpression do
         FactoryGirl.create(:classification, :parent_id => category.id, :name => 'prod', :description => 'Production')
 
         exp = MiqExpression.new("CONTAINS" => {"tag" => "Host.managed-environment", "value" => "prod"})
-        exp.to_human.should == "Host / Node.My Company Tags : Environment CONTAINS 'Production'"
+        expect(exp.to_human).to eq("Host / Node.My Company Tags : Environment CONTAINS 'Production'")
 
         exp = MiqExpression.new("CONTAINS" => {"tag" => "Host.managed-environment", "value" => "prod", "alias" => "Env"})
-        exp.to_human.should == "Env CONTAINS 'Production'"
+        expect(exp.to_human).to eq("Env CONTAINS 'Production'")
       end
     end
   end
@@ -832,42 +832,42 @@ describe MiqExpression do
     '
 
     sql, incl, attrs = exp.to_sql
-    attrs[:supported_by_sql].should == false
+    expect(attrs[:supported_by_sql]).to eq(false)
   end
 
   describe ".quick_search?" do
     it "detects false in hash" do
-      MiqExpression.quick_search?(exp).should be_false
+      expect(MiqExpression.quick_search?(exp)).to be_falsey
     end
 
     it "detects in hash" do
-      MiqExpression.quick_search?(qs_exp).should be_true
+      expect(MiqExpression.quick_search?(qs_exp)).to be_truthy
     end
 
     it "detects in complex hash" do
-      MiqExpression.quick_search?(complex_qs_exp).should be_true
+      expect(MiqExpression.quick_search?(complex_qs_exp)).to be_truthy
     end
 
     it "detects false in miq expression" do
-      MiqExpression.quick_search?(MiqExpression.new(exp)).should be_false
+      expect(MiqExpression.quick_search?(MiqExpression.new(exp))).to be_falsey
     end
 
     it "detects in miq expression" do
-      MiqExpression.quick_search?(MiqExpression.new(qs_exp)).should be_true
+      expect(MiqExpression.quick_search?(MiqExpression.new(qs_exp))).to be_truthy
     end
   end
 
   describe "#quick_search?" do
     it "detects false in hash" do
-      MiqExpression.new(exp).quick_search?.should be_false
+      expect(MiqExpression.new(exp).quick_search?).to be_falsey
     end
 
     it "detects in hash" do
-      MiqExpression.new(qs_exp).quick_search?.should be_true
+      expect(MiqExpression.new(qs_exp).quick_search?).to be_truthy
     end
 
     it "detects in complex hash" do
-      MiqExpression.new(complex_qs_exp).quick_search?.should be_true
+      expect(MiqExpression.new(complex_qs_exp).quick_search?).to be_truthy
     end
   end
 

--- a/spec/models/miq_expression/model_details_spec.rb
+++ b/spec/models/miq_expression/model_details_spec.rb
@@ -23,13 +23,13 @@ describe MiqExpression do
     context "with :typ=>tag" do
       it "VmInfra" do
         result = described_class.model_details("ManageIQ::Providers::InfraManager::Vm", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Virtual Machine.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Virtual Machine.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "VmCloud" do
         result = described_class.model_details("ManageIQ::Providers::CloudManager::Vm", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Instance.My Company Tags : Auto Approve - Max CPU")
-        result.map(&:first).should_not include("Instance.VM and Instance.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Instance.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).not_to include("Instance.VM and Instance.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "VmOrTemplate" do
@@ -39,32 +39,32 @@ describe MiqExpression do
                                                :include_my_tags => true,
                                                :userid          => "admin"
                                               )
-        result.map(&:first).should include("VM or Template.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("VM or Template.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "TemplateInfra" do
         result = described_class.model_details("ManageIQ::Providers::InfraManager::Template", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Template.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Template.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "TemplateCloud" do
         result = described_class.model_details("ManageIQ::Providers::CloudManager::Template", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Image.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Image.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "MiqTemplate" do
         result = described_class.model_details("MiqTemplate", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("VM Template and Image.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("VM Template and Image.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "EmsInfra" do
         result = described_class.model_details("ManageIQ::Providers::InfraManager", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Infrastructure Provider.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Infrastructure Provider.My Company Tags : Auto Approve - Max CPU")
       end
 
       it "EmsCloud" do
         result = described_class.model_details("ManageIQ::Providers::CloudManager", :typ => "tag", :include_model => true, :include_my_tags => true, :userid => "admin")
-        result.map(&:first).should include("Cloud Provider.My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("Cloud Provider.My Company Tags : Auto Approve - Max CPU")
       end
     end
 
@@ -74,12 +74,12 @@ describe MiqExpression do
                                                :typ           => "all",
                                                :include_model => false,
                                                :include_tags  => true)
-        result.map(&:first).should include("My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("My Company Tags : Auto Approve - Max CPU")
       end
 
       it "Service" do
         result = described_class.model_details("Service", :typ => "all", :include_model => false, :include_tags => true)
-        result.map(&:first).should include("My Company Tags : Auto Approve - Max CPU")
+        expect(result.map(&:first)).to include("My Company Tags : Auto Approve - Max CPU")
       end
     end
   end


### PR DESCRIPTION
Converts the `miq_expression` model specs to newer `expect` syntax.