### PR TITLE
Tenancy scoping for vms and templates

### DIFF
--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -16,6 +16,13 @@ module TenancyMixin
 
       tenant.accessible_tenant_ids(strategy)
     end
+
+    def tenant_id_clause(user_or_group)
+      tenant_ids = accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(self))
+      return if tenant_ids.empty?
+
+      {table_name => {:tenant_id => tenant_ids}}
+    end
   end
 
   def set_tenant

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -62,6 +62,7 @@ module Rbac
     'MiqAeNamespace'         => :ancestor_ids,
     'MiqRequest'             => nil, # tenant only
     'MiqRequestTask'         => nil, # tenant only
+    'MiqTemplate'            => :ancestor_ids,
     'Provider'               => :ancestor_ids,
     'ServiceTemplateCatalog' => :ancestor_ids,
     'ServiceTemplate'        => :ancestor_ids,
@@ -275,11 +276,9 @@ module Rbac
   end
 
   def self.find_options_for_tenant(klass, user_or_group, find_options = {})
-    tenant_ids = klass.accessible_tenant_ids(user_or_group, accessible_tenant_ids_strategy(klass))
-    return find_options if tenant_ids.empty?
+    tenant_id_clause = klass.tenant_id_clause(user_or_group)
 
-    tenant_id_clause = {klass.table_name => {:tenant_id => tenant_ids}}
-    find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause)
+    find_options[:conditions] = MiqExpression.merge_where_clauses(find_options[:conditions], tenant_id_clause) if tenant_id_clause
     find_options
   end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1904,6 +1904,14 @@ class VmOrTemplate < ActiveRecord::Base
     vms.all?(&:reconfigurable?)
   end
 
+  def self.tenant_id_clause(user_or_group)
+    template_tenant_ids = MiqTemplate.accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(MiqTemplate))
+    vm_tenant_ids       = Vm.accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(Vm))
+    return if template_tenant_ids.empty? && vm_tenant_ids.empty?
+
+    ["(template = true AND tenant_id IN (?)) OR (template = false AND tenant_id IN (?))", template_tenant_ids, vm_tenant_ids]
+  end
+
   private
 
   def set_tenant_from_group

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -137,56 +137,52 @@ describe Rbac do
       end
 
       context "tenant access strategy VMs and Templates" do
-        before do
-          @owned_template = FactoryGirl.create(:template_vmware, :tenant => @owner_tenant)
-          @child_tenant = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
-          @child_group  = FactoryGirl.create(:miq_group, :tenant => @child_tenant)
-        end
+        let(:owned_template) { FactoryGirl.create(:template_vmware, :tenant => owner_tenant) }
+        let(:child_tenant)   { FactoryGirl.create(:tenant, :divisible => false, :parent => owner_tenant) }
+        let(:child_group)    { FactoryGirl.create(:miq_group, :tenant => child_tenant) }
 
         context "searching MiqTemplate" do
           it "can't see descendant tenant's templates" do
-            @owned_template.update_attributes(:tenant_id => @child_tenant.id, :miq_group_id => @child_group.id)
-            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => @owner_group.id)
+            owned_template.update_attributes!(:tenant_id => child_tenant.id, :miq_group_id => child_group.id)
+            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => owner_group.id)
             expect(results).to eq []
           end
 
           it "can see ancestor tenant's templates" do
-            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_tenant.id)
-            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
-            expect(results).to eq [@owned_template]
+            owned_template.update_attributes!(:tenant_id => owner_tenant.id, :miq_group_id => owner_tenant.id)
+            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => child_group.id)
+            expect(results).to eq [owned_template]
           end
         end
 
         context "searching VmOrTemplate" do
-          before do
-            @child_child_tenant = FactoryGirl.create(:tenant, :divisible => false, :parent => @child_tenant)
-            @child_child_group  = FactoryGirl.create(:miq_group, :tenant => @child_child_tenant)
-          end
+          let(:child_child_tenant) { FactoryGirl.create(:tenant, :divisible => false, :parent => child_tenant) }
+          let(:child_child_group)  { FactoryGirl.create(:miq_group, :tenant => child_child_tenant) }
 
           it "can't see descendant tenant's templates but can see descendant tenant's VMs" do
