### PR TITLE
Purging mixin

### DIFF
--- a/app/models/drift_state/purging.rb
+++ b/app/models/drift_state/purging.rb
@@ -51,8 +51,8 @@ module DriftState::Purging
       total = 0
       purge_ids_for_remaining(remaining).each do |resource, id|
         resource_type, resource_id = *resource
-        conditions = where(:resource_type => resource_type, :resource_id => resource_id).where(arel_table[:id].lt(id))
-        total += purge_in_batches(conditions, window, total, &block)
+        scope = where(:resource_type => resource_type, :resource_id => resource_id).where(arel_table[:id].lt(id))
+        total += purge_in_batches(scope, window, total, &block)
       end
 
       _log.info("Purging drift states older than last #{remaining} results...Complete - Deleted #{total} records")
@@ -77,7 +77,7 @@ module DriftState::Purging
     # By Date
     #
 
-    def purge_conditions(older_than)
+    def purge_scope(older_than)
       where(arel_table[:timestamp].lt(older_than))
     end
   end

--- a/app/models/drift_state/purging.rb
+++ b/app/models/drift_state/purging.rb
@@ -1,5 +1,6 @@
 module DriftState::Purging
   extend ActiveSupport::Concern
+  include PurgingMixin
 
   module ClassMethods
     def purge_mode_and_value
@@ -28,6 +29,7 @@ module DriftState::Purging
       send("purge_count_by_#{mode}", value)
     end
 
+    # @param mode [:date, :remaining]
     def purge(mode, value, window = nil, &block)
       send("purge_by_#{mode}", value, window, &block)
     end
@@ -49,7 +51,7 @@ module DriftState::Purging
       total = 0
       purge_ids_for_remaining(remaining).each do |resource, id|
         resource_type, resource_id = *resource
-        conditions = [{:resource_type => resource_type, :resource_id => resource_id}, arel_table[:id].lt(id)]
+        conditions = where(:resource_type => resource_type, :resource_id => resource_id).where(arel_table[:id].lt(id))
         total += purge_in_batches(conditions, window, total, &block)
       end
 
@@ -75,41 +77,8 @@ module DriftState::Purging
     # By Date
     #
 
-    def purge_count_by_date(older_than)
-      conditions = arel_table[:timestamp].lt(older_than)
-      where(conditions).count
-    end
-
-    def purge_by_date(older_than, window = nil, &block)
-      _log.info("Purging drift states older than [#{older_than}]...")
-
-      window ||= purge_window_size
-      conditions = arel_table[:timestamp].lt(older_than)
-      total = purge_in_batches(conditions, window, &block)
-
-      _log.info("Purging drift states older than [#{older_than}]...Complete - Deleted #{total} records")
-    end
-
-    #
-    # Common methods
-    #
-
-    def purge_in_batches(conditions, window, total = 0)
-      query = select(:id).limit(window)
-      [conditions].flatten.each { |c| query = query.where(c) }
-
-      until (batch = query.dup.to_a).empty?
-        ids = batch.collect(&:id)
-
-        _log.info("Purging #{ids.length} drift states.")
-        count  = delete_all(:id => ids)
-        total += count
-
-        purge_associated_records(ids) if self.respond_to?(:purge_associated_records)
-
-        yield(count, total) if block_given?
-      end
-      total
+    def purge_conditions(older_than)
+      where(arel_table[:timestamp].lt(older_than))
     end
   end
 end

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -1,14 +1,12 @@
 module Metric::Purging
   def self.purge_date(type)
     value = VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, type.to_sym)
-    return if value.nil?
 
     case value
     when Numeric
       value.days.ago.utc
     when String
       value.to_i_with_method.seconds.ago.utc
-    when nil
     end
   end
 
@@ -50,56 +48,84 @@ module Metric::Purging
     end
   end
 
