### PR TITLE
Delete all in batches

### DIFF
--- a/app/models/miq_cim_association.rb
+++ b/app/models/miq_cim_association.rb
@@ -99,13 +99,8 @@ class MiqCimAssociation < ActiveRecord::Base
     q
   end
 
-  def self.cleanup_by_zone(zoneId)
-    total = 0
-    aq = select(:id).where(:zone_id => zoneId, :status => STATUS_STALE)
-    aq.find_in_batches(:batch_size => 100) do |aa|
-      ids = aa.collect(&:id)
-      total += delete_all(:id => ids)
-    end
-    _log.info "deleted #{total} stale associations for zone id #{zoneId}"
+  def self.cleanup_by_zone(zone_id)
+    total = where(:zone_id => zone_id, :status => STATUS_STALE).delete_all_in_batches(100)
+    _log.info "deleted #{total} stale associations for zone id #{zone_id}"
   end
 end

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -140,12 +140,9 @@ class MiqStorageMetric < ActiveRecord::Base
   end
 
   def self.metrics_count_by_date(older_than, metrics_classes)
-    count = 0
-    metrics_classes.each do |mc|
-      conditions = mc.arel_table[:statistic_time].lt(older_than)
-      count += mc.where(conditions).count
-    end
-    count
+    metrics_classes.collect do |mc|
+      mc.where(mc.arel_table[:statistic_time].lt(older_than)).count
+    end.sum
   end
   private_class_method :metrics_count_by_date
 
@@ -178,20 +175,13 @@ class MiqStorageMetric < ActiveRecord::Base
 
   def self.purge(older_than, rollup_type, window, metrics_classes)
     window ||= purge_window_size
-    gtotal = 0
-    metrics_classes.each do |mc|
-      conditions = mc.arel_table[:statistic_time].lt(older_than)
-      query = mc.select(:id).where(conditions)
+    metrics_classes.map do |mc|
+      query = mc.where(mc.arel_table[:statistic_time].lt(older_than))
       query = query.where(:rollup_type => rollup_type) unless rollup_type.nil?
-      total = 0
-      query.find_in_batches(:batch_size => window) do |ma|
-        ids = ma.collect(&:id)
-        total += mc.delete_all(:id => ids)
+      query.delete_in_batches(window).tap do |total|
+        _log.info "Purged #{total} records from #{mc.name} table."
       end
-      gtotal += total
-      _log.info "Purged #{total} records from #{mc.name} table."
-    end
-    gtotal
+    end.sum
   end
   private_class_method :purge
 

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -222,7 +222,7 @@ class MiqStorageMetric < ActiveRecord::Base
   # Called directly from MiqStorageMetric.
   #
   def self.metrics_rollup_class_names
-    subclasses.map(&:metrics_rollup_class_name)
+    subclasses.map(&:metrics_rollup_class_name).compact
   end
 
   #
@@ -239,7 +239,7 @@ class MiqStorageMetric < ActiveRecord::Base
   # Constant defined in subclass.
   #
   def self.derived_metrics_class_name
-    self::DERIVED_METRICS_CLASS_NAME unless self.const_defined?(:DERIVED_METRICS_CLASS_NAME)
+    self::DERIVED_METRICS_CLASS_NAME if self.const_defined?(:DERIVED_METRICS_CLASS_NAME)
   end
 
   #

--- a/lib/extensions/ar_delete_in_batches.rb
+++ b/lib/extensions/ar_delete_in_batches.rb
@@ -1,0 +1,32 @@
+module ArDeleteInBatches
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def delete_in_batches(window = 100, limit = nil)
+      ids = select(:id).limit(window)
+      total = 0
+      loop do
+        # determine how many records we want to try and delete
+        # if we are nearing our limit, reduce the count
+        current_window = limit ? (limit - total) : window
+        if current_window && (window > current_window)
+          ids = ids.limit(current_window)
+        end
+
+        # use a subquery
+        # do not fetch the ids
+        cur_ids = ids
+
+        count = unscoped.delete_all(:id => cur_ids)
+        break if count == 0
+        total += count
+
+        yield(count, total) if block_given?
+        break if count < window || (limit && total >= limit)
+      end
+      total
+    end
+  end
+end
+
+ActiveRecord::Base.send(:include, ArDeleteInBatches)

