### PR TITLE
Following commit for PR #5693 catalog item accordion not opening

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1862,7 +1862,6 @@ class CatalogController < ApplicationController
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
 
-    presenter[:open_accord] = 'sandt' if @sb[:active_tree] == :sandt_tree
     # have to make Catalog Items accordion active incase link on Catalog show screen was pressed
 
     # Decide whether to show paging controls


### PR DESCRIPTION
Small follow up for https://github.com/ManageIQ/manageiq/pull/5693

https://bugzilla.redhat.com/show_bug.cgi?id=1287584

Changes made in that PR will collapse an accordion when open_accord option is not empty. 
This option was cleared in the report_controller in 5693, it also needs to be cleared for the catalog items ( this PR)