-  def self.scope_for_interval(interval)
-    interval == 'realtime' ? Metric : MetricRollup.where(:capture_interval_name => interval)
+  def self.purge_window_size
+    VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, :purge_window_size) || 1000
+  end
+
+  def self.purge_conditions(older_than, interval)
+    scope = interval == 'realtime' ? Metric : MetricRollup.where(:capture_interval_name => interval)
+    scope.where(scope.arel_table[:timestamp].lteq(older_than))
   end
 
   def self.purge_count(older_than, interval)
-    scope_for_interval(interval).where('timestamp <= ?', older_than).count
+    purge_conditions(older_than, interval).count
   end
 
-  def self.purge(older_than, interval, window = nil, limit = nil)
-    _log.info("Purging #{limit.nil? ? "all" : limit} #{interval} metrics older than [#{older_than}]...")
+  def self.purge_associated_records(metric_type, ids)
+    # Since VimPerformanceTagValues are 6 * number of tags per performance
+    # record, we need to batch in smaller trips.
+    count_tag_values = 0
+    _log.info("Purging associated tag values.")
+    ids.each_slice(50) do |vp_ids|
+      tv_count, = Benchmark.realtime_block(:purge_vim_performance_tag_values) do
+        VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => metric_type)
+      end
+      count_tag_values += tv_count
+    end
+    _log.info("Purged #{count_tag_values} associated tag values.")
+    count_tag_values
+  end
 
-    scope = scope_for_interval(interval)
+  def self.purge(older_than, interval, window = nil, total_limit = nil, &block)
+    conditions = purge_conditions(older_than, interval)
+    window ||= purge_window_size
+    _log.info("Purging #{total_limit || "all"} #{interval} metrics older than [#{older_than}]...")
+    total, total_tag_values, timings = purge_in_batches(conditions, window, 0, total_limit, &block)
+    _log.info("Purging #{total_limit || "all"} #{interval} metrics older than [#{older_than}]...Complete - " +
+              "Deleted #{total} records and #{total_tag_values} associated tag values - Timings: #{timings.inspect}")
 
-    total = 0
+    total
+  end
+
+  def self.purge_in_batches(conditions, window, total = 0, total_limit = nil)
     total_tag_values = 0
+    query = conditions.select(:id).limit(window)
+
     _, timings = Benchmark.realtime_block(:total_time) do
-      window ||= (VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, :purge_window_size) || 1000)
-
-      while limit.nil? || total < limit
-        current_limit = limit.nil? ? window : [window, limit - total].min
-        ids, = Benchmark.realtime_block(:query_batch) do
-          scope.where('timestamp <= ?', older_than).limit(current_limit).pluck(:id)
+      loop do
+        left_to_delete = total_limit && (total_limit - total)
+        if total_limit && left_to_delete < window
+          current_window = left_to_delete
+          query = query.limit(current_window)
         end
-        break if ids.empty?
 
-        _log.info("Purging #{ids.length} #{interval} metrics.")
+        if conditions.klass == MetricRollup
+          batch_ids, _ = Benchmark.realtime_block(:query_batch) do
+            query.pluck(:id)
+          end
+          break if batch_ids.empty?
+          current_window = batch_ids.size
+        else
+          batch_ids = query
+        end
+
+        _log.info("Purging #{current_window} metrics.")
         count, = Benchmark.realtime_block(:purge_metrics) do
-          scope.unscoped.delete_all(:id => ids)
+          conditions.unscoped.delete_all(:id => batch_ids)
         end
+        break if count == 0
         total += count
 
-        if interval != 'realtime'
-          # Since VimPerformanceTagValues are 6 * number of tags per performance
-          # record, we need to batch in smaller trips.
-          count_tag_values = 0
-          _log.info("Purging associated tag values.")
-          ids.each_slice(50) do |vp_ids|
-            tv_count, = Benchmark.realtime_block(:purge_vim_performance_tag_values) do
-              VimPerformanceTagValue.delete_all(:metric_id => vp_ids, :metric_type => scope.name)
-            end
-            count_tag_values += tv_count
-            total_tag_values += tv_count
-          end
-          _log.info("Purged #{count_tag_values} associated tag values.")
+        if conditions.klass == MetricRollup
+          count_tag_values = purge_associated_records(conditions.name, batch_ids)
+          total_tag_values += count_tag_values
         end
 
         yield(count, total) if block_given?
