### PR TITLE
RSpec 3 conversion: lib/miq_automation_engine specs

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_collect_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_collect_spec.rb
@@ -18,33 +18,33 @@ module MiqAeCollectSpec
     MONTHS = {"January" => 1, "October" => 10, "June" => 6, "July" => 7, "February" => 2, "May" => 5, "March" => 3, "December" => 12, "August" => 8, "September" => 9, "November" => 11, "April" => 4}
     it "collects months" do
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_months", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
 
       # puts ws.to_xml
       months = ws.root("months")
-      months.should_not be_nil
-      months.class.to_s.should == "Hash"
-      months.length.should == 12
-      months.should == MONTHS
-      ws.root('sort').should == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-      ws.root('rsort').should == [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-      ws.root('count').should == 12
-      ws.root('min').should == 1
-      ws.root('max').should == 12
-      ws.root('mean').should == 6.5
+      expect(months).not_to be_nil
+      expect(months.class.to_s).to eq("Hash")
+      expect(months.length).to eq(12)
+      expect(months).to eq(MONTHS)
+      expect(ws.root('sort')).to eq([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+      expect(ws.root('rsort')).to eq([12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+      expect(ws.root('count')).to eq(12)
+      expect(ws.root('min')).to eq(1)
+      expect(ws.root('max')).to eq(12)
+      expect(ws.root('mean')).to eq(6.5)
     end
 
     WEEKDAYS = {"Wednesday" => 4, "Friday" => 6, "Saturday" => 7, "Tuesday" => 3, "Sunday" => 1, "Monday" => 2, "Thursday" => 5}
     it "collects weekdays" do
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_weekdays", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       # puts ws.to_xml
       weekdays = ws.root("weekdays")
-      weekdays.should_not be_nil
-      weekdays.class.to_s.should == "Hash"
-      weekdays.length.should == 7
-      weekdays.should == WEEKDAYS
-      ws.root('sum').should == 28
+      expect(weekdays).not_to be_nil
+      expect(weekdays.class.to_s).to eq("Hash")
+      expect(weekdays.length).to eq(7)
+      expect(weekdays).to eq(WEEKDAYS)
+      expect(ws.root('sum')).to eq(28)
     end
 
     it "collect on instance level overrides collect on class level" do
@@ -54,33 +54,33 @@ module MiqAeCollectSpec
       i1.set_field_collect(f1, "weekdays = [description]")
 
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_weekdays", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       # puts ws.to_xml
       weekdays = ws.root("weekdays")
-      weekdays.should_not be_nil
-      weekdays.class.to_s.should == "Array"
-      weekdays.length.should == 7
+      expect(weekdays).not_to be_nil
+      expect(weekdays.class.to_s).to eq("Array")
+      expect(weekdays.length).to eq(7)
     end
 
     it "gets proper value base on environment" do
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO?environment=dev#get_random_number", @user)
-      ws.should_not be_nil
-      ws.root("number").should == 3
+      expect(ws).not_to be_nil
+      expect(ws.root("number")).to eq(3)
 
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO?environment=test#get_random_number", @user)
-      ws.should_not be_nil
-      ws.root("number").should == 5
+      expect(ws).not_to be_nil
+      expect(ws.root("number")).to eq(5)
 
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO?environment=foo#get_random_number", @user)
-      ws.should_not be_nil
-      ws.root("number").should == 1
+      expect(ws).not_to be_nil
+      expect(ws.root("number")).to eq(1)
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO?environment=#get_random_number", @user)
-      ws.should_not be_nil
-      ws.root("number").should == 0
+      expect(ws).not_to be_nil
+      expect(ws.root("number")).to eq(0)
 
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_random_number", @user)
-      ws.should_not be_nil
-      ws.root("number").should == 0
+      expect(ws).not_to be_nil
+      expect(ws.root("number")).to eq(0)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_discovery_spec.rb
@@ -18,7 +18,7 @@ module MiqAeDiscoverySpec
     end
 
     it "properly processes MiqAeEvent.raise_ems_event" do
-      MiqAeEngine.should_receive(:deliver_queue)
+      expect(MiqAeEngine).to receive(:deliver_queue)
       MiqAeEvent.raise_ems_event(@event)
     end
 
@@ -42,14 +42,14 @@ module MiqAeDiscoverySpec
                 :tenant_id        => @tenant.id,
                 :automate_message => nil}
 
-        MiqAeEngine.should_receive(:deliver_queue).with(args, anything)
+        expect(MiqAeEngine).to receive(:deliver_queue).with(args, anything)
          MiqAeEvent.raise_ems_event(@event)
       end
     end
 
     it "properly processes Vm Scan Request" do
       ws = MiqAeEngine.instantiate("/EVM/VMSCAN/foo?target_vm_id=#{@vm.id}", @admin)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -37,51 +37,51 @@ describe MiqAeDomain do
 
     it 'can set other attributes in a domain object' do
       domain = MiqAeDomain.create!(:name => 'Fred', :tenant => root_tenant)
-      domain.update_attributes!(:priority => 10, :system => false).should be_true
+      expect(domain.update_attributes!(:priority => 10, :system => false)).to be_truthy
     end
   end
 
   context "Domain Overlays" do
     it "partial namespace should use the higher priority user instance" do
       ns = MiqAeNamespace.find_by_fqname('evm')
-      ns.should be_nil
+      expect(ns).to be_nil
       assert_method_executed('evm/AUTOMATE/test1', 'user', @user)
     end
 
     it "fully qualified namespace should execute the root method" do
       ns = MiqAeNamespace.find_by_fqname('root/evm')
-      ns.should_not be_nil
+      expect(ns).not_to be_nil
       assert_method_executed('root/evm/AUTOMATE/test2', 'root', @user)
     end
 
     it "partial namespace with wild card in relationship" do
       ns = MiqAeNamespace.find_by_fqname('evm')
-      ns.should be_nil
+      expect(ns).to be_nil
       assert_method_executed('evm/AUTOMATE/test_wildcard', 'user', @user)
     end
 
     it "a non existent partial namespace instance should fail" do
       ws = MiqAeEngine.instantiate('evm/AUTOMATE/non_existent', @user)
       roots = ws.roots
-      roots.should have(0).item
+      expect(roots.size).to eq(0)
     end
 
     it "a disabled namespace should not get picked up even if the instance exists" do
       ws = MiqAeEngine.instantiate('evm/AUTOMATE/should_not_get_used', @user)
       roots = ws.roots
-      roots.should have(0).item
+      expect(roots.size).to eq(0)
     end
 
     it "an enabled namespace should get picked up if the instance exists" do
       n3 = MiqAeNamespace.find_by_fqname('inert')
-      n3.enabled?.should be_false
+      expect(n3.enabled?).to be_falsey
       n3.update_attributes!(:enabled => true)
       assert_method_executed('evm/AUTOMATE/should_get_used', 'inert', @user)
     end
 
     it "partial namespace should use the higher priority users case insensitive instance" do
       ns = MiqAeNamespace.find_by_fqname('evm')
-      ns.should be_nil
+      expect(ns).to be_nil
       assert_method_executed('evm/AUTOMATE/TeSt1', 'user', @user)
     end
 
@@ -92,11 +92,11 @@ describe MiqAeDomain do
     end
 
     it "check list of enabled domains" do
-      MiqAeDomain.enabled.collect(&:name).should match_array(@enabled_domains)
+      expect(MiqAeDomain.enabled.collect(&:name)).to match_array(@enabled_domains)
     end
 
     it "check list of all domains" do
-      MiqAeDomain.all.collect(&:name).should match_array(@all_domains)
+      expect(MiqAeDomain.all.collect(&:name)).to match_array(@all_domains)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -69,12 +69,12 @@ module MiqAeEngineSpec
           puts "#{q.last_exception.class.name}: #{q.last_exception.message}"
           puts q.last_exception.backtrace
         end
-        status.should_not == MiqQueue::STATUS_ERROR
+        expect(status).not_to eq(MiqQueue::STATUS_ERROR)
       end
 
       context "when Automate instantiation fails" do
         before(:each) do
-          MiqAeEngine.stub(:resolve_automation_object).and_return(nil)
+          allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(nil)
         end
 
         it "with defaults and non-STI object" do
@@ -82,8 +82,8 @@ module MiqAeEngineSpec
           object_id   = @cluster.id
           automate_attrs = {"#{object_type}::#{object_type.underscore}" => object_id,
                             "User::user"                                => @user.id}
-          MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @cluster}).and_return('uri')
-          call_automate(object_type, object_id).should be_nil
+          expect(MiqAeEngine).to receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @cluster}).and_return('uri')
+          expect(call_automate(object_type, object_id)).to be_nil
         end
 
         it "with defaults and STI object" do
@@ -92,8 +92,8 @@ module MiqAeEngineSpec
           object_id   = @ems.id
           automate_attrs = {"#{base_name}::#{base_name.underscore}" => object_id,
                             "User::user"                            => @user.id}
-          MiqAeEngine.should_receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @ems}).and_return('uri')
-          call_automate(object_type, object_id).should be_nil
+          expect(MiqAeEngine).to receive(:create_automation_object).with(@instance_name, automate_attrs, {:vmdb_object => @ems}).and_return('uri')
+          expect(call_automate(object_type, object_id)).to be_nil
         end
       end
 
@@ -103,13 +103,13 @@ module MiqAeEngineSpec
             root = {'ae_result' => 'error'}
             @ws = double('ws')
             @ws.stub(:root => root)
-            MiqAeEngine.stub(:resolve_automation_object).and_return(@ws)
+            allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            call_automate(object_type, object_id).should == @ws
+            expect(call_automate(object_type, object_id)).to eq(@ws)
           end
         end
 
@@ -118,13 +118,13 @@ module MiqAeEngineSpec
             root = {'ae_result' => 'ok'}
             @ws = double('ws')
             @ws.stub(:root => root)
-            MiqAeEngine.stub(:resolve_automation_object).and_return(@ws)
+            allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            call_automate(object_type, object_id).should == @ws
+            expect(call_automate(object_type, object_id)).to eq(@ws)
           end
 
           it "with a starting point instead of /SYSTEM/PROCESS" do
@@ -133,8 +133,8 @@ module MiqAeEngineSpec
             args[:instance_name]    = "DEFAULT"
             args[:fqclass_name] = "Factory/StateMachines/ServiceProvision_template"
             args[:user_id] = @user.id
-            MiqAeEngine.should_receive(:create_automation_object).with("DEFAULT", attrs, :fqclass => "Factory/StateMachines/ServiceProvision_template").and_return('uri')
-            MiqAeEngine.deliver(args).should == @ws
+            expect(MiqAeEngine).to receive(:create_automation_object).with("DEFAULT", attrs, :fqclass => "Factory/StateMachines/ServiceProvision_template").and_return('uri')
+            expect(MiqAeEngine.deliver(args)).to eq(@ws)
           end
         end
 
@@ -145,22 +145,22 @@ module MiqAeEngineSpec
             @ws.stub(:root => root)
             @ws.stub(:persist_state_hash => {})
             @ws.stub(:current_state_info => {})
-            MiqAeEngine.stub(:resolve_automation_object).and_return(@ws)
+            allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 
           it "with defaults" do
             object_type = @ems.class.name
             object_id   = @ems.id
-            call_automate(object_type, object_id).should == @ws
+            expect(call_automate(object_type, object_id)).to eq(@ws)
 
-            MiqQueue.count.should == 1
+            expect(MiqQueue.count).to eq(1)
 
             q = MiqQueue.first
-            q.class_name.should == 'MiqAeEngine'
-            q.method_name.should == 'deliver'
-            q.zone.should == MiqServer.my_zone
-            q.role.should == 'automate'
-            q.msg_timeout.should == 60.minutes
+            expect(q.class_name).to eq('MiqAeEngine')
+            expect(q.method_name).to eq('deliver')
+            expect(q.zone).to eq(MiqServer.my_zone)
+            expect(q.role).to eq('automate')
+            expect(q.msg_timeout).to eq(60.minutes)
 
             args = {
               :object_type      => object_type,
@@ -176,7 +176,7 @@ module MiqAeEngineSpec
               :ae_state_started => @ae_state_started,
               :ae_state_retries => @ae_state_retries,
             }
-            q.args.first.should == args
+            expect(q.args.first).to eq(args)
           end
         end
       end
@@ -197,19 +197,19 @@ module MiqAeEngineSpec
           "/System/Process/REQUEST?#{extras}&message=get_dialogs&object_name=REQUEST&request=UI_PROVISION_INFO"                            => {'request' => 'UI_PROVISION_INFO', 'message' => 'get_dialogs'},
         }.each { |uri, attrs|
           saved = attrs.dup
-          MiqAeEngine.create_automation_object('REQUEST', attrs).should == uri
-          attrs.should == saved
+          expect(MiqAeEngine.create_automation_object('REQUEST', attrs)).to eq(uri)
+          expect(attrs).to eq(saved)
         }
 
         prov = MiqProvision.new
         prov.id = 42
-        MiqAeEngine.create_automation_object('REQUEST', {'request' => 'UI_PROVISION_INFO', 'message' => 'get_host_and_storage'}, :vmdb_object => prov).should == "/System/Process/REQUEST?MiqProvision%3A%3Amiq_provision=#{prov.id}&#{extras}&message=get_host_and_storage&object_name=REQUEST&request=UI_PROVISION_INFO&vmdb_object_type=miq_provision"
+        expect(MiqAeEngine.create_automation_object('REQUEST', {'request' => 'UI_PROVISION_INFO', 'message' => 'get_host_and_storage'}, :vmdb_object => prov)).to eq("/System/Process/REQUEST?MiqProvision%3A%3Amiq_provision=#{prov.id}&#{extras}&message=get_host_and_storage&object_name=REQUEST&request=UI_PROVISION_INFO&vmdb_object_type=miq_provision")
 
         user = User.new
         user.id = 42
         begin
           Thread.current[:user] = user
-          MiqAeEngine.create_automation_object('REQUEST', {'request' => 'UI_PROVISION_INFO', 'message' => 'get_host_and_storage'}, :vmdb_object => prov).should == "/System/Process/REQUEST?MiqProvision%3A%3Amiq_provision=#{prov.id}&#{extras}&User%3A%3Auser=#{user.id}&message=get_host_and_storage&object_name=REQUEST&request=UI_PROVISION_INFO&vmdb_object_type=miq_provision"
+          expect(MiqAeEngine.create_automation_object('REQUEST', {'request' => 'UI_PROVISION_INFO', 'message' => 'get_host_and_storage'}, :vmdb_object => prov)).to eq("/System/Process/REQUEST?MiqProvision%3A%3Amiq_provision=#{prov.id}&#{extras}&User%3A%3Auser=#{user.id}&message=get_host_and_storage&object_name=REQUEST&request=UI_PROVISION_INFO&vmdb_object_type=miq_provision")
         ensure
           Thread.current[:user] = nil
         end
@@ -219,7 +219,7 @@ module MiqAeEngineSpec
         vm = FactoryGirl.create(:vm_vmware)
         extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{extras}&VmOrTemplate%3A%3Avm=#{vm.id}&object_name=AUTOMATION&vmdb_object_type=vm"
-        MiqAeEngine.create_automation_object("AUTOMATION", {}, :vmdb_object => vm).should == uri
+        expect(MiqAeEngine.create_automation_object("AUTOMATION", {}, :vmdb_object => vm)).to eq(uri)
       end
 
       it "with a starting point other than /SYSTEM/PROCESS" do
@@ -228,7 +228,7 @@ module MiqAeEngineSpec
         uri = MiqAeEngine.create_automation_object("DEFAULT", {}, :vmdb_object => vm, :fqclass => fqclass)
         extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         expected_uri = "/#{fqclass}/DEFAULT?#{extras}&VmOrTemplate%3A%3Avm=#{vm.id}&object_name=DEFAULT&vmdb_object_type=vm"
-        uri.should == expected_uri
+        expect(uri).to eq(expected_uri)
       end
 
       it "will not override values in attrs" do
@@ -236,7 +236,7 @@ module MiqAeEngineSpec
         attrs = {"Host::host" => host.id, "MiqServer::miq_server" => "12"}
         extras = "MiqServer%3A%3Amiq_server=12"
         uri = "/System/Process/AUTOMATION?Host%3A%3Ahost=#{host.id}&#{extras}&object_name=AUTOMATION&vmdb_object_type=host"
-        MiqAeEngine.create_automation_object("AUTOMATION", attrs, :vmdb_object => host).should == uri
+        expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs, :vmdb_object => host)).to eq(uri)
       end
 
       it "will process an array of objects" do
@@ -246,7 +246,7 @@ module MiqAeEngineSpec
         result_str = "Array%3A%3Amy_hosts=" + hash["hosts"].collect { |h| "Host%3A%3A#{h.id}" }.join(",")
         extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{result_str}&#{extras}&object_name=AUTOMATION"
-        MiqAeEngine.create_automation_object("AUTOMATION", attrs).should == uri
+        expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs)).to eq(uri)
       end
 
       it "will process an empty array" do
@@ -254,7 +254,7 @@ module MiqAeEngineSpec
         result_str = "Array%3A%3Amy_hosts="""
         extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
         uri = "/System/Process/AUTOMATION?#{result_str}&#{extras}&object_name=AUTOMATION"
-        MiqAeEngine.create_automation_object("AUTOMATION", attrs).should == uri
+        expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs)).to eq(uri)
       end
 
       it "will process an array of objects with a server and user" do
@@ -263,49 +263,49 @@ module MiqAeEngineSpec
         attrs = {"MiqServer::miq_server" => "12", "array::tag" => "Classification::1,Classification::2"}
         result_str = "array%3A%3Atag=Classification%3A%3A1%2CClassification%3A%3A2"
         uri = "/System/Process/AUTOMATION?#{extras}&#{result_str}&object_name=AUTOMATION"
-        MiqAeEngine.create_automation_object("AUTOMATION", attrs).should == uri
+        expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs)).to eq(uri)
       end
     end
 
     context ".create_automation_attribute_key" do
       it "with a Vm (special case)" do
         vm = FactoryGirl.create(:vm_vmware)
-        MiqAeEngine.create_automation_attribute_key(vm).should == "VmOrTemplate::vm"
+        expect(MiqAeEngine.create_automation_attribute_key(vm)).to eq("VmOrTemplate::vm")
       end
 
       it "with an EMS" do
         ems = FactoryGirl.create(:ems_vmware)
-        MiqAeEngine.create_automation_attribute_key(ems).should == "ExtManagementSystem::ext_management_system"
+        expect(MiqAeEngine.create_automation_attribute_key(ems)).to eq("ExtManagementSystem::ext_management_system")
       end
 
       it "with a Host" do
         host = FactoryGirl.create(:host)
-        MiqAeEngine.create_automation_attribute_key(host).should == "Host::host"
+        expect(MiqAeEngine.create_automation_attribute_key(host)).to eq("Host::host")
       end
 
       it "with an EmsCluster" do
         cluster = FactoryGirl.create(:ems_cluster)
-        MiqAeEngine.create_automation_attribute_key(cluster).should == "EmsCluster::ems_cluster"
+        expect(MiqAeEngine.create_automation_attribute_key(cluster)).to eq("EmsCluster::ems_cluster")
       end
 
       it "with an Array:: name" do
-        MiqAeEngine.create_automation_attribute_key("Array::var1").should == "Array::var1"
+        expect(MiqAeEngine.create_automation_attribute_key("Array::var1")).to eq("Array::var1")
       end
     end
 
     context ".create_automation_attribute_class_name" do
       it "with an Array:: name" do
-        MiqAeEngine.create_automation_attribute_class_name("Array::fred").should == "Array::fred"
+        expect(MiqAeEngine.create_automation_attribute_class_name("Array::fred")).to eq("Array::fred")
       end
 
       it "with an VmOrTemplate" do
         vm = FactoryGirl.create(:vm_vmware)
-        MiqAeEngine.create_automation_attribute_class_name(vm).should == "VmOrTemplate"
+        expect(MiqAeEngine.create_automation_attribute_class_name(vm)).to eq("VmOrTemplate")
       end
 
       it "with an Host" do
         host = FactoryGirl.create(:host)
-        MiqAeEngine.create_automation_attribute_class_name(host).should == "Host"
+        expect(MiqAeEngine.create_automation_attribute_class_name(host)).to eq("Host")
       end
     end
 
@@ -319,8 +319,8 @@ module MiqAeEngineSpec
         result_str    = "Array::vms=" + hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
         result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
         result        = MiqAeEngine.create_automation_attributes(hash)
-        MiqAeEngine.create_automation_attributes_string(hash).should == result_str
-        result["Array::vms"].should == result_arr
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
+        expect(result["Array::vms"]).to eq(result_arr)
       end
 
       it "with an array containing a single Vm" do
@@ -328,21 +328,21 @@ module MiqAeEngineSpec
         result_str    = "Array::vms=" + hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
         result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
         result        = MiqAeEngine.create_automation_attributes(hash)
-        MiqAeEngine.create_automation_attributes_string(hash).should == result_str
-        result["Array::vms"].should == result_arr
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
+        expect(result["Array::vms"]).to eq(result_arr)
       end
 
       it "with an empty array" do
         result        = MiqAeEngine.create_automation_attributes({"vms" => []})
-        result["Array::vms"].should == ""
+        expect(result["Array::vms"]).to eq("")
       end
 
       it "with a hash containing a single Vm" do
         vm            = Vm.first
         hash          = {"vms" => vm}
         result        = MiqAeEngine.create_automation_attributes(hash)
-        MiqAeEngine.create_automation_attributes_string(hash).should == "VmOrTemplate::vms=#{vm.id}"
-        result["VmOrTemplate::vms"].should == vm.id
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq("VmOrTemplate::vms=#{vm.id}")
+        expect(result["VmOrTemplate::vms"]).to eq(vm.id)
       end
 
       it "with an array of Hosts" do
@@ -350,8 +350,8 @@ module MiqAeEngineSpec
         result_str    = "Array::hosts=" + hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
         result_arr    = hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
         result        = MiqAeEngine.create_automation_attributes(hash)
-        MiqAeEngine.create_automation_attributes_string(hash).should == result_str
-        result["Array::hosts"].should == result_arr
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
+        expect(result["Array::hosts"]).to eq(result_arr)
       end
 
       it "with multiple arrays" do
@@ -362,36 +362,36 @@ module MiqAeEngineSpec
         host_result_str = "Array::hosts=" + hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
         host_result_arr = hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
         result          = MiqAeEngine.create_automation_attributes(hash)
-        result["Array::vms"].should == vm_result_arr
-        result["Array::hosts"].should == host_result_arr
+        expect(result["Array::vms"]).to eq(vm_result_arr)
+        expect(result["Array::hosts"]).to eq(host_result_arr)
         result_str = MiqAeEngine.create_automation_attributes_string(hash)
-        result_str.should include(vm_result_str)
-        result_str.should include(host_result_str)
+        expect(result_str).to include(vm_result_str)
+        expect(result_str).to include(host_result_str)
       end
 
       it "with invalid object references" do
         hash          = {"vms" => ["bogus::12"]}
         result        = MiqAeEngine.create_automation_attributes(hash)
-        result["Array::vms"].should == "bogus::12"
-        MiqAeEngine.create_automation_attributes_string(hash).should == "Array::vms=bogus::12"
+        expect(result["Array::vms"]).to eq("bogus::12")
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq("Array::vms=bogus::12")
       end
 
       it "with garbage values" do
         hash          = {"vms" => ["bogus::12,garbage::moreso,notevenclose"]}
         bogus_arr     = "bogus::12,garbage::moreso,notevenclose"
         result        = MiqAeEngine.create_automation_attributes(hash)
-        result["Array::vms"].should == bogus_arr
-        MiqAeEngine.create_automation_attributes_string(hash).should == "Array::vms=bogus::12,garbage::moreso,notevenclose"
+        expect(result["Array::vms"]).to eq(bogus_arr)
+        expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq("Array::vms=bogus::12,garbage::moreso,notevenclose")
       end
 
       it "with a string value" do
-        MiqAeEngine.create_automation_attributes("somestring").should == "somestring"
-        MiqAeEngine.create_automation_attributes("somestring").should == "somestring"
+        expect(MiqAeEngine.create_automation_attributes("somestring")).to eq("somestring")
+        expect(MiqAeEngine.create_automation_attributes("somestring")).to eq("somestring")
       end
 
       it "with a string value" do
-        MiqAeEngine.create_automation_attributes("").should == ""
-        MiqAeEngine.create_automation_attributes("").should == ""
+        expect(MiqAeEngine.create_automation_attributes("")).to eq("")
+        expect(MiqAeEngine.create_automation_attributes("")).to eq("")
       end
     end
 
@@ -420,19 +420,19 @@ module MiqAeEngineSpec
 
     context ".automation_attribute_is_array?" do
       it "is true" do
-        MiqAeEngine.automation_attribute_is_array?("Array::doesntmatter").should be_true
+        expect(MiqAeEngine.automation_attribute_is_array?("Array::doesntmatter")).to be_truthy
       end
 
       it "is true lower case" do
-        MiqAeEngine.automation_attribute_is_array?("array::doesntmatter").should be_true
+        expect(MiqAeEngine.automation_attribute_is_array?("array::doesntmatter")).to be_truthy
       end
 
       it "is false" do
-        MiqAeEngine.automation_attribute_is_array?("somethingelse::doesntmatter").should be_false
+        expect(MiqAeEngine.automation_attribute_is_array?("somethingelse::doesntmatter")).to be_falsey
       end
 
       it "is false with nil value" do
-        MiqAeEngine.automation_attribute_is_array?(nil).should be_false
+        expect(MiqAeEngine.automation_attribute_is_array?(nil)).to be_falsey
       end
     end
 
@@ -442,7 +442,7 @@ module MiqAeEngineSpec
       extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
       uri =  "/namespace/more_namespace/my_favorite_class/REQUEST?#{extras}&#{msg_attrs}"
       attrs  = {'request' => 'NOT_THERE', 'message' => 'testmessage'}
-      MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start).should == uri
+      expect(MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start)).to eq(uri)
     end
 
     it "a namespace not containing a slash is parsed correctly " do
@@ -451,104 +451,104 @@ module MiqAeEngineSpec
       extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
       uri =  "/namespace/my_favorite_class/REQUEST?#{extras}&#{msg_attrs}"
       attrs  = {'request' => 'NOT_THERE', 'message' => 'testmessage'}
-      MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start).should == uri
+      expect(MiqAeEngine.create_automation_object('REQUEST', attrs, :fqclass => start)).to eq(uri)
     end
 
     it "instantiates attributes properly" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec1"), @domain)
 
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test3", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
-      roots.first.attributes["attr1"].should == "Gregg TEST2 Oleg"
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
+      expect(roots.first.attributes["attr1"]).to eq("Gregg TEST2 Oleg")
 
       ws.instantiate("/EVM/AUTOMATE/test2", @user)
-      ws.roots.length.should == 2
-      ws.roots[1].attributes["attr1"].should == "TEST2"
+      expect(ws.roots.length).to eq(2)
+      expect(ws.roots[1].attributes["attr1"]).to eq("TEST2")
 
       ws.instantiate("/EVM/AUTOMATE/test1", @user)
-      ws.roots.length.should == 3
-      ws.roots[2].attributes["attr1"].should == "frank"
+      expect(ws.roots.length).to eq(3)
+      expect(ws.roots[2].attributes["attr1"]).to eq("frank")
 
       ws.instantiate("/EVM/AUTOMATE/test4", @user)
-      ws.roots.length.should == 4
-      ws.roots[3].attributes["attr1"].should == "frank"
+      expect(ws.roots.length).to eq(4)
+      expect(ws.roots[3].attributes["attr1"]).to eq("frank")
 
       # puts ws.to_expanded_xml()
 
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test_password", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
-      MiqAePassword.decrypt_if_password(roots.first.attributes["password"]).should == "secret"
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
+      expect(MiqAePassword.decrypt_if_password(roots.first.attributes["password"])).to eq("secret")
       # puts ws.to_expanded_xml()
     end
 
     it "follows relationships properly" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "relation"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test3", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
 
       root = roots.first
-      root.namespace.should eql("#{@domain}/EVM")
-      root.klass.should eql("AUTOMATE")
-      root.instance.should eql("test3")
+      expect(root.namespace).to eql("#{@domain}/EVM")
+      expect(root.klass).to eql("AUTOMATE")
+      expect(root.instance).to eql("test3")
 
       children = root.children
-      children.should_not be_nil
-      children.length.should == 1
+      expect(children).not_to be_nil
+      expect(children.length).to eq(1)
 
       child = children.first
