### PR TITLE
RSpec 3 conversion: Services and Support

### DIFF
--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -7,19 +7,19 @@ describe AutomateImportService do
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload", :id => 42) }
 
     before do
-      ImportFileUpload.stub(:find).with("42").and_return(import_file_upload)
-      import_file_upload.stub(:destroy)
+      allow(ImportFileUpload).to receive(:find).with("42").and_return(import_file_upload)
+      allow(import_file_upload).to receive(:destroy)
 
-      MiqQueue.stub(:unqueue)
+      allow(MiqQueue).to receive(:unqueue)
     end
 
     it "destroys the import file upload" do
-      import_file_upload.should_receive(:destroy)
+      expect(import_file_upload).to receive(:destroy)
       automate_import_service.cancel_import("42")
     end
 
     it "destroys the queued deletion" do
-      MiqQueue.should_receive(:unqueue).with(
+      expect(MiqQueue).to receive(:unqueue).with(
         :class_name  => "ImportFileUpload",
         :instance_id => 42,
         :method_name => "destroy"
@@ -41,43 +41,43 @@ describe AutomateImportService do
         "overwrite" => true,
         "zip_file"  => "automate_temporary_zip.zip"
       }
-      MiqAeImport.stub(:new).with("carrot", import_options).and_return(miq_ae_import)
-      miq_ae_import.stub(:remove_unrelated_entries)
-      miq_ae_import.stub(:all_namespace_files).and_return([
+      allow(MiqAeImport).to receive(:new).with("carrot", import_options).and_return(miq_ae_import)
+      allow(miq_ae_import).to receive(:remove_unrelated_entries)
+      allow(miq_ae_import).to receive(:all_namespace_files).and_return([
         removable_entry,
         double(:name => "something_else/carrot"),
       ])
-      miq_ae_import.stub(:all_class_files).and_return([
+      allow(miq_ae_import).to receive(:all_class_files).and_return([
         removable_class_entry,
         double(:name => "something_else/carrot.class/class.yaml")
       ])
-      miq_ae_import.stub(:remove_entry)
-      miq_ae_import.stub(:update_sorted_entries)
-      miq_ae_import.stub(:import)
+      allow(miq_ae_import).to receive(:remove_entry)
+      allow(miq_ae_import).to receive(:update_sorted_entries)
+      allow(miq_ae_import).to receive(:import)
     end
 
     it "removes unrelated entries" do
-      miq_ae_import.should_receive(:remove_unrelated_entries).with("carrot")
+      expect(miq_ae_import).to receive(:remove_unrelated_entries).with("carrot")
       automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
     end
 
     it "removes the correct namespace file" do
-      miq_ae_import.should_receive(:remove_entry).with(removable_entry)
+      expect(miq_ae_import).to receive(:remove_entry).with(removable_entry)
       automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
     end
 
     it "removes the correct class file" do
-      miq_ae_import.should_receive(:remove_entry).with(removable_class_entry)
+      expect(miq_ae_import).to receive(:remove_entry).with(removable_class_entry)
       automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
     end
 
     it "updates the sorted entries" do
-      miq_ae_import.should_receive(:update_sorted_entries)
+      expect(miq_ae_import).to receive(:update_sorted_entries)
       automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
     end
 
     it "calls import" do
-      miq_ae_import.should_receive(:import)
+      expect(miq_ae_import).to receive(:import)
       automate_import_service.import_datastore(import_file_upload, "carrot", "potato", ["starch"])
     end
 
@@ -104,13 +104,13 @@ describe AutomateImportService do
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload", :id => 42).as_null_object }
 
     before do
-      ImportFileUpload.stub(:create).and_return(import_file_upload)
-      import_file_upload.stub(:store_binary_data_as_yml)
-      MiqQueue.stub(:put)
+      allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      allow(import_file_upload).to receive(:store_binary_data_as_yml)
+      allow(MiqQueue).to receive(:put)
     end
 
     it "stores the data" do
-      import_file_upload.should_receive(:store_binary_data_as_yml).with("the data", "Automate import")
+      expect(import_file_upload).to receive(:store_binary_data_as_yml).with("the data", "Automate import")
       automate_import_service.store_for_import("the data")
     end
 
@@ -120,7 +120,7 @@ describe AutomateImportService do
 
     it "queues a deletion" do
       Timecop.freeze(2014, 3, 5) do
-        MiqQueue.should_receive(:put).with(
+        expect(MiqQueue).to receive(:put).with(
           :class_name  => "ImportFileUpload",
           :instance_id => 42,
           :deliver_on  => 1.day.from_now,

--- a/spec/services/charts_layout_service_spec.rb
+++ b/spec/services/charts_layout_service_spec.rb
@@ -17,17 +17,17 @@ describe ChartsLayoutService do
   describe "#layout" do
     it "returns layout for specific class if exists" do
       chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
-      chart.should == host_openstack_infra_chart
+      expect(chart).to eq(host_openstack_infra_chart)
     end
 
     it "returns layout for fname if specific class does not exist" do
       chart = ChartsLayoutService.layout(host_redhat,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'Host')
-      chart.should == host_chart
+      expect(chart).to eq(host_chart)
     end
 
     it "returns base layout if fname is missing" do
       chart = ChartsLayoutService.layout(host_openstack_infra,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_util_charts')
-      chart.should == layout_chart
+      expect(chart).to eq(layout_chart)
     end
   end
 
@@ -35,17 +35,17 @@ describe ChartsLayoutService do
     it "shows CPU (%) by default for VmOpenstack" do
       # By default percent is visible and mhz not
       chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
-      chart.count { |x| x[:title] == "CPU (%)" }.should equal 1
-      chart.count { |x| x[:title] == "CPU (Mhz)" }.should equal 0
+      expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 1
+      expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 0
     end
 
     it "shows CPU (Mhz) instead of CPU (%), when applies_to_method methods are changed" do
       # Stub it so mhz is visible and percent not
-      vm_openstack.stub(:cpu_percent_available?).and_return(false)
-      vm_openstack.stub(:cpu_mhz_available?).and_return(true)
+      allow(vm_openstack).to receive(:cpu_percent_available?).and_return(false)
+      allow(vm_openstack).to receive(:cpu_mhz_available?).and_return(true)
       chart = ChartsLayoutService.layout(vm_openstack,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
-      chart.count { |x| x[:title] == "CPU (%)" }.should equal 0
-      chart.count { |x| x[:title] == "CPU (Mhz)" }.should equal 1
+      expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 0
+      expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 1
     end
   end
 end

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -11,7 +11,7 @@ describe ContainerTopologyService do
 
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
-      container_topology_service.stub(:retrieve_providers).and_return([FactoryGirl.create(:ems_kubernetes)])
+      allow(container_topology_service).to receive(:retrieve_providers).and_return([FactoryGirl.create(:ems_kubernetes)])
       expect(container_topology_service.build_kinds.keys).to match_array([:Container, :Host, :Kubernetes, :Node, :Pod, :Replicator, :Route, :Service, :VM])
     end
   end
@@ -46,7 +46,7 @@ describe ContainerTopologyService do
                                 :hardware => hardware)
       vm_rhev.update_attributes(:host => host, :raw_power_state => "up")
 
-      container_topology_service.stub(:retrieve_providers).and_return([ems_kube])
+      allow(container_topology_service).to receive(:retrieve_providers).and_return([ems_kube])
       container_replicator = ContainerReplicator.create(:ext_management_system => ems_kube,
                                                         :ems_ref => "8f8ca74c-3a41-11e5-a79a-001a4a231290",
                                                         :name => "replicator1")
@@ -141,7 +141,7 @@ describe ContainerTopologyService do
     it "topology contains the expected structure when vm is off" do
       # vm and host test cross provider correlation to infra provider
       vm_rhev.update_attributes(:raw_power_state => "down")
-      container_topology_service.stub(:retrieve_providers).and_return([ems_kube])
+      allow(container_topology_service).to receive(:retrieve_providers).and_return([ems_kube])
 
       container_group = ContainerGroup.create(:ext_management_system => ems_kube, :container_node => container_node,
                                               :name => "myPod", :ems_ref => "96c35ccd-3e00-11e5-a0d2-18037327aaeb",
@@ -149,7 +149,7 @@ describe ContainerTopologyService do
       container_service = ContainerService.create(:ext_management_system => ems_kube, :container_groups => [container_group],
                                                   :ems_ref => "95e49048-3e00-11e5-a0d2-18037327aaeb",
                                                   :name => "service1")
-      container_topology_service.stub(:entities).and_return([[container_node], [container_service]])
+      allow(container_topology_service).to receive(:entities).and_return([[container_node], [container_service]])
 
       expect(subject[:items]).to eq(
         "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id       => container_node.ems_ref,

--- a/spec/services/miq_policy_import_service_spec.rb
+++ b/spec/services/miq_policy_import_service_spec.rb
@@ -7,10 +7,10 @@ describe MiqPolicyImportService do
 
   describe "#cancel_import" do
     before do
-      import_file_upload.stub(:destroy)
-      miq_queue.stub(:destroy)
-      ImportFileUpload.stub(:find).with(123).and_return(import_file_upload)
-      MiqQueue.stub(:first).with(
+      allow(import_file_upload).to receive(:destroy)
+      allow(miq_queue).to receive(:destroy)
+      allow(ImportFileUpload).to receive(:find).with(123).and_return(import_file_upload)
+      allow(MiqQueue).to receive(:first).with(
         :conditions => {
           :class_name  => "ImportFileUpload",
           :instance_id => 123,
@@ -20,25 +20,25 @@ describe MiqPolicyImportService do
     end
 
     it "destroys the import file upload" do
-      import_file_upload.should_receive(:destroy)
+      expect(import_file_upload).to receive(:destroy)
       miq_policy_import_service.cancel_import(123)
     end
 
     it "destroys the queue item" do
-      miq_queue.should_receive(:destroy)
+      expect(miq_queue).to receive(:destroy)
       miq_policy_import_service.cancel_import(123)
     end
   end
 
   describe "#import_policy" do
     before do
-      import_file_upload.stub(:destroy)
-      import_file_upload.stub(:uploaded_yaml_content).and_return("upload_content")
-      miq_queue.stub(:destroy)
+      allow(import_file_upload).to receive(:destroy)
+      allow(import_file_upload).to receive(:uploaded_yaml_content).and_return("upload_content")
+      allow(miq_queue).to receive(:destroy)
 
-      ImportFileUpload.stub(:find).with(123).and_return(import_file_upload)
-      MiqPolicy.stub(:import_from_array)
-      MiqQueue.stub(:first).with(
+      allow(ImportFileUpload).to receive(:find).with(123).and_return(import_file_upload)
+      allow(MiqPolicy).to receive(:import_from_array)
+      allow(MiqQueue).to receive(:first).with(
         :conditions => {
           :class_name  => "ImportFileUpload",
           :instance_id => 123,
@@ -48,17 +48,17 @@ describe MiqPolicyImportService do
     end
 
     it "imports the policy using MiqPolicy" do
-      MiqPolicy.should_receive(:import_from_array).with("upload_content", :save => true)
+      expect(MiqPolicy).to receive(:import_from_array).with("upload_content", :save => true)
       miq_policy_import_service.import_policy(123)
     end
 
     it "destroys the import file upload" do
-      import_file_upload.should_receive(:destroy)
+      expect(import_file_upload).to receive(:destroy)
       miq_policy_import_service.import_policy(123)
     end
 
     it "destroys the queue item" do
-      miq_queue.should_receive(:destroy)
+      expect(miq_queue).to receive(:destroy)
       miq_policy_import_service.import_policy(123)
     end
   end
@@ -69,23 +69,23 @@ describe MiqPolicyImportService do
 
     context "when the import does not raise an error" do
       before do
-        MiqPolicy.stub(:import).with("file contents", :preview => true).and_return(:uploaded => "content")
-        MiqQueue.stub(:put_or_update)
-        ImportFileUpload.stub(:create).and_return(import_file_upload)
+        allow(MiqPolicy).to receive(:import).with("file contents", :preview => true).and_return(:uploaded => "content")
+        allow(MiqQueue).to receive(:put_or_update)
+        allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
       end
 
       it "stores the import file upload" do
-        import_file_upload.should_receive(:store_binary_data_as_yml).with("---\n:uploaded: content\n", "Policy import")
+        expect(import_file_upload).to receive(:store_binary_data_as_yml).with("---\n:uploaded: content\n", "Policy import")
         miq_policy_import_service.store_for_import(file_contents)
       end
 
       it "returns the import file upload" do
-        miq_policy_import_service.store_for_import(file_contents).should == import_file_upload
+        expect(miq_policy_import_service.store_for_import(file_contents)).to eq(import_file_upload)
       end
 
       it "queues deletion of the object" do
         Timecop.freeze(2014, 3, 4) do
-          MiqQueue.should_receive(:put_or_update).with(
+          expect(MiqQueue).to receive(:put_or_update).with(
             :class_name  => "ImportFileUpload",
             :instance_id => 1,
             :deliver_on  => 1.day.from_now,
@@ -98,7 +98,7 @@ describe MiqPolicyImportService do
 
     context "when the import does raise an error" do
       before do
-        MiqPolicy.stub(:import).with("file contents", :preview => true).and_raise
+        allow(MiqPolicy).to receive(:import).with("file contents", :preview => true).and_raise
       end
 
       it "reraises an InvalidMiqPolicyYaml error with a message" do

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -10,13 +10,13 @@ describe OrchestrationTemplateDialogService do
     it "creates a dialog from hot template with stack basic info and parameters" do
       dialog = dialog_service.create_dialog("test", template_hot)
 
-      dialog.should have_attributes(
+      expect(dialog).to have_attributes(
         :label   => "test",
         :buttons => "submit,cancel"
       )
 
       tabs = dialog.dialog_tabs
-      tabs.size.should == 1
+      expect(tabs.size).to eq(1)
       assert_stack_tab(tabs[0])
     end
 
@@ -41,7 +41,7 @@ describe OrchestrationTemplateDialogService do
     assert_tab_attributes(tab)
 
     groups = tab.dialog_groups
-    groups.size.should == 3
+    expect(groups.size).to eq(3)
 
     assert_aws_openstack_stack_group(groups[0])
     assert_parameter_group1(groups[1])
@@ -49,22 +49,22 @@ describe OrchestrationTemplateDialogService do
   end
 
   def assert_tab_attributes(tab)
-    tab.should have_attributes(
+    expect(tab).to have_attributes(
       :label   => "Basic Information",
       :display => "edit"
     )
   end
 
   def assert_aws_openstack_stack_group(group)
-    group.should have_attributes(
+    expect(group).to have_attributes(
       :label   => "Options",
       :display => "edit",
     )
 
     fields = group.dialog_fields
-    fields.size.should == 4
+    expect(fields.size).to eq(4)
 
-    fields[0].resource_action.fqname.should == "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
     assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
@@ -72,15 +72,15 @@ describe OrchestrationTemplateDialogService do
   end
 
   def assert_azure_stack_group(group)
-    group.should have_attributes(
+    expect(group).to have_attributes(
       :label   => "Options",
       :display => "edit",
     )
 
     fields = group.dialog_fields
-    fields.size.should == 5
+    expect(fields.size).to eq(5)
 
-    fields[0].resource_action.fqname.should == "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",        :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
     assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
@@ -89,18 +89,18 @@ describe OrchestrationTemplateDialogService do
   end
 
   def assert_field(field, clss, attributes)
-    field.should be_kind_of clss
-    field.should have_attributes(attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
   end
 
   def assert_parameter_group1(group)
-    group.should have_attributes(
+    expect(group).to have_attributes(
       :label   => "General parameters",
       :display => "edit",
     )
 
     fields = group.dialog_fields
-    fields.size.should == 3
+    expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
     assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
@@ -108,13 +108,13 @@ describe OrchestrationTemplateDialogService do
   end
 
   def assert_parameter_group2(group)
-    group.should have_attributes(
+    expect(group).to have_attributes(
       :label   => "DB parameters",
       :display => "edit",
     )
 
     fields = group.dialog_fields
-    fields.size.should == 3
+    expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox,     :name => "param_admin_pass", :validator_rule => '[a-zA-Z0-9]+')
     assert_field(fields[1], DialogFieldTextBox,     :name => "param_db_port",    :label => 'Port Number')

--- a/spec/services/privilege_checker_service_spec.rb
+++ b/spec/services/privilege_checker_service_spec.rb
@@ -7,7 +7,7 @@ describe PrivilegeCheckerService do
   describe "#valid_session?" do
     shared_examples_for "PrivilegeCheckerService#valid_session? that returns false" do
       it "returns false" do
-        privilege_checker.valid_session?(session, user).should be_false
+        expect(privilege_checker.valid_session?(session, user)).to be_falsey
       end
     end
 
@@ -38,7 +38,7 @@ describe PrivilegeCheckerService do
         let(:server) { active_record_instance_double("MiqServer", :logon_status => logon_status) }
 
         before do
-          MiqServer.stub(:my_server).with(true).and_return(server)
+          allow(MiqServer).to receive(:my_server).with(true).and_return(server)
         end
 
         context "when the server is not ready" do
@@ -51,7 +51,7 @@ describe PrivilegeCheckerService do
           let(:logon_status) { :ready }
 
           it "returns true" do
-            privilege_checker.valid_session?(session, user).should be_true
+            expect(privilege_checker.valid_session?(session, user)).to be_truthy
           end
         end
       end
@@ -72,7 +72,7 @@ describe PrivilegeCheckerService do
         let(:last_trans_time) { 2.hours.ago }
 
         it "returns true" do
-          privilege_checker.user_session_timed_out?(session, user).should be_true
+          expect(privilege_checker.user_session_timed_out?(session, user)).to be_truthy
         end
       end
 
@@ -80,7 +80,7 @@ describe PrivilegeCheckerService do
         let(:last_trans_time) { Time.current }
 
         it "returns false" do
-          privilege_checker.user_session_timed_out?(session, user).should be_false
+          expect(privilege_checker.user_session_timed_out?(session, user)).to be_falsey
         end
       end
     end
@@ -90,7 +90,7 @@ describe PrivilegeCheckerService do
       let(:last_trans_time) { nil }
 
       it "returns false" do
-        privilege_checker.user_session_timed_out?(session, user).should be_false
+        expect(privilege_checker.user_session_timed_out?(session, user)).to be_falsey
       end
     end
   end

--- a/spec/services/request_referer_service_spec.rb
+++ b/spec/services/request_referer_service_spec.rb
@@ -26,7 +26,7 @@ describe RequestRefererService do
       let(:string_to_test) { "Potato" }
 
       it "returns true" do
-        request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action).should be_true
+        expect(request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action)).to be_truthy
       end
     end
 
@@ -34,7 +34,7 @@ describe RequestRefererService do
       let(:string_to_test) { "Tomato" }
 
       it "returns false" do
-        request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action).should be_false
+        expect(request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action)).to be_falsey
       end
 
       describe "when the controller and action are on the IE8 exception list" do
@@ -44,7 +44,7 @@ describe RequestRefererService do
         let(:action)         { "download_data" }
 
         it "returns true" do
-          request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action).should be_true
+          expect(request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action)).to be_truthy
         end
       end
 
@@ -55,7 +55,7 @@ describe RequestRefererService do
         let(:action)         { "SpuddaFett" }
 
         it "returns false" do
-          request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action).should be_false
+          expect(request_referer_service.referer_valid?(referer, string_to_test, useragent, controller, action)).to be_falsey
         end
       end
     end
@@ -63,25 +63,25 @@ describe RequestRefererService do
 
   describe '#access_whitelisted?' do
     it "allows only GET" do
-      request_referer_service.access_whitelisted?(get_request,   controller_name, action_name).should be_true
-      request_referer_service.access_whitelisted?(post_request,  controller_name, action_name).should be_false
+      expect(request_referer_service.access_whitelisted?(get_request,   controller_name, action_name)).to be_truthy
+      expect(request_referer_service.access_whitelisted?(post_request,  controller_name, action_name)).to be_falsey
     end
 
     it "allows only whitelistet entry points" do
-      request_referer_service.access_whitelisted?(get_request, controller_name, dissallowed_action_name).should be_false
-      request_referer_service.access_whitelisted?(get_request, dissallowed_controller_name, action_name).should be_false
+      expect(request_referer_service.access_whitelisted?(get_request, controller_name, dissallowed_action_name)).to be_falsey
+      expect(request_referer_service.access_whitelisted?(get_request, dissallowed_controller_name, action_name)).to be_falsey
     end
 
     it "requires an 'id' when specified" do
-      request_referer_service.access_whitelisted?(get_request_no_id, controller_name, action_name).should be_false
+      expect(request_referer_service.access_whitelisted?(get_request_no_id, controller_name, action_name)).to be_falsey
     end
 
     it "requires no params, where none specified" do
-      request_referer_service.access_whitelisted?(get_request_no_id, controller_name_no_params, action_name_no_params).should be_true
+      expect(request_referer_service.access_whitelisted?(get_request_no_id, controller_name_no_params, action_name_no_params)).to be_truthy
     end
 
     it "disallows xml_http requests" do
-      request_referer_service.access_whitelisted?(get_request_xml_http, controller_name, action_name).should be_false
+      expect(request_referer_service.access_whitelisted?(get_request_xml_http, controller_name, action_name)).to be_falsey
     end
   end
 end

--- a/spec/services/widget_import_service_spec.rb
+++ b/spec/services/widget_import_service_spec.rb
@@ -5,7 +5,7 @@ describe WidgetImportService do
   let(:widget_import_validator) { auto_loaded_instance_double("WidgetImportValidator") }
 
   before do
-    MiqServer.stub(:my_server).and_return(active_record_instance_double("MiqServer", :zone_id => 1))
+    allow(MiqServer).to receive(:my_server).and_return(active_record_instance_double("MiqServer", :zone_id => 1))
   end
 
   describe "#cancel_import" do
@@ -13,19 +13,19 @@ describe WidgetImportService do
     let(:miq_queue) { active_record_instance_double("MiqQueue") }
 
     before do
-      ImportFileUpload.stub(:find).with("42").and_return(import_file_upload)
-      import_file_upload.stub(:destroy)
+      allow(ImportFileUpload).to receive(:find).with("42").and_return(import_file_upload)
+      allow(import_file_upload).to receive(:destroy)
 
-      MiqQueue.stub(:unqueue)
+      allow(MiqQueue).to receive(:unqueue)
     end
 
     it "destroys the import file upload" do
-      import_file_upload.should_receive(:destroy)
+      expect(import_file_upload).to receive(:destroy)
       widget_import_service.cancel_import("42")
     end
 
     it "destroys the queued deletion" do
-      MiqQueue.should_receive(:unqueue).with(
+      expect(MiqQueue).to receive(:unqueue).with(
         :class_name  => "ImportFileUpload",
         :instance_id => 42,
         :method_name => "destroy"
@@ -88,18 +88,18 @@ describe WidgetImportService do
     end
 
     before do
-      import_file_upload.stub(:destroy)
-      MiqQueue.stub(:unqueue)
+      allow(import_file_upload).to receive(:destroy)
+      allow(MiqQueue).to receive(:unqueue)
     end
 
     shared_examples_for "WidgetImportService#import_widgets that destroys temporary data" do
       it "destroys the import file upload" do
-        import_file_upload.should_receive(:destroy)
+        expect(import_file_upload).to receive(:destroy)
         widget_import_service.import_widgets(import_file_upload, widgets_to_import)
       end
 
       it "unqueues the miq_queue item" do
-        MiqQueue.should_receive(:unqueue).with(
+        expect(MiqQueue).to receive(:unqueue).with(
           :class_name  => "ImportFileUpload",
           :instance_id => 42,
           :method_name => "destroy"
@@ -111,7 +111,7 @@ describe WidgetImportService do
     shared_examples_for "WidgetImportService#import_widgets with a non existing widget" do
       it "builds a new widget" do
         widget_import_service.import_widgets(import_file_upload, widgets_to_import)
-        MiqWidget.first.should_not be_nil
+        expect(MiqWidget.first).not_to be_nil
       end
     end
 
@@ -119,8 +119,8 @@ describe WidgetImportService do
       context "when the list of widgets to import from the yaml includes an existing widget" do
         before do
           MiqWidget.create!(:description => "Test2", :title => "potato", :content_type => "report")
-          YAML.stub(:load).with(yaml_data) do
-            YAML.unstub(:load)
+          allow(YAML).to receive(:load).with(yaml_data) do
+            allow(YAML).to receive(:load).and_call_original
             widgets
           end
         end
@@ -147,8 +147,8 @@ describe WidgetImportService do
           context "when the RssFeed already exists" do
             before do
               RssFeed.create!(:name => "name", :title => "old title")
-              YAML.stub(:load).with(yaml_data) do
-                YAML.unstub(:load)
+              allow(YAML).to receive(:load).with(yaml_data) do
+                allow(YAML).to receive(:load).and_call_original
                 widgets
               end
             end
@@ -163,8 +163,8 @@ describe WidgetImportService do
 
           context "when the RssFeed does not already exist" do
             before do
-              YAML.stub(:load).with(yaml_data) do
-                YAML.unstub(:load)
+              allow(YAML).to receive(:load).with(yaml_data) do
+                allow(YAML).to receive(:load).and_call_original
                 widgets
               end
             end
@@ -187,8 +187,8 @@ describe WidgetImportService do
               :rpt_type  => "Custom",
               :title     => "original report title"
             )
-            YAML.stub(:load).with(yaml_data) do
-              YAML.unstub(:load)
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
               widgets
             end
           end
@@ -206,8 +206,8 @@ describe WidgetImportService do
 
         context "when the report does not exist" do
           before do
-            YAML.stub(:load).with(yaml_data) do
-              YAML.unstub(:load)
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
               widgets
             end
           end
@@ -224,8 +224,8 @@ describe WidgetImportService do
 
         context "when the schedule does not exist" do
           before do
-            YAML.stub(:load).with(yaml_data) do
-              YAML.unstub(:load)
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
               widgets
             end
           end
@@ -252,8 +252,8 @@ describe WidgetImportService do
               }
             )
 
-            YAML.stub(:load).with(yaml_data) do
-              YAML.unstub(:load)
+            allow(YAML).to receive(:load).with(yaml_data) do
+              allow(YAML).to receive(:load).and_call_original
               widgets
             end
           end
@@ -281,7 +281,7 @@ describe WidgetImportService do
 
     context "when the loaded yaml does not return widgets" do
       before do
-        YAML.stub(:load).with(yaml_data).and_return([{"MiqWidget" => {"not a" => "widget"}}])
+        allow(YAML).to receive(:load).with(yaml_data).and_return([{"MiqWidget" => {"not a" => "widget"}}])
       end
 
       it "raises a ParsedNonWidgetYamlError" do
@@ -296,18 +296,18 @@ describe WidgetImportService do
     let(:import_file_upload) { active_record_instance_double("ImportFileUpload", :id => 42).as_null_object }
 
     before do
-      ImportFileUpload.stub(:create).and_return(import_file_upload)
-      import_file_upload.stub(:store_binary_data_as_yml)
-      MiqQueue.stub(:put)
+      allow(ImportFileUpload).to receive(:create).and_return(import_file_upload)
+      allow(import_file_upload).to receive(:store_binary_data_as_yml)
+      allow(MiqQueue).to receive(:put)
     end
 
     context "when the imported file does not raise any errors while determining validity" do
       before do
-        widget_import_validator.stub(:determine_validity).with(import_file_upload).and_return(nil)
+        allow(widget_import_validator).to receive(:determine_validity).with(import_file_upload).and_return(nil)
       end
 
       it "stores the data" do
-        import_file_upload.should_receive(:store_binary_data_as_yml).with("the data", "Widget import")
+        expect(import_file_upload).to receive(:store_binary_data_as_yml).with("the data", "Widget import")
         widget_import_service.store_for_import("the data")
       end
 
@@ -317,7 +317,7 @@ describe WidgetImportService do
 
       it "queues a deletion" do
         Timecop.freeze(2014, 3, 5) do
-          MiqQueue.should_receive(:put).with(
+          expect(MiqQueue).to receive(:put).with(
             :class_name  => "ImportFileUpload",
             :instance_id => 42,
             :deliver_on  => 1.day.from_now,
@@ -332,7 +332,7 @@ describe WidgetImportService do
     context "when the imported file raises an error while determining validity" do
       before do
         error_to_be_raised = WidgetImportValidator::NonYamlError.new("Test message")
-        widget_import_validator.stub(:determine_validity).with(import_file_upload).and_raise(error_to_be_raised)
+        allow(widget_import_validator).to receive(:determine_validity).with(import_file_upload).and_raise(error_to_be_raised)
       end
 
       it "reraises with the original error" do
@@ -343,7 +343,7 @@ describe WidgetImportService do
 
       it "queues a deletion" do
         Timecop.freeze(2014, 3, 5) do
-          MiqQueue.should_receive(:put).with(
+          expect(MiqQueue).to receive(:put).with(
             :class_name  => "ImportFileUpload",
             :instance_id => 42,
             :deliver_on  => 1.day.from_now,

--- a/spec/support/automation_example_group.rb
+++ b/spec/support/automation_example_group.rb
@@ -20,6 +20,17 @@ module AutomationExampleGroup
         config.after(:suite) do
           MiqAeDatastore.reset
         end
+
+        # rspec-rails 3 will no longer automatically infer an example group's spec type
+        # from the file location. You can explicitly opt-in to the feature using this
+        # config option.
+        # To explicitly tag specs without using automatic inference, set the `:type`
+        # metadata manually:
+        #
+        #     describe ThingsController, :type => :controller do
+        #       # Equivalent to being in spec/controllers
+        #     end
+        config.infer_spec_type_from_file_location!
       end
 
       AutomationExampleGroup.fixtures_loaded = true

--- a/spec/support/automation_spec_helper.rb
+++ b/spec/support/automation_spec_helper.rb
@@ -21,10 +21,10 @@ module AutomationSpecHelper
 
   def assert_method_executed(uri, value, user)
     ws = MiqAeEngine.instantiate(uri, user)
-    ws.should_not be_nil
+    expect(ws).not_to be_nil
     roots = ws.roots
-    roots.should have(1).item
-    roots.first.attributes['method_executed'].should == value
+    expect(roots.size).to eq(1)
+    expect(roots.first.attributes['method_executed']).to eq(value)
   end
 
   def create_ae_model(attrs = {})

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -9,12 +9,12 @@ module ControllerSpecHelper
 
   def set_user_privileges(user = FactoryGirl.create(:user_with_group))
     allow(User).to receive(:server_timezone).and_return("UTC")
-    described_class.any_instance.stub(:set_user_time_zone)
+    allow_any_instance_of(described_class).to receive(:set_user_time_zone)
 
     # TODO: remove these stubs
-    controller.stub(:check_privileges).and_return(true)
+    allow(controller).to receive(:check_privileges).and_return(true)
     login_as user
-    User.any_instance.stub(:role_allows?).and_return(true)
+    allow_any_instance_of(User).to receive(:role_allows?).and_return(true)
   end
 
   shared_context "valid session" do
@@ -22,9 +22,9 @@ module ControllerSpecHelper
     let(:request_referer_service)   { auto_loaded_instance_double("RequestRefererService",   :allowed_access? => true) }
 
     before do
-      controller.stub(:set_user_time_zone)
-      PrivilegeCheckerService.stub(:new).and_return(privilege_checker_service)
-      RequestRefererService.stub(:new).and_return(request_referer_service)
+      allow(controller).to receive(:set_user_time_zone)
+      allow(PrivilegeCheckerService).to receive(:new).and_return(privilege_checker_service)
+      allow(RequestRefererService).to receive(:new).and_return(request_referer_service)
     end
   end
 

--- a/spec/support/custom_matchers/have_virtual_column.rb
+++ b/spec/support/custom_matchers/have_virtual_column.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :have_virtual_column do |name, type|
     vcol = klass.virtual_columns_hash[name.to_s]
     vcol.should_not  be_nil
     vcol.type.should == type
-    klass.instance_methods.include?(name.to_sym).should be_true
+    klass.instance_methods.include?(name.to_sym).should be_truthy
   end
 
   failure_message_for_should do |klass|

--- a/spec/support/custom_matchers/have_virtual_column.rb
+++ b/spec/support/custom_matchers/have_virtual_column.rb
@@ -1,9 +1,9 @@
 RSpec::Matchers.define :have_virtual_column do |name, type|
   match do |klass|
     vcol = klass.virtual_columns_hash[name.to_s]
-    vcol.should_not  be_nil
-    vcol.type.should == type
-    klass.instance_methods.include?(name.to_sym).should be_truthy
+    expect(vcol).to_not be_nil
+    expect(vcol.type).to eq(type)
+    klass.instance_methods.include?(name.to_sym)
   end
 
   failure_message_for_should do |klass|

--- a/spec/support/custom_matchers/match_relationship_tree.rb
+++ b/spec/support/custom_matchers/match_relationship_tree.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_relationship_tree do |expected_tree|
   match do |actual_tree|
-    actual_tree.length.should == expected_tree.length
+    expect(actual_tree.length).to eq(expected_tree.length)
 
     actual_tree   = sort_tree(actual_tree)
     expected_tree = sort_tree(expected_tree)
@@ -9,11 +9,11 @@ RSpec::Matchers.define :match_relationship_tree do |expected_tree|
       expected_array, expected_children = expected_tree[i]
       expected_type, expected_name, expected_options = expected_array
 
-      obj.should      be_instance_of(expected_type)
-      obj.name.should == expected_name
-      expected_options.each { |k, v| obj.send(k).should == v } if expected_options
+      expect(obj).to be_instance_of(expected_type)
+      expect(obj.name).to eq(expected_name)
+      expected_options.each { |k, v| expect(obj.send(k)).to eq(v) } if expected_options
 
-      children.should match_relationship_tree expected_children
+      expect(children).to match_relationship_tree expected_children
     end
   end
 

--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -2,43 +2,43 @@
 shared_examples_for 'record without latest derived metrics' do |message|
   it "#{message}" do
     @record.stub(:latest_derived_metrics => false)
-    subject.should == message
+    expect(subject).to eq(message)
   end
 end
 
 shared_examples_for 'record without perf data' do |message|
   it "#{message}" do
     @record.stub(:has_perf_data? => false)
-    subject.should == message
+    expect(subject).to eq(message)
   end
 end
 
 shared_examples_for 'record without ems events and policy events' do |message|
   it "#{message}" do
-    @record.stub(:has_events?).and_return(false)
-    subject.should == message
+    allow(@record).to receive(:has_events?).and_return(false)
+    expect(subject).to eq(message)
   end
 end
 
 shared_examples_for 'record with error message' do |name|
   it "returns the #{name} error message" do
     message = "xx #{name} message"
-    @record.stub(:is_available_now_error_message).with(name.to_sym).and_return(message)
-    subject.should == message
+    allow(@record).to receive(:is_available_now_error_message).with(name.to_sym).and_return(message)
+    expect(subject).to eq(message)
   end
 end
 
 shared_examples_for 'default case' do
-  it { should be_falsey }
+  it { is_expected.to be_falsey }
 end
 
 shared_examples_for 'default true_case' do
-  it { should be_truthy }
+  it { is_expected.to be_truthy }
 end
 
 shared_examples_for 'vm not powered on' do |message|
   it "#{message}" do
     @record.stub(:current_state => 'off')
-    subject.should == message
+    expect(subject).to eq(message)
   end
 end

--- a/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
@@ -1,30 +1,30 @@
 shared_examples_for "Vm operation is available when not powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    vm.is_available?(state).should be_false
+    expect(vm.is_available?(state)).to be_falsey
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    vm.is_available?(state).should be_true
+    expect(vm.is_available?(state)).to be_truthy
   end
 end
 
 shared_examples_for "Vm operation is available when powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    vm.is_available?(state).should be_true
+    expect(vm.is_available?(state)).to be_truthy
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    vm.is_available?(state).should be_false
+    expect(vm.is_available?(state)).to be_falsey
   end
 end
 
 shared_examples_for "Vm operation is not available" do
   it "is not available" do
-    vm.is_available?(state).should be_false
-    vm.is_available_now_error_message(state).should include("not available")
+    expect(vm.is_available?(state)).to be_falsey
+    expect(vm.is_available_now_error_message(state)).to include("not available")
   end
 end

--- a/spec/support/presenter_spec_helper.rb
+++ b/spec/support/presenter_spec_helper.rb
@@ -3,7 +3,7 @@ module PresenterSpecHelper
 
   def login_as(user)
     User.current_user = user
-    ActionController::TestSession.any_instance.stub(:userid).and_return(user.userid)
-    ActionController::TestSession.any_instance.stub(:group).and_return(user.current_group.try(:id))
+    allow_any_instance_of(ActionController::TestSession).to receive(:userid).and_return(user.userid)
+    allow_any_instance_of(ActionController::TestSession).to receive(:group).and_return(user.current_group.try(:id))
   end
 end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -64,10 +64,10 @@ module ServiceTemplateHelper
   end
 
   def request_stubs
-    @request.stub(:approved?).and_return(true)
-    MiqRequestTask.any_instance.stub(:approved?).and_return(true)
-    MiqProvision.any_instance.stub(:get_next_vm_name).and_return("fred")
-    @request.stub(:automate_event_failed?).and_return(false)
+    allow(@request).to receive(:approved?).and_return(true)
+    allow_any_instance_of(MiqRequestTask).to receive(:approved?).and_return(true)
+    allow_any_instance_of(MiqProvision).to receive(:get_next_vm_name).and_return("fred")
+    allow(@request).to receive(:automate_event_failed?).and_return(false)
   end
 
   def build_small_environment
@@ -80,13 +80,13 @@ module ServiceTemplateHelper
   end
 
   def service_template_stubs
-    ServiceTemplate.stub(:automate_result_include_service_template?) do |_uri, _user, name|
+    allow(ServiceTemplate).to receive(:automate_result_include_service_template?) do |_uri, _user, name|
       @allowed_service_templates.include?(name)
     end
   end
 
   def user_helper
-    User.any_instance.stub(:role).and_return("admin")
+    allow_any_instance_of(User).to receive(:role).and_return("admin")
     @user = FactoryGirl.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
   end
 end

--- a/spec/support/view_spec_helper.rb
+++ b/spec/support/view_spec_helper.rb
@@ -23,10 +23,10 @@ module ViewSpecHelper
   end
 
   def set_controller_for_view_to_be_restful
-    controller.stub(:restful?).and_return(true)
+    allow(controller).to receive(:restful?).and_return(true)
   end
 
   def set_controller_for_view_to_be_nonrestful
-    controller.stub(:restful?).and_return(false)
+    allow(controller).to receive(:restful?).and_return(false)
   end
 end

--- a/spec/support/workflow_spec_helper.rb
+++ b/spec/support/workflow_spec_helper.rb
@@ -27,7 +27,7 @@ module WorkflowSpecHelper
   def assert_automate_vm_name_lookup(user, vm_name = 'vm_name')
     stub_automate_workspace("get_vmname_url", user, vm_name)
 
-    MiqAeEngine.should_receive(:create_automation_object).with(
+    expect(MiqAeEngine).to receive(:create_automation_object).with(
       "REQUEST",
       hash_including(
         'request'    => 'UI_PROVISION_INFO',


### PR DESCRIPTION
Converts /services and /support spec to newer `expect` syntax