+        break if count < window || (total_limit && (total_limit <= total))
       end
     end
 
-    _log.info("Purging #{limit.nil? ? "all" : limit} #{interval} metrics older than [#{older_than}]...Complete - Deleted #{total} records and #{total_tag_values} associated tag values - Timings: #{timings.inspect}")
+    [total, total_tag_values, timings]
   end
 end

--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -60,8 +60,8 @@ module MiqReportResult::Purging
       window ||= purge_window_size
       total = 0
       purge_ids_for_remaining(remaining).each do |report_id, id|
-        conditions = purge_remaining_conditions(report_id, id)
-        total += purge_in_batches(conditions, window, total, &block)
+        scope = purge_remaining_conditions(report_id, id)
+        total += purge_in_batches(scope, window, total, &block)
       end
 
       _log.info("Purging report results older than last #{remaining} results...Complete - Deleted #{total} records")
@@ -88,7 +88,7 @@ module MiqReportResult::Purging
     #
     # By Date
     #
-    def purge_conditions(older_than)
+    def purge_scope(older_than)
       where(arel_table[:created_on].lt(older_than))
     end
   end

--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -1,5 +1,6 @@
 module MiqReportResult::Purging
   extend ActiveSupport::Concern
+  include PurgingMixin
 
   module ClassMethods
     def purge_mode_and_value
@@ -45,6 +46,10 @@ module MiqReportResult::Purging
     # By Remaining
     #
 
+    def purge_remaining_conditions(report_id, id)
+      where(:miq_report_id => report_id).where(arel_table[:id].lt(id))
+    end
+
     def purge_count_by_remaining(remaining)
       purge_counts_for_remaining(remaining).values.sum
     end
@@ -55,66 +60,36 @@ module MiqReportResult::Purging
       window ||= purge_window_size
       total = 0
       purge_ids_for_remaining(remaining).each do |report_id, id|
-        conditions = [{:miq_report_id => report_id}, arel_table[:id].lt(id)]
+        conditions = purge_remaining_conditions(report_id, id)
         total += purge_in_batches(conditions, window, total, &block)
       end
 
       _log.info("Purging report results older than last #{remaining} results...Complete - Deleted #{total} records")
+      total
     end
 
     def purge_counts_for_remaining(remaining)
       purge_ids_for_remaining(remaining).each_with_object({}) do |(report_id, id), h|
-        h[report_id] = where(:miq_report_id => report_id).where(arel_table[:id].lt(id)).count
+        h[report_id] = purge_remaining_conditions(report_id, id).count
       end
     end
 
+    # @param remaining [Numeric] the number of reports to keep per report_id
+    # for each report_id, keep a fixed number of reports
+    # @return [Hash<Numeric,Array<Numeric>>] hash with report_ids and the report_result_ids to be deleted
     def purge_ids_for_remaining(remaining)
-      # TODO: This can probably be done in a single query using group-bys or subqueries
-      select("DISTINCT miq_report_id").collect(&:miq_report_id).compact.sort.each_with_object({}) do |report_id, h|
-        results      = select(:id).where(:miq_report_id => report_id).order("id DESC").limit(remaining + 1)
-        h[report_id] = results[-2].id if results.length == remaining + 1
+      # TODO: in sql, use PARTITION BY and ROW_NUMBER()
+      distinct.pluck(:miq_report_id).compact.sort.each_with_object({}) do |report_id, h|
+        results      = where(:miq_report_id => report_id).order("id DESC").limit(remaining + 1).pluck(:id)
+        h[report_id] = results[-2] if results.length == remaining + 1
       end
     end
 
     #
     # By Date
     #
