### PR TITLE
Allow :icon instead of :image in GTL list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 gem "american_date"
 gem "azure-armrest",                  "=0.0.8"
 gem "default_value_for",              "~>3.0.1"
+gem "draper",                         "~>2.1.0"
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"
 gem "novnc-rails",                    "~>0.2"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1053,12 +1053,15 @@ class ApplicationController < ActionController::Base
 
     root = {:head => [], :rows => []}
 
+    has_checkbox = !@embedded && !@no_checkboxes
+    has_listicon = !%w(miqaeclass miqaeinstance).include?(view.db.downcase)  # do not add listicon for AE class show_list
+
     # Show checkbox or placeholder column
-    unless @embedded || @no_checkboxes
+    if has_checkbox
       root[:head] << {:is_narrow => true}
     end
 
-    unless %w(miqaeclass miqaeinstance).include?(view.db.downcase)  # do not add listicon for AE class show_list
+    if has_listicon
       # Icon column
       root[:head] << {:is_narrow => true}
     end
@@ -1082,13 +1085,12 @@ class ApplicationController < ActionController::Base
       new_row = {:id => list_row_id(row), :cells => []}
       root[:rows] << new_row
 
-      unless @embedded || @no_checkboxes
+      if has_checkbox
         new_row[:cells] << {:is_checkbox => true}
       end
 
       # Generate html for the list icon
-      # do not add listicon for AE class show_list
-      unless %w(miqaeclass miqaeinstance).include?(view.db.downcase)
+      if has_listicon
         item = listicon_item(view, row['id'])
 
         new_row[:cells] << {:title => 'View this item',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1094,7 +1094,8 @@ class ApplicationController < ActionController::Base
         item = listicon_item(view, row['id'])
 
         new_row[:cells] << {:title => 'View this item',
-                            :image => listicon_image(item, view)}
+                            :image => listicon_image(item, view),
+                            :icon  => listicon_icon(item)}
       end
 
       view.col_order.each_with_index do |col, col_idx|
@@ -1146,6 +1147,12 @@ class ApplicationController < ActionController::Base
     end
   end
   private :listicon_item
+
+  # Return the icon classname for the list view icon of a db,id pair
+  # this always supersedes listicon_image if not nil
+  def listicon_icon(item)
+    nil
+  end
 
   # Return the image name for the list view icon of a db,id pair
   def listicon_image(item, view)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1141,6 +1141,7 @@ class ApplicationController < ActionController::Base
              klass.find(id)    # Read the record from the db
            end
 
+    default = "100/#{(@listicon || view.db).underscore}.png"
     image = case item
             when ExtManagementSystem   then "100/vendor-#{item.image_name}.png"
             when Filesystem            then "ico/win/#{item.image_name.downcase}.ico"
@@ -1163,7 +1164,8 @@ class ApplicationController < ActionController::Base
                 "/pictures/#{item.picture.basename}"
               end
             end
-    list_row_image("100/", image, (@listicon || view.db).underscore, item)
+
+    list_row_image(image || default, item)
   end
 
   def get_host_for_vm(vm)
@@ -2574,8 +2576,8 @@ class ApplicationController < ActionController::Base
     to_cid(row['id'])
   end
 
-  def list_row_image(image_path, image, model_image, _item)
-    ActionController::Base.helpers.image_path(image || "#{image_path}#{model_image}.png")
+  def list_row_image(image, _item)
+    image
   end
 
   def render_flash_not_applicable_to_model(type, model_type = "items")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1151,38 +1151,22 @@ class ApplicationController < ActionController::Base
   # Return the icon classname for the list view icon of a db,id pair
   # this always supersedes listicon_image if not nil
   def listicon_icon(item)
-    case item
-    when ExtManagementSystem
-      item.decorate.fonticon
-    else
-      nil
-    end
+    item.decorate.try(:fonticon)
   end
 
   # Return the image name for the list view icon of a db,id pair
   def listicon_image(item, view)
     default = "100/#{(@listicon || view.db).underscore}.png"