--- a/spec/lib/extensions/ar_delete_in_batches_spec.rb
+++ b/spec/lib/extensions/ar_delete_in_batches_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe ArDeleteInBatches do
+  it "deletes none" do
+    expect(VmOrTemplate.delete_in_batches).to eq(0)
+  end
+
+  it "runs multiple batches" do
+    FactoryGirl.create_list(:vm, 5)
+
+    expect(VmOrTemplate.delete_in_batches(2)).to eq(5)
+    expect(VmOrTemplate.count).to eq(0)
+  end
+
+  it "short circuits when fewer records is detected" do
+    FactoryGirl.create_list(:vm, 1)
+
+    expect(VmOrTemplate.delete_in_batches(2)).to eq(1)
+    expect(VmOrTemplate.count).to eq(0)
+  end
+
+  it "limits deletions" do
+    FactoryGirl.create_list(:vm, 4)
+
+    expect(VmOrTemplate.delete_in_batches(2, 3)).to eq(3)
+    expect(VmOrTemplate.count).to eq(1)
+  end
+
+  it "supports scopes" do
+    FactoryGirl.create_list(:vm, 3, :location => "a")
+    FactoryGirl.create_list(:vm, 2, :location => "b")
+
+    expect(VmOrTemplate.where(:location => "a").delete_in_batches(2)).to eq(3)
+    expect(VmOrTemplate.count).to eq(2)
+  end
+
+  it "supports a block" do
+    FactoryGirl.create_list(:vm, 4)
+
+    block_count = 0
+    expect(VmOrTemplate.delete_in_batches(2) { |_count, _total| block_count += 1 }).to eq(4)
+    expect(VmOrTemplate.count).to eq(0)
+    expect(block_count).to eq(2) # called 2 times
+  end
+end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -237,52 +237,33 @@ describe EmsEvent do
         @new_event        = FactoryGirl.create(:ems_event, :timestamp => purge_date + 1.day)
       end
 
-      def assert_delete_calls_and_unpurged_ids(options)
-        expect(described_class).to receive(:delete_all).public_send(options[:delete_calls]).and_call_original
-        described_class.purge(purge_date, options[:window], options[:limit])
-        expect(described_class.order(:id).pluck(:id)).to eq(Array(options[:unpurged_ids]).sort)
+      def assert_unpurged_ids(unpurged_ids)
+        expect(described_class.order(:id).pluck(:id)).to eq(Array(unpurged_ids).sort)
       end
 
       it "purge_date and older" do
-        assert_delete_calls_and_unpurged_ids(
-          :delete_calls => :once,
-          :unpurged_ids => @new_event.id
-        )
+        described_class.purge(purge_date)
+        assert_unpurged_ids(@new_event.id)
       end
 
       it "with a window" do
-        assert_delete_calls_and_unpurged_ids(
-          :delete_calls => :twice,
-          :unpurged_ids => @new_event.id,
-          :window       => 1
-        )
+        described_class.purge(purge_date, 1)
+        assert_unpurged_ids(@new_event.id)
       end
 
       it "with a limit" do
-        assert_delete_calls_and_unpurged_ids(
-          :delete_calls => :once,
-          :unpurged_ids => [@purge_date_event.id, @new_event.id],
-          :window       => nil,
-          :limit        => 1
-        )
+        described_class.purge(purge_date, nil, 1)
+        assert_unpurged_ids([@purge_date_event.id, @new_event.id])
       end
 
       it "with window > limit" do
-        assert_delete_calls_and_unpurged_ids(
-          :delete_calls => :once,
-          :unpurged_ids => [@purge_date_event.id, @new_event.id],
-          :window       => 2,
-          :limit        => 1
-        )
+        described_class.purge(purge_date, 2, 1)
+        assert_unpurged_ids([@purge_date_event.id, @new_event.id])
       end
 
       it "with limit > window" do
-        assert_delete_calls_and_unpurged_ids(
-          :delete_calls => :twice,
-          :unpurged_ids => @new_event.id,
-          :window       => 1,
-          :limit        => 2
-        )
+        described_class.purge(purge_date, 1, 2)
+        assert_unpurged_ids(@new_event.id)
       end
     end
   end