-
-    def purge_count_by_date(older_than)
-      conditions = arel_table[:created_on].lt(older_than)
-      where(conditions).count
-    end
-
-    def purge_by_date(older_than, window = nil, &block)
-      _log.info("Purging report results older than [#{older_than}]...")
-
-      window ||= purge_window_size
-      conditions = arel_table[:created_on].lt(older_than)
-      total = purge_in_batches(conditions, window, &block)
-
-      _log.info("Purging report results older than [#{older_than}]...Complete - Deleted #{total} records")
-    end
-
-    #
-    # Common methods
-    #
-
-    def purge_in_batches(conditions, window, total = 0)
-      query = select(:id).limit(window)
-      [conditions].flatten.each { |c| query = query.where(c) }
-
-      until (batch = query.dup.to_a).empty?
-        ids = batch.collect(&:id)
-
-        _log.info("Purging #{ids.length} report results.")
-        count  = delete_all(:id => ids)
-        total += count
-
-        purge_associated_records(ids) if self.respond_to?(:purge_associated_records)
-
-        yield(count, total) if block_given?
-      end
-      total
+    def purge_conditions(older_than)
+      where(arel_table[:created_on].lt(older_than))
     end
   end
 end

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -2,7 +2,7 @@
 #
 # It is expected that the mixee will provide the following methods:
 #
-#   purge_conditions(older_than): This method will receive a Time object and
+#   purge_scope(older_than): This method will receive a Time object and
 #     should construct an ActiveRecord::Relation representing the conditions
 #     for purging.  The conditions should only be made up of where clauses.
 #
@@ -36,12 +36,12 @@ module PurgingMixin
     private
 
     def purge_count_by_date(older_than)
-      purge_conditions(older_than).count
+      purge_scope(older_than).count
     end
 
     def purge_by_date(older_than, window = nil, &block)
       _log.info("Purging #{table_name.humanize} older than [#{older_than}]...")
-      total = purge_in_batches(purge_conditions(older_than), window || purge_window_size, &block)
+      total = purge_in_batches(purge_scope(older_than), window || purge_window_size, &block)
       _log.info("Purging #{table_name.humanize} older than [#{older_than}]...Complete - Deleted #{total} records")
       total
     end

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -68,7 +68,7 @@ module PurgingMixin
         end
 
         _log.info("Purging #{current_window} #{table_name.humanize}.")
-        count  = unscoped.delete_all(:id => batch_ids)
+        count = unscoped.delete_all(:id => batch_ids)
         break if count == 0
         total += count
 

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -20,19 +20,17 @@
 #   purge_associated_records(ids): This is an optional method which will receive
 #     the ids of the records that have just been deleted, and should purge any
 #     other records associated with those ids.
+#   ? can this be auto defined looking at relations and destroy / delete
 module PurgingMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
     def purge(older_than = nil, window = nil, &block)
-      older_than ||= purge_date
-      window ||= purge_window_size
-      purge_by_date(older_than, window, &block)
+      purge_by_date(older_than || purge_date, window || purge_window_size, &block)
     end
 
     def purge_count(older_than = nil)
-      older_than ||= purge_date
-      purge_count_by_date(older_than)
+      purge_count_by_date(older_than || purge_date)
     end
 
     private
@@ -41,24 +39,43 @@ module PurgingMixin
       purge_conditions(older_than).count
     end
 
-    def purge_by_date(older_than, window, &block)
-      _log.info("Purging records older than [#{older_than}]...")
-      total = purge_in_batches(purge_conditions(older_than), window, &block)
-      _log.info("Purging records older than [#{older_than}]...Complete - Deleted #{total} records")
+    def purge_by_date(older_than, window = nil, &block)
+      _log.info("Purging #{table_name.humanize} older than [#{older_than}]...")
+      total = purge_in_batches(purge_conditions(older_than), window || purge_window_size, &block)
+      _log.info("Purging #{table_name.humanize} older than [#{older_than}]...Complete - Deleted #{total} records")
       total
     end
 
