### PR TITLE
gem sprockets 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
 gem "rails",                           "~>4.2.5"
 
-# Temporarily restrict Sprockets to < 3.0 while we deal with compatibility issues
-gem "sprockets-rails", "< 3.0.0"
-
 # Local gems
 path "gems/" do
   gem "manageiq_foreman", :require => false

--- a/lib/vmdb/productization.rb
+++ b/lib/vmdb/productization.rb
@@ -28,8 +28,10 @@ module Vmdb
     end
 
     def replace_directive_processor(type)
-      Rails.application.assets.unregister_processor(type, Sprockets::DirectiveProcessor)
-      Rails.application.assets.register_processor(type, DirectiveProcessor)
+      if Rails.application.assets.respond_to?(:register_processor)
+        Rails.application.assets.unregister_processor(type, Sprockets::DirectiveProcessor)
+        Rails.application.assets.register_processor(type, DirectiveProcessor)
+      end
     end
 
     # Override Rails' rake task component for precompilation to log separators on

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -308,11 +308,11 @@ describe Tenant do
 
     it "has a default login image" do
       tenant.save!
-      expect(tenant.login_logo.url).to match(/login-screen-logo.png/)
+      expect(tenant.login_logo.url).to match(/login-screen-logo.*\.png/)
     end
 
     it "has a default login image for root_tenant" do
-      expect(root_tenant.login_logo.url).to match(/login-screen-logo.png/)
+      expect(root_tenant.login_logo.url).to match(/login-screen-logo.*\.png/)
     end
 
     it "has custom login logo" do


### PR DESCRIPTION
fixes

```
NoMethodError: undefined method `unregister_processor' for nil:NilClass
/home/travis/build/ManageIQ/manageiq/lib/vmdb/productization.rb:52:in `replace_directive_processor'
/home/travis/build/ManageIQ/manageiq/lib/vmdb/productization.rb:47:in `prepare_asset_directive_processor'
/home/travis/build/ManageIQ/manageiq/lib/vmdb/productization.rb:6:in `prepare'
```
/cc @matthewd @chrisarcand 