--- a/spec/models/miq_storage_metric_spec.rb
+++ b/spec/models/miq_storage_metric_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MiqStorageMetric do
   let(:time) { Time.utc(2013, 4, 22, 8, 31) }
 
-  context ".purge_date" do
+  describe ".purge_date" do
     it "using Fixnum" do
       stub_server_configuration(:storage => {:metrics_history => {:token => 20}})
       Timecop.freeze(time) do
@@ -30,6 +30,15 @@ describe MiqStorageMetric do
       Timecop.freeze(time) do
         expect(described_class.purge_date(:token)).to eq nil
       end
+    end
+  end
+
+  describe '.purge_all_timer' do
+    it "works" do
+      # just use default of derived: 4.hours, hourly: 6.months, daily: 6.months
+      stub_server_configuration(:storage => {:metrics_history => {}})
+      OntapAggregateMetric.create
+      MiqStorageMetric.purge_all_timer
     end
   end
 end

--- a/spec/models/miq_storage_metric_spec.rb
+++ b/spec/models/miq_storage_metric_spec.rb
@@ -33,6 +33,99 @@ describe MiqStorageMetric do
     end
   end
 
+  describe '.sub_class_names' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.sub_class_names).to eq(%w(OntapAggregateMetric))
+    end
+  end
+
+  describe '.sub_classes' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.sub_classes).to eq([OntapAggregateMetric])
+    end
+  end
+
+  describe '.derived_metrics_class_names' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.derived_metrics_class_names).to eq(%w(OntapAggregateDerivedMetric))
+    end
+  end
+
+  describe '.derived_metrics_classes' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.derived_metrics_classes).to eq([OntapAggregateDerivedMetric])
+    end
+  end
+
+  describe '.metrics_rollup_class_names' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.metrics_rollup_class_names).to match_array(
+        %w(OntapAggregateMetricsRollup OntapDiskMetricsRollup OntapLunMetricsRollup
+           OntapSystemMetricsRollup OntapVolumeMetricsRollup))
+    end
+  end
+
+  describe '.metrics_rollup_classes' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.metrics_rollup_classes).to match_array([
+        OntapAggregateMetricsRollup, OntapDiskMetricsRollup, OntapLunMetricsRollup,
+        OntapSystemMetricsRollup, OntapVolumeMetricsRollup])
+    end
+  end
+
+  describe '.derived_metrics_class_name' do
+    it "detects own classes" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.derived_metrics_class_name).to eq("OntapAggregateDerivedMetric")
+    end
+
+    it "doesnt return other classes" do
+      OntapAggregateMetric.create
+      expect(MiqStorageMetric.derived_metrics_class_name).to be_nil
+    end
+  end
+
+  describe '.derived_metrics_class' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.derived_metrics_class).to eq(OntapAggregateDerivedMetric)
+    end
+  end
+
+  describe '#derived_metrics_class' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.new.derived_metrics_class).to eq(OntapAggregateDerivedMetric)
+    end
+  end
+
+  describe '.metrics_rollup_class_name' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.metrics_rollup_class_name).to eq("OntapAggregateMetricsRollup")
+    end
+  end
+
+  describe '.metrics_rollup_class' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.metrics_rollup_class).to eq(OntapAggregateMetricsRollup)
+    end
+  end
+
+  describe '#metrics_rollup_class' do
+    it "works" do
+      OntapAggregateMetric.create
+      expect(OntapAggregateMetric.new.metrics_rollup_class).to eq(OntapAggregateMetricsRollup)
+    end
+  end
+
   describe '.purge_all_timer' do
     it "works" do
       # just use default of derived: 4.hours, hourly: 6.months, daily: 6.months


### PR DESCRIPTION
In the process of merging this with purging mixin
You'll notice some overlap with that #5925

There are a bunch of competing implementations of the purging code.
This is in the process of merging most of them together.

**Performance impact:**

New code:
- no longer counts the rows in the database before deleting them.
- no longer pulls back all the ids and sends the list back to the database.
- Basically 1/2 the number of queries, and the queries that are run are no longer fetching and sending ids over the wire.
- smarter about deleting ids when getting close to a max window
- often runs 1 less iteration at the end.