-    def purge_in_batches(conditions, window, total = 0)
-      query = conditions.limit(window)
+    def purge_in_batches(conditions, window, total = 0, total_limit = nil)
+      query = conditions.select(:id).limit(window)
+      current_window = window
 
-      until (batch_ids = query.pluck(:id)).empty?
-        _log.info("Purging #{batch_ids.length} records.")
-        count  = delete_all(:id => batch_ids)
+      loop do
+        # nearing the end of our limit
+        left_to_delete = total_limit && (total_limit - total)
+        if total_limit && left_to_delete < window
+          current_window = left_to_delete
+          query = query.limit(current_window)
+        end
+
+        if respond_to?(:purge_associated_records)
+          # pull back ids - will slow performance
+          batch_ids = query.pluck(:id)
+          break if batch_ids.empty?
+          current_window = batch_ids.size
+        else
+          batch_ids = query
+        end
+
+        _log.info("Purging #{current_window} #{table_name.humanize}.")
+        count  = unscoped.delete_all(:id => batch_ids)
+        break if count == 0
         total += count
 
         purge_associated_records(batch_ids) if respond_to?(:purge_associated_records)
 
         yield(count, total) if block_given?
+        break if count < window || (total_limit && (total_limit <= total))
       end
       total
     end

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -45,6 +45,7 @@ module PurgingMixin
       _log.info("Purging records older than [#{older_than}]...")
       total = purge_in_batches(purge_conditions(older_than), window, &block)
       _log.info("Purging records older than [#{older_than}]...Complete - Deleted #{total} records")
+      total
     end
 
     def purge_in_batches(conditions, window, total = 0)

--- a/app/models/policy_event/purging.rb
+++ b/app/models/policy_event/purging.rb
@@ -22,7 +22,7 @@ class PolicyEvent < ActiveRecord::Base
       end
       alias_method :purge_timer, :purge_queue
 
-      def purge_conditions(older_than)
+      def purge_scope(older_than)
         where(arel_table[:timestamp].lt(older_than))
       end
 

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -61,20 +61,20 @@ module VmdbMetric::Purging
     # By Date
     #
 
-    # darn - an extra parameter than typical purge_conditoins
-    def purge_conditions(older_than, interval)
+    # darn - an extra parameter than typical purge_scope
+    def purge_scope(older_than, interval)
       where(:capture_interval_name => interval).where(arel_table[:timestamp].lt(older_than))
     end
 
     def purge_count_by_date(older_than, interval)
-      purge_conditions(older_than, interval).count
+      purge_scope(older_than, interval).count
     end
 
     def purge_by_date(older_than, interval, window = nil, &block)
       _log.info("Purging #{interval} metrics older than [#{older_than}]...")
 
-      conditions = purge_conditions(older_than, interval)
-      total = purge_in_batches(conditions, window || purge_window_size, &block)
+      scope = purge_scope(older_than, interval)
+      total = purge_in_batches(scope, window || purge_window_size, &block)
 
       _log.info("Purging #{interval} metrics older than [#{older_than}]...Complete - Deleted #{total} records")
       total

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -1,5 +1,6 @@
 module VmdbMetric::Purging
   extend ActiveSupport::Concern
+  include PurgingMixin
 
   module ClassMethods
     def purge_date(interval)
@@ -60,40 +61,22 @@ module VmdbMetric::Purging
     # By Date
     #
 
+    # darn - an extra parameter than typical purge_conditoins
+    def purge_conditions(older_than, interval)
+      where(:capture_interval_name => interval).where(arel_table[:timestamp].lt(older_than))
+    end
+
     def purge_count_by_date(older_than, interval)
-      where(:capture_interval_name => interval).where(arel_table[:timestamp].lt(older_than)).count
+      purge_conditions(older_than, interval).count
     end
 
     def purge_by_date(older_than, interval, window = nil, &block)
       _log.info("Purging #{interval} metrics older than [#{older_than}]...")
 