+
     image = case item
-            when ExtManagementSystem   then "100/vendor-#{item.image_name}.png"
-            when Filesystem            then "ico/win/#{item.image_name.downcase}.ico"
-            when Host                  then "100/vendor-#{item.vmm_vendor.downcase}.png"
-            when MiqEventDefinition    then "100/event-#{item.name.downcase}.png"
+            when EventLog, OsProcess
+              "100/#{@listicon.downcase}.png"
+            when Storage
+              "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
             when MiqRequest
-              case item.request_status.to_s.downcase
-              when "ok"    then "100/checkmark.png"
-              when "error" then "100/x.png"
-              else              "100/#{@listicon.downcase}.png"
-              end
-            when RegistryItem          then "100/#{item.image_name.downcase}.png"
-            when ResourcePool          then "100/#{item.vapp ? "vapp" : "resource_pool"}.png"
-            when VmOrTemplate          then "100/vendor-#{item.vendor.downcase}.png"
-            when ServiceResource       then "100/#{item.resource_type.to_s == "VmOrTemplate" ? "vm" : "service_template"}.png"
-            when Storage               then "100/piecharts/datastore/#{calculate_pct_img(item.v_free_space_percent_of_total)}.png"
-            when OsProcess, EventLog   then "100/#{@listicon.downcase}.png"
-            when Service, ServiceTemplate
-              if item.try(:picture)
-                "/pictures/#{item.picture.basename}"
-              end
+              item.decorate.listicon_image || "100/#{@listicon.downcase}.png"
+            else
+              item.decorate.try(:listicon_image)
             end
 
     list_row_image(image || default, item)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1089,8 +1089,10 @@ class ApplicationController < ActionController::Base
       # Generate html for the list icon
       # do not add listicon for AE class show_list
       unless %w(miqaeclass miqaeinstance).include?(view.db.downcase)
+        item = listicon_item(view, row['id'])
+
         new_row[:cells] << {:title => 'View this item',
-                            :image => listicon_image(view, row['id'])}
+                            :image => listicon_image(item, view)}
       end
 
       view.col_order.each_with_index do |col, col_idx|
@@ -1131,16 +1133,20 @@ class ApplicationController < ActionController::Base
     val == 100 ? 20 : ((val + 2) / 5.25).round # val is the percentage value of free space
   end
 
-  # Return the image name for the list view icon of a db,id pair
-  def listicon_image(view, id = nil)
+  def listicon_item(view, id = nil)
     id = @id if id.nil?
-    item = if @targets_hash
-             @targets_hash[id] # Get the record from the view
-           else
-             klass = view.db.constantize
-             klass.find(id)    # Read the record from the db
-           end
 
+    if @targets_hash
+      @targets_hash[id] # Get the record from the view
+    else
+      klass = view.db.constantize
+      klass.find(id)    # Read the record from the db
+    end
+  end
+  private :listicon_item
+
+  # Return the image name for the list view icon of a db,id pair
+  def listicon_image(item, view)
     default = "100/#{(@listicon || view.db).underscore}.png"
     image = case item
             when ExtManagementSystem   then "100/vendor-#{item.image_name}.png"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1151,7 +1151,7 @@ class ApplicationController < ActionController::Base
   # Return the icon classname for the list view icon of a db,id pair
   # this always supersedes listicon_image if not nil
   def listicon_icon(item)
-    item.decorate.try(:fonticon)
+    item.decorate.try(:fonticon) if item.decorator_class?
   end
 
   # Return the image name for the list view icon of a db,id pair
@@ -1166,7 +1166,7 @@ class ApplicationController < ActionController::Base
             when MiqRequest
               item.decorate.listicon_image || "100/#{@listicon.downcase}.png"
             else