-      child.namespace.should eql("#{@domain}/EVM")
-      child.klass.should eql("AUTOMATE")
-      child.instance.should eql("test2")
+      expect(child.namespace).to eql("#{@domain}/EVM")
+      expect(child.klass).to eql("AUTOMATE")
+      expect(child.instance).to eql("test2")
 
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test_wildcard", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       root = roots.first
       children = root.children
-      children.should_not be_nil
-      children.length.should == 2
+      expect(children).not_to be_nil
+      expect(children.length).to eq(2)
 
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test_message1", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       root = roots.first
       children = root.children
-      children.should_not be_nil
-      children.length.should == 1
+      expect(children).not_to be_nil
+      expect(children.length).to eq(1)
 
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test_message1#discover", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       root = roots.first
       children = root.children
-      children.should_not be_nil
-      children.length.should == 2
+      expect(children).not_to be_nil
+      expect(children.length).to eq(2)
     end
 
     it "does not allow cyclical relationships" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec2"), @domain)
-      lambda { MiqAeEngine.instantiate("/CYCLICAL/AUTOMATE/test4", @user) }.should raise_error(MiqAeException::CyclicalRelationship)
+      expect { MiqAeEngine.instantiate("/CYCLICAL/AUTOMATE/test4", @user) }.to raise_error(MiqAeException::CyclicalRelationship)
     end
 
     it "raises exception if invalid path" do
@@ -562,166 +562,166 @@ module MiqAeEngineSpec
     it "properly processes assertions" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec3"), @domain)
       ws = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test1", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
 
       ws = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test2", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 0
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(0)
 
       ws = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test3", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
 
       ws = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test4", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
     end
 
     it "properly processes inheritance" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "relation"), @domain)
 
       ws = MiqAeEngine.instantiate("/EVM/MY_AUTOMATE/test1", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
 
       obj = roots.first
-      ["attr1", "foo"].each { |a| obj.attributes.should have_key(a) }
-      obj.attributes["attr1"].should == "frank"
-      obj.attributes["foo"].should == "bar"
+      ["attr1", "foo"].each { |a| expect(obj.attributes).to have_key(a) }
+      expect(obj.attributes["attr1"]).to eq("frank")
+      expect(obj.attributes["foo"]).to eq("bar")
 
       ws = MiqAeEngine.instantiate("/EVM/MY_AUTOMATE/test2", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
 
       obj = roots.first
       ["attr1", "foo"].each { |a| assert obj.attributes.key?(a) }
-      obj.attributes["attr1"].should == "miqaedb:/EVM/AUTOMATE/test1"
-      obj.attributes["foo"].should == "bar"
+      expect(obj.attributes["attr1"]).to eq("miqaedb:/EVM/AUTOMATE/test1")
+      expect(obj.attributes["foo"]).to eq("bar")
     end
 
     it "properly processes .missing_instance" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "relation"), @domain)
 
       ws = MiqAeEngine.instantiate("/EVM/MY_AUTOMATE/test_boo", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 0
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(0)
     end
 
     it "properly processes substitution" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "substitution"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/A/a1", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       a1 = roots[0]
       b1 = a1.children[0]
-      b1.attributes["attr1"].should == "defaultA"
+      expect(b1.attributes["attr1"]).to eq("defaultA")
 
       ws = MiqAeEngine.instantiate("/EVM/A/a2", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       a2 = roots[0]
       b2 = a2.children[0]
-      b2.attributes["attr1"].should == "a2"
+      expect(b2.attributes["attr1"]).to eq("a2")
 
       ws = MiqAeEngine.instantiate("/EVM/B/b3", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       b3 = roots[0]
-      b3.attributes["attr2"].should == "b3"
+      expect(b3.attributes["attr2"]).to eq("b3")
 
       ws = MiqAeEngine.instantiate("/EVM/A/a4", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       a4 = roots[0]
       b4 = a4.children[0]
-      b4.attributes["attr1"].should == "a4"
+      expect(b4.attributes["attr1"]).to eq("a4")
 
-      -> { MiqAeEngine.instantiate("/EVM/A/a5", @user) }.should raise_error(MiqAeException::InvalidPathFormat)
-      -> { MiqAeEngine.instantiate("/EVM/A/a6", @user) }.should raise_error(MiqAeException::ObjectNotFound)
-      -> { MiqAeEngine.instantiate("/EVM/A/a7", @user) }.should raise_error(MiqAeException::ObjectNotFound)
+      expect { MiqAeEngine.instantiate("/EVM/A/a5", @user) }.to raise_error(MiqAeException::InvalidPathFormat)
+      expect { MiqAeEngine.instantiate("/EVM/A/a6", @user) }.to raise_error(MiqAeException::ObjectNotFound)
+      expect { MiqAeEngine.instantiate("/EVM/A/a7", @user) }.to raise_error(MiqAeException::ObjectNotFound)
 
       ws = MiqAeEngine.instantiate("/EVM/A/a8", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       a8 = roots[0]
       b8 = a8.children[0]
-      b8.attributes["attr1"].should == "${}"
+      expect(b8.attributes["attr1"]).to eq("${}")
 
       ws = MiqAeEngine.instantiate("/EVM/A/a9", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should == 1
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eq(1)
       a9 = roots[0]
       b9 = a9.children[0]
-      b9.attributes["attr1"].should == "foo"
+      expect(b9.attributes["attr1"]).to eq("foo")
 
       ws = MiqAeEngine.instantiate("/EVM/A/a10", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should eql(1)
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eql(1)
       a10 = roots[0]
       b10 = a10.children[0]
-      b10.attributes["attr1"].should eql('Bamm Bamm Rubble')
-      b10.attributes["attr3"].should eql('Pearl/Slaghoople')
+      expect(b10.attributes["attr1"]).to eql('Bamm Bamm Rubble')
+      expect(b10.attributes["attr3"]).to eql('Pearl/Slaghoople')
     end
 
     it "properly processes substitution with methods" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec4"), @domain)
-      MiqProvision.any_instance.stub(:validate).and_return(:true)
-      MiqProvision.any_instance.stub(:set_template_and_networking)
+      allow_any_instance_of(MiqProvision).to receive(:validate).and_return(:true)
+      allow_any_instance_of(MiqProvision).to receive(:set_template_and_networking)
       prov = MiqProvision.create!(:provision_type => 'clone_to_template', :state => 'pending', :status => 'Ok')
       ws   = MiqAeEngine.instantiate("/System/Process/REQUEST?MiqProvision::miq_provision=#{prov.id}&request=test_subst", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
 
       roots = ws.roots
-      roots.should_not be_nil
-      roots.should be_a_kind_of(Array)
-      roots.length.should eql(1)
+      expect(roots).not_to be_nil
+      expect(roots).to be_a_kind_of(Array)
+      expect(roots.length).to eql(1)
       root  = roots[0]
-      root['request'].should eql('test_subst')
+      expect(root['request']).to eql('test_subst')
       child = root.children[0]
-      child['test_attr'].should == "target_type=template"
+      expect(child['test_attr']).to eq("target_type=template")
     end
 
     it "processes arrays arguments properly" do
@@ -733,7 +733,7 @@ module MiqAeEngineSpec
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec5"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Array::my_objects=Vm::#{vm1.id},ExtManagementSystem::#{ems.id},Vm::#{vm2.id}", @user)
       my_objects_array = ws.root("my_objects")
-      my_objects_array.length.should == 3
+      expect(my_objects_array.length).to eq(3)
       my_objects_array.each { |o| o.kind_of?(MiqAeMethodService::MiqAeServiceModelBase) }
     end
 
@@ -741,8 +741,8 @@ module MiqAeEngineSpec
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_engine_spec6"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Array::my_objects=", @user)
       my_objects_array = ws.root("my_objects")
-      my_objects_array.length.should == 0
-      my_objects_array.should == []
+      expect(my_objects_array.length).to eq(0)
+      expect(my_objects_array).to eq([])
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_dispatch_spec.rb
@@ -18,7 +18,7 @@ describe "MiqAeMethodDispatch" do
                         :miq_group_id     => @user.current_group.id,
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
-    MiqServer.stub(:my_zone).and_return('default')
+    allow(MiqServer).to receive(:my_zone).and_return('default')
     @pidfile = File.join(Dir.mktmpdir, "rip_van_winkle.pid")
     clear_domain
   end

--- a/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
@@ -35,17 +35,17 @@ module MiqAeMethodSpec
       vm = FactoryGirl.create(:vm_vmware, :name => vm_name)
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_method_spec1"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Vm::vm=#{vm.id}", @user)
-      ws.root("vm_id_via_hash").should == vm.id
-      ws.root("vm_id_via_call").should == vm.id
-      ws.root("vm_name").should == vm.name
-      ws.root("vm_normalized_name").should == vm.name.tr(' ', '_')
+      expect(ws.root("vm_id_via_hash")).to eq(vm.id)
+      expect(ws.root("vm_id_via_call")).to eq(vm.id)
+      expect(ws.root("vm_name")).to eq(vm.name)
+      expect(ws.root("vm_normalized_name")).to eq(vm.name.tr(' ', '_'))
     end
 
     it "decrypts passwords upon request" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_method_spec2"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1", @user)
-      ws.root("decrypted").should == 'secret'
-      ws.root("encrypted").should == '********'
+      expect(ws.root("decrypted")).to eq('secret')
+      expect(ws.root("encrypted")).to eq('********')
     end
 
     it "properly processes instance methods via no inheritance" do
@@ -53,9 +53,9 @@ module MiqAeMethodSpec
       MiqAeDatastore.reset_default_namespace
       setup_methods
       ws = MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_default", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       ws = MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_inline", @user)
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       # puts ws.to_expanded_xml()
     end
 
@@ -63,39 +63,39 @@ module MiqAeMethodSpec
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "method2"), @domain)
       MiqAeDatastore.reset_default_namespace
       setup_methods
-      -> { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_missing_parameter", @user) }.should \
+      expect { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_missing_parameter", @user) }.to \
         raise_error(MiqAeException::MethodParmMissing)
-      -> { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_non_existent_internal", @user) }.should \
+      expect { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_non_existent_internal", @user) }.to \
         raise_error(MiqAeException::MethodNotFound)
-      -> { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_missing", @user) }.should \
+      expect { MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_missing", @user) }.to \
         raise_error(MiqAeException::MethodNotFound)
-      MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_internal", @user).should_not be_nil
-      MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_inline", @user).should_not be_nil
+      expect(MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_internal", @user)).not_to be_nil
+      expect(MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_inline", @user)).not_to be_nil
     end
 
     it "is case-insensitive for method invocation" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "method2"), @domain)
       MiqAeDatastore.reset_default_namespace
       setup_methods
-      MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_builtin_with_different_case", @user).should_not be_nil
+      expect(MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_builtin_with_different_case", @user)).not_to be_nil
     end
 
     it "can access *current* set of attributes from within method" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_method_spec4"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1", @user)
-      ws.root("current_namespace").should eql("#{@domain}/EVM")
-      ws.root("current_class").should eql('AUTOMATE')
-      ws.root("current_instance").should eql('test1')
-      ws.root("current_message").should eql('create')
-      ws.root("current_method").should eql('test')
+      expect(ws.root("current_namespace")).to eql("#{@domain}/EVM")
+      expect(ws.root("current_class")).to eql('AUTOMATE')
+      expect(ws.root("current_instance")).to eql('test1')
+      expect(ws.root("current_message")).to eql('create')
+      expect(ws.root("current_method")).to eql('test')
     end
 
     it "handles datatype conversion" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_method_spec5"), @domain)
       ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?flag=false&flag2=true&int=5&float=5.87&symbol=test&array=1,2,3", @user)
 
-      expect(ws.root("flag")).to   be_false
-      expect(ws.root("flag2")).to  be_true
+      expect(ws.root("flag")).to   be_falsey
+      expect(ws.root("flag2")).to  be_truthy
       expect(ws.root("int")).to    eq(5)
       expect(ws.root("float")).to  eq(5.87)
       expect(ws.root("symbol")).to eq(:test)
@@ -108,7 +108,7 @@ module MiqAeMethodSpec
       # and that the EVM Server and these tests use the same database.
 
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "method3"), @domain)
-      MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/WSTEST/test_inline", @user).should_not be_nil
+      expect(MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/WSTEST/test_inline", @user)).not_to be_nil
       # MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/WSTEST/test_perl_intra_method_get_set_get").should_not be_nil
 
       # Contents of Perl Script

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -31,7 +31,7 @@ module MiqAeObjectSpec
       hash = Hash.from_xml(xml)
       attrs = hash['MiqAeObject']['MiqAeAttribute']
       args.each do |key, value|
-        find_match(attrs, key, value).should be_true
+        expect(find_match(attrs, key, value)).to be_truthy
       end
     end
 
@@ -60,42 +60,42 @@ module MiqAeObjectSpec
 
     it "#process_args_as_attributes with a hash with no object reference" do
       result = @miq_obj.process_args_as_attributes("name" => "fred")
-      result["name"].should be_kind_of(String)
-      result["name"].should == "fred"
+      expect(result["name"]).to be_kind_of(String)
+      expect(result["name"]).to eq("fred")
     end
 
     it "#process_args_as_attributes with a hash with an object reference" do
       result = @miq_obj.process_args_as_attributes("VmOrTemplate::vm" => "#{@vm.id}")
-      result["vm_id"].should == @vm.id.to_s
-      result["vm"].should be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+      expect(result["vm_id"]).to eq(@vm.id.to_s)
+      expect(result["vm"]).to be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
     end
 
     it "#process_args_as_attributes with a single element array" do
       result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id}"})
-      result["vms"].should be_kind_of(Array)
-      result["vms"].length.should == 1
+      expect(result["vms"]).to be_kind_of(Array)
+      expect(result["vms"].length).to eq(1)
     end
 
     it "#process_args_as_attributes with an array" do
       vm2 = FactoryGirl.create(:vm_vmware)
       result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}"})
-      result["vms"].should be_kind_of(Array)
-      result["vms"].length.should == 2
+      expect(result["vms"]).to be_kind_of(Array)
+      expect(result["vms"].length).to eq(2)
     end
 
     it "#process_args_as_attributes with an array containing invalid entries" do
       vm2 = FactoryGirl.create(:vm_vmware)
       result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},fred::12,,VmOrTemplate::#{vm2.id}"})
-      result["vms"].should be_kind_of(Array)
-      result["vms"].length.should == 2
+      expect(result["vms"]).to be_kind_of(Array)
+      expect(result["vms"].length).to eq(2)
     end
 
     it "#process_args_as_attributes with an array containing disparate objects" do
       host    = FactoryGirl.create(:host)
       ems     = FactoryGirl.create(:ems_vmware)
       result  = @miq_obj.process_args_as_attributes({"Array::my_objects" => "VmOrTemplate::#{@vm.id},Host::#{host.id},ExtManagementSystem::#{ems.id}"})
-      result["my_objects"].should be_kind_of(Array)
-      result["my_objects"].length.should == 3
+      expect(result["my_objects"]).to be_kind_of(Array)
+      expect(result["my_objects"].length).to eq(3)
     end
 
     context "#enforce_state_maxima" do

--- a/spec/lib/miq_automation_engine/miq_ae_path_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_path_spec.rb
@@ -6,32 +6,32 @@ module MiqAePathSpec
     context "#to_s" do
       it "handles empty path" do
         path = MiqAePath.new
-        path.to_s.should == ""
+        expect(path.to_s).to eq("")
       end
 
       it "handles single namespace" do
         path = MiqAePath.new(:ae_namespace => "NAMESPACE")
-        path.to_s.should == "/NAMESPACE//"
+        expect(path.to_s).to eq("/NAMESPACE//")
       end
 
       it "handles compound namespace" do
         path = MiqAePath.new(:ae_namespace => "NAMESPACE/FOO")
-        path.to_s.should == "/NAMESPACE/FOO//"
+        expect(path.to_s).to eq("/NAMESPACE/FOO//")
       end
 
       it "handles namespace and class" do
         path = MiqAePath.new(:ae_namespace => "NAMESPACE", :ae_class => "CLASS")
-        path.to_s.should == "/NAMESPACE/CLASS/"
+        expect(path.to_s).to eq("/NAMESPACE/CLASS/")
       end
 
       it "handles namespace, class and instance" do
         path = MiqAePath.new(:ae_namespace => "NAMESPACE", :ae_class => "CLASS", :ae_instance => "INSTANCE")
-        path.to_s.should == "/NAMESPACE/CLASS/INSTANCE"
+        expect(path.to_s).to eq("/NAMESPACE/CLASS/INSTANCE")
       end
 
       it "handles namespace, class, instance and attribute" do
         path = MiqAePath.new(:ae_namespace => "NAMESPACE", :ae_class => "CLASS", :ae_instance => "INSTANCE", :ae_attribute => "ATTRIBUTE")
-        path.to_s.should == "/NAMESPACE/CLASS/INSTANCE/ATTRIBUTE"
+        expect(path.to_s).to eq("/NAMESPACE/CLASS/INSTANCE/ATTRIBUTE")
       end
     end
 
@@ -46,10 +46,10 @@ module MiqAePathSpec
       }
 
       path = MiqAePath.build(parts)
-      path.should be_kind_of MiqAePath
-      path.ae_namespace.should == ae_namespace
-      path.ae_class.should == ae_class
-      path.ae_instance.should == ae_instance
+      expect(path).to be_kind_of MiqAePath
+      expect(path.ae_namespace).to eq(ae_namespace)
+      expect(path.ae_class).to eq(ae_class)
+      expect(path.ae_instance).to eq(ae_instance)
     end
 
     it ".parse" do
@@ -65,11 +65,11 @@ module MiqAePathSpec
       path_string = MiqAePath.new(parts).to_s
       path = MiqAePath.parse(path_string)
 
-      path.should be_kind_of MiqAePath
-      path.ae_namespace.should == ae_namespace
-      path.ae_class.should == ae_class
-      path.ae_instance.should == ae_instance
-      path.to_s.should == path_string
+      expect(path).to be_kind_of MiqAePath
+      expect(path.ae_namespace).to eq(ae_namespace)
+      expect(path.ae_class).to eq(ae_class)
+      expect(path.ae_instance).to eq(ae_instance)
+      expect(path.to_s).to eq(path_string)
     end
 
     context ".split" do
@@ -88,10 +88,10 @@ module MiqAePathSpec
         path = MiqAePath.new(parts).to_s
         n, c, i, a = MiqAePath.split(path, method_options)
 
-        n.should == assertions[:ae_namespace]
-        c.should == assertions[:ae_class]
-        i.should == assertions[:ae_instance]
-        a.should == assertions[:ae_attribute]
+        expect(n).to eq(assertions[:ae_namespace])
+        expect(c).to eq(assertions[:ae_class])
+        expect(i).to eq(assertions[:ae_instance])
+        expect(a).to eq(assertions[:ae_attribute])
       end
 
       it "with simple namespace" do

--- a/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
@@ -53,121 +53,121 @@ module MiqAeProvisionSpec
 
       it "should instantiate lease_times" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_lease_times", @user)
-        ws.should_not be_nil
+        expect(ws).not_to be_nil
         ttls  = ws.root("ttls")
-        ttls.class.name.should == "Hash"
-        ttls.length.should == 5
+        expect(ttls.class.name).to eq("Hash")
+        expect(ttls.length).to eq(5)
       end
 
       it "should properly instantiate /EVMApplications/Provisioning/Information/Default#debug" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#debug", @user)
-        ws.should_not be_nil
+        expect(ws).not_to be_nil
         roots = ws.roots
-        roots.should_not be_nil
-        roots.should be_a_kind_of(Array)
-        roots.length.should == 1
+        expect(roots).not_to be_nil
+        expect(roots).to be_a_kind_of(Array)
+        expect(roots.length).to eq(1)
       end
 
       it "should instantiate ttl_warnings" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_ttl_warnings", @user)
-        ws.should_not be_nil
+        expect(ws).not_to be_nil
         warnings = ws.root("warnings")
-        warnings.class.name.should == "Hash"
-        warnings.length.should == 3
+        expect(warnings.class.name).to eq("Hash")
+        expect(warnings.length).to eq(3)
       end
 
       it "should instantiate allowed_num_vms" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=dev#get_allowed_num_vms", @user)
-        ws.should_not be_nil
-        ws.root("allowed").should == 3
+        expect(ws).not_to be_nil
+        expect(ws.root("allowed")).to eq(3)
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=test#get_allowed_num_vms", @user)
-        ws.should_not be_nil
-        ws.root("allowed").should == 5
+        expect(ws).not_to be_nil
+        expect(ws.root("allowed")).to eq(5)
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=foo#get_allowed_num_vms", @user)
-        ws.should_not be_nil
-        ws.root("allowed").should == 1
+        expect(ws).not_to be_nil
+        expect(ws.root("allowed")).to eq(1)
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=#get_allowed_num_vms", @user)
-        ws.should_not be_nil
-        ws.root("allowed").should == 0
+        expect(ws).not_to be_nil
+        expect(ws.root("allowed")).to eq(0)
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_allowed_num_vms", @user)
-        ws.should_not be_nil
-        ws.root("allowed").should == 0
+        expect(ws).not_to be_nil
+        expect(ws.root("allowed")).to eq(0)
       end
 
       it "should instantiate container_info" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=dev#get_container_info", @user)
-        ws.should_not be_nil
-        ws.root("ncpus").should == 1
-        ws.root("memory").should == 1
-        ws.root("vlan").should == "dev"
+        expect(ws).not_to be_nil
+        expect(ws.root("ncpus")).to eq(1)
+        expect(ws.root("memory")).to eq(1)
+        expect(ws.root("vlan")).to eq("dev")
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=test#get_container_info", @user)
-        ws.should_not be_nil
-        ws.root("ncpus").should == 2
-        ws.root("memory").should be_nil
-        ws.root("vlan").should be_nil
+        expect(ws).not_to be_nil
+        expect(ws.root("ncpus")).to eq(2)
+        expect(ws.root("memory")).to be_nil
+        expect(ws.root("vlan")).to be_nil
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=prod#get_container_info", @user)
-        ws.should_not be_nil
-        ws.root("ncpus").should be_nil
-        ws.root("memory").should == 4
-        ws.root("vlan").should == "production"
+        expect(ws).not_to be_nil
+        expect(ws.root("ncpus")).to be_nil
+        expect(ws.root("memory")).to eq(4)
+        expect(ws.root("vlan")).to eq("production")
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default?environment=foo#get_container_info", @user)
-        ws.should_not be_nil
-        ws.root("ncpus").should be_nil
-        ws.root("memory").should be_nil
-        ws.root("vlan").should be_nil
+        expect(ws).not_to be_nil
+        expect(ws.root("ncpus")).to be_nil
+        expect(ws.root("memory")).to be_nil
+        expect(ws.root("vlan")).to be_nil
       end
 
       it "should instantiate customization" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_customization", @user)
-        ws.should_not be_nil
-        ws.root("customization").should == EXPECTED_CUSTOMIZATION
+        expect(ws).not_to be_nil
+        expect(ws.root("customization")).to eq(EXPECTED_CUSTOMIZATION)
       end
 
       it "should have Domain class" do
         fqname = "#{@domain}/EVMApplications/Provisioning/Domain"
         klass = MiqAeClass.find_by_fqname(fqname)
-        klass.should_not be_nil
-        klass.ae_instances.length.should_not == 0
+        expect(klass).not_to be_nil
+        expect(klass.ae_instances.length).not_to eq(0)
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_domains", @user)
-        ws.should_not be_nil
+        expect(ws).not_to be_nil
 
         domains = ws.root['domains']
-        domains.should_not be_nil
-        domains.should be_a_kind_of(Array)
+        expect(domains).not_to be_nil
+        expect(domains).to be_a_kind_of(Array)
         domains.each { |domain|
-          domain.should be_a_kind_of(Hash)
-          [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| domain.should have_key(key) }
+          expect(domain).to be_a_kind_of(Hash)
+          [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| expect(domain).to have_key(key) }
         }
       end
 
       it "should have Network class" do
         fqname = "#{@domain}/EVMApplications/Provisioning/Network"
         klass = MiqAeClass.find_by_fqname(fqname)
-        klass.should_not be_nil
-        klass.ae_instances.length.should_not == 0
+        expect(klass).not_to be_nil
+        expect(klass.ae_instances.length).not_to eq(0)
 
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_networks", @user)
-        ws.should_not be_nil
+        expect(ws).not_to be_nil
 
         networks = ws.root['networks']
-        networks.should_not be_nil
-        networks.should be_a_kind_of(Array)
+        expect(networks).not_to be_nil
+        expect(networks).to be_a_kind_of(Array)
         networks.each { |network|
-          network.should be_a_kind_of(Hash)
-          [:scope, :vlan, :vc_id, :dhcp_servers].each { |key| network.should have_key(key) }
-          network[:dhcp_servers].should be_a_kind_of(Array)
+          expect(network).to be_a_kind_of(Hash)
+          [:scope, :vlan, :vc_id, :dhcp_servers].each { |key| expect(network).to have_key(key) }
+          expect(network[:dhcp_servers]).to be_a_kind_of(Array)
           network[:dhcp_servers].each { |dhcp|
-            dhcp.should be_a_kind_of(Hash)
-            [:domain, :ip, :name].each { |key| dhcp.should have_key(key) }
-            dhcp[:domain].should be_a_kind_of(Hash)
-            [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| dhcp[:domain].should have_key(key) }
+            expect(dhcp).to be_a_kind_of(Hash)
+            [:domain, :ip, :name].each { |key| expect(dhcp).to have_key(key) }
+            expect(dhcp[:domain]).to be_a_kind_of(Hash)
+            [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| expect(dhcp[:domain]).to have_key(key) }
           }
         }
       end

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -9,32 +9,32 @@ module MiqAeServiceModelSpec
     end
 
     it ".base_model" do
-      MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_model.should == MiqAeMethodService::MiqAeServiceVm
+      expect(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_model).to eq(MiqAeMethodService::MiqAeServiceVm)
     end
 
     it ".base_class" do
-      MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_class.should == MiqAeMethodService::MiqAeServiceVmOrTemplate
+      expect(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_class).to eq(MiqAeMethodService::MiqAeServiceVmOrTemplate)
     end
 
     it "vm should be valid" do
-      @vm.should be_kind_of(Vm)
-      @vm.should_not be_nil
-      @vm.id.should_not be_nil
+      expect(@vm).to be_kind_of(Vm)
+      expect(@vm).not_to be_nil
+      expect(@vm.id).not_to be_nil
     end
 
     it "ae_vm should be valid" do
-      @ae_vm.should be_kind_of(MiqAeMethodService::MiqAeServiceVm)
-      @ae_vm.instance_variable_get("@object").should == @vm
+      expect(@ae_vm).to be_kind_of(MiqAeMethodService::MiqAeServiceVm)
+      expect(@ae_vm.instance_variable_get("@object")).to eq(@vm)
     end
 
     it "ae_vm should have a special inspect method" do
       inspect = @ae_vm.inspect
-      inspect[0, 2].should == '#<'
-      inspect[-1, 1].should == '>'
+      expect(inspect[0, 2]).to eq('#<')
+      expect(inspect[-1, 1]).to eq('>')
     end
 
     it "ae_vm should have an associations method" do
-      @ae_vm.associations.should be_kind_of(Array)
+      expect(@ae_vm.associations).to be_kind_of(Array)
     end
 
     describe "#tag_assign" do
@@ -42,13 +42,13 @@ module MiqAeServiceModelSpec
       let(:tag)         { FactoryGirl.create(:classification_tag, :parent_id => category.id) }
 
       it "can assign an exiting tag to ae_vm" do
-        @ae_vm.tag_assign("#{category.name}/#{tag.name}").should be_true
-        @ae_vm.tagged_with?(category.name, tag.name).should be_true
+        expect(@ae_vm.tag_assign("#{category.name}/#{tag.name}")).to be_truthy
+        expect(@ae_vm.tagged_with?(category.name, tag.name)).to be_truthy
       end
 
       it "cannot assign a non-existing tag to ae_vm, but no error is raised" do
-        @ae_vm.tag_assign("#{category.name}/non_exisiting_tag").should be_true
-        @ae_vm.tagged_with?(category.name, 'non_exisiting_tag').should be_false
+        expect(@ae_vm.tag_assign("#{category.name}/non_exisiting_tag")).to be_truthy
+        expect(@ae_vm.tagged_with?(category.name, 'non_exisiting_tag')).to be_falsey
       end
     end
 
