### PR TITLE
Fix faulty password change raising logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,10 +116,10 @@ class User < ActiveRecord::Base
   def change_password(oldpwd, newpwd)
     auth = self.class.authenticator(userid)
     raise MiqException::MiqEVMLoginError, "password change not allowed when authentication mode is #{auth.class.proper_name}" unless auth.uses_stored_password?
-    raise MiqException::MiqEVMLoginError, "old password does not match current password" unless User.authenticate(userid, oldpwd)
-
-    self.password = newpwd
-    self.save!
+    if auth.authenticate(userid, oldpwd)
+      self.password = newpwd
+      self.save!
+    end
   end
 
   def ldap_group

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,12 +105,8 @@ describe User do
       password    = "wrongpwd"
       newpassword = "newpassword"
 
-      lambda do
-        @user.change_password(password, newpassword)
-      end.should
-      raise_error(MiqException::MiqEVMLoginError,
-                  "old password does not match current password"
-                 )
+      expect { @user.change_password(password, newpassword) }
+        .to raise_error(MiqException::MiqEVMLoginError)
     end
 
     it "should check for and get Managed and Belongs-to filters" do


### PR DESCRIPTION
Interestingly enough, the current spec for these lines checks for the
exception message "old password does not match current password" and
*passed* even though the _actual_ exception was a normal Authentication
Failed exception when running `authenticate` after the `unless`. For
some reason this spec _now_ correctly catches that the message is
incorrect with the upgrade to RSpec 2.99.

There are many ways to fix this issue: I could reraise the exception
in the app code with the correct message (kind of silly IMO) or
do as I have done - let's not reraise and just throw the exception
given from an invalid #authenticate.