### PR TITLE
remove constant from rspec

### DIFF
--- a/spec/migrations/20150907095639_add_container_image_digest_spec.rb
+++ b/spec/migrations/20150907095639_add_container_image_digest_spec.rb
@@ -4,27 +4,29 @@ require_migration
 describe AddContainerImageDigest do
   let(:container_image_stub) { migration_stub(:ContainerImage) }
 
-  ROW_ENTRIES = [
-    {:tag_in => 'sha256',     :tag_out => 'sha256',    :digest  => nil},
-    {:tag_in => 'sha384',     :tag_out => 'sha384',    :digest  => nil},
-    {:tag_in => 'sha512',     :tag_out => 'sha512',    :digest  => nil},
-    {:tag_in => 'sha256abc',  :tag_out => 'sha256abc', :digest  => nil},
-    {:tag_in => 'sha384abc',  :tag_out => 'sha384abc', :digest  => nil},
-    {:tag_in => 'sha512abc',  :tag_out => 'sha512abc', :digest  => nil},
-    {:tag_in => 'sha256:abc', :tag_out => nil,         :digest  => 'sha256:abc'},
-    {:tag_in => 'sha384:abc', :tag_out => nil,         :digest  => 'sha384:abc'},
-    {:tag_in => 'sha512:abc', :tag_out => nil,         :digest  => 'sha512:abc'}
-  ]
+  let(:row_entries) do
+    [
+      {:tag_in => 'sha256',     :tag_out => 'sha256',    :digest  => nil},
+      {:tag_in => 'sha384',     :tag_out => 'sha384',    :digest  => nil},
+      {:tag_in => 'sha512',     :tag_out => 'sha512',    :digest  => nil},
+      {:tag_in => 'sha256abc',  :tag_out => 'sha256abc', :digest  => nil},
+      {:tag_in => 'sha384abc',  :tag_out => 'sha384abc', :digest  => nil},
+      {:tag_in => 'sha512abc',  :tag_out => 'sha512abc', :digest  => nil},
+      {:tag_in => 'sha256:abc', :tag_out => nil,         :digest  => 'sha256:abc'},
+      {:tag_in => 'sha384:abc', :tag_out => nil,         :digest  => 'sha384:abc'},
+      {:tag_in => 'sha512:abc', :tag_out => nil,         :digest  => 'sha512:abc'}
+    ]
+  end
 
   migration_context :up do
     it "migrates a series of representative row" do
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         x[:image] = container_image_stub.create!(:tag => x[:tag_in])
       end
 
       migrate
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         expect(x[:image].reload).to have_attributes(
           :tag    => x[:tag_out],
           :digest => x[:digest]
@@ -35,7 +37,7 @@ describe AddContainerImageDigest do
 
   migration_context :down do
     it "migrates a series of representative row" do
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         x[:image] = container_image_stub.create!(
           :tag    => x[:tag_out],
           :digest => x[:digest]
@@ -44,7 +46,7 @@ describe AddContainerImageDigest do
 
       migrate
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         expect(x[:image].reload).to have_attributes(:tag => x[:tag_in])
       end
     end

--- a/spec/migrations/20151125081618_set_correct_sti_type_on_openstack_infra_miq_template_spec.rb
+++ b/spec/migrations/20151125081618_set_correct_sti_type_on_openstack_infra_miq_template_spec.rb
@@ -5,51 +5,54 @@ describe SetCorrectStiTypeOnOpenstackInfraMiqTemplate do
   let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
   let(:miq_template_stub) { migration_stub(:Vm) }
 
-  EMS_ROW_ENTRIES = [
-    {:type => "ManageIQ::Providers::Openstack::InfraManager"},
-    {:type => "ManageIQ::Providers::Openstack::CloudManager"},
-    {:type => "ManageIQ::Providers::AnotherManager"}
-  ]
+  let(:ems_row_entries) do
+    [
+      {:type => "ManageIQ::Providers::Openstack::InfraManager"},
+      {:type => "ManageIQ::Providers::Openstack::CloudManager"},
+      {:type => "ManageIQ::Providers::AnotherManager"}
+    ]
+  end
 
-  ROW_ENTRIES = [{
-                   :ems      => EMS_ROW_ENTRIES[0],
-                   :name     => "template_1",
-                   :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
-                   :type_out => 'ManageIQ::Providers::Openstack::InfraManager::Template'
-                 },
-                 {
-                   :ems      => EMS_ROW_ENTRIES[0],
-                   :name     => "template_2",
-                   :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
-                   :type_out => 'ManageIQ::Providers::Openstack::InfraManager::Template'
-                 },
-                 {
-                   :ems      => EMS_ROW_ENTRIES[1],
-                   :name     => "template_3",
-                   :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
-                   :type_out => 'ManageIQ::Providers::Openstack::CloudManager::Template'
-                 },
-                 {
-                   :ems      => EMS_ROW_ENTRIES[2],
-                   :name     => "template_4",
-                   :type_in  => 'ManageIQ::Providers::AnyManager::Template',
-                   :type_out => 'ManageIQ::Providers::AnyManager::Template'
-                 },
-  ]
+  let(:row_entries) do
+   [{
+      :ems      => ems_row_entries[0],
+      :name     => "template_1",
+      :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
+      :type_out => 'ManageIQ::Providers::Openstack::InfraManager::Template'
+    },
+    {
+      :ems      => ems_row_entries[0],
+      :name     => "template_2",
+      :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
+      :type_out => 'ManageIQ::Providers::Openstack::InfraManager::Template'
+    },
+    {
+      :ems      => ems_row_entries[1],
+      :name     => "template_3",
+      :type_in  => 'ManageIQ::Providers::Openstack::CloudManager::Template',
+      :type_out => 'ManageIQ::Providers::Openstack::CloudManager::Template'
+    },
+    {
+      :ems      => ems_row_entries[2],
+      :name     => "template_4",
+      :type_in  => 'ManageIQ::Providers::AnyManager::Template',
+      :type_out => 'ManageIQ::Providers::AnyManager::Template'
+    }]
+  end
 
   migration_context :up do
     it "migrates a series of representative row" do
-      EMS_ROW_ENTRIES.each do |x|
+      ems_row_entries.each do |x|
         x[:ems] = ext_management_system_stub.create!(:type => x[:type])
       end
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         x[:miq_template] = miq_template_stub.create!(:type => x[:type_in], :ems_id => x[:ems][:ems].id, :name => x[:name])
       end
 
       migrate
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         expect(x[:miq_template].reload).to have_attributes(
                                       :type   => x[:type_out],
                                       :name   => x[:name],
@@ -61,17 +64,17 @@ describe SetCorrectStiTypeOnOpenstackInfraMiqTemplate do
 
   migration_context :down do
     it "migrates a series of representative row" do
-      EMS_ROW_ENTRIES.each do |x|
+      ems_row_entries.each do |x|
         x[:ems] = ext_management_system_stub.create!(:type => x[:type])
       end
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         x[:miq_template] = miq_template_stub.create!(:type => x[:type_out], :ems_id => x[:ems][:ems].id, :name => x[:name])
       end
 
       migrate
 
-      ROW_ENTRIES.each do |x|
+      row_entries.each do |x|
         expect(x[:miq_template].reload).to have_attributes(
                                              :type   => x[:type_in],
                                              :name   => x[:name],


### PR DESCRIPTION
describe blocks are not a class, so these get
defined in global.

This tends not to be what we want to do