@@ -63,20 +63,20 @@ module MiqAeServiceModelSpec
         end
 
         it "can unassign a tag from ae_vm" do
-          @ae_vm.tag_unassign("#{category.name}/#{tag.name}").should be_true
-          @ae_vm.tagged_with?(category.name, tag.name).should be_false
+          expect(@ae_vm.tag_unassign("#{category.name}/#{tag.name}")).to be_truthy
+          expect(@ae_vm.tagged_with?(category.name, tag.name)).to be_falsey
         end
 
         it "unassigns only specified tag from ae_vm but not other tags from the same category" do
-          @ae_vm.tag_assign("#{category.name}/#{another_tag.name}").should be_true
+          expect(@ae_vm.tag_assign("#{category.name}/#{another_tag.name}")).to be_truthy
 
-          @ae_vm.tag_unassign("#{category.name}/#{tag.name}").should be_true
-          @ae_vm.tagged_with?(category.name, another_tag.name).should be_true
+          expect(@ae_vm.tag_unassign("#{category.name}/#{tag.name}")).to be_truthy
+          expect(@ae_vm.tagged_with?(category.name, another_tag.name)).to be_truthy
         end
       end
 
       it "does not raise an error when attempts to unassign a non-existing tag" do
-        @ae_vm.tag_unassign("#{category.name}/non_exisiting_tag").should be_true
+        expect(@ae_vm.tag_unassign("#{category.name}/non_exisiting_tag")).to be_truthy
       end
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -12,7 +12,7 @@ module MiqAeServiceSpec
 
     context "#attributes" do
       before do
-        @object.stub(:attributes).and_return('true'     => true,
+        allow(@object).to receive(:attributes).and_return('true'     => true,
                                              'false'    => false,
                                              'time'     => Time.parse('Aug 30, 2013'),
                                              'symbol'   => :symbol,
@@ -26,17 +26,17 @@ module MiqAeServiceSpec
       it "obscures passwords" do
         original_attributes = @object.attributes.dup
         attributes = @service_object.attributes
-        attributes['password'].should == '********'
-        @object.attributes.should == original_attributes
+        expect(attributes['password']).to eq('********')
+        expect(@object.attributes).to eq(original_attributes)
       end
     end
 
     context "#inspect" do
       it "returns the class, id and name" do
-        @object.stub(:object_name).and_return('fred')
+        allow(@object).to receive(:object_name).and_return('fred')
         regex = /#<MiqAeMethodService::MiqAeServiceObject:0x(\w+) name:.\"(?<name>\w+)\">/
         match = regex.match(@service_object.inspect)
-        match[:name].should eq('fred')
+        expect(match[:name]).to eq('fred')
       end
     end
   end
@@ -106,7 +106,7 @@ module MiqAeServiceSpec
 
         vms = miq_ae_service.vmdb('vm').find(:all)
         cache = miq_ae_service.instance_variable_get(:@drb_server_references)
-        expect(cache.any? { |x| x.object_id == vms.object_id }).to be_true
+        expect(cache.any? { |x| x.object_id == vms.object_id }).to be_truthy
       end
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_state_machine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_machine_spec.rb
@@ -21,9 +21,9 @@ module MiqAeStateMachineSpec
       ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED", @user)
       t1 = Time.now
 
-      ws.should_not be_nil
-      ws.root['ae_result'].should == 'ok'
-      ws.root['ae_state'].should == 'final'
+      expect(ws).not_to be_nil
+      expect(ws.root['ae_result']).to eq('ok')
+      expect(ws.root['ae_state']).to eq('final')
 
       # puts ws.to_xml
       #     puts "Old Provision Technique took #{t1 - t0} seconds"
@@ -37,9 +37,9 @@ module MiqAeStateMachineSpec
       ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
       t1 = Time.now
 
-      ws.should_not be_nil
-      ws.root['ae_result'].should == 'ok'
-      ws.root['ae_state'].should == ''
+      expect(ws).not_to be_nil
+      expect(ws.root['ae_result']).to eq('ok')
+      expect(ws.root['ae_state']).to eq('')
       # puts ws.to_xml
       #     puts "New Provision Technique took #{t1 - t0} seconds"
     end
@@ -53,9 +53,9 @@ module MiqAeStateMachineSpec
 
       ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
 
-      ws.should_not be_nil
-      ws.root['ae_result'].should == 'error'
-      ws.root['ae_state'].should == 'ProvisionCheck'
+      expect(ws).not_to be_nil
+      expect(ws.root['ae_result']).to eq('error')
+      expect(ws.root['ae_state']).to eq('ProvisionCheck')
       # puts ws.to_xml
     end
 
@@ -69,9 +69,9 @@ module MiqAeStateMachineSpec
 
       ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
 
-      ws.should_not be_nil
-      ws.root['ae_result'].should == 'error'
-      ws.root['ae_state'].should == 'ProvisionCheck'
+      expect(ws).not_to be_nil
+      expect(ws.root['ae_result']).to eq('error')
+      expect(ws.root['ae_state']).to eq('ProvisionCheck')
       # puts ws.to_xml
     end
 
@@ -87,7 +87,7 @@ module MiqAeStateMachineSpec
       ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
       t1 = Time.now
 
-      ws.should_not be_nil
+      expect(ws).not_to be_nil
       # puts ws.to_xml
       # puts "New Provision (with instance override) Technique took #{t1 - t0} seconds"
     end
@@ -102,14 +102,14 @@ module MiqAeStateMachineSpec
       i1.set_field_attribute(f1, method_string, :on_entry)
 
       ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
-      ws.root("test_root_object_attribute").should == "update_provision_status"
+      expect(ws.root("test_root_object_attribute")).to eq("update_provision_status")
     end
 
     it "sets ae_status_state properly" do
       EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
       ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
-      ws.root['ae_status_state'].should == 'on_exit'
+      expect(ws.root['ae_status_state']).to eq('on_exit')
     end
 
     it "executes on_entry fully qualified class methods properly" do
@@ -121,7 +121,7 @@ module MiqAeStateMachineSpec
       method_string = "SPEC_DOMAIN/factory/method.test_class_method(status => 'Testing class on entry method',status_state => 'on_entry')"
       i1.set_field_attribute(f1, method_string, :on_entry)
       ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
-      ws.root("test_root_object_attribute").should == "test_class_method"
+      expect(ws.root("test_root_object_attribute")).to eq("test_class_method")
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_state_missing_relation_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_missing_relation_spec.rb
@@ -65,20 +65,20 @@ describe "MiqAeStateMachine" do
   it "missing instance in first slot" do
     fqname = "#{@domain}/#{@namespace}/#{@state_class}/#{@state_instance1}"
     ws = MiqAeEngine.instantiate(fqname, @user)
-    ws.root['ae_result'].should eql('error')
+    expect(ws.root['ae_result']).to eql('error')
   end
 
   it "missing instance in middle slot" do
     fqname = "#{@domain}/#{@namespace}/#{@state_class}/#{@state_instance2}"
     ws = MiqAeEngine.instantiate(fqname, @user)
-    ws.root['ae_result'].should eql('error')
-    ws.root['var1'].should == '1'
+    expect(ws.root['ae_result']).to eql('error')
+    expect(ws.root['var1']).to eq('1')
   end
 
   it "missing instance in last slot" do
     fqname = "#{@domain}/#{@namespace}/#{@state_class}/#{@state_instance3}"
     ws = MiqAeEngine.instantiate(fqname, @user)
-    ws.root['ae_result'].should eql('error')
-    ws.root['var1'].should == '3'
+    expect(ws.root['ae_result']).to eql('error')
+    expect(ws.root['var1']).to eq('3')
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_uri_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_uri_spec.rb
@@ -15,18 +15,18 @@ module MiqAeUriSpec
         "message=get_vmname&request=UI_PROVISION_INFO"                             => {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'},
         "message=get_dialogs&request=UI_PROVISION_INFO"                            => {'request' => 'UI_PROVISION_INFO', 'message' => 'get_dialogs'},
       }.each do |query, hash|
-        MiqAeUri.hash2query(hash).should == query
-        MiqAeUri.query2hash(query).should == hash
+        expect(MiqAeUri.hash2query(hash)).to eq(query)
+        expect(MiqAeUri.query2hash(query)).to eq(hash)
       end
     end
 
     it "escape non-ASCII Numeric characters" do
       hash = {"test://dev?lab$~" => "OU=serverbuildingtest, OU=dev2"}
       query = MiqAeUri.hash2query(hash)
-      query.should == "test%3A%2F%2Fdev%3Flab%24%7E=OU%3Dserverbuildingtest%2C%20OU%3Ddev2"
+      expect(query).to eq("test%3A%2F%2Fdev%3Flab%24%7E=OU%3Dserverbuildingtest%2C%20OU%3Ddev2")
 
       result_hash = MiqAeUri.query2hash(query)
-      result_hash.should == hash
+      expect(result_hash).to eq(hash)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_compare_fields_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_compare_fields_spec.rb
@@ -184,7 +184,7 @@ describe MiqAeClassCompareFields do
   def class_check_status(class1, class2, status)
     diff_obj = MiqAeClassCompareFields.new(class1, class2)
     diff_obj.compare
-    diff_obj.status.should equal(status)
+    expect(diff_obj.status).to equal(status)
   end
 
   def prep_class_file_names(class1 = nil, class2 = nil)

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
@@ -25,7 +25,7 @@ describe MiqAeClassCopy do
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
       @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
       class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
-      class2.should_not be_nil
+      expect(class2).not_to be_nil
     end
   end
 
@@ -41,7 +41,7 @@ describe MiqAeClassCopy do
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
       @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{new_ns}", false)
       class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
-      class2.should_not be_nil
+      expect(class2).not_to be_nil
     end
   end
 
@@ -56,7 +56,7 @@ describe MiqAeClassCopy do
       class2 = MiqAeClassCopy.new(@src_fqname).as(new_name)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
       class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, new_name)
-      class2.should_not be_nil
+      expect(class2).not_to be_nil
     end
   end
 
@@ -83,7 +83,7 @@ describe MiqAeClassCopy do
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
       @ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{new_ns}", false)
       class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, new_name)
-      class2.should_not be_nil
+      expect(class2).not_to be_nil
     end
   end
 
@@ -105,17 +105,17 @@ describe MiqAeClassCopy do
       miq_ae_class_copy = double(MiqAeClassCopy)
       miq_ae_class = mock_model(MiqAeClass)
       new_ids = [miq_ae_class.id] * ids.length
-      miq_ae_class_copy.should_receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_class }
-      miq_ae_class.should_receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
-      MiqAeClass.should_receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { miq_ae_class }
-      MiqAeClassCopy.should_receive(:new).with(anything).exactly(ids.length).times { miq_ae_class_copy }
-      MiqAeClassCopy.copy_multiple(ids, domain).should match_array(new_ids)
+      expect(miq_ae_class_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_class }
+      expect(miq_ae_class).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
+      expect(MiqAeClass).to receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { miq_ae_class }
+      expect(MiqAeClassCopy).to receive(:new).with(anything).exactly(ids.length).times { miq_ae_class_copy }
+      expect(MiqAeClassCopy.copy_multiple(ids, domain)).to match_array(new_ids)
     end
   end
 
   def class_check_status(class1, class2, status)
     diff_obj = MiqAeClassCompareFields.new(class1, class2)
     diff_obj.compare
-    diff_obj.status.should equal(status)
+    expect(diff_obj.status).to equal(status)
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 include AutomationSpecHelper
 describe MiqAeClass do
-  it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:namespace_id) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:namespace_id) }
 
-  it { should allow_value("cla.ss1").for(:name) }
-  it { should allow_value("cla-ss1").for(:name) }
+  it { is_expected.to allow_value("cla.ss1").for(:name) }
+  it { is_expected.to allow_value("cla-ss1").for(:name) }
 
-  it { should_not allow_value("cla ss1").for(:name) }
-  it { should_not allow_value("cla:ss1").for(:name) }
+  it { is_expected.not_to allow_value("cla ss1").for(:name) }
+  it { is_expected.not_to allow_value("cla:ss1").for(:name) }
 
   it "should not create class without namespace" do
     expect { MiqAeClass.new(:name => "TEST").save! }.to raise_error(ActiveRecord::RecordInvalid)
@@ -21,29 +21,29 @@ describe MiqAeClass do
 
   it "should set the updated_by field on save" do
     c1 = MiqAeClass.create(:namespace => "TEST", :name => "oleg")
-    c1.updated_by.should == 'system'
+    expect(c1.updated_by).to eq('system')
   end
 
   it "should not create classes with the same name in the same namespace" do
     c1 = MiqAeClass.new(:namespace => "TEST", :name => "oleg")
-    c1.should_not be_nil
-    c1.save!.should be_true
+    expect(c1).not_to be_nil
+    expect(c1.save!).to be_truthy
     expect { MiqAeClass.new(:namespace => "TEST", :name => "OLEG").save! }.to raise_error(ActiveRecord::RecordInvalid)
     c2 = MiqAeClass.new(:namespace => "PROD", :name => "oleg")
-    c2.should_not be_nil
-    c2.save!.should be_true
+    expect(c2).not_to be_nil
+    expect(c2.save!).to be_truthy
   end
 
   it "should return editable as false if the parent namespace is not editable" do
     n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10, :system => true)
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
-    c1.should_not be_editable
+    expect(c1).not_to be_editable
   end
 
   it "should return editable as true if the parent namespace is editable" do
     n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1')
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
-    c1.should be_editable
+    expect(c1).to be_editable
   end
 
   context "cross domain instances" do
@@ -69,79 +69,79 @@ describe MiqAeClass do
     end
 
     it 'invalid path should return an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN').should be_empty
-      MiqAeClass.find_distinct_instances_across_domains(@user, nil).should be_empty
-      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/').should be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN')).to be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, nil)).to be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/')).to be_empty
     end
 
     it 'if the namespace does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/PROCESS').should be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/PROCESS')).to be_empty
     end
 
     it 'if the namespace exists but the class does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains(@user, 'SYSTEM/UNKNOWN').should be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, 'SYSTEM/UNKNOWN')).to be_empty
     end
 
     it 'if the namespace does not exist and the class does not exist we should get an empty array' do
-      MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/UNKNOWN').should be_empty
+      expect(MiqAeClass.find_distinct_instances_across_domains(@user, 'UNKNOWN/UNKNOWN')).to be_empty
     end
 
     it 'get sorted list of instances across domains with partial namespace' do
       non_fq_klass = 'SYSTEM/PROCESS'
       x = MiqAeClass.find_distinct_instances_across_domains(@user, non_fq_klass).collect(&:fqname)
-      @sorted_inst_list.should match_string_array_ignorecase(x)
+      expect(@sorted_inst_list).to match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of instances across domains with FQ namespace' do
       fq_klass = 'DOMAIN1/SYSTEM/PROCESS'
       x = MiqAeClass.find_distinct_instances_across_domains(@user, fq_klass).collect(&:fqname)
-      @sorted_inst_list.should match_string_array_ignorecase(x)
+      expect(@sorted_inst_list).to match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of instances across domains with /FQ namespace' do
       fq_klass = '/DOMAIN1/SYSTEM/PROCESS'
       x = MiqAeClass.find_distinct_instances_across_domains(@user, fq_klass).collect(&:fqname)
-      @sorted_inst_list.should match_string_array_ignorecase(x)
+      expect(@sorted_inst_list).to match_string_array_ignorecase(x)
     end
 
     it 'invalid path for similar named instance should return an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN').should be_empty
-      MiqAeClass.find_homonymic_instances_across_domains(@user, nil).should be_empty
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/').should be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN')).to be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, nil)).to be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/')).to be_empty
     end
 
     it 'invalid path no instance specified we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS').should be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS')).to be_empty
     end
 
     it 'if the namespace does not exist but class and instance exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS/FRED').should be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKNOWN/PROCESS/FRED')).to be_empty
     end
 
     it 'if the namespace, instance exists but the class does not exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'SYSTEM/UNKNOWN/FRED').should be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'SYSTEM/UNKNOWN/FRED')).to be_empty
     end
 
     it 'if the namespace,class, instance does not exist we should get an empty array' do
-      MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKOWN/UNKNOWN/UNKNOWN').should be_empty
+      expect(MiqAeClass.find_homonymic_instances_across_domains(@user, 'UNKOWN/UNKNOWN/UNKNOWN')).to be_empty
     end
 
     it 'get sorted list of same named instances across domains with partial namespace' do
       non_fq_inst = 'SYSTEM/PROCESS/Inst4'
       x = MiqAeClass.find_homonymic_instances_across_domains(@user, non_fq_inst).collect(&:fqname)
-      @inst4_list.should match_string_array_ignorecase(x)
+      expect(@inst4_list).to match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of same named instances across domains with FQ namespace' do
       fq_inst = 'DOMAIN1/SYSTEM/PROCESS/Inst4'
       x = MiqAeClass.find_homonymic_instances_across_domains(@user, fq_inst).collect(&:fqname)
-      @inst4_list.should match_string_array_ignorecase(x)
+      expect(@inst4_list).to match_string_array_ignorecase(x)
     end
 
     it 'get sorted list of same named instances across domains with /FQ namespace' do
       fq_inst = '/DOMAIN1/SYSTEM/PROCESS/Inst4'
       x = MiqAeClass.find_homonymic_instances_across_domains(@user, fq_inst).collect(&:fqname)
-      @inst4_list.should match_string_array_ignorecase(x)
+      expect(@inst4_list).to match_string_array_ignorecase(x)
     end
   end
 
@@ -169,7 +169,7 @@ describe MiqAeClass do
       }
 
       res = MiqAeClass.copy(options)
-      res.count.should eq(2)
+      expect(res.count).to eq(2)
     end
 
     it "copy classes under same namespace raise error when class exists" do
@@ -192,7 +192,7 @@ describe MiqAeClass do
       }
 
       res = MiqAeClass.copy(options)
-      res.count.should eq(2)
+      expect(res.count).to eq(2)
     end
   end
 
@@ -217,15 +217,15 @@ describe MiqAeClass do
     let(:ae_instance2) { MiqAeInstance.new }
 
     before do
-      ae_method1.stub(:fqname).and_return("z")
-      ae_method2.stub(:fqname).and_return("a")
-      ae_method1.stub(:to_export_xml) { |options| options[:builder].ae_method1 }
-      ae_method2.stub(:to_export_xml) { |options| options[:builder].ae_method2 }
+      allow(ae_method1).to receive(:fqname).and_return("z")
+      allow(ae_method2).to receive(:fqname).and_return("a")
+      allow(ae_method1).to receive(:to_export_xml) { |options| options[:builder].ae_method1 }
+      allow(ae_method2).to receive(:to_export_xml) { |options| options[:builder].ae_method2 }
 
-      ae_instance1.stub(:fqname).and_return("z")
-      ae_instance2.stub(:fqname).and_return("a")
-      ae_instance1.stub(:to_export_xml) { |options| options[:builder].ae_instance1 }
-      ae_instance2.stub(:to_export_xml) { |options| options[:builder].ae_instance2 }
+      allow(ae_instance1).to receive(:fqname).and_return("z")
+      allow(ae_instance2).to receive(:fqname).and_return("a")
+      allow(ae_instance1).to receive(:to_export_xml) { |options| options[:builder].ae_instance1 }
+      allow(ae_instance2).to receive(:to_export_xml) { |options| options[:builder].ae_instance2 }
     end
 
     context "when the class has ae_fields" do
@@ -234,8 +234,8 @@ describe MiqAeClass do
       let(:ae_field2) { MiqAeField.new(:priority => 1) }
 
       before do
-        ae_field1.stub(:to_export_xml) { |options| options[:builder].ae_field1 }
-        ae_field2.stub(:to_export_xml) { |options| options[:builder].ae_field2 }
+        allow(ae_field1).to receive(:to_export_xml) { |options| options[:builder].ae_field1 }
+        allow(ae_field2).to receive(:to_export_xml) { |options| options[:builder].ae_field2 }
       end
 
       it "produces the expected xml" do
@@ -262,7 +262,7 @@ describe MiqAeClass do
 
   it "#domain" do
     c1 = MiqAeClass.create(:namespace => "TEST/ABC", :name => "oleg")
-    c1.domain.name.should eql('TEST')
+    expect(c1.domain.name).to eql('TEST')
   end
 
   context "state_machine_class tests" do
@@ -274,31 +274,31 @@ describe MiqAeClass do
     it "class with only state field" do
       @c1.ae_fields.create(:name => "test_field", :substitute => false, :aetype => 'state')
       @c1.reload
-      @c1.state_machine?.should be_true
+      expect(@c1.state_machine?).to be_truthy
     end
 
     it "class with only attribute field" do
       @c1.ae_fields.create(:name => "test_field", :substitute => false, :aetype => 'attribute')
       @c1.reload
-      @c1.state_machine?.should be_false
+      expect(@c1.state_machine?).to be_falsey
     end
 
     it "update the field from attribute to state" do
       field1 = @c1.ae_fields.create(:name => "test_field", :substitute => false, :aetype => 'attribute')
       @c1.reload
-      @c1.state_machine?.should be_false
+      expect(@c1.state_machine?).to be_falsey
       field1.update_attributes(:aetype => 'state')
       @c1.reload
-      @c1.state_machine?.should be_true
+      expect(@c1.state_machine?).to be_truthy
     end
 
     it "remove the state field" do
       field1 = @c1.ae_fields.create(:name => "test_field1", :substitute => false, :aetype => 'state')
       @c1.reload
-      @c1.state_machine?.should be_true
+      expect(@c1.state_machine?).to be_truthy
       field1.destroy
       @c1.reload
-      @c1.state_machine?.should be_false
+      expect(@c1.state_machine?).to be_falsey
     end
   end
 
@@ -311,12 +311,12 @@ describe MiqAeClass do
       class_fqnames = %w(/FRED/A/B/C/CLASS1 /FREDDY/C/D/E/CLASS2)
       ids = ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.find_by_fqname(ns, false).id}" }
       ids += class_fqnames.collect { |cls| "MiqAeClass::#{MiqAeClass.find_by_fqname(cls).id}" }
-      MiqAeClass.waypoint_ids_for_state_machines.should match_array(ids)
+      expect(MiqAeClass.waypoint_ids_for_state_machines).to match_array(ids)
     end
 
     it "no state machine classes" do
       create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
-      MiqAeClass.waypoint_ids_for_state_machines.should be_empty
+      expect(MiqAeClass.waypoint_ids_for_state_machines).to be_empty
     end
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore/xml_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore/xml_export_spec.rb
@@ -24,41 +24,41 @@ describe MiqAeDatastore::XmlExport do
       miq_ae_classes
       custom_buttons
 
-      MiqAeClass.stub(:all).and_return(miq_ae_classes)
-      CustomButton.stub(:all).and_return(custom_buttons)
+      allow(MiqAeClass).to receive(:all).and_return(miq_ae_classes)
+      allow(CustomButton).to receive(:all).and_return(custom_buttons)
     end
 
     it "sorts the miq ae classes and returns the correct xml" do
-      miq_ae_class2.should_receive(:to_export_xml) do |options|
-        options[:builder].target!.should eq <<-XML
+      expect(miq_ae_class2).to receive(:to_export_xml) do |options|
+        expect(options[:builder].target!).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <MiqAeDatastore version="1.0">
         XML
-        options[:skip_instruct].should be_true
-        options[:indent].should eq(2)
+        expect(options[:skip_instruct]).to be_truthy
+        expect(options[:indent]).to eq(2)
         options[:builder].class2
       end
 
-      miq_ae_class1.should_receive(:to_export_xml) do |options|
-        options[:builder].target!.should eq <<-XML
+      expect(miq_ae_class1).to receive(:to_export_xml) do |options|
+        expect(options[:builder].target!).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <MiqAeDatastore version="1.0">
   <class2/>
         XML
-        options[:skip_instruct].should be_true
-        options[:indent].should eq(2)
+        expect(options[:skip_instruct]).to be_truthy
+        expect(options[:indent]).to eq(2)
         options[:builder].class1
       end
 
-      custom_button.should_receive(:to_export_xml) do |options|
-        options[:builder].target!.should eq <<-XML
+      expect(custom_button).to receive(:to_export_xml) do |options|
+        expect(options[:builder].target!).to eq <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <MiqAeDatastore version="1.0">
   <class2/>
   <class1/>
         XML
-        options[:skip_instruct].should be_true
-        options[:indent].should eq(2)
+        expect(options[:skip_instruct]).to be_truthy
+        expect(options[:indent]).to eq(2)
         options[:builder].custom_button
       end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -59,30 +59,30 @@ describe MiqAeDatastore do
   it "should test version" do
     MiqAeDatastore.reset
     setup_version_xml(MiqAeDatastore::XML_VERSION_MIN_SUPPORTED)
-    -> { MiqAeDatastore.import(@ver_fname) }.should_not raise_error
+    expect { MiqAeDatastore.import(@ver_fname) }.not_to raise_error
 
     MiqAeDatastore.reset
     setup_version_xml(MiqAeDatastore::XML_VERSION_MIN_SUPPORTED.to_f + 0.1)
-    -> { MiqAeDatastore.import(@ver_fname) }.should_not raise_error
+    expect { MiqAeDatastore.import(@ver_fname) }.not_to raise_error
 
     MiqAeDatastore.reset
     setup_version_xml(MiqAeDatastore::XML_VERSION_MIN_SUPPORTED.to_f - 0.1)
-    -> { MiqAeDatastore.import(@ver_fname) }.should raise_error(RuntimeError)
+    expect { MiqAeDatastore.import(@ver_fname) }.to raise_error(RuntimeError)
 
     MiqAeDatastore.reset
     setup_version_xml(nil)
-    -> { MiqAeDatastore.import(@ver_fname) }.should raise_error(RuntimeError)
+    expect { MiqAeDatastore.import(@ver_fname) }.to raise_error(RuntimeError)
   end
 
   it ".backup" do
-    MiqAeYamlExportZipfs.any_instance.should_receive(:export).once
+    expect_any_instance_of(MiqAeYamlExportZipfs).to receive(:export).once
     MiqAeDatastore.backup('zip_file'  => 'dummy', 'overwrite' => true)
   end
 
   it ".upload" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
-    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*", nil).once
+    expect(MiqAeDatastore).to receive(:import_yaml_zip).with(import_file, "*", nil).once
 
     MiqAeDatastore.upload(fd, "dummy.zip")
   end
@@ -90,24 +90,24 @@ describe MiqAeDatastore do
   it ".reset_default_namespace" do
     MiqAeDatastore.reset_default_namespace
     default_ns = MiqAeDomain.first || MiqAeNamespace.first
-    default_ns.name.should eq("$")
-    MiqAeClass.first.name.should     eq("Object")
-    MiqAeMethod.count.should         eq(3)
+    expect(default_ns.name).to eq("$")
+    expect(MiqAeClass.first.name).to     eq("Object")
+    expect(MiqAeMethod.count).to         eq(3)
   end
 
   it "temporary file cleanup for unsuccessful import" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
     expect { MiqAeDatastore.upload(fd, "dummy.zip") }.to raise_error
-    File.exist?(import_file).should be_false
+    expect(File.exist?(import_file)).to be_falsey
   end
 
   it "temporary file cleanup for successful import" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
-    MiqAeDatastore.should_receive(:import_yaml_zip).with(import_file, "*", nil).once
+    expect(MiqAeDatastore).to receive(:import_yaml_zip).with(import_file, "*", nil).once
     MiqAeDatastore.upload(fd, "dummy.zip")
-    File.exist?(import_file).should be_false
+    expect(File.exist?(import_file)).to be_falsey
   end
 
   describe "restore" do
@@ -115,18 +115,18 @@ describe MiqAeDatastore do
     let(:dummy_zipfile) { File.expand_path(File.join(File.dirname(__FILE__), "/miq_ae_datastore/data/dummy.zip")) }
 
     before do
-      MiqAeImport.stub(:new).and_return(miq_ae_yaml_import_zipfs)
-      miq_ae_yaml_import_zipfs.stub(:import)
+      allow(MiqAeImport).to receive(:new).and_return(miq_ae_yaml_import_zipfs)
+      allow(miq_ae_yaml_import_zipfs).to receive(:import)
     end
 
     it "validate arguments" do
       options_hash = {'restore' => true, 'preview' => false, 'zip_file' => dummy_zipfile}
-      MiqAeImport.should_receive(:new).with("*", options_hash)
+      expect(MiqAeImport).to receive(:new).with("*", options_hash)
       MiqAeDatastore.restore(dummy_zipfile)
     end
 
     it "imports" do
