### PR TITLE
[WIP] Just use standard rails caching for inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -17,7 +17,7 @@ module EmsRefresh::SaveInventory
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if target.kind_of?(ExtManagementSystem) || target.kind_of?(Host)
-                    target.vms_and_templates(true).to_a.dup
+                    target.vms_and_templates.to_a.dup
                   elsif target.kind_of?(Vm)
                     [target.ruby_clone]
                   else
@@ -196,7 +196,7 @@ module EmsRefresh::SaveInventory
       h[:backing_id] = h.fetch_path(:backing, :id)
     end
 
-    deletes = hardware.disks(true).dup
+    deletes = hardware.disks.dup
     save_inventory_multi(:disks, hardware, hashes, deletes, [:controller_type, :location], nil, [:storage, :backing])
   end
 
@@ -212,7 +212,7 @@ module EmsRefresh::SaveInventory
   def save_networks_inventory(hardware, hashes, mode = :refresh)
     return if hashes.nil?
 
-    deletes = hardware.networks(true).to_a.dup
+    deletes = hardware.networks.to_a.dup
 
     case mode
     when :refresh
@@ -231,29 +231,29 @@ module EmsRefresh::SaveInventory
 
     deletes = case mode
               when :refresh then nil
-              when :scan    then parent.system_services(true).dup
+              when :scan    then parent.system_services.dup
               end
 
     save_inventory_multi(:system_services, parent, hashes, deletes, [:typename, :name])
   end
 
   def save_guest_applications_inventory(parent, hashes)
-    deletes = parent.guest_applications(true).dup
+    deletes = parent.guest_applications.dup
     save_inventory_multi(:guest_applications, parent, hashes, deletes, [:arch, :typename, :name, :version])
   end
 
   def save_advanced_settings_inventory(parent, hashes)
-    deletes = parent.advanced_settings(true).dup
+    deletes = parent.advanced_settings.dup
     save_inventory_multi(:advanced_settings, parent, hashes, deletes, [:name])
   end
 
   def save_patches_inventory(parent, hashes)
-    deletes = parent.patches(true).dup
+    deletes = parent.patches.dup
     save_inventory_multi(:patches, parent, hashes, deletes, [:name])
   end
 
   def save_os_processes_inventory(os, hashes)
-    deletes = os.processes(true).dup
+    deletes = os.processes.dup
     save_inventory_multi(:processes, os, hashes, deletes, [:pid])
   end
 
@@ -262,7 +262,7 @@ module EmsRefresh::SaveInventory
 
     deletes = case mode
               when :refresh then nil
-              when :scan    then parent.custom_attributes(true).dup
+              when :scan    then parent.custom_attributes.dup
               end
 
     save_inventory_multi(:custom_attributes, parent, hashes, deletes, [:name, :section])
@@ -270,12 +270,12 @@ module EmsRefresh::SaveInventory
 
   def save_ems_custom_attributes_inventory(parent, hashes)
     return if hashes.nil?
-    deletes = parent.ems_custom_attributes(true).dup
+    deletes = parent.ems_custom_attributes.dup
     save_inventory_multi(:ems_custom_attributes, parent, hashes, deletes, [:section, :name])
   end
 
   def save_filesystems_inventory(parent, hashes)
-    deletes = parent.filesystems(true).dup
+    deletes = parent.filesystems.dup
     save_inventory_multi(:filesystems, parent, hashes, deletes, [:name])
   end
 
@@ -284,7 +284,7 @@ module EmsRefresh::SaveInventory
 
     hashes.each { |h| h[:parent_id] = nil } # Delink all snapshots
 
-    deletes = vm.snapshots(true).dup
+    deletes = vm.snapshots.dup
     save_inventory_multi(:snapshots, vm, hashes, deletes, [:uid])
 
     # Reset the relationship tree for the snapshots
@@ -297,7 +297,7 @@ module EmsRefresh::SaveInventory
   end
 
   def save_event_logs_inventory(os, hashes)
-    deletes = os.event_logs(true).dup
+    deletes = os.event_logs.dup
     save_inventory_multi(:event_logs, os, hashes, deletes, [:uid])
   end
 end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -104,7 +104,7 @@ module EmsRefresh::SaveInventoryInfra
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if (target == ems)
-                    target.hosts(true).to_a.dup
+                    target.hosts.to_a.dup
                   elsif target.kind_of?(Host)
                     [target.clone]
                   else
@@ -220,7 +220,6 @@ module EmsRefresh::SaveInventoryInfra
   def save_folders_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.ems_folders(true)
     deletes = if (target == ems)
                 ems.ems_folders.dup
               else
@@ -235,7 +234,6 @@ module EmsRefresh::SaveInventoryInfra
   def save_clusters_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.ems_clusters(true)
     deletes = if (target == ems)
                 ems.ems_clusters.dup
               else
@@ -250,7 +248,6 @@ module EmsRefresh::SaveInventoryInfra
   def save_resource_pools_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.resource_pools(true)
     deletes = if (target == ems)
                 ems.resource_pools.dup
               elsif target.kind_of?(Host)
