### PR TITLE
Downgrade sprockets-rails to < 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
 gem "rails",                           "~>4.2.5"
 
+# Temporarily restrict Sprockets to < 3.0 while we deal with compatibility issues
+gem "sprockets-rails", "< 3.0.0"
+
 # Local gems
 path "gems/" do
   gem "manageiq_foreman", :require => false


### PR DESCRIPTION
This is due to current failures on the test suites from `Rails.application.assets` being nil in test environments, and should be unrestricted once a proper set of fixes can be implemented

cc/ @matthewd @kbrock @Fryguy 