-      miq_ae_yaml_import_zipfs.should_receive(:import).once
+      expect(miq_ae_yaml_import_zipfs).to receive(:import).once
       MiqAeDatastore.restore(dummy_zipfile)
     end
 
@@ -138,9 +138,9 @@ describe MiqAeDatastore do
       domain_attributes = MiqAeDatastore.preserved_attrs_for_domains
       d2.update_attributes(:priority => 6, :enabled => false, :system => true)
       d1.update_attributes(:priority => 1, :enabled => true, :system => false)
-      MiqAeDatastore.preserved_attrs_for_domains.should_not eq(domain_attributes)
+      expect(MiqAeDatastore.preserved_attrs_for_domains).not_to eq(domain_attributes)
       MiqAeDatastore.restore_attrs_for_domains(domain_attributes)
-      MiqAeDatastore.preserved_attrs_for_domains.should eq(domain_attributes)
+      expect(MiqAeDatastore.preserved_attrs_for_domains).to eq(domain_attributes)
     end
   end
 
@@ -148,16 +148,16 @@ describe MiqAeDatastore do
     it "instance path" do
       create_ae_model(:name => 'DOM1', :priority => 20, :ae_class => 'cLaSS1',
                       :ae_namespace => 'A/b/C', :instance_name => 'Fred')
-      MiqAeDatastore.path_includes_domain?('/DOM1/A/b/C/Class1/Fred').should be_true
-      MiqAeDatastore.path_includes_domain?('/A/b/C/Class1/Fred').should be_false
+      expect(MiqAeDatastore.path_includes_domain?('/DOM1/A/b/C/Class1/Fred')).to be_truthy
+      expect(MiqAeDatastore.path_includes_domain?('/A/b/C/Class1/Fred')).to be_falsey
     end
 
     it "class path" do
       options = {:has_instance_name => false}
       create_ae_model(:name => 'DOM1', :priority => 20, :ae_class => 'cLaSS1',
                       :ae_namespace => 'A/b/C', :instance_name => 'Fred')
-      MiqAeDatastore.path_includes_domain?('/DOM1/A/b/C/Class1', options).should be_true
-      MiqAeDatastore.path_includes_domain?('/A/b/C/Class1', options).should be_false
+      expect(MiqAeDatastore.path_includes_domain?('/DOM1/A/b/C/Class1', options)).to be_truthy
+      expect(MiqAeDatastore.path_includes_domain?('/A/b/C/Class1', options)).to be_falsey
     end
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -10,7 +10,7 @@ describe MiqAeDomain do
     FactoryGirl.create(:miq_ae_domain, :name => 'TEST1')
     FactoryGirl.create(:miq_ae_domain, :name => 'TEST2', :priority => 10)
     d3 = FactoryGirl.create(:miq_ae_domain, :name => 'TEST3')
-    d3.priority.should eql(11)
+    expect(d3.priority).to eql(11)
   end
 
   context "reset priority" do
@@ -23,31 +23,31 @@ describe MiqAeDomain do
       after = {'TEST4' => 1, 'TEST3' => 2, 'TEST2' => 3, 'TEST1' => 4}
       ids   = after.collect { |dom, _| MiqAeDomain.find_by_fqname(dom).id }
       MiqAeDomain.reset_priority_by_ordered_ids(ids)
-      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with lowest priority is deleted" do
       MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST1').id)
       after = {'TEST2' => 1, 'TEST3' => 2, 'TEST4' => 3}
-      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with middle priority is deleted" do
       MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST3').id)
       after = {'TEST1' => 1, 'TEST2' => 2, 'TEST4' => 3}
-      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with highest priority is deleted" do
       MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST4').id)
       after = {'TEST1' => 1, 'TEST2' => 2, 'TEST3' => 3}
-      after.each { |dom, pri| MiqAeDomain.find_by_fqname(dom).priority.should eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after all domains are deleted" do
       %w(TEST1 TEST2 TEST3 TEST4).each { |name| MiqAeDomain.find_by_fqname(name).destroy }
       d1 = FactoryGirl.create(:miq_ae_domain, :name => 'TEST1')
-      d1.priority.should eql(1)
+      expect(d1.priority).to eql(1)
     end
   end
 
@@ -55,13 +55,13 @@ describe MiqAeDomain do
     it "should return unlocked_domains? as true if the there are any unlocked domains available" do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => false)
-      MiqAeDomain.any_unlocked?.should be_true
+      expect(MiqAeDomain.any_unlocked?).to be_truthy
     end
 
     it "should return unlocked_domains? as false if the there are no unlocked domains available" do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => true)
-      MiqAeDomain.any_unlocked?.should be_false
+      expect(MiqAeDomain.any_unlocked?).to be_falsey
     end
   end
 
@@ -70,14 +70,14 @@ describe MiqAeDomain do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => false)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd3', :priority => 10, :system => nil)
-      MiqAeDomain.all_unlocked.count.should eq(2)
+      expect(MiqAeDomain.all_unlocked.count).to eq(2)
     end
 
     it "should return empty array when there are no unlocked domains" do
       FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => true)
       FactoryGirl.create(:miq_ae_namespace, :name => 'd3', :priority => 10, :system => true)
-      MiqAeDomain.all_unlocked.count.should eq(0)
+      expect(MiqAeDomain.all_unlocked.count).to eq(0)
     end
   end
 
@@ -88,14 +88,14 @@ describe MiqAeDomain do
 
     it "missing class should get empty array" do
       result = MiqAeClass.get_homonymic_across_domains(@user, 'DOM1/CLASS1')
-      result.should be_empty
+      expect(result).to be_empty
     end
 
     it "get same named classes" do
       create_multiple_domains
       expected = %w(/DOM2/A/b/C/cLaSS1 /DOM1/A/B/C/CLASS1 /DOM3/a/B/c/CLASs1)
       result = MiqAeClass.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1', true)
-      expected.should match_string_array_ignorecase(result.collect(&:fqname))
+      expect(expected).to match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 
@@ -106,7 +106,7 @@ describe MiqAeDomain do
 
     it "missing instance should get empty array" do
       result = MiqAeInstance.get_homonymic_across_domains(@user, 'DOM1/CLASS1/nothing')
-      result.should be_empty
+      expect(result).to be_empty
     end
 
     it "get same named instances" do
@@ -118,7 +118,7 @@ describe MiqAeDomain do
         /DOM3/a/B/c/CLASs1/instance1
       )
       result = MiqAeInstance.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1/instance1')
-      expected.should match_string_array_ignorecase(result.collect(&:fqname))
+      expect(expected).to match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 
@@ -129,14 +129,14 @@ describe MiqAeDomain do
 
     it "missing method should get empty array" do
       result = MiqAeMethod.get_homonymic_across_domains(@user, 'DOM1/CLASS1/nothing')
-      result.should be_empty
+      expect(result).to be_empty
     end
 
     it "get same named methods" do
       create_multiple_domains_with_methods
       expected = %w(/DOM2/A/b/C/cLaSS1/method1 /DOM1/A/B/C/CLASS1/method1 /DOM3/a/B/c/CLASs1/method1)
       result = MiqAeMethod.get_homonymic_across_domains(@user, '/DOM1/A/B/C/CLASS1/method1', true)
-      expected.should match_string_array_ignorecase(result.collect(&:fqname))
+      expect(expected).to match_string_array_ignorecase(result.collect(&:fqname))
     end
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_export_spec.rb
@@ -7,7 +7,7 @@ describe MiqAeExport do
     let(:tenant2) { FactoryGirl.create(:tenant) }
 
     before do
-      MiqAeExport.stub(:write_domain).and_return("")
+      allow(MiqAeExport).to receive(:write_domain).and_return("")
       create_ae_model(:name => "dom1", :tenant => tenant1)
       create_ae_model(:name => "dom2", :tenant => tenant2)
     end

--- a/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
@@ -51,14 +51,14 @@ describe MiqAeField do
       # remove the invalid unsaved record in the association by clearing it
       @c1.ae_fields.clear
       f1 = @c1.ae_fields.build(:name => "TEST")
-      f1.should_not be_nil
-      f1.save!.should be_true
+      expect(f1).not_to be_nil
+      expect(f1.save!).to be_truthy
     end
 
     it "should not create fields with invalid names" do
       ["fie ld1", "fie-ld1", "fie:ld1"].each do |name|
         f1 = @c1.ae_fields.build(:name => name)
-        f1.should_not be_nil
+        expect(f1).not_to be_nil
         expect { f1.save! }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
@@ -66,43 +66,43 @@ describe MiqAeField do
     it "should process boolean fields properly" do
       fname1 = "TEST_EVALUATE"
       f1 = @c1.ae_fields.build(:name => fname1)
-      f1.save!.should be_true
-      f1.substitute?.should be_true
+      expect(f1.save!).to be_truthy
+      expect(f1.substitute?).to be_truthy
 
       f1.substitute = false
-      f1.save!.should be_true
-      f1.substitute?.should be_false
+      expect(f1.save!).to be_truthy
+      expect(f1.substitute?).to be_falsey
 
       f1.substitute = nil
-      f1.should be_valid
+      expect(f1).to be_valid
 
       f1.destroy
 
       f1 = @c1.ae_fields.build(:name => fname1, :substitute => false)
-      f1.save!.should be_true
-      f1.substitute?.should be_false
+      expect(f1.save!).to be_truthy
+      expect(f1.substitute?).to be_falsey
 
       f1.destroy
 
       f1 = @c1.ae_fields.build(:name => fname1, :substitute => "FRANK")
       # f1 = @c1.ae_fields.new
-      f1.should be_valid
-      f1.substitute?.should be_true
-      f1.save!.should be_true
+      expect(f1).to be_valid
+      expect(f1.substitute?).to be_truthy
+      expect(f1.save!).to be_truthy
 
       f1.destroy
     end
 
     it "should set the updated_by field on save" do
       f1 =  @c1.ae_fields.create(:name => "field")
-      f1.updated_by.should == 'system'
+      expect(f1.updated_by).to eq('system')
     end
 
     it "should validate unique case-independent names" do
       fname1 = "TEST_UNIQ"
       fname2 = "Test_Uniq"
       f1 = @c1.ae_fields.build(:name => fname1)
-      f1.save!.should be_true
+      expect(f1.save!).to be_truthy
       f2 = @c1.ae_fields.build(:name => fname2)
       expect { f2.save! }.to raise_error(ActiveRecord::RecordInvalid)
 
@@ -114,14 +114,14 @@ describe MiqAeField do
       fname1 = "test1"
       fname2 = "test2"
       f2 = @c1.ae_fields.build(:name => fname2, :aetype => "attribute", :priority => 2)
-      f2.save!.should be_true
+      expect(f2.save!).to be_truthy
       @c1.reload
       fields = @c1.ae_fields
       expect(fields.length).to eq(1)
       expect(fields[0].priority).to eq(2)
 
       f1 = @c1.ae_fields.build(:name => fname1, :aetype => "attribute", :priority => 1)
-      f1.save!.should be_true
+      expect(f1.save!).to be_truthy
       @c1.reload
 
       fields = @c1.ae_fields
@@ -136,8 +136,8 @@ describe MiqAeField do
     it "should validate datatypes" do
       MiqAeField.available_datatypes.each do |datatype|
         f = @c1.ae_fields.build(:name => "fname_#{datatype}", :aetype => "attribute", :datatype => datatype)
-        f.should be_valid
-        f.save!.should be_true
+        expect(f).to be_valid
+        expect(f.save!).to be_truthy
       end
       expect(@c1.reload.ae_fields.length).to eq(MiqAeField.available_datatypes.length)
 
@@ -146,30 +146,30 @@ describe MiqAeField do
 
       %w(foo bar).each do |datatype|
         f = @c1.ae_fields.build(:name => "fname_#{datatype}", :aetype => "attribute", :datatype => datatype)
-        f.should_not be_valid
+        expect(f).not_to be_valid
       end
     end
 
     it "should not change boolean value for substitute field when updating existing AE field record" do
       field1 = @c1.ae_fields.create(:name => "test_field", :substitute => false)
-      field1.substitute.should be_false
+      expect(field1.substitute).to be_falsey
       field2 = MiqAeField.find_by_name_and_class_id("test_field", @c1.id)
-      field2.save.should be_true
-      field2.substitute.should be_false
+      expect(field2.save).to be_truthy
+      expect(field2.substitute).to be_falsey
     end
 
     it "should return editable as false if the parent namespace/class is not editable" do
       n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10, :system => true)
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       f1 = FactoryGirl.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
-      f1.should_not be_editable
+      expect(f1).not_to be_editable
     end
 
     it "should return editable as true if the parent namespace/class is editable" do
       n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1')
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       f1 = FactoryGirl.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
-      f1.should be_editable
+      expect(f1).to be_editable
     end
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_compare_values_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_compare_values_spec.rb
@@ -56,7 +56,7 @@ describe MiqAeInstanceCompareValues do
   def instance_check_status(instance1, instance2, status)
     diff_obj = MiqAeInstanceCompareValues.new(instance1, instance2)
     diff_obj.compare
-    diff_obj.status.should equal(status)
+    expect(diff_obj.status).to equal(status)
   end
 
   def prep_instance_file_names(inst1 = nil, inst2 = nil)

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
@@ -80,7 +80,7 @@ describe MiqAeInstanceCopy do
       cp.as('incompatible_one', 'NS2', true)
       ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/ns2", false)
       ic_class = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
-      MiqAeInstance.find_by_class_id_and_name(ic_class.id, 'incompatible_one').should_not be_nil
+      expect(MiqAeInstance.find_by_class_id_and_name(ic_class.id, 'incompatible_one')).not_to be_nil
     end
   end
 
@@ -101,19 +101,19 @@ describe MiqAeInstanceCopy do
       ids    = [1, 2, 3]
       ins_copy = double(MiqAeInstanceCopy)
       ins = mock_model(MiqAeInstance)
-      ins_copy.should_receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { ins }
+      expect(ins_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { ins }
       new_ids = [ins.id] * ids.length
-      ins.should_receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
-      MiqAeInstance.should_receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { ins }
-      MiqAeInstanceCopy.should_receive(:new).with(fqname, true).exactly(1).times { ins_copy }
-      MiqAeInstanceCopy.should_receive(:new).with(fqname, false).exactly(ids.length - 1).times { ins_copy }
-      MiqAeInstanceCopy.copy_multiple(ids, domain).should match_array(new_ids)
+      expect(ins).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
+      expect(MiqAeInstance).to receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { ins }
+      expect(MiqAeInstanceCopy).to receive(:new).with(fqname, true).exactly(1).times { ins_copy }
+      expect(MiqAeInstanceCopy).to receive(:new).with(fqname, false).exactly(ids.length - 1).times { ins_copy }
+      expect(MiqAeInstanceCopy.copy_multiple(ids, domain)).to match_array(new_ids)
     end
   end
 
   def validate_instance(instance1, instance2, status)
     obj = MiqAeInstanceCompareValues.new(instance1, instance2)
     obj.compare
-    obj.status.should eq(status)
+    expect(obj.status).to eq(status)
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
@@ -11,24 +11,24 @@ describe MiqAeInstance do
     it "should create instance" do
       iname1 = "instance1"
       i1 = @c1.ae_instances.build(:name => iname1)
-      i1.should_not be_nil
-      i1.save!.should be_true
+      expect(i1).not_to be_nil
+      expect(i1.save!).to be_truthy
       @c2 = MiqAeClass.find(@c1.id)
-      @c2.should_not be_nil
-      @c2.ae_instances.should_not be_nil
+      expect(@c2).not_to be_nil
+      expect(@c2.ae_instances).not_to be_nil
       expect(@c2.ae_instances.count).to eq(1)
       i1.destroy
     end
 
     it "should set the updated_by field on save" do
       i1 = @c1.ae_instances.create(:name => "instance1")
-      i1.updated_by.should == 'system'
+      expect(i1.updated_by).to eq('system')
     end
 
     it "should not create instances with invalid names" do
       ["insta nce1", "insta:nce1"].each do |iname|
         i1 = @c1.ae_instances.build(:name => iname)
-        i1.should_not be_nil
+        expect(i1).not_to be_nil
         expect { i1.save! }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
@@ -36,7 +36,7 @@ describe MiqAeInstance do
     it "should create instances with valid names" do
       ["insta-nce1", "insta.nce1"].each do |iname|
         i1 = @c1.ae_instances.build(:name => iname)
-        i1.should_not be_nil
+        expect(i1).not_to be_nil
         expect { i1.save! }.to_not raise_error
       end
     end
@@ -50,7 +50,7 @@ describe MiqAeInstance do
       fname_bad = "fieldX"
 
       # Set/Get a value that doesn't yet exist, by field name
-      i1.get_field_value(@fname1).should be_nil
+      expect(i1.get_field_value(@fname1)).to be_nil
       expect { i1.set_field_value(@fname1, value1) }.to_not raise_error
       expect(i1.get_field_value(@fname1)).to eq(value1)
 
@@ -65,7 +65,7 @@ describe MiqAeInstance do
       i1.ae_values.destroy_all
 
       # Set/Get a value that doesn't yet exist, by field
-      i1.get_field_value(@f1).should be_nil
+      expect(i1.get_field_value(@f1)).to be_nil
       expect { i1.set_field_value(@f1, value1) }.to_not raise_error
       expect(i1.get_field_value(@f1)).to eq(value1)
 
@@ -105,12 +105,12 @@ describe MiqAeInstance do
       # Set/Get a value that doesn't yet exist, by field name
       expect(MiqAePassword.decrypt(f1.default_value)).to eq(default_value)
       f1.default_value = nil
-      f1.default_value.should be_nil
+      expect(f1.default_value).to be_nil
       f1.default_value = default_value
       expect(MiqAePassword.decrypt(f1.default_value)).to eq(default_value)
 
       # Set/Get a value that doesn't yet exist, by field name
-      i1.get_field_value(fname1).should be_nil
+      expect(i1.get_field_value(fname1)).to be_nil
       expect { i1.set_field_value(fname1, value1) }.to_not raise_error
       expect(MiqAePassword.decrypt(i1.get_field_value(fname1))).to eq(value1)
 
@@ -136,7 +136,7 @@ describe MiqAeInstance do
       f2.destroy
       i1.reload
 
-      MiqAeValue.where(:field_id => f2_id).should be_empty
+      expect(MiqAeValue.where(:field_id => f2_id)).to be_empty
       expect { i1.set_field_value(fname2, value1) }.to raise_error(MiqAeException::FieldNotFound)
       expect { i1.get_field_value(fname2)         }.to raise_error(MiqAeException::FieldNotFound)
     end
@@ -145,14 +145,14 @@ describe MiqAeInstance do
       n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10, :system => true)
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryGirl.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
-      i1.should_not be_editable
+      expect(i1).not_to be_editable
     end
 
     it "should return editable as true if the parent namespace/class is editable" do
       n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1')
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryGirl.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
-      i1.should be_editable
+      expect(i1).to be_editable
     end
   end
 
@@ -176,10 +176,10 @@ describe MiqAeInstance do
     let(:ae_values) { [ae_value] }
 
     before do
-      ae_field1.stub(:id).and_return(42)
-      ae_field2.stub(:id).and_return(84)
+      allow(ae_field1).to receive(:id).and_return(42)
+      allow(ae_field2).to receive(:id).and_return(84)
 
-      ae_value.stub(:to_export_xml) do |options|
+      allow(ae_value).to receive(:to_export_xml) do |options|
         options[:builder].ae_value
       end
     end
@@ -249,6 +249,6 @@ describe MiqAeInstance do
     n1 = FactoryGirl.create(:miq_ae_domain, :name => 'dom1', :priority => 10, :system => true)
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     i1 = FactoryGirl.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
-    i1.domain.name.should eql('dom1')
+    expect(i1.domain.name).to eql('dom1')
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_compare_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_compare_spec.rb
@@ -76,7 +76,7 @@ describe MiqAeMethodCompare do
   def method_check_status(method1, method2, status)
     diff_obj = MiqAeMethodCompare.new(method1, method2)
     diff_obj.compare
-    diff_obj.status.should equal(status)
+    expect(diff_obj.status).to equal(status)
   end
 
   def prep_method_file_names(meth1 = nil, meth2 = nil)

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
@@ -91,18 +91,18 @@ describe MiqAeMethodCopy do
       ids    = [1, 2, 3]
       miq_ae_method_copy = double(MiqAeMethodCopy)
       miq_ae_method = mock_model(MiqAeMethod)
-      miq_ae_method_copy.should_receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_method }
+      expect(miq_ae_method_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_method }
       new_ids = [miq_ae_method.id] * ids.length
-      miq_ae_method.should_receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
-      MiqAeMethod.should_receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { miq_ae_method }
-      MiqAeMethodCopy.should_receive(:new).with(fqname).exactly(ids.length).times { miq_ae_method_copy }
-      MiqAeMethodCopy.copy_multiple(ids, domain).should match_array(new_ids)
+      expect(miq_ae_method).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
+      expect(MiqAeMethod).to receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { miq_ae_method }
+      expect(MiqAeMethodCopy).to receive(:new).with(fqname).exactly(ids.length).times { miq_ae_method_copy }
+      expect(MiqAeMethodCopy.copy_multiple(ids, domain)).to match_array(new_ids)
     end
   end
 
   def validate_method(meth1, meth2, status)
     obj = MiqAeMethodCompare.new(meth1, meth2)
     obj.compare
-    obj.status.should eq(status)
+    expect(obj.status).to eq(status)
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_spec.rb
@@ -10,7 +10,7 @@ describe MiqAeMethod do
                             :scope    => "instance",
                             :language => "ruby",
                             :location => "inline")
-    f1.should_not be_editable
+    expect(f1).not_to be_editable
   end
 
   it "should return editable as true if the parent namespace/class is editable" do
@@ -22,7 +22,7 @@ describe MiqAeMethod do
                             :scope    => "instance",
                             :language => "ruby",
                             :location => "inline")
-    f1.should be_editable
+    expect(f1).to be_editable
   end
 
   context "#copy" do
@@ -57,7 +57,7 @@ describe MiqAeMethod do
       }
 
       res = MiqAeMethod.copy(options)
-      res.count.should eq(2)
+      expect(res.count).to eq(2)
     end
 
     it "copy instances under same namespace raise error when class exists" do
@@ -79,7 +79,7 @@ describe MiqAeMethod do
       }
 
       res = MiqAeMethod.copy(options)
-      res.count.should eq(2)
+      expect(res.count).to eq(2)
     end
   end
 
@@ -100,7 +100,7 @@ describe MiqAeMethod do
     let(:miq_ae_field) { MiqAeField.new }
 
     before do
-      miq_ae_field.stub(:to_export_xml) do |options|
+      allow(miq_ae_field).to receive(:to_export_xml) do |options|
         options[:builder].inputs
       end
     end
@@ -124,6 +124,6 @@ describe MiqAeMethod do
                             :scope    => "instance",
                             :language => "ruby",
                             :location => "inline")
-    m1.domain.name.should eql('dom1')
+    expect(m1.domain.name).to eql('dom1')
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
@@ -1,59 +1,59 @@
 require "spec_helper"
 
 describe MiqAeNamespace do