@@ -264,22 +261,22 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)
-    deletes = ems.customization_specs(true).dup
+    deletes = ems.customization_specs.dup
     save_inventory_multi(:customization_specs, ems, hashes, deletes, [:name])
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)
-    deletes = guest_device.miq_scsi_targets(true).dup
+    deletes = guest_device.miq_scsi_targets.dup
     save_inventory_multi(:miq_scsi_targets, guest_device, hashes, deletes, [:uid_ems], :miq_scsi_luns)
   end
 
   def save_miq_scsi_luns_inventory(miq_scsi_target, hashes)
-    deletes = miq_scsi_target.miq_scsi_luns(true).dup
+    deletes = miq_scsi_target.miq_scsi_luns.dup
     save_inventory_multi(:miq_scsi_luns, miq_scsi_target, hashes, deletes, [:uid_ems])
   end
 
   def save_switches_inventory(host, hashes)
-    deletes = host.switches(true).dup
+    deletes = host.switches.dup
     save_inventory_multi(:switches, host, hashes, deletes, [:uid_ems], :lans)
 
     host.save!
@@ -298,12 +295,12 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_lans_inventory(switch, hashes)
-    deletes = switch.lans(true).dup
+    deletes = switch.lans.dup
     save_inventory_multi(:lans, switch, hashes, deletes, [:uid_ems])
   end
 
   def save_storage_files_inventory(storage, hashes)
-    deletes = storage.storage_files(true).dup
+    deletes = storage.storage_files.dup
     save_inventory_multi(:storage_files, storage, hashes, deletes, [:name])
   end
 end

--- a/app/models/ems_refresh/save_inventory_networks.rb
+++ b/app/models/ems_refresh/save_inventory_networks.rb
@@ -13,7 +13,6 @@ module EmsRefresh
     def save_cloud_networks_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.cloud_networks(true)
       deletes = if (target == ems)
                   ems.cloud_networks.dup
                 else
@@ -36,7 +35,7 @@ module EmsRefresh
     end
 
     def save_cloud_subnets_inventory(cloud_network, hashes)
-      deletes = cloud_network.cloud_subnets(true).dup
+      deletes = cloud_network.cloud_subnets.dup
 
       hashes.each do |h|
         h[:availability_zone_id] = h.fetch_path(:availability_zone, :id)
@@ -51,7 +50,6 @@ module EmsRefresh
     def save_security_groups_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.security_groups(true)
       deletes = if (target == ems)
                   ems.security_groups.dup
                 else
@@ -86,7 +84,6 @@ module EmsRefresh
     def save_floating_ips_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.floating_ips(true)
       deletes = if (target == ems)
                   ems.floating_ips.dup
                 else
@@ -121,7 +118,7 @@ module EmsRefresh
           [:name]
         end
 
-      deletes = parent.firewall_rules(true).dup
+      deletes = parent.firewall_rules.dup
       save_inventory_multi(:firewall_rules, parent, hashes, deletes, find_key, nil, [:source_security_group])
 
       parent.save!
@@ -131,7 +128,6 @@ module EmsRefresh
     def save_network_routers_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.network_routers(true)
       deletes = if (target == ems)
                   ems.network_routers.dup
                 else
@@ -156,7 +152,6 @@ module EmsRefresh
     def save_network_ports_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      ems.network_ports(true)
       deletes = if (target == ems)
                   ems.network_ports.dup
                 else

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -18,7 +18,7 @@ module EmsRefresh
     def save_orchestration_stacks_inventory(ems, hashes, target = nil)
       target = ems if target.nil?
 
-      deletes = target == ems ? ems.orchestration_stacks(true).dup : []
+      deletes = target == ems ? ems.orchestration_stacks.dup : []
 
       hashes.each do |h|
         h[:orchestration_template_id] = h.fetch_path(:orchestration_template, :id)
@@ -33,7 +33,7 @@ module EmsRefresh
                                     [:parameters, :outputs, :resources],
                                     [:parent, :orchestration_template, :cloud_tenant])
 
-      store_ids_for_new_records(ems.orchestration_stacks(true), hashes, :ems_ref)
+      store_ids_for_new_records(ems.orchestration_stacks, hashes, :ems_ref)
 
       save_orchestration_stack_nesting(stacks.index_by(&:id), hashes)
     end
@@ -46,7 +46,7 @@ module EmsRefresh
     end
 
     def save_parameters_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.parameters(true).dup
+      deletes = orchestration_stack.parameters.dup
 
       save_inventory_multi(:parameters,
                            orchestration_stack,
@@ -56,7 +56,7 @@ module EmsRefresh
     end
 
     def save_outputs_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.outputs(true).dup
+      deletes = orchestration_stack.outputs.dup
 
       save_inventory_multi(:outputs,
                            orchestration_stack,
@@ -66,7 +66,7 @@ module EmsRefresh
     end
 
     def save_resources_inventory(orchestration_stack, hashes)
-      deletes = orchestration_stack.resources(true).dup
+      deletes = orchestration_stack.resources.dup
 
       save_inventory_multi(:resources,
                            orchestration_stack,


### PR DESCRIPTION
As a lark, what would happen if we didn't clear our our inventory caches so much?

I don't see why we have to clear out the associations every chance we get

/cc @dmetzger57 I have a feeling this would be a big win. If this passes, I can get more concrete numbers