### PR TITLE
Fix issue where sort! was called on an ActiveRecord::Relation.

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -99,14 +99,11 @@ module MiqServer::WorkerManagement::Monitor
 
   def do_system_limit_exceeded
     self.class.monitor_class_names_in_kill_order.each do |class_name|
-      workers = class_name.constantize.find_current
+      workers = class_name.constantize.find_current.to_a
       next if workers.empty?
 
-      key = workers.first.memory_usage.nil? ? "id" : "memory_usage"
-      # sorting an array of objects by an attribute that could be nil
-      workers.sort! { |a, b| (a[key] && b[key]) ? (a[key] <=> b[key]) : (a[key] ? -1 : 1) }
+      w = workers.sort_by { |w| [w.memory_usage || -1, w.id] }.last
 
-      w = workers.last
       msg = "#{w.format_full_log_msg} is being stopped because system resources exceeded threshold, it will be restarted once memory has freed up"
       _log.warn(msg)
       MiqEvent.raise_evm_event_queue_in_region(w.miq_server, "evm_server_memory_exceeded", :event_details => msg, :type => w.class.name)

--- a/spec/factories/miq_worker.rb
+++ b/spec/factories/miq_worker.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
   factory :miq_worker do
-    pid             Process.pid
+    pid    { rand(99999) }
+    status "ready"
   end
 
   factory :miq_ui_worker, :class => "MiqUiWorker", :parent => :miq_worker
+
+  factory :miq_ems_metrics_processor_worker, :class => "MiqEmsMetricsProcessorWorker", :parent => :miq_worker
 end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -13,7 +13,7 @@ describe "MiqWorker Monitor" do
 
     context "A worker" do
       before(:each) do
-        @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => rand(20))
+        @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       end
 
       it "MiqServer#clean_worker_records" do
@@ -41,6 +41,31 @@ describe "MiqWorker Monitor" do
         ids = @miq_server.check_not_responding
         expect(@miq_server.miq_workers.length).to eq(1)
         expect(ids).to eq([@worker.id])
+      end
+
+      describe "#do_system_limit_exceeded" do
+        before do
+          @worker_to_keep = FactoryGirl.create(:miq_ems_metrics_processor_worker,
+            :miq_server   => @miq_server,
+            :memory_usage => 1.gigabytes
+          )
+          @worker_to_kill = FactoryGirl.create(:miq_ems_metrics_processor_worker,
+            :miq_server   => @miq_server,
+            :memory_usage => 2.gigabytes
+          )
+        end
+
+        it "will kill the worker with the highest memory" do
+          expect(@miq_server).to receive(:restart_worker).with(@worker_to_kill, :memory_exceeded)
+          @miq_server.do_system_limit_exceeded
+        end
+
+        it "will handle workers with nil memory_usage" do
+          @worker_to_keep.update_attributes!(:memory_usage => nil)
+
+          expect(@miq_server).to receive(:restart_worker).with(@worker_to_kill, :memory_exceeded)
+          @miq_server.do_system_limit_exceeded
+        end
       end
 
       context "with no messages" do


### PR DESCRIPTION
The MiqServer#do_system_limit_exceeded method was calling sort! on an
ActiveRecord::Relation.  The specs were added to verify, but then it
was also revealed that the sorting method was not sufficient anyway.
This fix removes the sort! and also fixes the sorting logic.

This issue was missed because it didn't have specs, but also because it
is rarely called, only happening when workers need to be killed due to
low system resources.

@jrafanie Please review.
cc @blomquisg @theute