-  it { should validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
 
-  it { should allow_value("name.space1").for(:name) }
-  it { should allow_value("name-space1").for(:name) }
-  it { should allow_value("name$space1").for(:name) }
+  it { is_expected.to allow_value("name.space1").for(:name) }
+  it { is_expected.to allow_value("name-space1").for(:name) }
+  it { is_expected.to allow_value("name$space1").for(:name) }
 
-  it { should_not allow_value("name space1").for(:name) }
-  it { should_not allow_value("name:space1").for(:name) }
+  it { is_expected.not_to allow_value("name space1").for(:name) }
+  it { is_expected.not_to allow_value("name:space1").for(:name) }
 
   it "should find or create namespaces by fqname" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("System/TEST")
-    n1.should_not be_nil
-    n1.save!.should be_true
+    expect(n1).not_to be_nil
+    expect(n1.save!).to be_truthy
 
     n2 = MiqAeNamespace.find_by_fqname("SYSTEM/test")
-    n2.should_not be_nil
-    n2.should == n1
+    expect(n2).not_to be_nil
+    expect(n2).to eq(n1)
 
     n2 = MiqAeNamespace.find_by_fqname("system")
-    n2.should_not be_nil
-    n2.should == n1.parent
+    expect(n2).not_to be_nil
+    expect(n2).to eq(n1.parent)
 
-    MiqAeNamespace.find_by_fqname("TEST").should be_nil
+    expect(MiqAeNamespace.find_by_fqname("TEST")).to be_nil
   end
 
   it "should set the updated_by field on save" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("foo/bar")
-    n1.updated_by.should == 'system'
+    expect(n1.updated_by).to eq('system')
 
     n2 = MiqAeNamespace.find_by_fqname("foo")
-    n2.updated_by.should == 'system'
+    expect(n2.updated_by).to eq('system')
   end
 
   it "should have system property as false by default" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("ns1/ns2")
-    n1.system.should be_false
+    expect(n1.system).to be_falsey
     n2 = MiqAeNamespace.find_or_create_by_fqname("ns1")
-    n2.system.should be_false
+    expect(n2.system).to be_falsey
   end
 
   it "should return editable as false if the parent has the system property set to true" do
     n1 = MiqAeNamespace.create!(:name => 'ns1', :priority => 10, :system => true)
-    n1.should_not be_editable
+    expect(n1).not_to be_editable
 
     n2 = MiqAeNamespace.create!(:name => 'ns2', :parent_id => n1.id)
 
     n3 = MiqAeNamespace.create!(:name => 'ns3', :parent_id => n2.id)
-    n3.should_not be_editable
+    expect(n3).not_to be_editable
   end
 
   it "should return editable as true if the namespace doesn't have the system property defined" do
     n1 = MiqAeNamespace.create!(:name => 'ns1')
-    n1.should be_editable
+    expect(n1).to be_editable
   end
 
   it 'find_by_fqname works with and without leading slash' do
@@ -62,12 +62,12 @@ describe MiqAeNamespace do
   end
 
   it 'empty namespace string should return nil' do
-    MiqAeNamespace.find_by_fqname(nil).should be_nil
-    MiqAeNamespace.find_by_fqname('').should be_nil
+    expect(MiqAeNamespace.find_by_fqname(nil)).to be_nil
+    expect(MiqAeNamespace.find_by_fqname('')).to be_nil
   end
 
   it "#domain" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("System/TEST")
-    n1.domain.name.should eql('System')
+    expect(n1.domain.name).to eql('System')
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_xml_yaml_converter_spec.rb
@@ -57,36 +57,36 @@ module MiqAeDatastoreConverter
 
       it "convert a domain from XML into a ZIP and import it in" do
         MiqAeDatastore::XmlYamlConverter.convert(@root_xml, @domain, 'zip_file' => @zip_file)
-        MiqAeDomain.count.should eql(0)
-        MiqAeNamespace.count.should eql(0)
-        MiqAeClass.count.should eql(0)
-        MiqAeInstance.count.should eql(0)
-        MiqAeField.count.should eql(0)
+        expect(MiqAeDomain.count).to eql(0)
+        expect(MiqAeNamespace.count).to eql(0)
+        expect(MiqAeClass.count).to eql(0)
+        expect(MiqAeInstance.count).to eql(0)
+        expect(MiqAeField.count).to eql(0)
         import_options = {}
         import_options['preview'] = false
         import_options['zip_file'] = @zip_file
         MiqAeImport.new(@domain, import_options).import
-        MiqAeDomain.count.should eql(1)
-        MiqAeDomain.first.ae_namespaces.count.should eql(1)
-        MiqAeClass.count.should eql(1)
-        MiqAeInstance.count.should eql(2)
+        expect(MiqAeDomain.count).to eql(1)
+        expect(MiqAeDomain.first.ae_namespaces.count).to eql(1)
+        expect(MiqAeClass.count).to eql(1)
+        expect(MiqAeInstance.count).to eql(2)
       end
 
       it "convert a domain from XML into filesystem and import it in" do
         MiqAeDatastore::XmlYamlConverter.convert(@root_xml, @domain, 'export_dir' => @export_dir)
-        MiqAeDomain.count.should eql(0)
-        MiqAeNamespace.count.should eql(0)
-        MiqAeClass.count.should eql(0)
-        MiqAeInstance.count.should eql(0)
-        MiqAeField.count.should eql(0)
+        expect(MiqAeDomain.count).to eql(0)
+        expect(MiqAeNamespace.count).to eql(0)
+        expect(MiqAeClass.count).to eql(0)
+        expect(MiqAeInstance.count).to eql(0)
+        expect(MiqAeField.count).to eql(0)
         import_options = {}
         import_options['preview'] = false
         import_options['import_dir'] = @export_dir
         MiqAeImport.new(@domain, import_options).import
-        MiqAeDomain.count.should eql(1)
-        MiqAeDomain.first.ae_namespaces.count.should eql(1)
-        MiqAeClass.count.should eql(1)
-        MiqAeInstance.count.should eql(2)
+        expect(MiqAeDomain.count).to eql(1)
+        expect(MiqAeDomain.first.ae_namespaces.count).to eql(1)
+        expect(MiqAeClass.count).to eql(1)
+        expect(MiqAeInstance.count).to eql(2)
       end
     end
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -74,7 +74,7 @@ describe MiqAeDatastore do
       options = {'zip_file' => @zip_file}
       expect { export_model(@manageiq_domain.name, options) }
         .to raise_error(MiqAeException::FileExists)
-      File.exist?(@zip_file).should be_true
+      expect(File.exist?(@zip_file)).to be_truthy
     end
 
     it "an existing yaml file should raise exception" do
@@ -82,7 +82,7 @@ describe MiqAeDatastore do
       options = {'yaml_file' => @yaml_file}
       expect { export_model(@manageiq_domain.name, options) }
         .to raise_error(MiqAeException::FileExists)
-      File.exist?(@yaml_file).should be_true
+      expect(File.exist?(@yaml_file)).to be_truthy
     end
 
     it "an existing directory with overwrite should not raise exception" do
@@ -172,7 +172,7 @@ describe MiqAeDatastore do
       namespace_file = File.join(@export_dir, @manageiq_domain.name, @aen1.name, '__namespace__.yaml')
       data = YAML.load_file(namespace_file)
       hash = data.fetch_path('object', 'attributes')
-      expect(hash.key?('tenant_id')).to be_false
+      expect(hash.key?('tenant_id')).to be_falsey
     end
   end
 
@@ -230,14 +230,14 @@ describe MiqAeDatastore do
       export_model(@manageiq_domain.name)
       data = YAML.load_file(@instance_file)
       password_field_hash = data.fetch_path('object', 'fields').detect { |h| h.keys[0] == 'password_field' }
-      password_field_hash.fetch_path('password_field', 'value').should eq(MiqAePassword.encrypt(@clear_password))
+      expect(password_field_hash.fetch_path('password_field', 'value')).to eq(MiqAePassword.encrypt(@clear_password))
     end
 
     it "domain, check default password field is not in clear text" do
       export_model(@manageiq_domain.name)
       data = YAML.load_file(@class_file)
       password_field_hash = data.fetch_path('object', 'schema').detect { |h| h['field']['name'] == 'default_password_field' }
-      password_field_hash.fetch_path('field', 'default_value').should eq(MiqAePassword.encrypt(@clear_default_password))
+      expect(password_field_hash.fetch_path('field', 'default_value')).to eq(MiqAePassword.encrypt(@clear_default_password))
     end
 
     it "domain, as directory" do
@@ -261,19 +261,19 @@ describe MiqAeDatastore do
       check_counts('dom'  => 1, 'ns'    => 3,  'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
       dom = MiqAeDomain.find_by_fqname(@manageiq_domain.name, false)
-      dom.should be_system
-      dom.should be_enabled
+      expect(dom).to be_system
+      expect(dom).to be_enabled
     end
 
     it "domain, priority 0 should get retained for manageiq domain" do
       export_model(@manageiq_domain.name)
-      @manageiq_domain.priority.should equal(0)
+      expect(@manageiq_domain.priority).to equal(0)
       reset_and_import(@export_dir, @manageiq_domain.name)
       check_counts('dom'  => 1,  'ns'   => 3,  'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
 
       ns = MiqAeNamespace.find_by_fqname(@manageiq_domain.name, false)
-      ns.priority.should equal(0)
+      expect(ns.priority).to equal(0)
     end
 
     it "domain, using import_as (new domain name), to directory" do
@@ -298,7 +298,7 @@ describe MiqAeDatastore do
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8,  'inst'  => 20,
                    'meth' => 6, 'field' => 24, 'value' => 16)
-      MiqAeDomain.find_by_fqname(import_options['import_as']).should_not be_nil
+      expect(MiqAeDomain.find_by_fqname(import_options['import_as'])).not_to be_nil
     end
 
     it "domain, using export_as (new domain name), to directory" do
@@ -323,7 +323,7 @@ describe MiqAeDatastore do
       reset_and_import(@export_dir, @export_as, import_options)
       check_counts('dom'  => 1, 'ns'    => 3,  'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
-      MiqAeDomain.find_by_fqname(@export_as).should_not be_nil
+      expect(MiqAeDomain.find_by_fqname(@export_as)).not_to be_nil
     end
 
     it "domain, import only namespace, to directory" do
@@ -523,8 +523,8 @@ describe MiqAeDatastore do
                    'meth' => 2, 'field' => 6, 'value' => 4)
       aen1_aec1  = MiqAeClass.find_by_name('manageiq_test_class_1')
       builtin_method = MiqAeMethod.find_by_class_id_and_name(aen1_aec1.id, 'test2')
-      builtin_method.location.should eql 'builtin'
-      builtin_method.data.should be_nil
+      expect(builtin_method.location).to eql 'builtin'
+      expect(builtin_method.data).to be_nil
     end
 
     it "class, without methods, to directory" do
@@ -567,11 +567,11 @@ describe MiqAeDatastore do
       @customer_domain.update_attributes(:enabled => true)
       export_model(ALL_DOMAINS, export_options)
       reset_and_import(@export_dir, ALL_DOMAINS, import_options)
-      MiqAeDomain.find_by_fqname(@manageiq_domain.name, false).priority.should eql(0)
+      expect(MiqAeDomain.find_by_fqname(@manageiq_domain.name, false).priority).to eql(0)
       cust_domain = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
-      cust_domain.priority.should eql(1)
-      cust_domain.should be_enabled
-      MiqAeNamespace.find_by_fqname('$', false).should_not be_nil
+      expect(cust_domain.priority).to eql(1)
+      expect(cust_domain).to be_enabled
+      expect(MiqAeNamespace.find_by_fqname('$', false)).not_to be_nil
     end
   end
 
@@ -580,7 +580,7 @@ describe MiqAeDatastore do
     import_as = options['import_as'].presence
     if import_as.blank?
       MiqAeDatastore.reset
-      [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| k.count.should == 0 }
+      [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| expect(k.count).to eq(0) }
     end
     import_options = {'preview' => true,
                       'tenant'  => @tenant,
@@ -588,7 +588,7 @@ describe MiqAeDatastore do
     MiqAeImport.new(domain, import_options).import
 
     if import_as.blank?
-      [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| k.count.should == 0 }
+      [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each { |k| expect(k.count).to eq(0) }
     end
     import_options['preview'] = false
     MiqAeImport.new(domain, import_options).import
@@ -742,13 +742,13 @@ describe MiqAeDatastore do
   end
 
   def check_counts(counts)
-    MiqAeDomain.count.should eql(counts['dom'])    if counts.key?('dom')
+    expect(MiqAeDomain.count).to eql(counts['dom'])    if counts.key?('dom')
     ns_count = 0
     MiqAeDomain.all.each do |d|
       d.ae_namespaces.each { |ns| ns_count += child_namespace_count(ns) }
     end
-    ns_count.should eql(counts['ns'])    if counts.key?('ns')
-    MiqAeClass.count.should eql(counts['class']) if counts.key?('class')
+    expect(ns_count).to eql(counts['ns'])    if counts.key?('ns')
+    expect(MiqAeClass.count).to eql(counts['class']) if counts.key?('class')
     check_class_component_counts counts
     validate_additional_columns
   end
@@ -770,14 +770,14 @@ describe MiqAeDatastore do
   end
 
   def validate_relation(rel)
-    @additional_columns.each { |k, v| v.should eql(rel[k]) }
+    @additional_columns.each { |k, v| expect(v).to eql(rel[k]) }
   end
 
   def check_class_component_counts(counts)
-    MiqAeInstance.count.should eql(counts['inst'])  if counts.key?('inst')
-    MiqAeMethod.count.should eql(counts['meth'])  if counts.key?('meth')
-    MiqAeField.count.should eql(counts['field']) if counts.key?('field')
-    MiqAeValue.count.should eql(counts['value']) if counts.key?('value')
+    expect(MiqAeInstance.count).to eql(counts['inst'])  if counts.key?('inst')
+    expect(MiqAeMethod.count).to eql(counts['meth'])  if counts.key?('meth')
+    expect(MiqAeField.count).to eql(counts['field']) if counts.key?('field')
+    expect(MiqAeValue.count).to eql(counts['value']) if counts.key?('value')
   end
 
   def create_bogus_zip_file

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
@@ -14,7 +14,7 @@ describe MiqAeYamlImport do
       let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant} }
 
       it "returns true" do
-        expect(miq_ae_yaml_import.new_domain_name_valid?).to be_true
+        expect(miq_ae_yaml_import.new_domain_name_valid?).to be_truthy
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_availability_zone_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_availability_zone_spec.rb
@@ -10,24 +10,24 @@ module MiqAeServiceAvailabilityZoneSpec
     end
 
     it "check values" do
-      @service_availability_zone.name.should == "us-west-1a"
-      @service_availability_zone.should be_kind_of(MiqAeMethodService::MiqAeServiceAvailabilityZone)
+      expect(@service_availability_zone.name).to eq("us-west-1a")
+      expect(@service_availability_zone).to be_kind_of(MiqAeMethodService::MiqAeServiceAvailabilityZone)
     end
 
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
 
     it "#vms_and_templates" do
-      described_class.instance_methods.should include(:vms_and_templates)
+      expect(described_class.instance_methods).to include(:vms_and_templates)
     end
 
     it "#cloud_subnets" do
-      described_class.instance_methods.should include(:cloud_subnets)
+      expect(described_class.instance_methods).to include(:cloud_subnets)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_network_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_network_spec.rb
@@ -3,43 +3,43 @@ require "spec_helper"
 module MiqAeServiceCloudNetworkSpec
   describe MiqAeMethodService::MiqAeServiceCloudNetwork do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#cloud_subnets" do
-      described_class.instance_methods.should include(:cloud_subnets)
+      expect(described_class.instance_methods).to include(:cloud_subnets)
     end
 
     it "#security_groups" do
-      described_class.instance_methods.should include(:security_groups)
+      expect(described_class.instance_methods).to include(:security_groups)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
 
     it "#floating_ips" do
-      described_class.instance_methods.should include(:floating_ips)
+      expect(described_class.instance_methods).to include(:floating_ips)
     end
 
     it "#network_ports" do
-      described_class.instance_methods.should include(:network_ports)
+      expect(described_class.instance_methods).to include(:network_ports)
     end
 
     it "#network_routers" do
-      described_class.instance_methods.should include(:network_routers)
+      expect(described_class.instance_methods).to include(:network_routers)
     end
 
     it "#public_networks" do
-      described_class.instance_methods.should include(:public_networks)
+      expect(described_class.instance_methods).to include(:public_networks)
     end
 
     it "#private_networks" do
-      described_class.instance_methods.should include(:private_networks)
+      expect(described_class.instance_methods).to include(:private_networks)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_resource_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_resource_quota_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 module MiqAeServiceCloudResourceQuotaSpec
   describe MiqAeMethodService::MiqAeServiceCloudResourceQuota do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#used" do
-      described_class.instance_methods.should include(:used)
+      expect(described_class.instance_methods).to include(:used)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_subnet_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_subnet_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 module MiqAeServiceCloudSubnetSpec
   describe MiqAeMethodService::MiqAeServiceCloudSubnet do
     it "#cloud_network" do
-      described_class.instance_methods.should include(:cloud_network)
+      expect(described_class.instance_methods).to include(:cloud_network)
     end
 
     it "#availability_zone" do
-      described_class.instance_methods.should include(:availability_zone)
+      expect(described_class.instance_methods).to include(:availability_zone)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_tenant_spec.rb
@@ -3,35 +3,35 @@ require "spec_helper"
 module MiqAeServiceCloudTenantSpec
   describe MiqAeMethodService::MiqAeServiceCloudTenant do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#security_groups" do
-      described_class.instance_methods.should include(:security_groups)
+      expect(described_class.instance_methods).to include(:security_groups)
     end
 
     it "#cloud_networks" do
-      described_class.instance_methods.should include(:cloud_networks)
+      expect(described_class.instance_methods).to include(:cloud_networks)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
 
     it "#vms_and_templates" do
-      described_class.instance_methods.should include(:vms_and_templates)
+      expect(described_class.instance_methods).to include(:vms_and_templates)
     end
 
     it "#miq_templates" do
-      described_class.instance_methods.should include(:miq_templates)
+      expect(described_class.instance_methods).to include(:miq_templates)
     end
 
     it "#floating_ips" do
-      described_class.instance_methods.should include(:floating_ips)
+      expect(described_class.instance_methods).to include(:floating_ips)
     end
 
     it "#cloud_resource_quotas" do
-      described_class.instance_methods.should include(:cloud_resource_quotas)
+      expect(described_class.instance_methods).to include(:cloud_resource_quotas)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_ems_event_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_ems_event_spec.rb
@@ -15,14 +15,14 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
 
   context "#refresh" do
     it "when queued" do
-      EmsRefresh.should_receive(:queue_refresh).once.with([@ems])
+      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems])
       @service_event.refresh("src_vm")
     end
 
     it "when with multiple targets" do
       @vm.update_attributes(:ext_management_system => @ems)
-      EmsRefresh.should_receive(:queue_refresh).once do |args|
-        args.should match_array([@ems, @vm])
+      expect(EmsRefresh).to receive(:queue_refresh).once do |args|
+        expect(args).to match_array([@ems, @vm])
       end
 
       @service_event.refresh("src_vm", "dest_vm")
@@ -32,27 +32,27 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:ext_management_system => nil)
       @service_event.reload
 
-      EmsRefresh.should_not_receive(:queue_refresh)
+      expect(EmsRefresh).not_to receive(:queue_refresh)
       @service_event.refresh("dest_vm")
     end
 
     it "when target is empty string" do
-      EmsRefresh.should_not_receive(:queue_refresh)
+      expect(EmsRefresh).not_to receive(:queue_refresh)
       @service_event.refresh("")
     end
 
     it "when target is empty" do
-      EmsRefresh.should_not_receive(:queue_refresh)
+      expect(EmsRefresh).not_to receive(:queue_refresh)
       @service_event.refresh
     end
 
     it "when target is nil" do
-      EmsRefresh.should_not_receive(:queue_refresh)
+      expect(EmsRefresh).not_to receive(:queue_refresh)
       @service_event.refresh(nil)
     end
 
     it "when target is an array" do
-      EmsRefresh.should_receive(:queue_refresh).once.with([@ems])
+      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems])
       @service_event.refresh(%w(src_vm dest_vm))
     end
   end
@@ -65,17 +65,17 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
     end
 
     it "when event raised" do
-      MiqEvent.should_receive(:raise_evm_event).with(@vm, @event, anything)
+      expect(MiqEvent).to receive(:raise_evm_event).with(@vm, @event, anything)
       @service_event.policy("src_vm", @event, "host")
     end
 
     it "when target is nil" do
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy(nil, @event, "host")
     end
 
     it "when target is blank" do
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy("", @event, "host")
     end
 
@@ -83,12 +83,12 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:ext_management_system => nil)
       @service_event.reload
 
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy("src_vm", @event, "host")
     end
 
     it "when policy event is nil and ems event has event_type = nil" do
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy("src_vm", nil, "host")
     end
 
@@ -96,7 +96,7 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:event_type => "someEventType")
       @service_event.reload
 
-      MiqEvent.should_receive(:raise_evm_event).with(@vm, "someEventType", anything)
+      expect(MiqEvent).to receive(:raise_evm_event).with(@vm, "someEventType", anything)
       @service_event.policy("src_vm", nil, "host")
     end
 
@@ -104,23 +104,23 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:vm_or_template => nil)
       @service_event.reload
 
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy("src_vm", @event, "host")
     end
 
     it "when policy source object is nil" do
       @vm.update_attributes(:host => nil)
 
-      MiqEvent.should_not_receive(:raise_evm_event)
+      expect(MiqEvent).not_to receive(:raise_evm_event)
       @service_event.policy("src_vm", @event, "host")
     end
 
     it "when uses default policy source" do
-      MiqEvent.should_receive(:raise_evm_event) do |vm, event, inputs|
-        vm.should eq(@vm)
-        event.should eq(@event)
-        inputs.should have_key(:ext_management_systems)
-        inputs[:ext_management_systems].should eq(@ems)
+      expect(MiqEvent).to receive(:raise_evm_event) do |vm, event, inputs|
+        expect(vm).to eq(@vm)
+        expect(event).to eq(@event)
+        expect(inputs).to have_key(:ext_management_systems)
+        expect(inputs[:ext_management_systems]).to eq(@ems)
       end
       @service_event.policy("src_vm", @event, nil)
     end
@@ -128,12 +128,12 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
 
   context "#scan" do
     it "when target is found" do
-      VmOrTemplate.any_instance.should_receive(:scan)
+      expect_any_instance_of(VmOrTemplate).to receive(:scan)
       @service_event.scan("src_vm")
     end
 
     it "when target is not found" do
-      EmsEvent.any_instance.should_receive(:refresh).with("dest_vm", "dest_host")
+      expect_any_instance_of(EmsEvent).to receive(:refresh).with("dest_vm", "dest_host")
       @service_event.scan("dest_vm", "dest_host")
     end
   end
@@ -153,7 +153,7 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:vm_or_template => nil)
       @service_event.reload
 
-      EmsEvent.any_instance.should_receive(:refresh).with("src_vm")
+      expect_any_instance_of(EmsEvent).to receive(:refresh).with("src_vm")
       @service_event.src_vm_as_template(false)
     end
   end
@@ -168,14 +168,14 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @ems_event.update_attributes(:vm_or_template => nil)
       @service_event.reload
 
-      EmsEvent.any_instance.should_receive(:refresh).with("src_vm")
+      expect_any_instance_of(EmsEvent).to receive(:refresh).with("src_vm")
       @service_event.change_event_target_state("src_vm", "suspended")
     end
   end
 
   %w(disconnect_storage refresh_on_reconfig).each do |method|
     it "#src_vm_#{method}" do
-      VmOrTemplate.any_instance.should_receive(method.to_sym).once
+      expect_any_instance_of(VmOrTemplate).to receive(method.to_sym).once
       @service_event.send("src_vm_#{method}")
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_firewall_rule_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_firewall_rule_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 module MiqAeServiceFirewallRuleSpec
   describe MiqAeMethodService::MiqAeServiceFirewallRule do
     it "#resource" do
-      described_class.instance_methods.should include(:resource)
+      expect(described_class.instance_methods).to include(:resource)
     end
 
     it "#source_security_group" do
-      described_class.instance_methods.should include(:source_security_group)
+      expect(described_class.instance_methods).to include(:source_security_group)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_flavor_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_flavor_spec.rb
@@ -10,19 +10,19 @@ module MiqAeServiceFlavorSpec
     end
 
     it "check values" do
-      @service_flavor.name.should == "small"
-      @service_flavor.description.should == "really small"
-      @service_flavor.cpus.should == 1
-      @service_flavor.memory.should == 2.gigabytes
-      @service_flavor.should be_kind_of(MiqAeMethodService::MiqAeServiceFlavor)
+      expect(@service_flavor.name).to eq("small")
+      expect(@service_flavor.description).to eq("really small")
+      expect(@service_flavor.cpus).to eq(1)
+      expect(@service_flavor.memory).to eq(2.gigabytes)
+      expect(@service_flavor).to be_kind_of(MiqAeMethodService::MiqAeServiceFlavor)
     end
 
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_floating_ip_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_floating_ip_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 module MiqAeServiceFloatingIpSpec
   describe MiqAeMethodService::MiqAeServiceFloatingIp do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#vm" do
-      described_class.instance_methods.should include(:vm)
+      expect(described_class.instance_methods).to include(:vm)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_host_spec.rb
@@ -20,38 +20,38 @@ module MiqAeServiceHostSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.vmdb('host')"
         @ae_method.update_attributes(:data => method)
         ae_result = invoke_ae.root(@ae_result_key)
-        ae_result.should == MiqAeMethodService::MiqAeServiceHost
+        expect(ae_result).to eq(MiqAeMethodService::MiqAeServiceHost)
 
-        ae_result.count.should == 1
+        expect(ae_result.count).to eq(1)
 
         hosts = ae_result.all
-        hosts[0].should be_kind_of(MiqAeMethodService::MiqAeServiceHost)
-        hosts[0].id.should == @host.id
+        expect(hosts[0]).to be_kind_of(MiqAeMethodService::MiqAeServiceHost)
+        expect(hosts[0].id).to eq(@host.id)
 
         method   = "$evm.root['#{@ae_result_key}'] = $evm.vmdb('host').count"
         @ae_method.update_attributes(:data => method)
         ae_result = invoke_ae.root(@ae_result_key)
-        ae_result.should == 1
+        expect(ae_result).to eq(1)
       end
 
       it "with id" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.vmdb('host', #{@host.id})"
         @ae_method.update_attributes(:data => method)
         ae_result = invoke_ae.root(@ae_result_key)
-        ae_result.should be_kind_of(MiqAeMethodService::MiqAeServiceHost)
-        ae_result.id.should == @host.id
+        expect(ae_result).to be_kind_of(MiqAeMethodService::MiqAeServiceHost)
+        expect(ae_result.id).to eq(@host.id)
       end
 
       it "with array of ids" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.vmdb('host', [#{@host.id}])"
         @ae_method.update_attributes(:data => method)
         ae_result = invoke_ae.root(@ae_result_key)
-        ae_result.should be_kind_of(Array)
+        expect(ae_result).to be_kind_of(Array)
 
         hosts = ae_result
-        hosts.length.should == 1
-        hosts[0].should be_kind_of(MiqAeMethodService::MiqAeServiceHost)
-        hosts[0].id.should == @host.id
+        expect(hosts.length).to eq(1)
+        expect(hosts[0]).to be_kind_of(MiqAeMethodService::MiqAeServiceHost)
+        expect(hosts[0].id).to eq(@host.id)
       end
     end
 
@@ -59,24 +59,24 @@ module MiqAeServiceHostSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['host'].ems_custom_keys"
       @ae_method.update_attributes(:data => method)
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should be_kind_of(Array)
-      ae_result.should be_empty
+      expect(ae_result).to be_kind_of(Array)
+      expect(ae_result).to be_empty
 
       key1   = 'key1'
       value1 = 'value1'
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @host, :name => key1, :value => value1)
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should be_kind_of(Array)
-      ae_result.length.should == 1
-      ae_result.first.should == key1
+      expect(ae_result).to be_kind_of(Array)
+      expect(ae_result.length).to eq(1)
+      expect(ae_result.first).to eq(key1)
 
       key2   = 'key2'
       value2 = 'value2'
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @host, :name => key2, :value => value2)
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should be_kind_of(Array)
-      ae_result.length.should == 2
-      ae_result.sort.should == [key1, key2]
+      expect(ae_result).to be_kind_of(Array)
+      expect(ae_result.length).to eq(2)
+      expect(ae_result.sort).to eq([key1, key2])
     end
 
     it "#ems_custom_get" do
@@ -85,11 +85,11 @@ module MiqAeServiceHostSpec
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['host'].ems_custom_get('#{key}')"
       @ae_method.update_attributes(:data => method)
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should be_nil
+      expect(ae_result).to be_nil
 
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @host, :name => key, :value => value)
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should == value
+      expect(ae_result).to eq(value)
     end
 
     it "#get_realtime_metric" do
@@ -98,9 +98,9 @@ module MiqAeServiceHostSpec
       function = :max
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['host'].get_realtime_metric('#{metric}', #{range}, :#{function})"
       @ae_method.update_attributes(:data => method)
-      Host.any_instance.should_receive(:get_performance_metric).with(:realtime, metric, range, function).once
+      expect_any_instance_of(Host).to receive(:get_performance_metric).with(:realtime, metric, range, function).once
       ae_result = invoke_ae.root(@ae_result_key)
-      ae_result.should be_nil
+      expect(ae_result).to be_nil
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-amazon-cloud_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-amazon-cloud_manager_spec.rb
@@ -15,12 +15,12 @@ module MiqAeServiceManageIQ_Providers_Amazon_CloudManagerSpec
 
     it "#flavors" do
       flavor = @ems_amazon.flavors.first
-      flavor.should be_kind_of(MiqAeMethodService::MiqAeServiceFlavor)
+      expect(flavor).to be_kind_of(MiqAeMethodService::MiqAeServiceFlavor)
     end
 
     it "#availability_zones" do
       availability_zone = @ems_amazon.availability_zones.first
-      availability_zone.should be_kind_of(MiqAeMethodService::MiqAeServiceAvailabilityZone)
+      expect(availability_zone).to be_kind_of(MiqAeMethodService::MiqAeServiceAvailabilityZone)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
@@ -25,7 +25,7 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
           %w(template clone_to_vm clone_to_template).each do |request_type|
             it "should set #{request_type} for #{t}" do
               @miq_provision.update_attributes(:request_type => request_type)
-              ae_svc_prov.provision_type.should eq(request_type)
+              expect(ae_svc_prov.provision_type).to eq(request_type)
             end
           end
         end
@@ -33,13 +33,13 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
         context "#target_type" do
           it "clone_to_template" do
             @miq_provision.update_attributes(:provision_type => 'clone_to_template')
-            ae_svc_prov.target_type.should eq('template')
+            expect(ae_svc_prov.target_type).to eq('template')
           end
 
           %w(template clone_to_vm).each do |provision_type|
             it "#{provision_type}" do
               @miq_provision.update_attributes(:provision_type => provision_type)
-              ae_svc_prov.target_type.should eq('vm')
+              expect(ae_svc_prov.target_type).to eq('vm')
             end
           end
         end
@@ -47,18 +47,18 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
         context "#source_type" do
           it "works with a template" do
             @cloud_image.update_attributes(:template => true)
-            ae_svc_prov.source_type.should eq('template')
+            expect(ae_svc_prov.source_type).to eq('template')
           end
 
           it "works with a vm" do
             @cloud_image.update_attributes(:template => false)
-            ae_svc_prov.source_type.should eq('vm')
+            expect(ae_svc_prov.source_type).to eq('vm')
           end
         end
 
         context "customization_templates" do
           it "workflow exposes allowed_customization_templates" do
-            workflow_klass.instance_methods.should include(:allowed_customization_templates)
+            expect(workflow_klass.instance_methods).to include(:allowed_customization_templates)
           end
 
           context "with a customization_template" do
@@ -67,203 +67,203 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
               ct_struct = [MiqHashStruct.new(:id               => @ct.id,
                                              :name             => @ct.name,
                                              :evm_object_class => @ct.class.base_class.name.to_sym)]
-              workflow_klass.any_instance.stub(:allowed_customization_templates).and_return(ct_struct)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_customization_templates).and_return(ct_struct)
             end
 
             it "#eligible_customization_templates" do
               result = ae_svc_prov.eligible_customization_templates
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq(MiqAeMethodService::MiqAeServiceCustomizationTemplate)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCustomizationTemplate)
             end
 
             it "#set_customization_template" do
               ae_svc_prov.eligible_customization_templates.each { |ct| ae_svc_prov.set_customization_template(ct) }
 
-              @miq_provision.reload.options[:customization_template_id].should     eq([@ct.id, @ct.name])
-              @miq_provision.reload.options[:customization_template_script].should eq(@ct.script)
+              expect(@miq_provision.reload.options[:customization_template_id]).to     eq([@ct.id, @ct.name])
+              expect(@miq_provision.reload.options[:customization_template_script]).to eq(@ct.script)
             end
           end
         end
 
         context "availability_zone" do
           it "workflow exposes allowed_availability_zones" do
-            workflow_klass.instance_methods.should include(:allowed_availability_zones)
+            expect(workflow_klass.instance_methods).to include(:allowed_availability_zones)
           end
 
           context "with an availability_zone" do
             before do
               @ci = FactoryGirl.create("availability_zone_#{t}")
-              workflow_klass.any_instance.stub(:allowed_availability_zones).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_availability_zones).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_availability_zones" do
               result = ae_svc_prov.eligible_availability_zones
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
             end
 
             it "#set_availability_zone" do
               ae_svc_prov.eligible_availability_zones.each { |rsc| ae_svc_prov.set_availability_zone(rsc) }
 
