### PR TITLE
Add XFSProbe to the top of the list of reordered known Filesystem Probes

### DIFF
--- a/gems/pending/fs/MiqFS/FsProbe.rb
+++ b/gems/pending/fs/MiqFS/FsProbe.rb
@@ -14,6 +14,7 @@ module FsProbe
   PROBE_FILES.unshift("Ext4Probe")     if PROBE_FILES.delete("Ext4Probe")
   PROBE_FILES.unshift("Ext3Probe")     if PROBE_FILES.delete("Ext3Probe")
   PROBE_FILES.unshift("NTFSProbe")     if PROBE_FILES.delete("NTFSProbe")
+  PROBE_FILES.unshift("XFSProbe")      if PROBE_FILES.delete("XFSProbe")
 
   def self.getFsMod(dobj, probes = nil)
     probes = PROBE_FILES if probes.nil?


### PR DESCRIPTION
Add XFSProbe to the top of the list of reordered known Filesystem probes
handled by FsProbe.  This change was omitted when XFS was
added as a supported filesystem.  With RHEL7 XFS is the
default filesystem and this adds the filesystem to the top of the list
rather than waiting for all other known types to be checked first.

@roliveri @Fryguy @chessbyte please review.  Note that this one line
change was originally added to https://github.com/ManageIQ/manageiq/pull/2428
orthogonally but removed from there and adde here separately.