### PR TITLE
Fixed model name passed in to hybrid_name method.

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -34,8 +34,8 @@ module Menu
       end
 
       def infrastructure_menu_section
-        hosts_name    = hybrid_name(EmsCluster, N_("Hosts"),    N_("Nodes"),            N_("Hosts / Nodes"))
-        clusters_name = hybrid_name(Host,       N_("Clusters"), N_("Deployment Roles"), N_("Clusters / Deployment Roles"))
+        hosts_name    = hybrid_name(Host,       N_("Hosts"),    N_("Nodes"),            N_("Hosts / Nodes"))
+        clusters_name = hybrid_name(EmsCluster, N_("Clusters"), N_("Deployment Roles"), N_("Clusters / Deployment Roles"))
 
         Menu::Section.new(:inf, N_("Infrastructure"), [
           Menu::Item.new('ems_infra',        N_('Providers'),        'ems_infra',     {:feature => 'ems_infra_show_list'},     '/ems_infra'),

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -17,4 +17,65 @@ describe Menu::DefaultMenu do
       Menu::DefaultMenu.default_menu
     end
   end
+
+  context "infrastructure_menu_section" do
+    before do
+      @ems_openstack = FactoryGirl.create(:ems_openstack_infra)
+      @ems_vmware = FactoryGirl.create(:ems_vmware)
+    end
+
+    it "shows correct title for Hosts submenu item when openstack only records exist" do
+      FactoryGirl.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Clusters", "Nodes", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+
+    it "shows correct title for Hosts submenu item when non-openstack only records exist" do
+      FactoryGirl.create(:host_vmware, :ems_id => @ems_vmware.id)
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+
+    it "shows correct title for Hosts submenu item when both openstack & non-openstack only records exist" do
+      FactoryGirl.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
+      FactoryGirl.create(:host_vmware, :ems_id => @ems_vmware.id)
+
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Clusters", "Hosts / Nodes", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+
+    it "shows correct title for Clusters submenu item when openstack only records exist" do
+      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
+
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+
+    it "shows correct title for Clusters submenu item when non-openstack only records exist" do
+      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
+
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+
+    it "shows correct title for Clusters submenu item when both openstack & non-openstack only records exist" do
+      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
+      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
+
+      menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
+      result = ["Providers", "Clusters / Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",
+                "Datastores", "Repositories", "PXE", "Requests", "Configuration Management"]
+      expect(menu).to eq(result)
+    end
+  end
 end


### PR DESCRIPTION
- Incorrect model name was causing incorrect label to be displayed on the secondary navigation bar. To recreate this issue db should only contain openstack Hosts, and no openstack Clusters.
- Added spec test to verify labels for Hosts & Clusters in different modes depending upon existence of openstack/non-openstack records in the db

https://bugzilla.redhat.com/show_bug.cgi?id=1288496
https://bugzilla.redhat.com/show_bug.cgi?id=1290554

@dclarizio please review