### PR TITLE
Fix Incorrect Usage of MemoryBuffer in XFS AllocationGroup

### DIFF
--- a/gems/pending/fs/xfs/allocation_group.rb
+++ b/gems/pending/fs/xfs/allocation_group.rb
@@ -115,7 +115,6 @@ module XFS
       @stream.seek(AG_INODEINFO_SIZE, IO::SEEK_CUR)
       @agfl                   = AG_FREELIST.decode(@stream.read(AG_FREELIST_SIZE))
       @stream.seek(-(AG_FREESPACE_SIZE + AG_INODEINFO_SIZE + AG_FREELIST_SIZE))
-      @allocation_group_block = MemoryBuffer.create(sb['block_size'])
       @allocation_group_block = @stream.read(sb['block_size'])
 
       # Grab some quick facts & make sure there's nothing wrong. Tight qualification.


### PR DESCRIPTION
The AllocationGroup code in XFS initializes a MemoryBuffer
via MemoryBuffer.create and then uses the local variable
pointing to the buffer for the data read from the XFS filesystem,
discarding the newly allocated buffer.
We now read the data directly into the buffer so the space is not wasted.

@roliveri @Fryguy @chessbyte please review this simple fix.  Thanks.