### PR TITLE
Remove ui_lookup_for_availability_zone_types() and use gettext instead

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1176,11 +1176,6 @@ module ApplicationHelper
     attributes
   end
 
-  def title_for_availability_zones(plural = false)
-    key = "availability_zone"
-    ui_lookup(:availability_zone_types => plural ? key.pluralize : key)
-  end
-
   def title_for_hosts
     title_for_host(true)
   end

--- a/app/views/availability_zone/_main.html.haml
+++ b/app/views/availability_zone/_main.html.haml
@@ -3,5 +3,5 @@
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
   .col-md-12.col-lg-6
-    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %s") % title_for_availability_zones, :items => textual_group_availability_zone_totals}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for Availability Zone"), :items => textual_group_availability_zone_totals}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -789,10 +789,6 @@ en:
       write_hit_ios_per_sec:       Write Hit (IOPS)
       write_ios_per_sec:           Write (IOPS)
 
-    availability_zone_types:
-      availability_zone:     Availability Zone
-      availability_zones:    Availability Zones
-
     compare:
       Host:         Host Properties
       Vm:           VM Properties

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -84,8 +84,6 @@ module Vmdb
         ui_lookup_for_ems_cluster_types(options[:ems_cluster_types])
       elsif options[:ui_title]
         ui_lookup_for_title(options[:ui_title])
-      elsif options[:availability_zone_types]
-        ui_lookup_for_availability_zone_types(options[:availability_zone_types])
       else
         ''
       end
@@ -110,10 +108,6 @@ module Vmdb
 
     def ui_lookup_for_title(text)
       Dictionary.gettext(text, :type => :ui_title, :notfound => :titleize)
-    end
-
-    def ui_lookup_for_availability_zone_types(text)
-      Dictionary.gettext(text, :type => :availability_zone_types, :notfound => :titleize)
     end
 
     # Wrap a report html table body with html table tags and headers for the columns


### PR DESCRIPTION
This is part of effort leading towards complete ui_lookup() removal
and its replacement with gettext.

Part of: #5907