### PR TITLE
SSUI - authentication related changes

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -30,7 +30,11 @@ class ApiController
         else
           @auth_user     = @api_token_mgr.token_get_info(@module, @auth_token, :userid)
           @auth_user_obj = userid_to_userobj(@auth_user)
-          @api_token_mgr.reset_token(@module, @auth_token)
+
+          unless request.env['HTTP_X_AUTH_SKIP_TOKEN_RENEWAL'] == 'true'
+            @api_token_mgr.reset_token(@module, @auth_token)
+          end
+
           authorize_user_group(@auth_user_obj)
           validate_user_identity(@auth_user_obj)
           User.current_user = @auth_user_obj

--- a/spa_ui/self_service/.jscsrc
+++ b/spa_ui/self_service/.jscsrc
@@ -47,7 +47,6 @@
   "disallowSpacesInNamedFunctionExpression": {
     "beforeOpeningRoundBrace": true
   },
-  "disallowTrailingComma": true,
   "maximumLineLength": {
     "value": 120,
     "allExcept": [

--- a/spa_ui/self_service/.jscsrc
+++ b/spa_ui/self_service/.jscsrc
@@ -48,7 +48,7 @@
     "beforeOpeningRoundBrace": true
   },
   "maximumLineLength": {
-    "value": 120,
+    "value": 140,
     "allExcept": [
       "regex",
       "comments",

--- a/spa_ui/self_service/.jshintrc
+++ b/spa_ui/self_service/.jshintrc
@@ -32,7 +32,7 @@
   "maxdepth"      : 4,        // {int} Max depth of nested blocks (within functions)
   "maxstatements" : 30,       // {int} Max number statements per function
   "maxcomplexity" : 10,       // {int} Max cyclomatic complexity per function
-  "maxlen"        : 120,      // {int} Max number of characters per line
+  "maxlen"        : 140,      // {int} Max number of characters per line
 
   // Relaxing
   "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)

--- a/spa_ui/self_service/bower.json
+++ b/spa_ui/self_service/bower.json
@@ -18,23 +18,24 @@
     "sinon": "http://sinonjs.org/releases/sinon-1.15.4.js"
   },
   "dependencies": {
+    "angular": "~1.4.6",
+    "angular-animate": "~1.4.6",
+    "angular-base64": "~2.0.5",
+    "angular-bootstrap": "~0.13.0",
+    "angular-messages": "~1.4.6",
+    "angular-mocks": "~1.4.6",
+    "angular-patternfly": "~2.3.2",
+    "angular-resource": "~1.4.6",
+    "angular-sanitize": "~1.4.6",
+    "angular-ui-router": "~0.2.15",
+    "font-awesome": "~4.4.0",
+    "jquery": "~2.1.0",
     "lodash": "~3.9.0",
     "moment": "~2.10.0",
-    "jquery": "~2.1.0",
-    "toastr": "~2.1.1",
-    "font-awesome": "~4.4.0",
-    "angular": "~1.4.6",
-    "angular-resource": "~1.4.6",
-    "angular-animate": "~1.4.6",
-    "angular-sanitize": "~1.4.6",
-    "angular-messages": "~1.4.6",
-    "angular-ui-router": "~0.2.15",
-    "angular-mocks": "~1.4.6",
+    "ngprogress": "~1.1.2",
+    "ngstorage": "~0.3.10",
     "patternfly": "~2.3.0",
-    "angular-patternfly": "~2.3.2",
-    "angular-bootstrap": "~0.13.0",
-    "angular-base64": "~2.0.5",
-    "ngprogress": "~1.1.2"
+    "toastr": "~2.1.1"
   },
   "overrides": {
     "patternfly": {

--- a/spa_ui/self_service/client/app/app.module.js
+++ b/spa_ui/self_service/client/app/app.module.js
@@ -5,7 +5,6 @@
     'app.config',
     'app.states',
     'ngProgress',
-    'ngStorage',
   ]);
   angular.module('app').controller('AppController', ['$rootScope', '$scope', 'ngProgressFactory',
     function($rootScope, $scope, ngProgressFactory) {

--- a/spa_ui/self_service/client/app/app.module.js
+++ b/spa_ui/self_service/client/app/app.module.js
@@ -4,7 +4,8 @@
     'app.core',
     'app.config',
     'app.states',
-    'ngProgress'
+    'ngProgress',
+    'ngStorage',
   ]);
   angular.module('app').controller('AppController', ['$rootScope', '$scope', 'ngProgressFactory',
     function($rootScope, $scope, ngProgressFactory) {

--- a/spa_ui/self_service/client/app/components/navigation/_navigation.sass
+++ b/spa_ui/self_service/client/app/components/navigation/_navigation.sass
@@ -22,3 +22,8 @@
 
     a:hover
       color: $color-lochmara-approx
+
+.navbar__user-name
+  display: inline-block
+  color: $color-white
+  margin-left: 1ex

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.html
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.html
@@ -7,7 +7,7 @@
       <span class="icon-bar"></span>
     </button>
     <a ui-sref="dashboard" class="navbar-brand">
-      <img class="navbar-brand-name" src="images/brand.svg" alt="{{ :: vm.text.name }}"/>
+      <img class="navbar-brand-name" src="images/brand.svg" alt="{{ ::vm.text.name }}"/>
     </a>
   </div>
 
@@ -23,7 +23,8 @@
     <ul class="nav navbar-nav navbar-right navbar-iconic">
       <li dropdown>
         <a dropdown-toggle class="nav-item-iconic">
-          <i title="{{ ::vm.user().name }}" class="fa pficon-user"></i>
+          <i title="{{ ::vm.user().email }}" class="fa pficon-user"></i>
+          <p class="navbar__user-name">{{ ::vm.user().name }}</p>
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.html
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.html
@@ -22,8 +22,8 @@
     </ul>
     <ul class="nav navbar-nav navbar-right navbar-iconic">
       <li dropdown>
-        <a dropdown-toggle class="nav-item-iconic">
-          <i title="{{ ::vm.user().email }}" class="fa pficon-user"></i>
+        <a dropdown-toggle class="nav-item-iconic" title="{{ ::vm.user().userid }}">
+          <i class="fa pficon-user"></i>
           <p class="navbar__user-name">{{ ::vm.user().name }}</p>
           <span class="caret"></span>
         </a>

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -49,7 +49,7 @@
   }
 
   /** @ngInject */
-  function init($rootScope, $state, Session, jQuery) {
+  function init($rootScope, $state, Session, jQuery, $sessionStorage) {
     $rootScope.$on('$stateChangeStart', changeStart);
     $rootScope.$on('$stateChangeError', changeError);
     $rootScope.$on('$stateChangeSuccess', changeSuccess);
@@ -59,10 +59,25 @@
         return;
       }
 
-      if (!Session.active()) {
-        event.preventDefault();
-        $state.transitionTo('login');
+      if (Session.active()) {
+        return;
       }
+
+      $sessionStorage.$sync();
+      if ($sessionStorage.token) {
+        event.preventDefault();
+
+        Session.create({
+          auth_token: $sessionStorage.token,
+          expires_on: moment().add(5, 'minutes'),
+        });
+
+        $state.go('dashboard');
+        return;
+      }
+
+      event.preventDefault();
+      $state.transitionTo('login');
     }
 
     function changeError(event, toState, toParams, fromState, fromParams, error) {

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -63,14 +63,11 @@
         return;
       }
 
-      $sessionStorage.$sync();
+      $sessionStorage.$sync();  // needed when called right on reload
       if ($sessionStorage.token) {
         event.preventDefault();
 
-        Session.create({
-          auth_token: $sessionStorage.token,
-          expires_on: moment().add(5, 'minutes'),
-        });
+        Session.create({ auth_token: $sessionStorage.token });
 
         $state.go('dashboard');
         return;

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -66,6 +66,7 @@
       $sessionStorage.$sync();  // needed when called right on reload
       if ($sessionStorage.token) {
         Session.create({ auth_token: $sessionStorage.token });
+
         return;
       }
 

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -42,10 +42,10 @@
         var Session = $injector.get('Session');
 
         if ('login' !== $state.current.name) {
-          // a bit of a hack to prevent multiple instances of the same notification - cleared on login submit
-          if (!Notifications.session_timed_out) {
+          // prevent multiple instances of the same notification - cleared on login submit
+          if (!Session.timeout_notified) {
             Notifications.message('danger', '', 'Your session has timed out.', true);
-            Notifications.session_timed_out = true;
+            Session.timeout_notified = true;
           }
 
           Session.destroy();

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -67,7 +67,7 @@
       if ($sessionStorage.token) {
         Session.create({ auth_token: $sessionStorage.token });
 
-        return;
+        return Session.loadUser();
       }
 
       event.preventDefault();

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -38,10 +38,17 @@
 
       function endSession() {
         var $state = $injector.get('$state');
+        var Notifications = $injector.get('Notifications');
+        var Session = $injector.get('Session');
 
         if ('login' !== $state.current.name) {
-          $injector.get('Notifications').message('danger', '', 'Your session has timed out.', true);
-          $injector.get('Session').destroy();
+          // a bit of a hack to prevent multiple instances of the same notification - cleared on login submit
+          if (! Notifications.session_timed_out) {
+            Notifications.message('danger', '', 'Your session has timed out.', true);
+            Notifications.session_timed_out = true;
+          }
+
+          Session.destroy();
           $state.go('login');
         }
       }

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -65,11 +65,7 @@
 
       $sessionStorage.$sync();  // needed when called right on reload
       if ($sessionStorage.token) {
-        event.preventDefault();
-
         Session.create({ auth_token: $sessionStorage.token });
-
-        $state.go('dashboard');
         return;
       }
 

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -43,7 +43,7 @@
 
         if ('login' !== $state.current.name) {
           // a bit of a hack to prevent multiple instances of the same notification - cleared on login submit
-          if (! Notifications.session_timed_out) {
+          if (!Notifications.session_timed_out) {
             Notifications.message('danger', '', 'Your session has timed out.', true);
             Notifications.session_timed_out = true;
           }

--- a/spa_ui/self_service/client/app/config/navigation.config.js
+++ b/spa_ui/self_service/client/app/config/navigation.config.js
@@ -47,18 +47,34 @@
     NavCounts.add('marketplace', fetchServiceTemplates, 60 * 1000);
 
     function fetchRequests() {
-      CollectionsApi.query('service_requests').then(lodash.partial(updateCount, 'requests'));
+      var options = {
+        _auto_refresh: true,
+      };
+
+      CollectionsApi.query('service_requests', options)
+        .then(lodash.partial(updateCount, 'requests'));
     }
 
     function fetchServices() {
-      var options = {expand: false, filter: ['service_id>0'] };
-      CollectionsApi.query('services', options).then(lodash.partial(updateServicesCount, 'services'));
+      var options = {
+        expand: false,
+        filter: ['service_id>0'],
+        _auto_refresh: true,
+      };
+
+      CollectionsApi.query('services', options)
+        .then(lodash.partial(updateServicesCount, 'services'));
     }
 
     function fetchServiceTemplates() {
-      var options = {expand: false, filter: ['service_template_catalog_id>0', 'display=true'] };
-      CollectionsApi.query('service_templates', options).then(
-        lodash.partial(updateServiceTemplatesCount, 'marketplace'));
+      var options = {
+        expand: false,
+        filter: ['service_template_catalog_id>0', 'display=true'],
+        _auto_refresh: true,
+      };
+
+      CollectionsApi.query('service_templates', options)
+        .then(lodash.partial(updateServiceTemplatesCount, 'marketplace'));
     }
 
     function updateCount(item, data) {

--- a/spa_ui/self_service/client/app/config/navigation.config.js
+++ b/spa_ui/self_service/client/app/config/navigation.config.js
@@ -48,7 +48,7 @@
 
     function fetchRequests() {
       var options = {
-        _auto_refresh: true,
+        auto_refresh: true,
       };
 
       CollectionsApi.query('service_requests', options)
@@ -59,7 +59,7 @@
       var options = {
         expand: false,
         filter: ['service_id>0'],
-        _auto_refresh: true,
+        auto_refresh: true,
       };
 
       CollectionsApi.query('services', options)
@@ -70,7 +70,7 @@
       var options = {
         expand: false,
         filter: ['service_template_catalog_id>0', 'display=true'],
-        _auto_refresh: true,
+        auto_refresh: true,
       };
 
       CollectionsApi.query('service_templates', options)

--- a/spa_ui/self_service/client/app/resources/collections-api.factory.js
+++ b/spa_ui/self_service/client/app/resources/collections-api.factory.js
@@ -89,7 +89,7 @@
       var config = {};
       options = options || {};
 
-      if (options._auto_refresh) {
+      if (options.auto_refresh) {
         config.headers = {
           'X-Auth-Skip-Token-Renewal': 'true',
         };

--- a/spa_ui/self_service/client/app/resources/collections-api.factory.js
+++ b/spa_ui/self_service/client/app/resources/collections-api.factory.js
@@ -17,7 +17,8 @@
     function query(collection, options) {
       var url = API_BASE + '/api/' + collection;
 
-      return $http.get(url + buildQuery(options)).then(handleSuccess);
+      return $http.get(url + buildQuery(options), buildConfig(options))
+        .then(handleSuccess);
 
       function handleSuccess(response) {
         return response.data;
@@ -27,7 +28,8 @@
     function get(collection, id, options) {
       var url = API_BASE + '/api/' + collection + '/' + id;
 
-      return $http.get(url + buildQuery(options)).then(handleSuccess);
+      return $http.get(url + buildQuery(options), buildConfig(options))
+        .then(handleSuccess);
 
       function handleSuccess(response) {
         return response.data;
@@ -37,7 +39,8 @@
     function post(collection, id, options, data) {
       var url = API_BASE + '/api/' + collection + '/' + id + buildQuery(options);
 
-      return $http.post(url, data).then(handleSuccess);
+      return $http.post(url, data, buildConfig(options))
+        .then(handleSuccess);
 
       function handleSuccess(response) {
         return response.data;
@@ -48,7 +51,6 @@
 
     function buildQuery(options) {
       var params = [];
-
       options = options || {};
 
       if (options.expand) {
@@ -76,11 +78,24 @@
         params.push('sort_options=' + options.sort_options);
       }
 
-      if (0 < params.length) {
+      if (params.length) {
         return '?' + params.join('&');
       }
 
       return '';
+    }
+
+    function buildConfig(options) {
+      var config = {};
+      options = options || {};
+
+      if (options._auto_refresh) {
+        config.headers = {
+          'X-Auth-Skip-Token-Renewal': 'true',
+        };
+      }
+
+      return config;
     }
   }
 })();

--- a/spa_ui/self_service/client/app/services/services.module.js
+++ b/spa_ui/self_service/client/app/services/services.module.js
@@ -1,5 +1,7 @@
 (function() {
   'use strict';
 
-  angular.module('app.services', []);
+  angular.module('app.services', [
+    'ngStorage',
+  ]);
 })();

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -16,7 +16,8 @@
       create: create,
       destroy: destroy,
       active: active,
-      currentUser: currentUser
+      currentUser: currentUser,
+      loadUser: loadUser,
     };
 
     destroy();
@@ -34,6 +35,13 @@
       model.user = {};
       delete $http.defaults.headers.common['X-Auth-Token'];
       delete $sessionStorage.token;
+    }
+
+    function loadUser() {
+      return $http.get('/api')
+        .then(function(response) {
+          currentUser(response.data.identity);
+        });
     }
 
     function currentUser(user) {

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -8,7 +8,6 @@
   function SessionFactory($http, moment, $sessionStorage) {
     var model = {
       token: null,
-      expiresOn: moment().subtract(1, 'seconds'),
       user: {}
     };
 
@@ -26,14 +25,12 @@
 
     function create(data) {
       model.token = data.auth_token;
-      model.expiresOn = moment(data.expires_on);
       $http.defaults.headers.common['X-Auth-Token'] = model.token;
       $sessionStorage.token = model.token;
     }
 
     function destroy() {
       model.token = null;
-      model.expiresOn = moment().subtract(1, 'seconds');
       model.user = {};
       delete $http.defaults.headers.common['X-Auth-Token'];
       delete $sessionStorage.token;
@@ -50,7 +47,8 @@
     // Helpers
 
     function active() {
-      return model.token && model.expiresOn.isAfter();
+      // may not be current, but if we have one, we'll rely on API 401ing if it's not
+      return model.token;
     }
   }
 })();

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -5,7 +5,7 @@
     .factory('Session', SessionFactory);
 
   /** @ngInject */
-  function SessionFactory($http, moment) {
+  function SessionFactory($http, moment, $sessionStorage) {
     var model = {
       token: null,
       expiresOn: moment().subtract(1, 'seconds'),
@@ -28,6 +28,7 @@
       model.token = data.auth_token;
       model.expiresOn = moment(data.expires_on);
       $http.defaults.headers.common['X-Auth-Token'] = model.token;
+      $sessionStorage.token = model.token;
     }
 
     function destroy() {
@@ -35,6 +36,7 @@
       model.expiresOn = moment().subtract(1, 'seconds');
       model.user = {};
       delete $http.defaults.headers.common['X-Auth-Token'];
+      delete $sessionStorage.token;
     }
 
     function currentUser(user) {

--- a/spa_ui/self_service/client/app/states/dashboard/dashboard.state.spec.js
+++ b/spa_ui/self_service/client/app/states/dashboard/dashboard.state.spec.js
@@ -13,7 +13,6 @@ describe('Dashboard', function() {
 
     Session.create({
       auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-      expires_on: d + 'Z'
     });
     $httpBackend.whenGET('').respond(200);
   });

--- a/spa_ui/self_service/client/app/states/login/login.state.js
+++ b/spa_ui/self_service/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session, Notifications) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session) {
     var vm = this;
 
     vm.title = 'Login';
@@ -41,7 +41,7 @@
 
     function onSubmit() {
       // clearing a flag that *could* have been set before redirect to /login
-      Notifications.session_timed_out = false;
+      Session.timeout_notified = false;
 
       return AuthenticationApi.login(vm.credentials.login, vm.credentials.password)
         .then(Session.loadUser)

--- a/spa_ui/self_service/client/app/states/login/login.state.js
+++ b/spa_ui/self_service/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, CollectionsApi, Session, Notifications) {
     var vm = this;
 
     vm.title = 'Login';
@@ -40,6 +40,9 @@
     vm.onSubmit = onSubmit;
 
     function onSubmit() {
+      // clearing a flag that *could* have been set before redirect to /login
+      Notifications.session_timed_out = false;
+
       return AuthenticationApi.login(vm.credentials.login, vm.credentials.password)
         .then(Session.loadUser)
         .then(function() {

--- a/spa_ui/self_service/client/app/states/login/login.state.js
+++ b/spa_ui/self_service/client/app/states/login/login.state.js
@@ -40,22 +40,11 @@
     vm.onSubmit = onSubmit;
 
     function onSubmit() {
-      AuthenticationApi.login(vm.credentials.login, vm.credentials.password).then(handleSuccess);
-
-      function handleSuccess() {
-        var options = {expand: 'resources', filter: ['userid=' + vm.credentials.login]};
-
-        CollectionsApi.query('users', options).then(handleUserInfo);
-        $state.go('dashboard');
-
-        function handleUserInfo(data) {
-          if (!data.resources || 0 === data.resources.length) {
-            return Session.currentUser({name: 'Unknown User', email: ''});
-          }
-
-          Session.currentUser({name: data.resources[0].name, email: data.resources[0].email});
-        }
-      }
+      return AuthenticationApi.login(vm.credentials.login, vm.credentials.password)
+        .then(Session.loadUser)
+        .then(function() {
+          $state.go('dashboard');
+        });
     }
   }
 })();

--- a/spa_ui/self_service/client/index.html
+++ b/spa_ui/self_service/client/index.html
@@ -23,11 +23,11 @@
   </style>
   <!-- build:css styles/lib.css -->
   <!-- bower:css -->
-  <link rel="stylesheet" href="/bower_components/toastr/toastr.css" />
-  <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly.css" />
-  <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly-additions.css" />
   <link rel="stylesheet" href="/bower_components/angular-patternfly/dist/styles/angular-patternfly.css" />
   <link rel="stylesheet" href="/bower_components/ngprogress/ngProgress.css" />
+  <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly.css" />
+  <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly-additions.css" />
+  <link rel="stylesheet" href="/bower_components/toastr/toastr.css" />
   <!-- endbower -->
   <!-- endbuild -->
 
@@ -49,24 +49,25 @@
   <!-- build:js js/lib.js -->
   <!-- bower:js -->
   <script src="/bower_components/jquery/dist/jquery.js"></script>
+  <script src="/bower_components/angular/angular.js"></script>
+  <script src="/bower_components/angular-animate/angular-animate.js"></script>
+  <script src="/bower_components/angular-base64/angular-base64.js"></script>
+  <script src="/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+  <script src="/bower_components/angular-messages/angular-messages.js"></script>
+  <script src="/bower_components/angular-mocks/angular-mocks.js"></script>
+  <script src="/bower_components/angular-patternfly/dist/angular-patternfly.js"></script>
+  <script src="/bower_components/angular-resource/angular-resource.js"></script>
+  <script src="/bower_components/angular-sanitize/angular-sanitize.js"></script>
+  <script src="/bower_components/angular-ui-router/release/angular-ui-router.js"></script>
   <script src="/bower_components/lodash/lodash.js"></script>
   <script src="/bower_components/moment/moment.js"></script>
-  <script src="/bower_components/toastr/toastr.js"></script>
-  <script src="/bower_components/angular/angular.js"></script>
-  <script src="/bower_components/angular-resource/angular-resource.js"></script>
-  <script src="/bower_components/angular-animate/angular-animate.js"></script>
-  <script src="/bower_components/angular-sanitize/angular-sanitize.js"></script>
-  <script src="/bower_components/angular-messages/angular-messages.js"></script>
-  <script src="/bower_components/angular-ui-router/release/angular-ui-router.js"></script>
-  <script src="/bower_components/angular-mocks/angular-mocks.js"></script>
+  <script src="/bower_components/ngprogress/build/ngprogress.js"></script>
+  <script src="/bower_components/ngstorage/ngStorage.js"></script>
   <script src="/bower_components/patternfly/components/bootstrap/dist/js/bootstrap.js"></script>
   <script src="/bower_components/patternfly/components/bootstrap-datepicker/dist/js/bootstrap-datepicker.js"></script>
   <script src="/bower_components/patternfly/components/bootstrap-select/dist/js/bootstrap-select.js"></script>
   <script src="/bower_components/patternfly/dist/js/patternfly.js"></script>
-  <script src="/bower_components/angular-patternfly/dist/angular-patternfly.js"></script>
-  <script src="/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-  <script src="/bower_components/angular-base64/angular-base64.js"></script>
-  <script src="/bower_components/ngprogress/build/ngprogress.js"></script>
+  <script src="/bower_components/toastr/toastr.js"></script>
   <!-- endbower -->
   <!-- endbuild -->
 


### PR DESCRIPTION
Changes in SSUI:

   * when you push reload, previously it would just go to the login screen, now it goes to the same screen as before (but any state not bound to the url (and authentication token) is lost)
   * token is remembered in sessionStorage
   * logged in user info is no longer retrieved from the user collection on login, but from the /api/ .identity field, on reload or login - added Session.loadUser()
   * the full name of the currently logged in user is shown by the icon, not only on hover
   * the autorefresh requests are now sent with a new X-Auth-Skip-Token-Renewal: true header, but anything triggered by user action doesn't have it
   * removed broken expiresOn logic from client (was from before the api started resetting token expiration), we now rely on 401 responses for that
   * the "session timed out" notification is only shown once when redirected to the login screen, previously it would create a new one for each failing request (so typically 3 at once)

Changes in API:

   * do not reset token expiration if X-Auth-Skip-Token-Renewal is sent (with the value of "true")

Changes in tooling:

   * removed the `disallowTrailingComma` rule for jscs, we're no longer targetting old-IE so there's no longer reason for that
   * extended line lenght limit to 140 characters (from 120) - related: jscs-dev/node-jscs#2032

Note:

   * the bower.json / index.html churn is caused by current version of bower sorting the dependencies - the only real change is adding ngStorage


https://bugzilla.redhat.com/show_bug.cgi?id=1285284