### PR TITLE
Add certmonger functionality to appliance console

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -24,6 +24,7 @@ require 'rubygems'
 require 'bcrypt'
 require 'linux_admin'
 require 'util/vmdb-logger'
+require 'awesome_spawn'
 include HighLine::SystemExtensions
 
 require 'i18n'
@@ -88,6 +89,7 @@ require 'appliance_console/external_httpd_authentication'
 require 'appliance_console/temp_storage_configuration'
 require 'appliance_console/key_configuration'
 require 'appliance_console/scap'
+require 'appliance_console/certificate_authority'
 
 require 'appliance_console/prompts'
 include ApplianceConsole::Prompts
@@ -320,6 +322,27 @@ Date and Time Configuration
           say("\nExternal Authentication configuration failed!\n")
           press_any_key
           raise MiqSignalError
+        end
+
+      when I18n.t("advanced_settings.ca")
+        say("#{selection}\n\n")
+        begin
+          ca = CertificateAuthority.new(:hostname => host)
+          if ca.ask_questions && ca.activate
+            say "\ncertificate result: #{ca.status_string}"
+            unless ca.complete?
+              say "After the certificates are retrieved, rerun to update service configuration files"
+            end
+            press_any_key
+          else
+            say("\nCertificates not fetched.\n")
+            press_any_key
+          end
+        rescue AwesomeSpawn::CommandResultError => e
+          say e.result.output
+          say e.result.error
+          say ""
+          press_any_key
         end
 
       when I18n.t("advanced_settings.evmstop")

--- a/gems/pending/appliance_console/certificate_authority.rb
+++ b/gems/pending/appliance_console/certificate_authority.rb
@@ -29,6 +29,17 @@ module ApplianceConsole
       @ca_name ||= "ipa"
     end
 
+    def ask_questions
+      if ipa?
+        self.principal = just_ask("IPA Server Principal", @principal)
+        self.password  = ask_for_password("IPA Server Principal Password", @password)
+      end
+      self.pgclient = ask_yn("Configure certificate for postgres client", "Y")
+      self.pgserver = ask_yn("Configure certificate for postgres server", "Y")
+      self.http = ask_yn("Configure certificate for http server", "Y")
+      true
+    end
+
     def activate
       valid_environment?
 


### PR DESCRIPTION
We have added the ability for customers to create custom ssl certificates in 8/2014. Unfortunately, at that time, we could only add this functionality to the appliance_console_cli and not the menu one.

Today, the appliance_console is separate. We can now merge this functionality into appliance console proper.

@abellotti @carbonin This was an old branch from 8/2014. Do we want to do something like this? Should I push this forward?

old BZ of note: https://bugzilla.redhat.com/show_bug.cgi?id=1130658