### PR TITLE
Reset @display to 'main' when viewing list of associations.

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -534,6 +534,7 @@ module ApplicationController::CiProcessing
     # generate the grid/tile/list url to come back here when gtl buttons are pressed
     @gtl_url       = "/#{@db}/#{@listicon.pluralize}/#{@record.id}?"
     @showtype      = "details"
+    @display       = "main"
     @no_checkboxes = true
     @showlinks     = true
 

--- a/spec/views/host/_show.html.haml_spec.rb
+++ b/spec/views/host/_show.html.haml_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+include ApplicationHelper
+
+describe "host/show.html.haml" do
+  shared_examples_for "miq_before_onload JS is needed" do
+    it "renders proper JS" do
+      js_string = "var miq_after_onload = \"miqAsyncAjax('/host/#{action}/#{host.id}');\""
+      render
+      rendered.should include(js_string)
+    end
+  end
+
+  # TODO: For speed, replace next line with active_record_instance_double when available
+  let(:host) { FactoryGirl.create(:host_vmware, :name => 'My Host') }
+  let(:action) { 'index' }
+
+  before do
+    assign(:record, host)
+    assign(:ajax_action, action)
+    assign(:showtype, showtype)
+  end
+
+  context "when showtype is 'performance'" do
+    let(:showtype) { "performance" }
+
+    before do
+      assign(:perf_options, :chart_type => :performance)
+    end
+
+    it_behaves_like "miq_before_onload JS is needed"
+  end
+
+  context "when showtype is 'timeline'" do
+    let(:showtype) { "timeline" }
+
+    before do
+      assign(:tl_options, {})
+    end
+
+    it_behaves_like "miq_before_onload JS is needed"
+  end
+
+  context "when showtype is 'details'" do
+    let(:showtype) { "details" }
+    let(:display) { "main" }
+
+    it "should render gtl view" do
+      assign(:lastaction, "host_services")
+      assign(:view, OpenStruct.new(:table => OpenStruct.new(:data => [])))
+      render
+      expect(view).to render_template(partial: 'layouts/gtl', :locals => {:action_url => 'host_services'})
+    end
+  end
+end


### PR DESCRIPTION
Fixed show details method to set @display to 'main' to fix links to associations from Host summary screen

https://bugzilla.redhat.com/show_bug.cgi?id=1290403
https://bugzilla.redhat.com/show_bug.cgi?id=1292581
https://bugzilla.redhat.com/show_bug.cgi?id=1292580

@dclarizio please review.