### PR TITLE
Remove Sat 5 from the Red Hat Updates screen

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -11,7 +11,6 @@ module OpsController::Settings::RHN
 
   SUBSCRIPTION_TYPES =
     [['Red Hat Subscription Management', 'sm_hosted'],
-     ['Red Hat Satellite 5',             'rhn_satellite'],
      ['Red Hat Satellite 6',             'rhn_satellite6']]
 
   def rhn_subscription_types


### PR DESCRIPTION
Remove Sat 5 from the Red Hat Updates screen as it is no longer supported

https://bugzilla.redhat.com/show_bug.cgi?id=1291872