-              item.decorate.try(:listicon_image)
+              item.decorate.try(:listicon_image) if item.decorator_class?
             end
 
     list_row_image(image || default, item)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1151,7 +1151,12 @@ class ApplicationController < ActionController::Base
   # Return the icon classname for the list view icon of a db,id pair
   # this always supersedes listicon_image if not nil
   def listicon_icon(item)
-    nil
+    case item
+    when ExtManagementSystem
+      item.decorate.fonticon
+    else
+      nil
+    end
   end
 
   # Return the image name for the list view icon of a db,id pair

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -883,9 +883,10 @@ class ProviderForemanController < ApplicationController
     end
   end
 
-  def list_row_image(image_path, image, model_image, item)
-    if item.name == _("Unassigned Profiles Group")
-      image_path ? "#{image_path}folder.png" : "folder"
+  def list_row_image(_image, item = nil)
+    # Unassigned Profiles Group
+    if item.kind_of?(ConfigurationProfile) && empty_configuration_profile_record?(item)
+      'folder'
     else
       super
     end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -1,0 +1,7 @@
+class ExtManagementSystemDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+end

--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -4,4 +4,8 @@ class ExtManagementSystemDecorator < Draper::Decorator
   def fonticon
     nil
   end
+
+  def listicon_image
+    "100/vendor-#{image_name}.png"
+  end
 end

--- a/app/decorators/filesystem_decorator.rb
+++ b/app/decorators/filesystem_decorator.rb
@@ -1,0 +1,11 @@
+class FilesystemDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "ico/win/#{image_name.downcase}.ico"
+  end
+end

--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -1,0 +1,11 @@
+class HostDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/vendor-#{vmm_vendor.downcase}.png"
+  end
+end

--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Kubernetes::ContainerManagerDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    "pficon-kubernetes".freeze
+  end
+end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Openshift::ContainerManagerDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    "pficon-openshift".freeze
+  end
+end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -2,6 +2,6 @@ class ManageIQ::Providers::Openshift::ContainerManagerDecorator < Draper::Decora
   delegate_all
 
   def fonticon
-    "pficon-openshift".freeze
+    "pficon pficon-openshift fa-lg".freeze
   end
 end

--- a/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
@@ -2,6 +2,6 @@ class ManageIQ::Providers::OpenshiftEnterprise::ContainerManagerDecorator < Drap
   delegate_all
 
   def fonticon
-    "pficon-openshift".freeze
+    "pficon pficon-openshift fa-lg".freeze
   end
 end

--- a/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::OpenshiftEnterprise::ContainerManagerDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    "pficon-openshift".freeze
+  end
+end

--- a/app/decorators/miq_event_definition_decorator.rb
+++ b/app/decorators/miq_event_definition_decorator.rb
@@ -1,0 +1,11 @@
+class MiqEventDefinitionDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/event-#{name.downcase}.png"
+  end
+end

--- a/app/decorators/miq_request_decorator.rb
+++ b/app/decorators/miq_request_decorator.rb
@@ -1,0 +1,18 @@
+class MiqRequestDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    case request_status.to_s.downcase
+    when "ok"
+      "100/checkmark.png"
+    when "error"
+      "100/x.png"
+    # else - handled in application controller
+    #  "100/#{@listicon.downcase}.png"
+    end
+  end
+end

--- a/app/decorators/registry_item_decorator.rb
+++ b/app/decorators/registry_item_decorator.rb
@@ -1,0 +1,11 @@
+class RegistryItemDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{image_name.downcase}.png"
+  end
+end

--- a/app/decorators/resource_pool_decorator.rb
+++ b/app/decorators/resource_pool_decorator.rb
@@ -1,0 +1,11 @@
+class ResourcePoolDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{vapp ? "vapp" : "resource_pool"}.png"
+  end
+end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,0 +1,11 @@
+class ServiceDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "/pictures/#{picture.basename}" if try(:picture)
+  end
+end