-              @miq_provision.reload.options[:placement_availability_zone].should eq([@ci.id, @ci.name])
+              expect(@miq_provision.reload.options[:placement_availability_zone]).to eq([@ci.id, @ci.name])
             end
           end
         end
 
         context "instance_types" do
           it "workflow exposes allowed_instance_types" do
-            workflow_klass.instance_methods.should include(:allowed_instance_types)
+            expect(workflow_klass.instance_methods).to include(:allowed_instance_types)
           end
 
           context "with an instance_type" do
             before do
               @ci = FactoryGirl.create("flavor_#{t}")
-              workflow_klass.any_instance.stub(:allowed_instance_types).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_instance_types).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_instance_types" do
               result = ae_svc_prov.eligible_instance_types
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
             end
 
             it "#set_instance_type" do
               ae_svc_prov.eligible_instance_types.each { |rsc| ae_svc_prov.set_instance_type(rsc) }
 
-              @miq_provision.reload.options[:instance_type].should eq([@ci.id, @ci.name])
+              expect(@miq_provision.reload.options[:instance_type]).to eq([@ci.id, @ci.name])
             end
           end
         end
 
         context "security_groups" do
           it "workflow exposes allowed_security_groups" do
-            workflow_klass.instance_methods.should include(:allowed_security_groups)
+            expect(workflow_klass.instance_methods).to include(:allowed_security_groups)
           end
 
           context "with a security_group" do
             before do
               @ci = FactoryGirl.create("security_group_#{t}")
-              workflow_klass.any_instance.stub(:allowed_security_groups).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_security_groups).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_security_groups" do
               result = ae_svc_prov.eligible_security_groups
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
             end
 
             it "#set_security_group" do
               ae_svc_prov.eligible_security_groups.each { |rsc| ae_svc_prov.set_security_group(rsc) }
 
-              @miq_provision.reload.options[:security_groups].should eq([@ci.id])
+              expect(@miq_provision.reload.options[:security_groups]).to eq([@ci.id])
             end
           end
         end
 
         context "cloud_networks" do
           it "workflow exposes allowed_cloud_networks" do
-            workflow_klass.instance_methods.should include(:allowed_cloud_networks)
+            expect(workflow_klass.instance_methods).to include(:allowed_cloud_networks)
           end
 
           context "with a cloud_network" do
             before do
               @ci = FactoryGirl.create(:cloud_network)
-              workflow_klass.any_instance.stub(:allowed_cloud_networks).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_cloud_networks).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_cloud_networks" do
               result = ae_svc_prov.eligible_cloud_networks
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq(MiqAeMethodService::MiqAeServiceCloudNetwork)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCloudNetwork)
             end
 
             it "#set_cloud_network" do
               ae_svc_prov.eligible_cloud_networks.each { |rsc| ae_svc_prov.set_cloud_network(rsc) }
 
-              @miq_provision.reload.options[:cloud_network].should eq([@ci.id, @ci.name])
+              expect(@miq_provision.reload.options[:cloud_network]).to eq([@ci.id, @ci.name])
             end
           end
         end
 
         context "cloud_subnets" do
           it "workflow exposes allowed_cloud_subnets" do
-            workflow_klass.instance_methods.should include(:allowed_cloud_subnets)
+            expect(workflow_klass.instance_methods).to include(:allowed_cloud_subnets)
           end
 
           context "with a cloud_subnet" do
             before do
               @ci = FactoryGirl.create(:cloud_subnet)
-              workflow_klass.any_instance.stub(:allowed_cloud_subnets).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_cloud_subnets).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_cloud_subnets" do
               result = ae_svc_prov.eligible_cloud_subnets
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq(MiqAeMethodService::MiqAeServiceCloudSubnet)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCloudSubnet)
             end
 
             it "#set_cloud_subnet" do
               ae_svc_prov.eligible_cloud_subnets.each { |rsc| ae_svc_prov.set_cloud_subnet(rsc) }
 
-              @miq_provision.reload.options[:cloud_subnet].should eq([@ci.id, @ci.name])
+              expect(@miq_provision.reload.options[:cloud_subnet]).to eq([@ci.id, @ci.name])
             end
           end
         end
 
         context "floating_ip_addresses" do
           it "workflow exposes allowed_floating_ip_addresses" do
-            workflow_klass.instance_methods.should include(:allowed_floating_ip_addresses)
+            expect(workflow_klass.instance_methods).to include(:allowed_floating_ip_addresses)
           end
 
           context "with a floating_ip_address" do
             before do
               @ci = FactoryGirl.create("floating_ip_#{t}")
-              workflow_klass.any_instance.stub(:allowed_floating_ip_addresses).and_return(@ci.id => @ci.address)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_floating_ip_addresses).and_return(@ci.id => @ci.address)
             end
 
             it "#eligible_floating_ip_addresses" do
               result = ae_svc_prov.eligible_floating_ip_addresses
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
             end
 
             it "#set_floating_ip_address" do
               ae_svc_prov.eligible_floating_ip_addresses.each { |rsc| ae_svc_prov.set_floating_ip_address(rsc) }
 
-              @miq_provision.reload.options[:floating_ip_address].should eq([@ci.id, @ci.address])
+              expect(@miq_provision.reload.options[:floating_ip_address]).to eq([@ci.id, @ci.address])
             end
           end
         end
 
         context "guest_access_key_pairs" do
           it "workflow exposes allowed_guest_access_key_pairs" do
-            workflow_klass.instance_methods.should include(:allowed_guest_access_key_pairs)
+            expect(workflow_klass.instance_methods).to include(:allowed_guest_access_key_pairs)
           end
 
           context "with a key_pairs" do
             before do
               @ci = FactoryGirl.create("auth_key_pair_#{t}")
-              workflow_klass.any_instance.stub(:allowed_guest_access_key_pairs).and_return(@ci.id => @ci.name)
+              allow_any_instance_of(workflow_klass).to receive(:allowed_guest_access_key_pairs).and_return(@ci.id => @ci.name)
             end
 
             it "#eligible_guest_access_key_pairs" do
               result = ae_svc_prov.eligible_guest_access_key_pairs
 
-              result.should be_kind_of(Array)
-              result.first.class.should eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              expect(result).to be_kind_of(Array)
+              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
             end
 
             it "#set_guest_access_key_pairs" do
               ae_svc_prov.eligible_guest_access_key_pairs.each { |rsc| ae_svc_prov.set_guest_access_key_pair(rsc) }
 
-              @miq_provision.reload.options[:guest_access_key_pair].should eq([@ci.id, @ci.name])
+              expect(@miq_provision.reload.options[:guest_access_key_pair]).to eq([@ci.id, @ci.name])
             end
           end
         end
@@ -271,26 +271,26 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
         if t == 'openstack'
           context "cloud_tenants" do
             it "workflow exposes allowed_cloud_tenants" do
-              workflow_klass.instance_methods.should include(:allowed_cloud_tenants)
+              expect(workflow_klass.instance_methods).to include(:allowed_cloud_tenants)
             end
 
             context "with a cloud_tenant" do
               before do
                 @ct = FactoryGirl.create("cloud_tenant")
-                workflow_klass.any_instance.stub(:allowed_cloud_tenants).and_return(@ct.id => @ct.name)
+                allow_any_instance_of(workflow_klass).to receive(:allowed_cloud_tenants).and_return(@ct.id => @ct.name)
               end
 
               it "#eligible_cloud_tenants" do
                 result = ae_svc_prov.eligible_cloud_tenants
 
-                result.should be_kind_of(Array)
-                result.first.class.should eq("MiqAeMethodService::MiqAeServiceCloudTenant".constantize)
+                expect(result).to be_kind_of(Array)
+                expect(result.first.class).to eq("MiqAeMethodService::MiqAeServiceCloudTenant".constantize)
               end
 
               it "#set_cloud_tenant" do
                 ae_svc_prov.eligible_cloud_tenants.each { |rsc| ae_svc_prov.set_cloud_tenant(rsc) }
 
-                @miq_provision.reload.options[:cloud_tenant].should eq([@ct.id, @ct.name])
+                expect(@miq_provision.reload.options[:cloud_tenant]).to eq([@ct.id, @ct.name])
               end
             end
           end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
@@ -36,31 +36,31 @@ module MiqAeServiceVmOpenstackSpec
         end
 
         it "#flavor" do
-          @vm.flavor.should be_kind_of(service_class_for :flavor)
+          expect(@vm.flavor).to be_kind_of(service_class_for :flavor)
         end
 
         it "#availability_zone" do
-          @vm.availability_zone.should be_kind_of(service_class_for :availability_zone)
+          expect(@vm.availability_zone).to be_kind_of(service_class_for :availability_zone)
         end
 
         it "#cloud_network" do
-          @vm.cloud_network.should be_kind_of(MiqAeMethodService::MiqAeServiceCloudNetwork)
+          expect(@vm.cloud_network).to be_kind_of(MiqAeMethodService::MiqAeServiceCloudNetwork)
         end
 
         it "#cloud_subnet" do
-          @vm.cloud_subnet.should be_kind_of(MiqAeMethodService::MiqAeServiceCloudSubnet)
+          expect(@vm.cloud_subnet).to be_kind_of(MiqAeMethodService::MiqAeServiceCloudSubnet)
         end
 
         it "#floating_ip" do
-          @vm.floating_ip.should be_kind_of(service_class_for :floating_ip)
+          expect(@vm.floating_ip).to be_kind_of(service_class_for :floating_ip)
         end
 
         it "#security_groups" do
-          @vm.security_groups.first.should be_kind_of(service_class_for :security_group)
+          expect(@vm.security_groups.first).to be_kind_of(service_class_for :security_group)
         end
 
         it "#key_pairs" do
-          @vm.key_pairs.first.should be_kind_of(service_class_for :auth_key_pair)
+          expect(@vm.key_pairs.first).to be_kind_of(service_class_for :auth_key_pair)
         end
       end
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager_spec.rb
@@ -3,43 +3,43 @@ require "spec_helper"
 module MiqAeServiceEmsCloudSpec
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager do
     it "#availability_zones" do
-      described_class.instance_methods.should include(:availability_zones)
+      expect(described_class.instance_methods).to include(:availability_zones)
     end
 
     it "#cloud_networks" do
-      described_class.instance_methods.should include(:cloud_networks)
+      expect(described_class.instance_methods).to include(:cloud_networks)
     end
 
     it "#cloud_tenants" do
-      described_class.instance_methods.should include(:cloud_tenants)
+      expect(described_class.instance_methods).to include(:cloud_tenants)
     end
 
     it "#flavors" do
-      described_class.instance_methods.should include(:flavors)
+      expect(described_class.instance_methods).to include(:flavors)
     end
 
     it "#floating_ips" do
-      described_class.instance_methods.should include(:floating_ips)
+      expect(described_class.instance_methods).to include(:floating_ips)
     end
 
     it "#key_pairs" do
-      described_class.instance_methods.should include(:key_pairs)
+      expect(described_class.instance_methods).to include(:key_pairs)
     end
 
     it "#security_groups" do
-      described_class.instance_methods.should include(:security_groups)
+      expect(described_class.instance_methods).to include(:security_groups)
     end
 
     it "#cloud_resource_quotas" do
-      described_class.instance_methods.should include(:cloud_resource_quotas)
+      expect(described_class.instance_methods).to include(:cloud_resource_quotas)
     end
 
     it "#cloud_networks_public" do
-      described_class.instance_methods.should include(:public_networks)
+      expect(described_class.instance_methods).to include(:public_networks)
     end
 
     it "#cloud_networks_private" do
-      described_class.instance_methods.should include(:private_networks)
+      expect(described_class.instance_methods).to include(:private_networks)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_resource_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_resource_quota_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 module MiqAeServiceCloudResourceQuotaOpenstackSpec
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_CloudResourceQuota do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#used" do
-      described_class.instance_methods.should include(:used)
+      expect(described_class.instance_methods).to include(:used)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-openstack-cloud_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-openstack-cloud_manager_spec.rb
@@ -15,12 +15,12 @@ module MiqAeServiceEmsOpenstackSpec
 
     it "#flavors" do
       flavor = @ems_openstack.flavors.first
-      flavor.should be_kind_of(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Flavor)
+      expect(flavor).to be_kind_of(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Flavor)
     end
 
     it "#availability_zones" do
       availability_zone = @ems_openstack.availability_zones.first
-      availability_zone.should be_kind_of(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_AvailabilityZone)
+      expect(availability_zone).to be_kind_of(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_AvailabilityZone)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
@@ -53,9 +53,9 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
         @ae_method.update_attributes(:data => method)
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
+        expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
         [:id, :provision_type, :state, :status, :src_vm_id, :userid].each do |meth|
-          ae_object.send(meth).should == @miq_provision_request.send(meth)
+          expect(ae_object.send(meth)).to eq(@miq_provision_request.send(meth))
         end
       end
     end
@@ -64,31 +64,31 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_nil
+      expect(ae_object).to be_nil
 
       vm = FactoryGirl.create(:vm_vmware, :name => "vm42", :location => "vm42/vm42.vmx")
       @miq_provision.vm = vm
       @miq_provision.save!
 
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceVm)
-      [:id, :name, :location].each { |meth| ae_object.send(meth).should == vm.send(meth) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceVm)
+      [:id, :name, :location].each { |meth| expect(ae_object.send(meth)).to eq(vm.send(meth)) }
     end
 
     it "#vm_template" do
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
-      [:id, :name, :location].each { |meth| ae_object.send(meth).should == @vm_template.send(meth) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
+      [:id, :name, :location].each { |meth| expect(ae_object.send(meth)).to eq(@vm_template.send(meth)) }
     end
 
     it "#execute" do
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
       @ae_method.update_attributes(:data => method)
 
-      MiqProvision.any_instance.should_receive(:execute_queue).once
-      invoke_ae.root(@ae_result_key).should be_true
+      expect_any_instance_of(MiqProvision).to receive(:execute_queue).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 
     it "#request_type" do
@@ -97,7 +97,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
 
       %w( template clone_to_vm clone_to_template ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == @miq_provision.provision_type
+        expect(invoke_ae.root(@ae_result_key)).to eq(@miq_provision.provision_type)
       end
     end
 
@@ -105,28 +105,28 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
       method += ".register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should be_true
-      @miq_provision[:options][:callbacks].should be_nil
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
+      expect(@miq_provision[:options][:callbacks]).to be_nil
       @miq_provision.reload
       callback_hash = @miq_provision[:options][:callbacks]
-      callback_hash.count.should eq(1)
-      callback_hash[:first_time_out].should == 'do_something_great'
+      expect(callback_hash.count).to eq(1)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
     end
 
     it "#register_automate_callback - with previous callbacks" do
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision']"
       method += ".register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      @miq_provision[:options][:callbacks].should be_nil
+      expect(@miq_provision[:options][:callbacks]).to be_nil
       opts = @miq_provision.options.dup
       opts[:callbacks] = {:next_time_around => 'do_something_better_yet'}
       @miq_provision.update_attributes(:options => opts)
-      invoke_ae.root(@ae_result_key).should be_true
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
       @miq_provision.reload
       callback_hash = @miq_provision[:options][:callbacks]
-      callback_hash.count.should eq(2)
-      callback_hash[:first_time_out].should eq('do_something_great')
-      callback_hash[:next_time_around].should == 'do_something_better_yet'
+      expect(callback_hash.count).to eq(2)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
+      expect(callback_hash[:next_time_around]).to eq('do_something_better_yet')
     end
 
     it "#target_type" do
@@ -135,12 +135,12 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
 
       %w( clone_to_template ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'template'
+        expect(invoke_ae.root(@ae_result_key)).to eq('template')
       end
 
       %w( template clone_to_vm ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'vm'
+        expect(invoke_ae.root(@ae_result_key)).to eq('vm')
       end
     end
 
@@ -152,15 +152,15 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
           :name             => @iso_image.name,
           :evm_object_class => @iso_image.class.base_class.name.to_sym)
                            ]
-        MiqProvisionWorkflow.any_instance.stub(:allowed_iso_images).and_return(iso_image_struct)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_iso_images).and_return(iso_image_struct)
       end
 
       it "eligible_iso_images" do
         method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceIsoImage
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceIsoImage)
       end
 
       it "set_iso_image" do
@@ -170,7 +170,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:iso_image_id].should == [@iso_image.id, @iso_image.name]
+        expect(@miq_provision.reload.options[:iso_image_id]).to eq([@iso_image.id, @iso_image.name])
       end
     end
 
@@ -183,13 +183,13 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
       it "works with a template" do
         @vm_template.template = true
         @vm_template.save!
-        invoke_ae.root(@ae_result_key).should == 'template'
+        expect(invoke_ae.root(@ae_result_key)).to eq('template')
       end
 
       it "works with a vm" do
         @vm_template.template = false
         @vm_template.save!
-        invoke_ae.root(@ae_result_key).should == 'vm'
+        expect(invoke_ae.root(@ae_result_key)).to eq('vm')
       end
     end
 
@@ -201,43 +201,43 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
 
       it "return sub class" do
         result = invoke_ae.root(@ae_result_key)
-        result.class.should eq MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Provision
+        expect(result.class).to eq MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Provision
       end
 
       it "#status" do
         result = invoke_ae.root(@ae_result_key)
-        result.status.should eq 'retry'
+        expect(result.status).to eq 'retry'
       end
 
       it "#associations" do
         result = invoke_ae.root(@ae_result_key)
-        result.associations.should_not be_empty
+        expect(result.associations).not_to be_empty
       end
 
       it "#statemachine_task_status state not finished, status of error returns a retry" do
         @miq_provision.update_attributes(:status => "Error")
-        ae_svc_prov.status.should eq('retry')
+        expect(ae_svc_prov.status).to eq('retry')
       end
 
       it "#statemachine_task_status state not finished, status of ok returns a retry" do
         @miq_provision.update_attributes(:status => "ok")
-        ae_svc_prov.status.should eq('retry')
+        expect(ae_svc_prov.status).to eq('retry')
       end
 
       it "#statemachine_task_status finished state, status of error returns error " do
         @miq_provision.update_attributes(:status => "Error", :state => "finished",
                                          :vm => FactoryGirl.create(:vm_vmware))
-        ae_svc_prov.status.should eq('error')
+        expect(ae_svc_prov.status).to eq('error')
       end
 
       it "#statemachine_task_status finished state, status of ok returns error " do
         @miq_provision.update_attributes(:status => "Ok", :state => "finished")
-        ae_svc_prov.status.should eq('error')
+        expect(ae_svc_prov.status).to eq('error')
       end
 
       it "#statemachine_task_status finished state, status of ok returns ok " do
         @miq_provision.update_attributes(:status => "Ok", :state => "finished", :vm => FactoryGirl.create(:vm_vmware))
-        ae_svc_prov.status.should eq('ok')
+        expect(ae_svc_prov.status).to eq('ok')
       end
     end
 
@@ -246,15 +246,15 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         @ct = FactoryGirl.create(:customization_template, :name => "Test Templates", :script => "script_text")
         ct_struct = [MiqHashStruct.new(:id => @ct.id, :name => @ct.name,
                                        :evm_object_class => @ct.class.base_class.name.to_sym)]
-        MiqProvisionWorkflow.any_instance.stub(:allowed_customization_templates).and_return(ct_struct)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_customization_templates).and_return(ct_struct)
       end
 
       it "#eligible_customization_templates" do
         method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceCustomizationTemplate
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCustomizationTemplate)
       end
 
       it "#set_customization_template" do
@@ -264,8 +264,8 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:customization_template_id].should eq([@ct.id, @ct.name])
-        @miq_provision.reload.options[:customization_template_script].should eq(@ct.script)
+        expect(@miq_provision.reload.options[:customization_template_id]).to eq([@ct.id, @ct.name])
+        expect(@miq_provision.reload.options[:customization_template_script]).to eq(@ct.script)
       end
     end
 
@@ -274,20 +274,20 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         @cs = FactoryGirl.create(:customization_spec, :name => "Test Specs", :spec => {"script_text" => "blah"})
         cs_struct = [MiqHashStruct.new(:id => @cs.id, :name => @cs.name,
                                        :evm_object_class => @cs.class.base_class.name.to_sym)]
-        MiqProvisionVirtWorkflow.any_instance.stub(:allowed_customization_specs).and_return(cs_struct)
+        allow_any_instance_of(MiqProvisionVirtWorkflow).to receive(:allowed_customization_specs).and_return(cs_struct)
 
         allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow)
           .to receive(:get_dialogs).and_return(:dialogs => {})
-        MiqRequestWorkflow.any_instance.stub(:normalize_numeric_fields)
-        ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.any_instance.stub(:update_field_visibility)
+        allow_any_instance_of(MiqRequestWorkflow).to receive(:normalize_numeric_fields)
+        allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow).to receive(:update_field_visibility)
       end
 
       it "#eligible_customization_specs" do
         method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_specs"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceCustomizationSpec
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCustomizationSpec)
       end
 
       it "#set_customization_spec" do
@@ -297,8 +297,8 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:sysprep_custom_spec].should == [@cs.id, @cs.name]
-        @miq_provision.reload.options[:sysprep_enabled].should == %w(fields Specification)
+        expect(@miq_provision.reload.options[:sysprep_custom_spec]).to eq([@cs.id, @cs.name])
+        expect(@miq_provision.reload.options[:sysprep_enabled]).to eq(%w(fields Specification))
       end
 
       it "#set_customization_spec passing the name of the spec" do
@@ -308,24 +308,24 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:sysprep_custom_spec].should == [@cs.id, @cs.name]
-        @miq_provision.reload.options[:sysprep_enabled].should == %w(fields Specification)
+        expect(@miq_provision.reload.options[:sysprep_custom_spec]).to eq([@cs.id, @cs.name])
+        expect(@miq_provision.reload.options[:sysprep_enabled]).to eq(%w(fields Specification))
       end
     end
 
     context "resource_pools" do
       before(:each) do
         @rsc = FactoryGirl.create(:resource_pool)
-        MiqProvisionWorkflow.any_instance.stub(:allowed_resource_pools).and_return(@rsc.id => @rsc.name)
-        MiqProvisionWorkflow.any_instance.stub(:allowed_respools).and_return(@rsc.id => @rsc.name)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_resource_pools).and_return(@rsc.id => @rsc.name)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_respools).and_return(@rsc.id => @rsc.name)
       end
 
       it "#eligible_resource_pools" do
         method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceResourcePool
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceResourcePool)
       end
 
       it "#set_resource_pools" do
@@ -335,7 +335,7 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_ProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:placement_rp_name].should == [@rsc.id, @rsc.name]
+        expect(@miq_provision.reload.options[:placement_rp_name]).to eq([@rsc.id, @rsc.name])
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -6,8 +6,8 @@ module MiqAeServiceVmVmwareSpec
     let(:service_vm) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
 
     before do
