### PR TITLE
individual perf_capture_#{interval} methods

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -87,7 +87,7 @@ module Metric::Capture
   #
 
   def self.perf_capture_health_check(zone)
-    q_items = MiqQueue.select(:method_name, :created_on).order("created_on ASC")
+    q_items = MiqQueue.select(:method_name, :created_on).order(:created_on)
               .where(:state       => "ready",
                      :role        => "ems_metrics_collector",
                      :method_name => %w(perf_capture perf_capture_realtime perf_capture_hourly perf_capture_historical),

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -90,7 +90,8 @@ module Metric::CiMixin::Capture
           end
           qi
         else
-          _log.debug "Skipping capture of #{log_target} - Performance capture for interval #{qi[:method_name].sub("perf_capture_","")} is still running"
+          interval = qi[:method_name].sub("perf_capture_", "")
+          _log.debug "Skipping capture of #{log_target} - Performance capture for interval #{interval} is still running"
           # NOTE: do not update the message queue
           nil
         end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -98,6 +98,18 @@ module Metric::CiMixin::Capture
     end
   end
 
+  def perf_capture_realtime(*args)
+    perf_capture('realtime', *args)
+  end
+
+  def perf_capture_hourly(*args)
+    perf_capture('hourly', *args)
+  end
+
+  def perf_capture_historical(*args)
+    perf_capture('historical', *args)
+  end
+
   def perf_capture(interval_name, start_time = nil, end_time = nil)
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
     raise ArgumentError, "end_time cannot be specified if start_time is nil" if start_time.nil? && !end_time.nil?

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -688,6 +688,18 @@ class Storage < ApplicationRecord
     [MiqRegion.my_region].compact unless interval_name == 'realtime'
   end
 
+  def perf_capture_realtime(*args)
+    perf_capture('realtime', *args)
+  end
+
+  def perf_capture_hourly(*args)
+    perf_capture('hourly', *args)
+  end
+
+  def perf_capture_historical(*args)
+    perf_capture('historical', *args)
+  end
+
   # TODO: See if we can reuse the main perf_capture method, and only overwrite the perf_collect_metrics method
   def perf_capture(interval_name)
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -72,7 +72,6 @@ describe Metric::Capture do
     let(:vm) { FactoryGirl.create(:vm_perf, :ext_management_system => ems) }
     let(:vm2) { FactoryGirl.create(:vm_perf, :ext_management_system => ems) }
 
-
     it "should queue up realtime capture for vm" do
       vm.perf_capture_realtime_now
       vm2.perf_capture_realtime_now
@@ -81,7 +80,7 @@ describe Metric::Capture do
       expect(Metric::Capture._log).to receive(:info).with(/2 "realtime" captures on the queue.*oldest:.*recent:/)
       expect(Metric::Capture._log).to receive(:info).with(/0 "hourly" captures on the queue/)
       expect(Metric::Capture._log).to receive(:info).with(/0 "historical" captures on the queue/)
-      described_class.perf_capture_health_check
+      described_class.perf_capture_health_check(miq_server.zone)
     end
   end
 end

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -138,7 +138,7 @@ describe Metric::CiMixin::Capture do
     end
 
     allow(@vm).to receive(:state_changed_on).and_return(second_collection_period_start)
-    @vm.perf_capture_realtime(Time.parse('2013-08-28T11:01:40Z'), Time.parse(second_collection_period_start))
+    @vm.perf_capture_realtime(Time.parse('2013-08-28T11:01:40Z').utc, Time.parse(second_collection_period_start).utc)
 
     # 2.collection period, save all metrics
     allow(@metering).to receive(:get_statistics) do |name, _options|
@@ -152,7 +152,7 @@ describe Metric::CiMixin::Capture do
     end
 
     allow(@vm).to receive(:state_changed_on).and_return(second_collection_period_start)
-    @vm.perf_capture_realtime(Time.parse(second_collection_period_start), Time.parse('2013-08-28T14:02:00Z'))
+    @vm.perf_capture_realtime(Time.parse(second_collection_period_start).utc, Time.parse('2013-08-28T14:02:00Z').utc)
 
     @metrics_by_ts = {}
     @vm.metrics.each do |x|
@@ -181,6 +181,6 @@ describe Metric::CiMixin::Capture do
 
   def parse_datetime(datetime)
     datetime << "Z" if datetime.size == 19
-    Time.parse(datetime)
+    Time.parse(datetime).utc
   end
 end

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -138,7 +138,7 @@ describe Metric::CiMixin::Capture do
     end
 
     allow(@vm).to receive(:state_changed_on).and_return(second_collection_period_start)
-    @vm.perf_capture('realtime', Time.parse('2013-08-28T11:01:40Z'), Time.parse(second_collection_period_start))
+    @vm.perf_capture_realtime(Time.parse('2013-08-28T11:01:40Z'), Time.parse(second_collection_period_start))
 
     # 2.collection period, save all metrics
     allow(@metering).to receive(:get_statistics) do |name, _options|
@@ -152,7 +152,7 @@ describe Metric::CiMixin::Capture do
     end
 
     allow(@vm).to receive(:state_changed_on).and_return(second_collection_period_start)
-    @vm.perf_capture('realtime', Time.parse(second_collection_period_start), Time.parse('2013-08-28T14:02:00Z'))
+    @vm.perf_capture_realtime(Time.parse(second_collection_period_start), Time.parse('2013-08-28T14:02:00Z'))
 
     @metrics_by_ts = {}
     @vm.metrics.each do |x|

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -314,7 +314,7 @@ describe Metric do
         context "capturing vm realtime data" do
           before(:each) do
             @alarm_event = "vm_perf_complete"
-            @vm.perf_capture('realtime')
+            @vm.perf_capture_realtime
           end
 
           it "should have collected performances" do

--- a/tools/log_processing/perf_timings.rb
+++ b/tools/log_processing/perf_timings.rb
@@ -54,7 +54,7 @@ all_timings = Hash.new { |k, v| k[v] = [] }
 vim_collect_timings = {}
 
 MiqLoggerProcessor.new(logfile).each do |line|
-  next unless line =~ /MIQ\((Vm|Host|Storage|EmsCluster|ExtManagementSystem|MiqEnterprise)\.(vim_collect_perf_data|perf_capture|perf_process|perf_rollup)\).+Timings:? (\{.+)$/
+  next unless line =~ /MIQ\((Vm|Host|Storage|EmsCluster|ExtManagementSystem|MiqEnterprise)\.(vim_collect_perf_data|perf_capture_?[a-z]*|perf_process|perf_rollup)\).+Timings:? (\{.+)$/
   target, method, timings = $1, $2, $3
 
   target.downcase!


### PR DESCRIPTION
Introduce individual `perf_capture_#{interval}` methods

**BEFORE:**

Currently, we have a generic `perf_capture` method.
The args (3 possible values) contain which `perf_capture` to perform.

When we queue, we look for a unique entry, so we need to look at the args to determine if it already exists.
This increases our "delivery envelope" and makes transition to a queue more difficult.

**AFTER:**

This change allows us to not look at `args` for delivery (and uniqueness)
This change allows us to count entries in the queue without deserialization. <== **performance win**
This change allows us to remove a bunch of ifs in the generic method.


/cc @Fryguy @chessbyte part of a higher order desire to remove args from the delivery envelope and remove `:args_selector` functionality.