--- a/app/decorators/service_resource_decorator.rb
+++ b/app/decorators/service_resource_decorator.rb
@@ -1,0 +1,11 @@
+class ServiceResourceDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{resource_type.to_s == "VmOrTemplate" ? "vm" : "service_template"}.png"
+  end
+end

--- a/app/decorators/service_template_decorator.rb
+++ b/app/decorators/service_template_decorator.rb
@@ -1,0 +1,11 @@
+class ServiceTemplateDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "/pictures/#{picture.basename}" if try(:picture)
+  end
+end

--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -1,0 +1,11 @@
+class VmOrTemplateDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/vendor-#{vendor.downcase}.png"
+  end
+end

--- a/app/views/layouts/_gtl.html.haml
+++ b/app/views/layouts/_gtl.html.haml
@@ -1,4 +1,3 @@
-- listicon_image ||= nil
 - button_div ||= "center_tb"
 - rec_display = ""
 - no_rec_display = "display:none"
@@ -36,8 +35,7 @@
                             :action_url => action_url})
     - elsif @gtl_type == "list"
       = render(:partial => "layouts/gtl/list",
-               :locals  => {:table          => table,
-                            :button_div     => button_div,
-                            :view           => view,
-                            :action_url     => action_url,
-                            :listicon_image => listicon_image})
+               :locals  => {:table      => table,
+                            :button_div => button_div,
+                            :view       => view,
+                            :action_url => action_url})

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -73,5 +73,8 @@
                                       :alt     => cell[:title]}
                 = cell[:text]
             - else
-              = image_tag(cell[:image], :alt => cell[:title], :title => cell[:title]) if cell[:image]
+              - if cell[:icon]
+                %i{:class => cell[:icon], :title => cell[:title]}
+              - elsif cell[:image]
+                = image_tag(image_path(cell[:image]), :alt => cell[:title], :title => cell[:title])
               = cell[:text]

--- a/app/views/layouts/_x_gtl.html.haml
+++ b/app/views/layouts/_x_gtl.html.haml
@@ -1,4 +1,3 @@
-- listicon_image ||= nil
 - button_div ||= "center_tb"
 - rec_display          = ""
 - no_rec_display       = "display:none"
@@ -28,4 +27,4 @@
       - elsif @gtl_type == "tile"
         = render :partial => "layouts/gtl/tile", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}
       - elsif @gtl_type == "list"
-        = render :partial => "layouts/gtl/list", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url, :listicon_image => listicon_image}
+        = render :partial => "layouts/gtl/list", :locals => {:table => table, :button_div => button_div, :view => view, :action_url => action_url}

--- a/app/views/layouts/quadicon/_single_quad.html.haml
+++ b/app/views/layouts/quadicon/_single_quad.html.haml
@@ -7,7 +7,7 @@
   - elsif item.kind_of?(ManageIQ::Providers::Foreman::ConfigurationManager)
     - img = "vendor-#{item.image_name}"
   - elsif item.kind_of?(ConfigurationProfile)
-    - img = controller.send(:list_row_image, nil, item.class.base_class.to_s.underscore, "configuration_profile", item)
+    - img = controller.send(:list_row_image, item.class.base_class.to_s.underscore, item)
   - else
     - img = item.class.base_class.to_s.underscore
   .flobj


### PR DESCRIPTION
This changes `view_to_hash` to call both `listicon_image` and (new) `listicon_icon`, showing the icon if present, falling back to the image when not.

Right now, `listicon_icon` only handles ExtManagementSystem descendants, but should be trivial to extend for other types - just need to add more decorators.

Also introduces draper decorators to manageiq.

[Trello#135](https://trello.com/c/1SaMtTyl/135-images-and-font-icons-in-list-views)

Before:

![fonticon-pre](https://cloud.githubusercontent.com/assets/289743/11955587/0dbdcfac-a8ab-11e5-9af1-033c6ec7eee4.png)

After:

![fonticon-post](https://cloud.githubusercontent.com/assets/289743/11955588/112da7ca-a8ab-11e5-9539-0631fe0eeb73.png)
