### PR TITLE
Add Persistent Volume Claims + UI

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -7,8 +7,13 @@ module PersistentVolumeHelper::TextualSummary
     %i(name creation_timestamp resource_version capacity access_modes reclaim_policy status_phase
        storage_medium_type gce_pd_resource git_repository git_revision nfs_server
        iscsi_target_portal iscsi_target_qualified_name iscsi_target_lun_number glusterfs_endpoint_name
-       persistent_volume_claim_name rados_ceph_monitors rados_image_name rados_pool_name rados_user_name rados_keyring
+       rados_ceph_monitors rados_image_name rados_pool_name rados_user_name rados_keyring
        volume_path fs_type read_only volume_id partition secret_name)
+  end
+
+  def textual_group_claim_properties
+    @claim = @record.persistent_volume_claim
+    %i(claim_name claim_creation_timestamp desired_access_modes) if @claim
   end
 
   def textual_group_relationships
@@ -102,12 +107,6 @@ module PersistentVolumeHelper::TextualSummary
      :value => name} if name
   end
 
-  def textual_persistent_volume_claim_name
-    claim_name = @record.claim_name
-    {:label => _("Persistent Volume Claim Name"),
-     :value => claim_name} if claim_name
-  end
-
   def textual_rados_ceph_monitors
     ceph_monitors = @record.rbd_ceph_monitors
     {:label => _("Rados Ceph Monitors"),
@@ -166,5 +165,19 @@ module PersistentVolumeHelper::TextualSummary
 
   def textual_secret_name
     @record.common_secret
+  end
+
+  def textual_claim_name
+    {:label => _("Name"),
+     :value => @claim.name}
+  end
+
+  def textual_claim_creation_timestamp
+    {:label => _("Creation timestamp"),
+     :value => format_timezone(@claim.ems_created_on)}
+  end
+
+  def textual_desired_access_modes
+    @claim.desired_access_modes.join(',')
   end
 end

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -2,4 +2,8 @@ class PersistentVolumeClaim < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_volumes
   serialize :capacity, Hash
+
+  def persistent_volume
+    container_volumes.find_by_type('PersistentVolume')
+  end
 end

--- a/app/views/persistent_volume/_main.html.haml
+++ b/app/views/persistent_volume/_main.html.haml
@@ -3,6 +3,8 @@
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"),
                                                                :items => textual_group_properties}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Volume Claim"),
+                                                               :items => textual_group_claim_properties}
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}


### PR DESCRIPTION
Parse and save Persistent Volume Claims and display them in the Volumes page. 
Persistent Volume Claim is a user's request for a Persistent Volume. Pods access storage by using the claim as a volume. The cluster finds the claim in the pod's namespace and uses it to get the Persistent Volume backing the claim, the volume is then mounted to the host and into the pod.

![claim2](https://cloud.githubusercontent.com/assets/11769555/14767537/a0c8a60a-0a30-11e6-8e01-1403c619d607.png)