-            @owned_template.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
-            @owned_vm.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
-            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
-            expect(results).to eq [@owned_vm]
+            owned_template.update_attributes!(:tenant_id => child_child_tenant.id, :miq_group_id => child_child_group.id)
+            owned_vm.update_attributes(:tenant_id => child_child_tenant.id, :miq_group_id => child_child_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => child_group.id)
+            expect(results).to eq [owned_vm]
           end
 
           it "can see ancestor tenant's templates but can't see ancestor tenant's VMs" do
-            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
-            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
-            expect(results).to eq [@owned_template]
+            owned_template.update_attributes!(:tenant_id => owner_tenant.id, :miq_group_id => owner_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => child_group.id)
+            expect(results).to eq [owned_template]
           end
 
           it "can see ancestor tenant's templates and descendant tenant's VMs" do
-            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
-            @owned_vm.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
-            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
-            expect(results).to eq [@owned_template, @owned_vm]
+            owned_template.update_attributes!(:tenant_id => owner_tenant.id, :miq_group_id => owner_group.id)
+            owned_vm.update_attributes(:tenant_id => child_child_tenant.id, :miq_group_id => child_child_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => child_group.id)
+            expect(results).to eq [owned_template, owned_vm]
           end
 
           it "can't see descendant tenant's templates nor ancestor tenant's VMs" do
-            @owned_template.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
-            @owned_vm.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
-            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            owned_template.update_attributes!(:tenant_id => child_child_tenant.id, :miq_group_id => child_child_group.id)
+            owned_vm.update_attributes(:tenant_id => owner_tenant.id, :miq_group_id => owner_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => child_group.id)
             expect(results).to eq []
           end
         end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -136,6 +136,62 @@ describe Rbac do
         end
       end
 
+      context "tenant access strategy VMs and Templates" do
+        before do
+          @owned_template = FactoryGirl.create(:template_vmware, :tenant => @owner_tenant)
+          @child_tenant = FactoryGirl.create(:tenant, :divisible => false, :parent => @owner_tenant)
+          @child_group  = FactoryGirl.create(:miq_group, :tenant => @child_tenant)
+        end
+
+        context "searching MiqTemplate" do
+          it "can't see descendant tenant's templates" do
+            @owned_template.update_attributes(:tenant_id => @child_tenant.id, :miq_group_id => @child_group.id)
+            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => @owner_group.id)
+            expect(results).to eq []
+          end
+
+          it "can see ancestor tenant's templates" do
+            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_tenant.id)
+            results, = Rbac.search(:class => "MiqTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            expect(results).to eq [@owned_template]
+          end
+        end
+
+        context "searching VmOrTemplate" do
+          before do
+            @child_child_tenant = FactoryGirl.create(:tenant, :divisible => false, :parent => @child_tenant)
+            @child_child_group  = FactoryGirl.create(:miq_group, :tenant => @child_child_tenant)
+          end
+
+          it "can't see descendant tenant's templates but can see descendant tenant's VMs" do
+            @owned_template.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
+            @owned_vm.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            expect(results).to eq [@owned_vm]
+          end
+
+          it "can see ancestor tenant's templates but can't see ancestor tenant's VMs" do
+            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            expect(results).to eq [@owned_template]
+          end
+
+          it "can see ancestor tenant's templates and descendant tenant's VMs" do
+            @owned_template.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
+            @owned_vm.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            expect(results).to eq [@owned_template, @owned_vm]
+          end
+
+          it "can't see descendant tenant's templates nor ancestor tenant's VMs" do
+            @owned_template.update_attributes(:tenant_id => @child_child_tenant.id, :miq_group_id => @child_child_group.id)
+            @owned_vm.update_attributes(:tenant_id => @owner_tenant.id, :miq_group_id => @owner_group.id)
+            results, = Rbac.search(:class => "VmOrTemplate", :results_format => :objects, :miq_group_id => @child_group.id)
+            expect(results).to eq []
+          end
+        end
+      end
+
       context "tenant 0" do
         it "can see requests owned by any tenants" do
           request_task = FactoryGirl.create(:miq_request_task, :tenant => owner_tenant)


### PR DESCRIPTION
- Added logic to handle different scoping rules for vm and templates where both classes derive from the same base model, VmOrTemplate, and share the same table, vms.
- Templates owned by the current tenant and all parent tenants (ancestors) should be accessible current tenant.
- Vms owned by the current tenant and all child tenants (descendants) should be accessible from the current tenant.
- There are places in the app that require RBAC searching on both classes at the same time, making this change necessary.

https://bugzilla.redhat.com/show_bug.cgi?id=1292285