-      Vm.any_instance.stub(:my_zone).and_return('default')
-      MiqServer.stub(:my_zone).and_return('default')
+      allow_any_instance_of(Vm).to receive(:my_zone).and_return('default')
+      allow(MiqServer).to receive(:my_zone).and_return('default')
       @base_queue_options = {
         :class_name  => vm.class.name,
         :instance_id => vm.id,
@@ -26,7 +26,7 @@ module MiqAeServiceVmVmwareSpec
     it "#set_number_of_cpus" do
       service_vm.set_number_of_cpus(1)
 
-      MiqQueue.first.should have_attributes(
+      expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'set_number_of_cpus',
           :args        => [1])
@@ -36,7 +36,7 @@ module MiqAeServiceVmVmwareSpec
     it "#set_memory" do
       service_vm.set_memory(100)
 
-      MiqQueue.first.should have_attributes(
+      expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'set_memory',
           :args        => [100])
@@ -46,7 +46,7 @@ module MiqAeServiceVmVmwareSpec
     it "#add_disk" do
       service_vm.add_disk('disk_1', 100)
 
-      MiqQueue.first.should have_attributes(
+      expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'add_disk',
           :args        => ['disk_1', 100])
@@ -56,7 +56,7 @@ module MiqAeServiceVmVmwareSpec
     it "#remove_from_disk async"do
       service_vm.remove_from_disk(false)
 
-      MiqQueue.first.should have_attributes(
+      expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'vm_destroy',
           :args        => [])
@@ -66,7 +66,7 @@ module MiqAeServiceVmVmwareSpec
     it "#create_snapshot without memory" do
       service_vm.create_snapshot('snap', 'crackle & pop')
 
-      MiqQueue.first.args.first.should have_attributes(
+      expect(MiqQueue.first.args.first).to have_attributes(
         :task        => 'create_snapshot',
         :memory      => false,
         :name        => 'snap',
@@ -77,7 +77,7 @@ module MiqAeServiceVmVmwareSpec
     it "#create_snapshot with memory" do
       service_vm.create_snapshot('snap', 'crackle & pop', true)
 
-      MiqQueue.first.args.first.should have_attributes(
+      expect(MiqQueue.first.args.first).to have_attributes(
         :task        => 'create_snapshot',
         :memory      => true,
         :name        => 'snap',

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_methods_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_methods_spec.rb
@@ -19,7 +19,7 @@ module MiqAeServiceMethodsSpec
         method   = "$evm.root['#{@ae_result_key}'] = nil.blank?"
         @ae_method.update_attributes(:data => method)
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
     end
 
@@ -35,22 +35,22 @@ module MiqAeServiceMethodsSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, #{options[:content_type].inspect})"
       @ae_method.update_attributes(:data => method)
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => true do
-        GenericMailer.should_receive(:deliver).with(:automation_notification, options).once
+        expect(GenericMailer).to receive(:deliver).with(:automation_notification, options).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
 
       method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, #{options[:content_type].inspect})"
       @ae_method.update_attributes(:data => method)
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => false do
-        MiqQueue.should_receive(:put).with(
+        expect(MiqQueue).to receive(:put).with(
           :class_name  => 'GenericMailer',
           :method_name => "deliver",
           :args        => [:automation_notification, options],
           :role        => "notifier",
           :zone        => nil).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
     end
 
@@ -62,20 +62,20 @@ module MiqAeServiceMethodsSpec
       @ae_method.update_attributes(:data => method)
 
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => true do
-        MiqSnmp.should_receive(:trap_v1).with(inputs).once
+        expect(MiqSnmp).to receive(:trap_v1).with(inputs).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
 
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => false do
-        MiqQueue.should_receive(:put).with(
+        expect(MiqQueue).to receive(:put).with(
           :class_name  => "MiqSnmp",
           :method_name => "trap_v1",
           :args        => [inputs],
           :role        => "notifier",
           :zone        => nil).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
     end
 
@@ -87,20 +87,20 @@ module MiqAeServiceMethodsSpec
       @ae_method.update_attributes(:data => method)
 
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => true do
-        MiqSnmp.should_receive(:trap_v2).with(inputs).once
+        expect(MiqSnmp).to receive(:trap_v2).with(inputs).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
 
       MiqAeMethodService::MiqAeServiceMethods.with_constants :SYNCHRONOUS => false do
-        MiqQueue.should_receive(:put).with(
+        expect(MiqQueue).to receive(:put).with(
           :class_name  => "MiqSnmp",
           :method_name => "trap_v2",
           :args        => [inputs],
           :role        => "notifier",
           :zone        => nil).once
         ae_object = invoke_ae.root(@ae_result_key)
-        ae_object.should be_true
+        expect(ae_object).to be_truthy
       end
     end
 
@@ -108,14 +108,14 @@ module MiqAeServiceMethodsSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:vm_templates)"
       @ae_method.update_attributes(:data => method)
 
-      invoke_ae.root(@ae_result_key).should be_empty
+      expect(invoke_ae.root(@ae_result_key)).to be_empty
 
       v1 = FactoryGirl.create(:vm_vmware, :ems_id => 42, :vendor => 'vmware')
       t1 = FactoryGirl.create(:template_vmware, :ems_id => 42)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 1
-      ae_object.first.id.should == t1.id
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(1)
+      expect(ae_object.first.id).to eq(t1.id)
     end
 
     it "#category_exists?" do
@@ -123,10 +123,10 @@ module MiqAeServiceMethodsSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:category_exists?, #{category.inspect})"
       @ae_method.update_attributes(:data => method)
 
-      invoke_ae.root(@ae_result_key).should be_false
+      expect(invoke_ae.root(@ae_result_key)).to be_falsey
 
       FactoryGirl.create(:classification, :name => category)
-      invoke_ae.root(@ae_result_key).should be_true
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_request_spec.rb
@@ -4,8 +4,8 @@ module MiqAeServiceMiqHostProvisionRequestSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceMiqHostProvisionRequest do
     def assert_ae_host_provision_matches_ar_host_provision(ae_object, ar_object)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqHostProvision)
-      [:id, :provision_type, :state, :options].each { |method| ae_object.send(method).should == ar_object.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqHostProvision)
+      [:id, :provision_type, :state, :options].each { |method| expect(ae_object.send(method)).to eq(ar_object.send(method)) }
     end
 
     before(:each) do
@@ -36,7 +36,7 @@ module MiqAeServiceMiqHostProvisionRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_host_provision_request'].miq_host_provisions"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should == []
+      expect(ae_object).to eq([])
 
       miq_host_provision1 = FactoryGirl.create(:miq_host_provision, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok')
       miq_host_provision2 = FactoryGirl.create(:miq_host_provision, :provision_type => 'host_pxe_install', :state => 'pending', :status => 'Ok')
@@ -44,17 +44,17 @@ module MiqAeServiceMiqHostProvisionRequestSpec
       @miq_host_provision_request.miq_host_provisions = [miq_host_provision1]
       @miq_host_provision_request.save!
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 1
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(1)
       assert_ae_host_provision_matches_ar_host_provision(ae_object.first, miq_host_provision1)
 
       @miq_host_provision_request.miq_host_provisions = [miq_host_provision1, miq_host_provision2]
       @miq_host_provision_request.save!
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 2
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(2)
       ae_object.each do |miq_ae_host_provision|
-        [miq_host_provision1.id, miq_host_provision2.id].should include(miq_ae_host_provision.id)
+        expect([miq_host_provision1.id, miq_host_provision2.id]).to include(miq_ae_host_provision.id)
         ar_object =
           case miq_ae_host_provision.id
           when miq_host_provision1.id then miq_host_provision1
@@ -67,7 +67,7 @@ module MiqAeServiceMiqHostProvisionRequestSpec
     it "#ci_type" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_host_provision_request'].ci_type"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should == 'host'
+      expect(invoke_ae.root(@ae_result_key)).to eq('host')
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_host_provision_spec.rb
@@ -24,8 +24,8 @@ module MiqAeServiceMiqHostProvisionSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_host_provision'].miq_host_provision_request"
       @ae_method.update_attributes!(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqHostProvisionRequest)
-      [:id, :provision_type, :state, :userid].each { |method| ae_object.send(method).should == miq_host_provision_request.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqHostProvisionRequest)
+      [:id, :provision_type, :state, :userid].each { |method| expect(ae_object.send(method)).to eq(miq_host_provision_request.send(method)) }
     end
 
     it "#host" do
@@ -35,8 +35,8 @@ module MiqAeServiceMiqHostProvisionSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_host_provision'].host"
       @ae_method.update_attributes!(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceHost)
-      [:id].each { |method| ae_object.send(method).should == host.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceHost)
+      [:id].each { |method| expect(ae_object.send(method)).to eq(host.send(method)) }
     end
 
     context "#status" do
@@ -47,22 +47,22 @@ module MiqAeServiceMiqHostProvisionSpec
 
       it "#status should return 'retry' unless state is finished or provisioned" do
         @miq_host_provision.update_attributes(:state => 'queued')
-        invoke_ae.root(@ae_result_key).should == 'retry'
+        expect(invoke_ae.root(@ae_result_key)).to eq('retry')
       end
 
       it "#status should return 'ok' when state is finished or provisioned and host has been rediscovered" do
-        MiqHostProvision.any_instance.stub(:host_rediscovered?).and_return(true)
+        allow_any_instance_of(MiqHostProvision).to receive(:host_rediscovered?).and_return(true)
         ['finished', 'provisioned'].each do |state|
           @miq_host_provision.update_attributes(:state => state)
-          invoke_ae.root(@ae_result_key).should == 'ok'
+          expect(invoke_ae.root(@ae_result_key)).to eq('ok')
         end
       end
 
       it "#status should return 'error' when state is finished or provisioned and host has not been rediscovered" do
-        MiqHostProvision.any_instance.stub(:host_rediscovered?).and_return(false)
+        allow_any_instance_of(MiqHostProvision).to receive(:host_rediscovered?).and_return(false)
         ['finished', 'provisioned'].each do |state|
           @miq_host_provision.update_attributes(:state => state)
-          invoke_ae.root(@ae_result_key).should == 'error'
+          expect(invoke_ae.root(@ae_result_key)).to eq('error')
         end
       end
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_request_spec.rb
@@ -4,8 +4,8 @@ module MiqAeServiceMiqProvisionRequestSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
     def assert_ae_provision_matches_ar_provision(ae_object, ar_object)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvision)
-      [:id, :provision_type, :state, :options].each { |method| ae_object.send(method).should == ar_object.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvision)
+      [:id, :provision_type, :state, :options].each { |method| expect(ae_object.send(method)).to eq(ar_object.send(method)) }
     end
 
     before(:each) do
@@ -38,7 +38,7 @@ module MiqAeServiceMiqProvisionRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_provisions"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should == []
+      expect(ae_object).to eq([])
 
       options       = {}
       options[:src_vm_id] = [@vm_template.id, @vm_template.name]
@@ -49,17 +49,17 @@ module MiqAeServiceMiqProvisionRequestSpec
       @miq_provision_request.miq_provisions = [miq_provision1]
       @miq_provision_request.save!
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 1
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(1)
       assert_ae_provision_matches_ar_provision(ae_object.first, miq_provision1)
 
       @miq_provision_request.miq_provisions = [miq_provision1, miq_provision2]
       @miq_provision_request.save!
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 2
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(2)
       ae_object.each do |miq_ae_provision|
-        [miq_provision1.id, miq_provision2.id].should include(miq_ae_provision.id)
+        expect([miq_provision1.id, miq_provision2.id]).to include(miq_ae_provision.id)
         ar_object =
           case miq_ae_provision.id
           when miq_provision1.id then miq_provision1
@@ -73,8 +73,8 @@ module MiqAeServiceMiqProvisionRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].vm_template"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
-      [:id, :name, :location].each { |method| ae_object.send(method).should == @vm_template.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
+      [:id, :name, :location].each { |method| expect(ae_object.send(method)).to eq(@vm_template.send(method)) }
     end
 
     it "#request_type" do
@@ -83,7 +83,7 @@ module MiqAeServiceMiqProvisionRequestSpec
 
       %w( template clone_to_vm clone_to_template ).each do |provision_type|
         @miq_provision_request.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == @miq_provision_request.provision_type
+        expect(invoke_ae.root(@ae_result_key)).to eq(@miq_provision_request.provision_type)
       end
     end
 
@@ -93,39 +93,39 @@ module MiqAeServiceMiqProvisionRequestSpec
 
       %w( clone_to_template ).each do |provision_type|
         @miq_provision_request.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'template'
+        expect(invoke_ae.root(@ae_result_key)).to eq('template')
       end
 
       %w( template clone_to_vm ).each do |provision_type|
         @miq_provision_request.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'vm'
+        expect(invoke_ae.root(@ae_result_key)).to eq('vm')
       end
     end
 
     it "#register_automate_callback - no previous callbacks" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should be_true
-      @miq_provision_request[:options][:callbacks].should be_nil
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
+      expect(@miq_provision_request[:options][:callbacks]).to be_nil
       @miq_provision_request.reload
       callback_hash = @miq_provision_request[:options][:callbacks]
-      callback_hash.count.should == 1
-      callback_hash[:first_time_out].should == 'do_something_great'
+      expect(callback_hash.count).to eq(1)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
     end
 
     it "#register_automate_callback - with previous callbacks" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      @miq_provision_request[:options][:callbacks].should be_nil
+      expect(@miq_provision_request[:options][:callbacks]).to be_nil
       opts = @miq_provision_request.options.dup
       opts[:callbacks] = {:next_time_around => 'do_something_better_yet'}
       @miq_provision_request.update_attributes(:options => opts)
-      invoke_ae.root(@ae_result_key).should be_true
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
       @miq_provision_request.reload
       callback_hash = @miq_provision_request[:options][:callbacks]
-      callback_hash.count.should == 2
-      callback_hash[:first_time_out].should == 'do_something_great'
-      callback_hash[:next_time_around].should == 'do_something_better_yet'
+      expect(callback_hash.count).to eq(2)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
+      expect(callback_hash[:next_time_around]).to eq('do_something_better_yet')
     end
 
     it "#source_type" do
@@ -135,18 +135,18 @@ module MiqAeServiceMiqProvisionRequestSpec
       vm = VmOrTemplate.find(@vm_template.id)
       vm.template = true
       vm.save!
-      invoke_ae.root(@ae_result_key).should == 'template'
+      expect(invoke_ae.root(@ae_result_key)).to eq('template')
 
       vm = VmOrTemplate.find(@vm_template.id)
       vm.template = false
       vm.save!
-      invoke_ae.root(@ae_result_key).should == 'vm'
+      expect(invoke_ae.root(@ae_result_key)).to eq('vm')
     end
 
     it "#ci_type" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].ci_type"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should == 'vm'
+      expect(invoke_ae.root(@ae_result_key)).to eq('vm')
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_provision_spec.rb
@@ -42,39 +42,39 @@ module MiqAeServiceMiqProvisionSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
-      [:id, :provision_type, :state, :status, :src_vm_id, :userid].each { |method| ae_object.send(method).should == miq_provision_request.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
+      [:id, :provision_type, :state, :status, :src_vm_id, :userid].each { |method| expect(ae_object.send(method)).to eq(miq_provision_request.send(method)) }
     end
 
     it "#vm" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_nil
+      expect(ae_object).to be_nil
 
       vm = FactoryGirl.create(:vm_vmware, :name => "vm42", :location => "vm42/vm42.vmx")
       @miq_provision.vm = vm
       @miq_provision.save!
 
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceVm)
-      [:id, :name, :location].each { |method| ae_object.send(method).should == vm.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceVm)
+      [:id, :name, :location].each { |method| expect(ae_object.send(method)).to eq(vm.send(method)) }
     end
 
     it "#vm_template" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
-      [:id, :name, :location].each { |method| ae_object.send(method).should == @vm_template.send(method) }
+      expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
+      [:id, :name, :location].each { |method| expect(ae_object.send(method)).to eq(@vm_template.send(method)) }
     end
 
     it "#execute" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
       @ae_method.update_attributes(:data => method)
 
-      MiqProvision.any_instance.should_receive(:execute_queue).once
-      invoke_ae.root(@ae_result_key).should be_true
+      expect_any_instance_of(MiqProvision).to receive(:execute_queue).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 
     it "#request_type" do
@@ -83,34 +83,34 @@ module MiqAeServiceMiqProvisionSpec
 
       %w( template clone_to_vm clone_to_template ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == @miq_provision.provision_type
+        expect(invoke_ae.root(@ae_result_key)).to eq(@miq_provision.provision_type)
       end
     end
 
     it "#register_automate_callback - no previous callbacks" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should be_true
-      @miq_provision[:options][:callbacks].should be_nil
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
+      expect(@miq_provision[:options][:callbacks]).to be_nil
       @miq_provision.reload
       callback_hash = @miq_provision[:options][:callbacks]
-      callback_hash.count.should == 1
-      callback_hash[:first_time_out].should == 'do_something_great'
+      expect(callback_hash.count).to eq(1)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
     end
 
     it "#register_automate_callback - with previous callbacks" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
       @ae_method.update_attributes(:data => method)
-      @miq_provision[:options][:callbacks].should be_nil
+      expect(@miq_provision[:options][:callbacks]).to be_nil
       opts = @miq_provision.options.dup
       opts[:callbacks] = {:next_time_around => 'do_something_better_yet'}
       @miq_provision.update_attributes(:options => opts)
-      invoke_ae.root(@ae_result_key).should be_true
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
       @miq_provision.reload
       callback_hash = @miq_provision[:options][:callbacks]
-      callback_hash.count.should == 2
-      callback_hash[:first_time_out].should == 'do_something_great'
-      callback_hash[:next_time_around].should == 'do_something_better_yet'
+      expect(callback_hash.count).to eq(2)
+      expect(callback_hash[:first_time_out]).to eq('do_something_great')
+      expect(callback_hash[:next_time_around]).to eq('do_something_better_yet')
     end
 
     it "#set_vm_notes" do
@@ -129,12 +129,12 @@ module MiqAeServiceMiqProvisionSpec
 
       %w( clone_to_template ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'template'
+        expect(invoke_ae.root(@ae_result_key)).to eq('template')
       end
 
       %w( template clone_to_vm ).each do |provision_type|
         @miq_provision.update_attributes(:provision_type => provision_type)
-        invoke_ae.root(@ae_result_key).should == 'vm'
+        expect(invoke_ae.root(@ae_result_key)).to eq('vm')
       end
     end
 
@@ -142,15 +142,15 @@ module MiqAeServiceMiqProvisionSpec
       before(:each) do
         @iso_image = FactoryGirl.create(:iso_image, :name => "Test ISO Image")
         iso_image_struct = [MiqHashStruct.new(:id => "IsoImage::#{@iso_image.id}", :name => @iso_image.name, :evm_object_class => @iso_image.class.base_class.name.to_sym)]
-        MiqProvisionWorkflow.any_instance.stub(:allowed_iso_images).and_return(iso_image_struct)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_iso_images).and_return(iso_image_struct)
       end
 
       it "eligible_iso_images" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceIsoImage
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceIsoImage)
       end
 
       it "set_iso_image" do
@@ -160,7 +160,7 @@ module MiqAeServiceMiqProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:iso_image_id].should == [@iso_image.id, @iso_image.name]
+        expect(@miq_provision.reload.options[:iso_image_id]).to eq([@iso_image.id, @iso_image.name])
       end
     end
 
@@ -173,13 +173,13 @@ module MiqAeServiceMiqProvisionSpec
       it "works with a template" do
         @vm_template.template = true
         @vm_template.save!
-        invoke_ae.root(@ae_result_key).should == 'template'
+        expect(invoke_ae.root(@ae_result_key)).to eq('template')
       end
 
       it "works with a vm" do
         @vm_template.template = false
         @vm_template.save!
-        invoke_ae.root(@ae_result_key).should == 'vm'
+        expect(invoke_ae.root(@ae_result_key)).to eq('vm')
       end
     end
 
@@ -187,15 +187,15 @@ module MiqAeServiceMiqProvisionSpec
       before(:each) do
         @ct = FactoryGirl.create(:customization_template, :name => "Test Templates", :script => "script_text")
         ct_struct = [MiqHashStruct.new(:id => @ct.id, :name => @ct.name, :evm_object_class => @ct.class.base_class.name.to_sym)]
-        MiqProvisionWorkflow.any_instance.stub(:allowed_customization_templates).and_return(ct_struct)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_customization_templates).and_return(ct_struct)
       end
 
       it "#eligible_customization_templates" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceCustomizationTemplate
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCustomizationTemplate)
       end
 
       it "#set_customization_template" do
@@ -205,24 +205,24 @@ module MiqAeServiceMiqProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:customization_template_id].should == [@ct.id, @ct.name]
-        @miq_provision.reload.options[:customization_template_script].should == @ct.script
+        expect(@miq_provision.reload.options[:customization_template_id]).to eq([@ct.id, @ct.name])
+        expect(@miq_provision.reload.options[:customization_template_script]).to eq(@ct.script)
       end
     end
 
     context "resource_pools" do
       before(:each) do
         @rsc = FactoryGirl.create(:resource_pool)
-        MiqProvisionWorkflow.any_instance.stub(:allowed_resource_pools).and_return(@rsc.id => @rsc.name)
-        MiqProvisionWorkflow.any_instance.stub(:allowed_respools).and_return(@rsc.id => @rsc.name)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_resource_pools).and_return(@rsc.id => @rsc.name)
+        allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_respools).and_return(@rsc.id => @rsc.name)
       end
 
       it "#eligible_resource_pools" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_kind_of(Array)
-        result.first.class.should == MiqAeMethodService::MiqAeServiceResourcePool
+        expect(result).to be_kind_of(Array)
+        expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceResourcePool)
       end
 
       it "#set_resource_pools" do
@@ -232,7 +232,7 @@ module MiqAeServiceMiqProvisionSpec
         AUTOMATE_SCRIPT
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        @miq_provision.reload.options[:placement_rp_name].should == [@rsc.id, @rsc.name]
+        expect(@miq_provision.reload.options[:placement_rp_name]).to eq([@rsc.id, @rsc.name])
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module MiqAeServiceMiqRequestSpec
   describe MiqAeMethodService::MiqAeServiceMiqRequest do
     def assert_ae_user_matches_ar_user(ae_user, ar_user)
-      ae_user.should be_kind_of(MiqAeMethodService::MiqAeServiceUser)
-      [:id, :name, :userid, :email].each { |method| ae_user.send(method).should == ar_user.send(method) }
+      expect(ae_user).to be_kind_of(MiqAeMethodService::MiqAeServiceUser)
+      [:id, :name, :userid, :email].each { |method| expect(ae_user.send(method)).to eq(ar_user.send(method)) }
     end
 
     before(:each) do
@@ -26,8 +26,8 @@ module MiqAeServiceMiqRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].approve('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      MiqRequest.any_instance.should_receive(:approve).with(approver, reason).once
-      invoke_ae.root(@ae_result_key).should  be_true
+      expect_any_instance_of(MiqRequest).to receive(:approve).with(approver, reason).once
+      expect(invoke_ae.root(@ae_result_key)).to  be_truthy
     end
 
     it "#deny" do
@@ -35,21 +35,21 @@ module MiqAeServiceMiqRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].deny('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      MiqRequest.any_instance.should_receive(:deny).with(approver, reason).once
-      invoke_ae.root(@ae_result_key).should  be_true
+      expect_any_instance_of(MiqRequest).to receive(:deny).with(approver, reason).once
+      expect(invoke_ae.root(@ae_result_key)).to  be_truthy
     end
 
     it "#pending" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].pending"
       @ae_method.update_attributes(:data => method)
-      MiqRequest.any_instance.should_receive(:pending).once
-      invoke_ae.root(@ae_result_key).should  be_true
+      expect_any_instance_of(MiqRequest).to receive(:pending).once
+      expect(invoke_ae.root(@ae_result_key)).to  be_truthy
     end
 
     it "#approvers" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].approvers"
       @ae_method.update_attributes(:data => method)
-      invoke_ae.root(@ae_result_key).should == []
+      expect(invoke_ae.root(@ae_result_key)).to eq([])
 
       wilma          = FactoryGirl.create(:user_with_email_and_group)
       betty          = FactoryGirl.create(:user_with_email_and_group)
@@ -59,12 +59,12 @@ module MiqAeServiceMiqRequestSpec
       @miq_request.save!
 
       approvers = invoke_ae.root(@ae_result_key)
-      approvers.should be_kind_of(Array)
-      approvers.length.should == 2
+      expect(approvers).to be_kind_of(Array)
+      expect(approvers.length).to eq(2)
 
       approvers.each do |ae_user|
-        ae_user.should be_kind_of(MiqAeMethodService::MiqAeServiceUser)
-        [wilma.id, betty.id].should include(ae_user.id)
+        expect(ae_user).to be_kind_of(MiqAeMethodService::MiqAeServiceUser)
+        expect([wilma.id, betty.id]).to include(ae_user.id)
         ar_user =
           case ae_user.id
           when wilma.id then wilma
@@ -85,9 +85,9 @@ module MiqAeServiceMiqRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].authorized?"
       @ae_method.update_attributes(:data => method)
       [true, false].each do |expected_authorized|
-        MiqRequest.any_instance.stub(:authorized?).and_return(expected_authorized)
+        allow_any_instance_of(MiqRequest).to receive(:authorized?).and_return(expected_authorized)
         authorized = invoke_ae.root(@ae_result_key)
-        authorized.should == expected_authorized
+        expect(authorized).to eq(expected_authorized)
       end
     end
 
@@ -101,29 +101,29 @@ module MiqAeServiceMiqRequestSpec
 
       ae_resource = invoke_ae.root(@ae_result_key)
       ae_class    = "MiqAeMethodService::MiqAeService#{resource.class.name.gsub(/::/, '_')}".constantize
-      ae_resource.should be_kind_of(ae_class)
-      [:userid, :src_vm_id].each { |method| ae_resource.send(method).should == resource.send(method) }
+      expect(ae_resource).to be_kind_of(ae_class)
+      [:userid, :src_vm_id].each { |method| expect(ae_resource.send(method)).to eq(resource.send(method)) }
     end
 
     it "#reason" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].reason"
       @ae_method.update_attributes(:data => method)
       reason = invoke_ae.root(@ae_result_key)
-      reason.should be_nil
+      expect(reason).to be_nil
 
       betty          = FactoryGirl.create(:user_with_email_and_group)
       betty_approval = FactoryGirl.create(:miq_approval, :approver => betty)
       @miq_request.miq_approvals = [betty_approval]
       @miq_request.save!
 
-      MiqApproval.any_instance.stub(:authorized?).and_return(true)
-      MiqRequest.any_instance.stub(:approval_denied)
+      allow_any_instance_of(MiqApproval).to receive(:authorized?).and_return(true)
+      allow_any_instance_of(MiqRequest).to receive(:approval_denied)
 
       betty_reason = "Where's Barney?"
       betty_approval.deny(betty.userid, betty_reason)
       # betty_approval.update_attributes(:state => 'denied', :reason => betty_reason)
       reason = invoke_ae.root(@ae_result_key)
-      reason.should == betty_reason
+      expect(reason).to eq(betty_reason)
 
       wilma          = FactoryGirl.create(:user_with_email_and_group)
       wilma_approval = FactoryGirl.create(:miq_approval, :approver => wilma)
@@ -133,7 +133,7 @@ module MiqAeServiceMiqRequestSpec
       # wilma_approval.update_attributes(:state => 'denied', :reason => wilma_reason)
       reasons = invoke_ae.root(@ae_result_key)
       # Order of reasons is indeterminate
-      reasons.split('; ').each { |reason| [betty_reason, wilma_reason].include?(reason).should be_true }
+      reasons.split('; ').each { |reason| expect([betty_reason, wilma_reason].include?(reason)).to be_truthy }
     end
 
     it "#options" do
@@ -141,7 +141,7 @@ module MiqAeServiceMiqRequestSpec
       @ae_method.update_attributes(:data => method)
       options = {:a => 1, :b => 'two'}
       @miq_request.update_attributes(:options => options)
-      invoke_ae.root(@ae_result_key).should == options
+      expect(invoke_ae.root(@ae_result_key)).to eq(options)
     end
 
     it "#get_option" do
@@ -152,7 +152,7 @@ module MiqAeServiceMiqRequestSpec
       [['three hundred', 'three hundred'], [['one', 'two'], 'one']].each do |value, expected|
         options = {:a => 1, :b => 'two', key => value}
         @miq_request.update_attributes(:options => options)
-        invoke_ae.root(@ae_result_key).should == expected
+        expect(invoke_ae.root(@ae_result_key)).to eq(expected)
       end
     end
 
@@ -166,7 +166,7 @@ module MiqAeServiceMiqRequestSpec
       invoke_ae
       new_options      = options.dup
       new_options[key] = value
-      @miq_request.reload.options.should == new_options
+      expect(@miq_request.reload.options).to eq(new_options)
     end
 
     it "#get_tag" do
@@ -174,23 +174,23 @@ module MiqAeServiceMiqRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_tag('#{category}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequest.any_instance.should_receive(:get_tag).with(category).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequest).to receive(:get_tag).with(category).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#get_tags" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_tags"
       @ae_method.update_attributes(:data => method)
       tags = ['tag1', 'tag2']
-      MiqRequest.any_instance.should_receive(:get_tags).once.and_return(tags)
-      invoke_ae.root(@ae_result_key).should == tags
+      expect_any_instance_of(MiqRequest).to receive(:get_tags).once.and_return(tags)
+      expect(invoke_ae.root(@ae_result_key)).to eq(tags)
     end
 
     context "#clear_tag" do
       it "should work with no parms" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].clear_tag"
         @ae_method.update_attributes(:data => method)
-        MiqRequest.any_instance.should_receive(:clear_tag).with(nil, nil).once
+        expect_any_instance_of(MiqRequest).to receive(:clear_tag).with(nil, nil).once
         invoke_ae
       end
 
@@ -198,7 +198,7 @@ module MiqAeServiceMiqRequestSpec
         category = 'category1'
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].clear_tag('#{category}')"
         @ae_method.update_attributes(:data => method)
-        MiqRequest.any_instance.should_receive(:clear_tag).with(category, nil).once
+        expect_any_instance_of(MiqRequest).to receive(:clear_tag).with(category, nil).once
         invoke_ae
       end
 
@@ -207,7 +207,7 @@ module MiqAeServiceMiqRequestSpec
         tag_name = 'tag_name1'
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].clear_tag('#{category}', '#{tag_name}')"
         @ae_method.update_attributes(:data => method)
-        MiqRequest.any_instance.should_receive(:clear_tag).with(category, tag_name).once
+        expect_any_instance_of(MiqRequest).to receive(:clear_tag).with(category, tag_name).once
         invoke_ae
       end
     end
@@ -217,16 +217,16 @@ module MiqAeServiceMiqRequestSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_classification('#{category}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequest.any_instance.should_receive(:get_classification).with(category).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequest).to receive(:get_classification).with(category).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#get_classifications" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_classifications"
       @ae_method.update_attributes(:data => method)
       classifications = ['classification1', 'classification2']
-      MiqRequest.any_instance.should_receive(:get_classifications).once.and_return(classifications)
-      invoke_ae.root(@ae_result_key).should == classifications
+      expect_any_instance_of(MiqRequest).to receive(:get_classifications).once.and_return(classifications)
+      expect(invoke_ae.root(@ae_result_key)).to eq(classifications)
     end
 
     it "#set_message" do
@@ -234,7 +234,7 @@ module MiqAeServiceMiqRequestSpec
       method  = "$evm.root['miq_request'].set_message('#{message}')"
       @ae_method.update_attributes(:data => method)
       invoke_ae
-      @miq_request.reload.message.should == message
+      expect(@miq_request.reload.message).to eq(message)
     end
 
     it "#description=" do
@@ -242,7 +242,7 @@ module MiqAeServiceMiqRequestSpec
       method  = "$evm.root['miq_request'].description=('#{description}')"
       @ae_method.update_attributes(:data => method)
       invoke_ae
-      @miq_request.reload.description.should == description
+      expect(@miq_request.reload.description).to eq(description)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_task_spec.rb
@@ -19,8 +19,8 @@ module MiqAeServiceMiqRequestTaskSpec
     it "#execute" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].execute"
       @ae_method.update_attributes(:data => method)
-      MiqRequestTask.any_instance.should_receive(:execute_queue).once
-      invoke_ae.root(@ae_result_key).should be_true
+      expect_any_instance_of(MiqRequestTask).to receive(:execute_queue).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 
     it "#miq_request" do
@@ -32,16 +32,16 @@ module MiqAeServiceMiqRequestTaskSpec
       @miq_request_task.update_attributes(:miq_request => miq_request)
 
       result = invoke_ae.root(@ae_result_key)
-      result.should be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-      result.id.should == miq_request.id
+      expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      expect(result.id).to eq(miq_request.id)
     end
 
     it "#options" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].options"
       @ae_method.update_attributes(:data => method)
       options = {:a => 1, :b => 'two'}
-      MiqRequestTask.any_instance.should_receive(:options).once.and_return(options)
-      invoke_ae.root(@ae_result_key).should == options
+      expect_any_instance_of(MiqRequestTask).to receive(:options).once.and_return(options)
+      expect(invoke_ae.root(@ae_result_key)).to eq(options)
     end
 
     it "#get_option" do