-      window ||= purge_window_size
-      t = arel_table
-      conditions = [{:capture_interval_name => interval}, arel_table[:timestamp].lt(older_than)]
-      total = purge_in_batches(conditions, window, &block)
+      conditions = purge_conditions(older_than, interval)
+      total = purge_in_batches(conditions, window || purge_window_size, &block)
 
       _log.info("Purging #{interval} metrics older than [#{older_than}]...Complete - Deleted #{total} records")
-    end
-
-    #
-    # Common methods
-    #
-
-    def purge_in_batches(conditions, window, total = 0)
-      query = select(:id).limit(window)
-      [conditions].flatten.each { |c| query = query.where(c) }
-
-      until (batch = query.dup.to_a).empty?
-        ids = batch.collect(&:id)
-
-        _log.info("Purging #{ids.length} metrics.")
-        count  = delete_all(:id => ids)
-        total += count
-
-        purge_associated_records(ids) if self.respond_to?(:purge_associated_records)
-
-        yield(count, total) if block_given?
-      end
       total
     end
   end

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -72,12 +72,7 @@ describe DriftState do
       end
     end
 
-    it "#purge_ids_for_remaining" do
-      expect(described_class.send(:purge_ids_for_remaining, 1))
-        .to eq(["VmOrTemplate", 1] => @rr1.last.id, ["VmOrTemplate", 2] => @rr2.last.id)
-    end
-
-    it "#purge_counts_for_remaining" do
+    it "#purge_counts_for_remaining (used by tools - expensive, avoid)" do
       expect(described_class.send(:purge_counts_for_remaining, 1))
         .to eq(["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2)
     end

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -109,18 +109,11 @@ describe MiqReportResult do
       end
     end
 
-    # private method - not sure if we need
-    it "#purge_ids_for_remaining" do
-      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({1 => @rr1.last.id, 2 => @rr2.last.id})
-    end
-
-    # private method - not sure if we need (and this is very expensive)
-    it "#purge_counts_for_remaining" do
+    it "#purge_counts_for_remaining (used by tools - avoid, it is very expensive)" do
       expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({1 => 1, 2 => 2})
     end
 
-    context "#purge_count" do
-      # private method - not sure who uses (and this is very expensive)
+    context "#purge_count (used by tools - avoid, it is very expensive)" do
       it "by remaining" do
         expect(described_class.purge_count(:remaining, 1)).to eq(3)
       end

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -109,15 +109,18 @@ describe MiqReportResult do
       end
     end
 
+    # private method - not sure if we need
     it "#purge_ids_for_remaining" do
       expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({1 => @rr1.last.id, 2 => @rr2.last.id})
     end
 
+    # private method - not sure if we need (and this is very expensive)
     it "#purge_counts_for_remaining" do
       expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({1 => 1, 2 => 2})
     end
 
     context "#purge_count" do
+      # private method - not sure who uses (and this is very expensive)
       it "by remaining" do
         expect(described_class.purge_count(:remaining, 1)).to eq(3)
       end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -1,82 +1,79 @@
 describe PurgingMixin do
-  describe ".purge" do
-    let(:example_class) { PolicyEvent }
-    let(:example_associated_class) { PolicyEventContent }
-    let(:purge_date) { 2.weeks.ago }
+  let(:example_class) { PolicyEvent }
+  let(:example_associated_class) { PolicyEventContent }
+  let(:purge_date) { 2.weeks.ago }
 
-    before do
-      events = (-2..2).collect do |date_modifier|
+  describe ".purge_date" do
+    it "purge_date should not raise exception" do
+      allow(example_class).to receive(:purge_config).with(:keep_policy_events).and_return(120)
+      expect(example_class.purge_date).to be_within(1.second).of(120.seconds.ago.utc)
+    end
+  end
+
+  describe ".purge" do
+    let(:events) do
+      (-2..2).collect do |date_modifier|
         FactoryGirl.create(:policy_event, :timestamp => purge_date + date_modifier.days)
       end
-      @unpurged_ids = events[-2, 2].collect(&:id)
+    end
+    let(:all_ids) { events.collect(&:id) }
+    let(:unpurged_ids) { all_ids[-2, 2] }
+
+    it "with no records" do
+      expect(example_class.purge(purge_date)).to eq(0)
     end
 
     it "with a date out of range" do
-      expect(example_class).to receive(:delete_all).never
-      expect(example_associated_class).to receive(:delete_all).never
-      example_class.purge(6.months.ago)
+      events # create events
+      expect(example_class.purge(6.months.ago)).to eq(0)
+      expect(example_class.pluck(:id)).to match_array(all_ids)
     end
 
-    it "purge_date should not raise exception" do
-      allow(example_class).to receive(:purge_config).with(:keep_policy_events).and_return(120)
-      example_class.purge_date
-    end
-
-    it "with a date out of range from configuration" do
+    it "with a date out of range" do
+      events # create events
       allow(example_class).to receive(:purge_date).and_return(6.months.ago)
-
-      expect(example_class).to receive(:delete_all).never
-      expect(example_associated_class).to receive(:delete_all).never
-      example_class.purge
+      expect(example_class.purge).to eq(0)
+      expect(example_class.pluck(:id)).to match_array(all_ids)
     end
 
     it "with a date within range" do
-      expect(example_class).to receive(:delete_all).once.and_call_original
-      expect(example_associated_class).to receive(:delete_all).once.and_call_original
-      example_class.purge(purge_date + 1.second)
-      expect(example_class.pluck(:id)).to match_array @unpurged_ids
+      events # create events
+      expect(example_class.purge(purge_date + 1.second)).to eq(3)
+      expect(example_class.pluck(:id)).to match_array unpurged_ids
     end
 
     it "with a date within range from configuration" do
+      events # create events
       allow(example_class).to receive(:purge_date).and_return(purge_date + 1.second)
-
-      expect(example_class).to receive(:delete_all).once.and_call_original
-      expect(example_associated_class).to receive(:delete_all).once.and_call_original
-      example_class.purge
-      expect(example_class.pluck(:id)).to match_array @unpurged_ids
+      expect(example_class.purge).to eq(3)
+      expect(example_class.pluck(:id)).to match_array unpurged_ids
     end
 
     it "with a date covering the whole range" do
-      expect(example_class).to receive(:delete_all).once.and_call_original
-      expect(example_associated_class).to receive(:delete_all).once.and_call_original
-      example_class.purge(Time.now)
+      events # create events
+      expect(example_class.purge(Time.now)).to eq(5)
       expect(example_class.pluck(:id)).to match_array []
     end
 
     it "with a date covering the whole range from configuration" do
+      events # create events
       allow(example_class).to receive(:purge_date).and_return(Time.now)
-
-      expect(example_class).to receive(:delete_all).once.and_call_original
-      expect(example_associated_class).to receive(:delete_all).once.and_call_original
-      example_class.purge
+      expect(example_class.purge(Time.now)).to eq(5)
       expect(example_class.pluck(:id)).to match_array []
     end
 
     it "with a date and a window" do
-      expect(example_class).to receive(:delete_all).twice.and_call_original
-      expect(example_associated_class).to receive(:delete_all).twice.and_call_original
-      example_class.purge(purge_date + 1.second, 2)
-      expect(example_class.pluck(:id)).to match_array @unpurged_ids
+      events # create events
+      expect(example_class.purge(purge_date + 1.second, 2)).to eq(2)
+      expect(example_class.pluck(:id)).to match_array all_ids[-3, 3]
     end
 
     it "with a date and a window from configuration" do
+      events # create events
       allow(example_class).to receive(:purge_date).and_return(purge_date + 1.second)
       allow(example_class).to receive(:purge_window_size).and_return(2)
-
-      expect(example_class).to receive(:delete_all).twice.and_call_original
-      expect(example_associated_class).to receive(:delete_all).twice.and_call_original
-      example_class.purge
-      expect(example_class.pluck(:id)).to match_array @unpurged_ids
+      expect(example_class.purge).to eq(2)
+      expect(example_class.pluck(:id)).to match_array all_ids[-3, 3]
     end
   end
 end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -17,7 +17,6 @@ describe PurgingMixin do
       end
     end
     let(:all_ids) { events.collect(&:id) }
-    let(:unpurged_ids) { all_ids[-2, 2] }
 
     it "with no records" do
       expect(example_class.purge(purge_date)).to eq(0)
@@ -39,33 +38,33 @@ describe PurgingMixin do
     it "with a date within range" do
       events # create events
       expect(example_class.purge(purge_date + 1.second)).to eq(3)
-      expect(example_class.pluck(:id)).to match_array unpurged_ids
+      expect(example_class.pluck(:id)).to match_array all_ids.last(2)
     end
 
     it "with a date within range from configuration" do
       events # create events
       allow(example_class).to receive(:purge_date).and_return(purge_date + 1.second)
       expect(example_class.purge).to eq(3)
-      expect(example_class.pluck(:id)).to match_array unpurged_ids
+      expect(example_class.pluck(:id)).to match_array all_ids.last(2)
     end
 
     it "with a date covering the whole range" do
       events # create events
-      expect(example_class.purge(Time.now)).to eq(5)
+      expect(example_class.purge(Time.now.utc)).to eq(5)
       expect(example_class.pluck(:id)).to match_array []
     end
 
     it "with a date covering the whole range from configuration" do
       events # create events
       allow(example_class).to receive(:purge_date).and_return(Time.now)
-      expect(example_class.purge(Time.now)).to eq(5)
+      expect(example_class.purge(Time.now.utc)).to eq(5)
       expect(example_class.pluck(:id)).to match_array []
     end
 
     it "with a date and a window" do
       events # create events
       expect(example_class.purge(purge_date + 1.second, 2)).to eq(3)
-      expect(example_class.pluck(:id)).to match_array all_ids[-2, 2]
+      expect(example_class.pluck(:id)).to match_array all_ids.last(2)
     end
 
     it "with a date and a window from configuration" do
@@ -73,7 +72,7 @@ describe PurgingMixin do
       allow(example_class).to receive(:purge_date).and_return(purge_date + 1.second)
       allow(example_class).to receive(:purge_window_size).and_return(2)
       expect(example_class.purge).to eq(3)
-      expect(example_class.pluck(:id)).to match_array all_ids[-2, 2]
+      expect(example_class.pluck(:id)).to match_array all_ids.last(2)
     end
   end
 end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -64,16 +64,16 @@ describe PurgingMixin do
 
     it "with a date and a window" do
       events # create events
-      expect(example_class.purge(purge_date + 1.second, 2)).to eq(2)
-      expect(example_class.pluck(:id)).to match_array all_ids[-3, 3]
+      expect(example_class.purge(purge_date + 1.second, 2)).to eq(3)
+      expect(example_class.pluck(:id)).to match_array all_ids[-2, 2]
     end
 
     it "with a date and a window from configuration" do
       events # create events
       allow(example_class).to receive(:purge_date).and_return(purge_date + 1.second)
       allow(example_class).to receive(:purge_window_size).and_return(2)
-      expect(example_class.purge).to eq(2)
-      expect(example_class.pluck(:id)).to match_array all_ids[-3, 3]
+      expect(example_class.purge).to eq(3)
+      expect(example_class.pluck(:id)).to match_array all_ids[-2, 2]
     end
   end
 end


### PR DESCRIPTION
Start to consolidate all the `purging.rb` implementations.

- Purging realtime metrics no longer brings back all ids. (still necessary for the rollups)
- Using more of the purging mixin boilerplate (e.g.: delete by date, configuration variables)
- Using arel for field comparison.
- metric/purging now looks very similar to the mixins/purging
- removed some implementation specific specs around calling `delete_all`.

/cc @matthewd @dmetzger57 fyi