### PR TITLE
Fix availability zone views when infra provider is not attached

### DIFF
--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -35,7 +35,7 @@ module AvailabilityZoneHelper::TextualSummary
   end
 
   def textual_block_storage_disk_capacity
-    return nil unless @record.respond_to?(:block_storage_disk_capacity)
+    return nil unless @record.respond_to?(:block_storage_disk_capacity) && !@record.ext_management_system.provider.nil?
     {:value => number_to_human_size(@record.block_storage_disk_capacity.gigabytes, :precision => 2)}
   end
 


### PR DESCRIPTION
When an OpenStack infrastructure provider is not attached to
the cloud provider, a "undefined method 'infra_ems'" error is
thrown. This fix adds a nil check on provider. If it is nil,
the disk capacity is not shown for the availability zone.

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1291774