@@ -49,8 +49,8 @@ module MiqAeServiceMiqRequestTaskSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option('#{key}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequestTask.any_instance.should_receive(:get_option).with(key).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequestTask).to receive(:get_option).with(key).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#get_option_last" do
@@ -58,8 +58,8 @@ module MiqAeServiceMiqRequestTaskSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option_last('#{key}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequestTask.any_instance.should_receive(:get_option_last).with(key).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequestTask).to receive(:get_option_last).with(key).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#set_option" do
@@ -72,7 +72,7 @@ module MiqAeServiceMiqRequestTaskSpec
       invoke_ae
       new_options = options.dup
       new_options[key] = value
-      @miq_request_task.reload.options.should == new_options
+      expect(@miq_request_task.reload.options).to eq(new_options)
     end
 
     it "#get_tag" do
@@ -80,16 +80,16 @@ module MiqAeServiceMiqRequestTaskSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_tag('#{category}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequestTask.any_instance.should_receive(:get_tag).with(category).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequestTask).to receive(:get_tag).with(category).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#get_tags" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_tags"
       @ae_method.update_attributes(:data => method)
       tags = ['tag1', 'tag2']
-      MiqRequestTask.any_instance.should_receive(:get_tags).once.and_return(tags)
-      invoke_ae.root(@ae_result_key).should == tags
+      expect_any_instance_of(MiqRequestTask).to receive(:get_tags).once.and_return(tags)
+      expect(invoke_ae.root(@ae_result_key)).to eq(tags)
     end
 
     it "#get_classification" do
@@ -97,16 +97,16 @@ module MiqAeServiceMiqRequestTaskSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_classification('#{category}')"
       @ae_method.update_attributes(:data => method)
       value = 'three hundred'
-      MiqRequestTask.any_instance.should_receive(:get_classification).with(category).once.and_return(value)
-      invoke_ae.root(@ae_result_key).should == value
+      expect_any_instance_of(MiqRequestTask).to receive(:get_classification).with(category).once.and_return(value)
+      expect(invoke_ae.root(@ae_result_key)).to eq(value)
     end
 
     it "#get_classifications" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_classifications"
       @ae_method.update_attributes(:data => method)
       classifications = ['classification1', 'classification2']
-      MiqRequestTask.any_instance.should_receive(:get_classifications).once.and_return(classifications)
-      invoke_ae.root(@ae_result_key).should == classifications
+      expect_any_instance_of(MiqRequestTask).to receive(:get_classifications).once.and_return(classifications)
+      expect(invoke_ae.root(@ae_result_key)).to eq(classifications)
     end
 
     context "#message=" do
@@ -118,13 +118,13 @@ module MiqAeServiceMiqRequestTaskSpec
 
       it "should call update_and_notify_parent when miq_request_task.state != 'finished'" do
         @miq_request_task.update_attributes(:state => 'ok')
-        MiqRequestTask.any_instance.should_receive(:update_and_notify_parent).with(:message => @message).once
+        expect_any_instance_of(MiqRequestTask).to receive(:update_and_notify_parent).with(:message => @message).once
         invoke_ae
       end
 
       it "should not call update_and_notify_parent when miq_request_task.state == 'finished'" do
         @miq_request_task.update_attributes(:state => 'finished')
-        MiqRequestTask.any_instance.should_receive(:update_and_notify_parent).with(:message => @message).never
+        expect_any_instance_of(MiqRequestTask).to receive(:update_and_notify_parent).with(:message => @message).never
         invoke_ae
       end
     end
@@ -133,7 +133,7 @@ module MiqAeServiceMiqRequestTaskSpec
       message = 'message1'
       method   = "$evm.root['miq_request_task'].finished('#{message}')"
       @ae_method.update_attributes(:data => method)
-      MiqRequestTask.any_instance.should_receive(:update_and_notify_parent).with(:state => 'finished', :message => message).once
+      expect_any_instance_of(MiqRequestTask).to receive(:update_and_notify_parent).with(:state => 'finished', :message => message).once
       invoke_ae
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_port_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_port_spec.rb
@@ -3,23 +3,23 @@ require "spec_helper"
 module MiqAeServiceCloudNetworkSpec
   describe MiqAeMethodService::MiqAeServiceNetworkPort do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#cloud_subnet" do
-      described_class.instance_methods.should include(:cloud_subnet)
+      expect(described_class.instance_methods).to include(:cloud_subnet)
     end
 
     it "#cloud_network" do
-      described_class.instance_methods.should include(:cloud_network)
+      expect(described_class.instance_methods).to include(:cloud_network)
     end
 
     it "#device" do
-      described_class.instance_methods.should include(:device)
+      expect(described_class.instance_methods).to include(:device)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_router_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_router_spec.rb
@@ -3,35 +3,35 @@ require "spec_helper"
 module MiqAeServiceCloudNetworkSpec
   describe MiqAeMethodService::MiqAeServiceNetworkRouter do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#public_network" do
-      described_class.instance_methods.should include(:public_network)
+      expect(described_class.instance_methods).to include(:public_network)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
 
     it "#floating_ips" do
-      described_class.instance_methods.should include(:floating_ips)
+      expect(described_class.instance_methods).to include(:floating_ips)
     end
 
     it "#network_ports" do
-      described_class.instance_methods.should include(:network_ports)
+      expect(described_class.instance_methods).to include(:network_ports)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
 
     it "#private_networks" do
-      described_class.instance_methods.should include(:private_networks)
+      expect(described_class.instance_methods).to include(:private_networks)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
@@ -10,8 +10,8 @@ module MiqAeServiceOrchestrationStackSpec
     context "#add_to_service" do
       it "adds a stack to service_resources of a valid service" do
         service_stack.add_to_service(service_service)
-        service.service_resources[0].resource_id.should == stack.id
-        service.service_resources[0].resource_type.should == stack.class.name
+        expect(service.service_resources[0].resource_id).to eq(stack.id)
+        expect(service.service_resources[0].resource_type).to eq(stack.class.name)
       end
 
       it "raises an error when adding a stack to an invalid service" do
@@ -22,15 +22,15 @@ module MiqAeServiceOrchestrationStackSpec
     context "normalized_live_status" do
       it "gets the live status of the stack and normalizes the status" do
         status = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack::Status.new('CREATING', nil)
-        OrchestrationStack.any_instance.stub(:raw_status) { status }
+        allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { status }
 
-        service_stack.normalized_live_status.should == ['transient', "CREATING"]
+        expect(service_stack.normalized_live_status).to eq(['transient', "CREATING"])
       end
 
       it "shows the status as not_exist for non-existing stacks" do
-        OrchestrationStack.any_instance.stub(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'test failure' }
+        allow_any_instance_of(OrchestrationStack).to receive(:raw_status) { raise MiqException::MiqOrchestrationStackNotExistError, 'test failure' }
 
-        service_stack.normalized_live_status.should == ['not_exist', 'test failure']
+        expect(service_stack.normalized_live_status).to eq(['not_exist', 'test failure'])
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_security_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_security_group_spec.rb
@@ -3,23 +3,23 @@ require "spec_helper"
 module MiqAeServiceSecurityGroupSpec
   describe MiqAeMethodService::MiqAeServiceSecurityGroup do
     it "#ext_management_system" do
-      described_class.instance_methods.should include(:ext_management_system)
+      expect(described_class.instance_methods).to include(:ext_management_system)
     end
 
     it "#cloud_network" do
-      described_class.instance_methods.should include(:cloud_network)
+      expect(described_class.instance_methods).to include(:cloud_network)
     end
 
     it "#cloud_tenant" do
-      described_class.instance_methods.should include(:cloud_tenant)
+      expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
     it "#firewall_rules" do
-      described_class.instance_methods.should include(:firewall_rules)
+      expect(described_class.instance_methods).to include(:firewall_rules)
     end
 
     it "#vms" do
-      described_class.instance_methods.should include(:vms)
+      expect(described_class.instance_methods).to include(:vms)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_orchestration_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_orchestration_spec.rb
@@ -14,29 +14,29 @@ module MiqAeServiceServiceOrchestrationSpec
 
     it "sets and gets orchestration_template" do
       service_service.orchestration_template = ae_orch_template
-      service.orchestration_template.should == orch_template
-      service_service.orchestration_template.object_class.name.should == 'OrchestrationTemplate'
+      expect(service.orchestration_template).to eq(orch_template)
+      expect(service_service.orchestration_template.object_class.name).to eq('OrchestrationTemplate')
     end
 
     it "sets and gets orchestration_manager" do
       service_service.orchestration_manager = ae_orch_manager
-      service.orchestration_manager.should == orch_manager
-      service_service.orchestration_manager.object_class.name.should == 'ManageIQ::Providers::Amazon::CloudManager'
+      expect(service.orchestration_manager).to eq(orch_manager)
+      expect(service_service.orchestration_manager.object_class.name).to eq('ManageIQ::Providers::Amazon::CloudManager')
     end
 
     it "sets and gets stack_name" do
       service_service.stack_name = 'stack_name'
-      service_service.stack_name.should == 'stack_name'
+      expect(service_service.stack_name).to eq('stack_name')
     end
 
     it "sets and gets stack_options" do
       service_service.stack_options = stack_opts
-      service_service.stack_options.should == stack_opts
+      expect(service_service.stack_options).to eq(stack_opts)
     end
 
     it "sets and gets update_options" do
       service_service.update_options = stack_opts
-      service_service.update_options.should == stack_opts
+      expect(service_service.update_options).to eq(stack_opts)
     end
 
     it "allows to assign orchestration_template from service_template" do
@@ -44,7 +44,7 @@ module MiqAeServiceServiceOrchestrationSpec
 
       service_service.orchestration_template = service_service.service_template.orchestration_template
 
-      service.orchestration_template.should == orch_template
+      expect(service.orchestration_template).to eq(orch_template)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_request_spec.rb
@@ -20,7 +20,7 @@ module MiqAeServiceServiceReconfigureRequestSpec
     end
 
     it "returns 'service' for ci_type" do
-      invoke_ae.root('ci_type').should == 'service'
+      expect(invoke_ae.root('ci_type')).to eq('service')
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_reconfigure_task_spec.rb
@@ -29,13 +29,13 @@ module MiqAeServiceServiceReconfigureTaskSpec
       it "returns 'ok' when state is finished" do
         task.update_attributes(:state => "finished")
 
-        invoke_ae.root('result').should == 'ok'
+        expect(invoke_ae.root('result')).to eq('ok')
       end
 
       it "returns 'retry' when state is pending" do
         task.update_attributes(:state => "pending")
 
-        invoke_ae.root('result').should == 'retry'
+        expect(invoke_ae.root('result')).to eq('retry')
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
@@ -20,7 +20,7 @@ module MiqAeServiceServiceSpec
     end
 
     it "#remove_from_vmdb" do
-      Service.count.should == 1
+      expect(Service.count).to eq(1)
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['service'].remove_from_vmdb"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
@@ -55,7 +55,7 @@ module MiqAeServiceServiceSpec
         invoke_ae
 
         @service.reload
-        expect(@service.display).to be_false
+        expect(@service.display).to be_falsey
       end
     end
 
@@ -70,7 +70,7 @@ module MiqAeServiceServiceSpec
         invoke_ae
 
         @parent.reload
-        @parent.direct_service_children.collect(&:id).should == [@service.id]
+        expect(@parent.direct_service_children.collect(&:id)).to eq([@service.id])
       end
 
       it "clears the parent service" do
@@ -150,8 +150,8 @@ EOF
       # method = "$evm.root['#{@ae_result_key}'] = $evm.root['service'].retire_service_resources"
 
       # @ae_method.update_attributes(:data => method)
-      expect(service.service_resources).to have(1).thing
-      expect(service.service_resources.first.resource.respond_to?(:retire_now)).to be_true
+      expect(service.service_resources.size).to eq(1)
+      expect(service.service_resources.first.resource.respond_to?(:retire_now)).to be_truthy
       service_service.retire_service_resources
       # ae_object = invoke_ae.root(@ae_result_key)
     end
@@ -163,43 +163,43 @@ EOF
 
       service_service.finish_retirement
 
-      expect(service_service.retired).to be_true
+      expect(service_service.retired).to be_truthy
       expect(service_service.retires_on).to eq(Date.today)
       expect(service_service.retirement_state).to eq("retired")
     end
 
     it "#retiring - false" do
-      expect(service_service.retiring?).to be_false
+      expect(service_service.retiring?).to be_falsey
     end
 
     it "#retiring? - true" do
       service_service.retirement_state = 'retiring'
 
-      expect(service_service.retiring?).to be_true
+      expect(service_service.retiring?).to be_truthy
     end
 
     it "#error_retiring? - false" do
-      expect(service_service.error_retiring?).to be_false
+      expect(service_service.error_retiring?).to be_falsey
     end
 
     it "#error_retiring? - true" do
       service_service.retirement_state = 'error'
 
-      expect(service_service.error_retiring?).to be_true
+      expect(service_service.error_retiring?).to be_truthy
     end
 
     it "#retires_on - today" do
       service_service.retires_on = Date.today
       service.reload
 
-      expect(service.retirement_due?).to be_true
+      expect(service.retirement_due?).to be_truthy
     end
 
     it "#retires_on - tomorrow" do
       service_service.retires_on = Date.today + 1
       service.reload
 
-      expect(service.retirement_due?).to be_false
+      expect(service.retirement_due?).to be_falsey
     end
 
     it "#retirement_warn" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -24,8 +24,8 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_request'].approve('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      MiqRequest.any_instance.should_receive(:approve).with(approver, reason).once
-      invoke_ae.root(@ae_result_key).should be_true
+      expect_any_instance_of(MiqRequest).to receive(:approve).with(approver, reason).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 
     it "#user_message" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_task_spec.rb
@@ -23,8 +23,8 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
     it "#execute" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].execute"
       @ae_method.update_attributes(:data => method)
-      ServiceTemplateProvisionTask.any_instance.should_receive(:execute_queue).once
-      invoke_ae.root(@ae_result_key).should be_true
+      expect_any_instance_of(ServiceTemplateProvisionTask).to receive(:execute_queue).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 
     it "#user_message" do
@@ -50,7 +50,7 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
         @ae_method.update_attributes!(:data => method)
 
-        invoke_ae.root(@ae_result_key).should == 'ok'
+        expect(invoke_ae.root(@ae_result_key)).to eq('ok')
       end
 
       it "when state is finished" do
@@ -58,7 +58,7 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
         @ae_method.update_attributes!(:data => method)
 
-        invoke_ae.root(@ae_result_key).should == 'ok'
+        expect(invoke_ae.root(@ae_result_key)).to eq('ok')
       end
 
       it "when state is pending" do
@@ -66,7 +66,7 @@ module MiqAeServiceServiceTemplateProvisionTaskSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
         @ae_method.update_attributes!(:data => method)
 
-        invoke_ae.root(@ae_result_key).should == 'retry'
+        expect(invoke_ae.root(@ae_result_key)).to eq('retry')
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_spec.rb
@@ -21,7 +21,7 @@ module MiqAeServiceServiceTemplateSpec
           method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template'].type_display "
           @ae_method.update_attributes(:data => method)
           type_display = invoke_ae.root(@ae_result_key)
-          type_display.should == 'Unknown'
+          expect(type_display).to eq('Unknown')
         end
 
         it "with service_type of atomic" do
@@ -29,7 +29,7 @@ module MiqAeServiceServiceTemplateSpec
           method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template'].type_display "
           @ae_method.update_attributes(:data => method)
           type_display = invoke_ae.root(@ae_result_key)
-          type_display.should == 'Item'
+          expect(type_display).to eq('Item')
         end
 
         it "with service_type of composite" do
@@ -37,7 +37,7 @@ module MiqAeServiceServiceTemplateSpec
           method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template'].type_display "
           @ae_method.update_attributes(:data => method)
           type_display = invoke_ae.root(@ae_result_key)
-          type_display.should == 'Bundle'
+          expect(type_display).to eq('Bundle')
         end
       end
     end
@@ -52,8 +52,8 @@ module MiqAeServiceServiceTemplateSpec
         service = FactoryGirl.create(:service, :service_template_id => @service_service_template.id)
         first_service = @service_service_template.services.first
 
-        first_service.should    be_kind_of(MiqAeMethodService::MiqAeServiceService)
-        first_service.id.should eq(service.id)
+        expect(first_service).to    be_kind_of(MiqAeMethodService::MiqAeServiceService)
+        expect(first_service.id).to eq(service.id)
       end
 
       context "with a service resource" do
@@ -65,8 +65,8 @@ module MiqAeServiceServiceTemplateSpec
         it "#service_resources" do
           first_service_resource = @service_service_template.service_resources.first
 
-          first_service_resource.should    be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
-          first_service_resource.id.should eq(@service_resource.id)
+          expect(first_service_resource).to    be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
+          expect(first_service_resource.id).to eq(@service_resource.id)
         end
 
         it "#service_templates" do
@@ -74,8 +74,8 @@ module MiqAeServiceServiceTemplateSpec
           @service_resource.update_attributes(:resource => sub_service_template)
           first_service_template = @service_service_template.service_templates.first
 
-          first_service_template.should    be_kind_of(MiqAeMethodService::MiqAeServiceServiceTemplate)
-          first_service_template.id.should eq(sub_service_template.id)
+          expect(first_service_template).to    be_kind_of(MiqAeMethodService::MiqAeServiceServiceTemplate)
+          expect(first_service_template.id).to eq(sub_service_template.id)
         end
       end
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -45,7 +45,7 @@ module MiqAeServiceSpec
       @ae_method.update_attributes(:data => automate_method_script)
       result = invoke_ae.root(@ae_result_key)
       dom_obj.update_attributes!(:system => false)
-      result.should be_false
+      expect(result).to be_falsey
     end
 
     context "$evm.instance_exists?" do
@@ -53,14 +53,14 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('/bogus/evenworse/fred')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
 
       it "existing instance " do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
       end
     end
 
@@ -69,7 +69,7 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
 
       it "readonly domain" do
@@ -81,20 +81,20 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1' )"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         # Now the instance should exist
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         # Make sure we can get instance values
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
-        result_hash.should be_kind_of(Hash)
-        result_hash.length.should == 3
+        expect(result_hash).to be_kind_of(Hash)
+        expect(result_hash.length).to eq(3)
       end
     end
 
@@ -104,7 +104,7 @@ module MiqAeServiceSpec
           method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/testadd')"
           @ae_method.update_attributes(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
-          result_hash.should == {}
+          expect(result_hash).to eq({})
         end
 
         context "instance found" do
@@ -112,25 +112,25 @@ module MiqAeServiceSpec
             method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*')"
             @ae_method.update_attributes(:data => method)
             result_hash = invoke_ae.root(@ae_result_key)
-            result_hash.should be_kind_of(Hash)
-            result_hash.length.should == 1
+            expect(result_hash).to be_kind_of(Hash)
+            expect(result_hash.length).to eq(1)
             key = 'test1'
-            result_hash.keys.should == [key]
-            result_hash[key].should be_kind_of(Hash)
-            result_hash[key].length.should == 3
+            expect(result_hash.keys).to eq([key])
+            expect(result_hash[key]).to be_kind_of(Hash)
+            expect(result_hash[key].length).to eq(3)
           end
 
           it "with path option specified" do
             method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*', :path => true)"
             @ae_method.update_attributes(:data => method)
             result_hash = invoke_ae.root(@ae_result_key)
-            result_hash.should be_kind_of(Hash)
-            result_hash.length.should == 1
+            expect(result_hash).to be_kind_of(Hash)
+            expect(result_hash.length).to eq(1)
             key = "/#{@domain}/EVM/AUTOMATE/test1"
-            [key].should match_string_array_ignorecase(result_hash.keys)
+            expect([key]).to match_string_array_ignorecase(result_hash.keys)
             key = result_hash.keys.first
-            result_hash[key].should be_kind_of(Hash)
-            result_hash[key].length.should == 3
+            expect(result_hash[key]).to be_kind_of(Hash)
+            expect(result_hash[key].length).to eq(3)
           end
         end
       end
@@ -148,12 +148,12 @@ module MiqAeServiceSpec
           method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te?t1*')"
           @ae_method.update_attributes(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
-          result_hash.should be_kind_of(Hash)
-          result_hash.length.should == 3
+          expect(result_hash).to be_kind_of(Hash)
+          expect(result_hash.length).to eq(3)
           ['test1', 'test12', 'teXt12'].each do |iname|
-            result_hash.keys.should include iname
-            result_hash[iname].should be_kind_of(Hash)
-            result_hash[iname].length.should == 3
+            expect(result_hash.keys).to include iname
+            expect(result_hash[iname]).to be_kind_of(Hash)
+            expect(result_hash[iname].length).to eq(3)
           end
         end
 
@@ -161,12 +161,12 @@ module MiqAeServiceSpec
           method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test*')"
           @ae_method.update_attributes(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
-          result_hash.should be_kind_of(Hash)
-          result_hash.length.should == 3
+          expect(result_hash).to be_kind_of(Hash)
+          expect(result_hash.length).to eq(3)
           ['test1', 'test12', 'test21'].each do |iname|
-            result_hash.keys.should include iname
-            result_hash[iname].should be_kind_of(Hash)
-            result_hash[iname].length.should == 3
+            expect(result_hash.keys).to include iname
+            expect(result_hash[iname]).to be_kind_of(Hash)
+            expect(result_hash[iname].length).to eq(3)
           end
         end
 
@@ -174,12 +174,12 @@ module MiqAeServiceSpec
           method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1*')"
           @ae_method.update_attributes(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
-          result_hash.should be_kind_of(Hash)
-          result_hash.length.should == 2
+          expect(result_hash).to be_kind_of(Hash)
+          expect(result_hash.length).to eq(2)
           ['test1', 'test12'].each do |iname|
-            result_hash.keys.should include iname
-            result_hash[iname].should be_kind_of(Hash)
-            result_hash[iname].length.should == 3
+            expect(result_hash.keys).to include iname
+            expect(result_hash[iname]).to be_kind_of(Hash)
+            expect(result_hash[iname].length).to eq(3)
           end
         end
 
@@ -187,12 +187,12 @@ module MiqAeServiceSpec
           method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1?')"
           @ae_method.update_attributes(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
-          result_hash.should be_kind_of(Hash)
-          result_hash.length.should == 1
+          expect(result_hash).to be_kind_of(Hash)
+          expect(result_hash.length).to eq(1)
           ['test12'].each do |iname|
-            result_hash.keys.should include iname
-            result_hash[iname].should be_kind_of(Hash)
-            result_hash[iname].length.should == 3
+            expect(result_hash.keys).to include iname
+            expect(result_hash[iname]).to be_kind_of(Hash)
+            expect(result_hash[iname].length).to eq(3)
           end
         end
       end
@@ -203,15 +203,15 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
-        result_hash.should be_nil
+        expect(result_hash).to be_nil
       end
 
       it "instance exists" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
-        result_hash.should be_kind_of(Hash)
-        result_hash.length.should == 3
+        expect(result_hash).to be_kind_of(Hash)
+        expect(result_hash.length).to eq(3)
       end
     end
 
@@ -220,14 +220,14 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should.nil?
+        expect(result).to be_nil
       end
 
       it "instance does exist" do
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should be_nil
+        expect(result).to be_nil
       end
     end
 
@@ -236,7 +236,7 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/testadd', 'foo')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
 
       it "instance does exist" do
@@ -244,12 +244,12 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/test1', #{display_name.inspect})"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == display_name
+        expect(result).to eq(display_name)
       end
     end
 
@@ -258,7 +258,7 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
 
       it "readonly domain" do
@@ -270,12 +270,12 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue', 'var1' => 'variablevalue1'})"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevaluechanged', 'var1' => 'variablevalue1changed'})"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
       end
     end
 
@@ -284,7 +284,7 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/bogus/evenworse/fred')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
 
       it "cannot delete instances from other tenants" do
@@ -292,7 +292,7 @@ module MiqAeServiceSpec
         method = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@other_domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        expect(result).to be_false
+        expect(result).to be_falsey
       end
 
       it "check if an instance exists in the other tenant" do
@@ -300,7 +300,7 @@ module MiqAeServiceSpec
         method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@other_domain}/EVM/AUTOMATE/test1')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        expect(result).to be_false
+        expect(result).to be_falsey
       end
 
       it "cannot add instances into other tenants" do
@@ -308,7 +308,7 @@ module MiqAeServiceSpec
         method = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@other_domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevaluechanged', 'var1' => 'variablevalue1changed'})"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        expect(result).to be_false
+        expect(result).to be_falsey
       end
 
       it "readonly domain " do
@@ -321,29 +321,29 @@ module MiqAeServiceSpec
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
 
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue' , 'var1' => 'variablevalue1'})"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         # Now the instance should exist
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == true
+        expect(result).to eq(true)
 
         # Now the instance should not exist
         method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update_attributes(:data => method)
         result = invoke_ae.root(@ae_result_key)
-        result.should == false
+        expect(result).to eq(false)
       end
     end
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_user_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_user_spec.rb
@@ -8,7 +8,7 @@ module MiqAeServiceUserSpec
     ["current_group", "miq_group"].each do |group|
       it "##{group}" do
         user # create before setting expectation
-        User.any_instance.should_receive(:current_group).and_call_original
+        expect_any_instance_of(User).to receive(:current_group).and_call_original
         expect(service_user.send(group)).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqGroup)
       end
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -23,24 +23,24 @@ module MiqAeServiceVmSpec
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].ems_custom_keys"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.should be_empty
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object).to be_empty
 
       key1   = 'key1'
       value1 = 'value1'
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @vm, :name => key1, :value => value1)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 1
-      ae_object.first.should == key1
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(1)
+      expect(ae_object.first).to eq(key1)
 
       key2   = 'key2'
       value2 = 'value2'
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @vm, :name => key2, :value => value2)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_kind_of(Array)
-      ae_object.length.should == 2
-      ae_object.sort.should == [key1, key2]
+      expect(ae_object).to be_kind_of(Array)
+      expect(ae_object.length).to eq(2)
+      expect(ae_object.sort).to eq([key1, key2])
     end
 
     it "#ems_custom_get" do
@@ -49,19 +49,19 @@ module MiqAeServiceVmSpec
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].ems_custom_get('#{key}')"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should be_nil
+      expect(ae_object).to be_nil
 
       c1 = FactoryGirl.create(:ems_custom_attribute, :resource => @vm, :name => key, :value => value)
       ae_object = invoke_ae.root(@ae_result_key)
-      ae_object.should == value
+      expect(ae_object).to eq(value)
     end
 
     it "#remove_from_vmdb" do
-      VmOrTemplate.count.should == 1
+      expect(VmOrTemplate.count).to eq(1)
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].remove_from_vmdb"
       @ae_method.update_attributes(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
-      VmOrTemplate.count.should == 0
+      expect(VmOrTemplate.count).to eq(0)
     end
 
     context "with a service" do
@@ -75,8 +75,8 @@ module MiqAeServiceVmSpec
           @ae_method.update_attributes(:data => method)
           ae_object = invoke_ae.root(@ae_result_key)
 
-          ae_object.should be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
-          @service.vms.count.should == 1
+          expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
+          expect(@service.vms.count).to eq(1)
         end
 
         it "with an existing service relationship" do
@@ -93,7 +93,7 @@ module MiqAeServiceVmSpec
           method = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].remove_from_service"
           @ae_method.update_attributes(:data => method)
 
-          invoke_ae.root(@ae_result_key).should be_nil
+          expect(invoke_ae.root(@ae_result_key)).to be_nil
         end
 
         it "with an existing service relationship" do
@@ -101,7 +101,7 @@ module MiqAeServiceVmSpec
           method = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].remove_from_service"
           @ae_method.update_attributes(:data => method)
 
-          invoke_ae.root(@ae_result_key).should be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
+          expect(invoke_ae.root(@ae_result_key)).to be_kind_of(MiqAeMethodService::MiqAeServiceServiceResource)
         end
       end
     end
@@ -125,43 +125,43 @@ module MiqAeServiceVmSpec
 
       service_vm.finish_retirement
 
-      expect(service_vm.retired).to be_true
+      expect(service_vm.retired).to be_truthy
       expect(service_vm.retires_on).to eq(Date.today)
       expect(service_vm.retirement_state).to eq("retired")
     end
 
     it "#retiring? - false" do
-      expect(service_vm.retiring?).to be_false
+      expect(service_vm.retiring?).to be_falsey
     end
 
     it "#retiring - true" do
       service_vm.retirement_state = 'retiring'
 
-      expect(service_vm.retiring?).to be_true
+      expect(service_vm.retiring?).to be_truthy
     end
 
     it "#error_retiring? - false" do
-      expect(service_vm.error_retiring?).to be_false
+      expect(service_vm.error_retiring?).to be_falsey
     end
 
     it "#error_retiring - true" do
       service_vm.retirement_state = 'error'
 
-      expect(service_vm.error_retiring?).to be_true
+      expect(service_vm.error_retiring?).to be_truthy
     end
 
     it "#retires_on - today" do
       service_vm.retires_on = Date.today
       vm.reload
 
-      expect(vm.retirement_due?).to be_true
+      expect(vm.retirement_due?).to be_truthy
     end
 
     it "#retires_on - tomorrow" do
       service_vm.retires_on = Date.today + 1
       vm.reload
 
-      expect(vm.retirement_due?).to be_false
+      expect(vm.retirement_due?).to be_falsey
     end
 
     it "#retirement_warn" do


### PR DESCRIPTION
Converts lib/miq_automation_engine to the newer `expect` syntax

What I believe to be the very last of the 1,000+ line PRs for this conversion!