### PR TITLE
RSpec 3 conversion: Remaining miq_* specs

### DIFF
--- a/spec/models/miq_alert_eval_internal_spec.rb
+++ b/spec/models/miq_alert_eval_internal_spec.rb
@@ -28,8 +28,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to true" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_true
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_truthy
       end
     end
 
@@ -58,8 +58,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to true" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_true
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_truthy
       end
     end
 
@@ -79,8 +79,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to false" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_false
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_falsey
       end
     end
 
@@ -100,8 +100,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to false" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_false
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_falsey
       end
     end
 
@@ -127,8 +127,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to false" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_false
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_falsey
       end
     end
 
@@ -149,8 +149,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to true" do
-        -> { @result = @alert.evaluate(@vm) }.should_not raise_error
-        @result.should be_true
+        expect { @result = @alert.evaluate(@vm) }.not_to raise_error
+        expect(@result).to be_truthy
       end
     end
   end
@@ -180,8 +180,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to false" do
-        -> { @result = @alert.evaluate(@host) }.should_not raise_error
-        @result.should be_false
+        expect { @result = @alert.evaluate(@host) }.not_to raise_error
+        expect(@result).to be_falsey
       end
     end
   end
@@ -201,8 +201,8 @@ describe "MiqAlert Evaluation Internal" do
       end
 
       it "should result to true" do
-        -> { @result = @alert.evaluate(@server) }.should_not raise_error
-        @result.should be_true
+        expect { @result = @alert.evaluate(@server) }.not_to raise_error
+        expect(@result).to be_truthy
       end
     end
   end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -33,11 +33,11 @@ describe MiqAlert do
 
       it "should alert 'VM Guest Windows Event Log Error - NtpClient' should be evaluated" do
         msg = MiqQueue.get(:role => "notifier")
-        msg.should_not be_nil
+        expect(msg).not_to be_nil
 
         alert = MiqAlert.find_by_id(msg.instance_id)
-        alert.should_not be_nil
-        alert.description.should == 'VM Guest Windows Event Log Error - NtpClient'
+        expect(alert).not_to be_nil
+        expect(alert.description).to eq('VM Guest Windows Event Log Error - NtpClient')
       end
     end
 
@@ -53,14 +53,14 @@ describe MiqAlert do
       it "should queue up the correct alert for each event" do
         guids = @events_to_alerts.collect(&:last).uniq
         messages = MiqQueue.order("id")
-        messages.length.should == @events_to_alerts.length
+        expect(messages.length).to eq(@events_to_alerts.length)
 
         messages.each_with_index do |msg, i|
           alert = MiqAlert.find_by(:id => msg.instance_id)
-          alert.should_not be_nil
+          expect(alert).not_to be_nil
 
           event, guid = @events_to_alerts[i]
-          guids.include?(alert.guid).should be_true
+          expect(guids.include?(alert.guid)).to be_truthy
         end
       end
     end
@@ -72,7 +72,7 @@ describe MiqAlert do
 
       it "should not evaluate any alerts" do
         @msg = MiqQueue.get(:role => "notifier")
-        @msg.should be_nil
+        expect(@msg).to be_nil
       end
     end
 
@@ -89,7 +89,7 @@ describe MiqAlert do
 
         it "should always perform evaluation if not previously evaluated (after 4 minutes)" do
           Timecop.travel 4.minutes do
-            @alert.postpone_evaluation?(@vm).should be_false
+            expect(@alert.postpone_evaluation?(@vm)).to be_falsey
           end
         end
       end
@@ -103,19 +103,19 @@ describe MiqAlert do
       end
 
       it "should have a link from the MiqAlert to the miq alert status" do
-        @alert.miq_alert_statuses.count(:conditions => {:resource_type => @vm.class.base_class.name, :resource_id => @vm.id}).should == 1
+        expect(@alert.miq_alert_statuses.count(:conditions => {:resource_type => @vm.class.base_class.name, :resource_id => @vm.id})).to eq(1)
       end
 
       it "should have a miq alert status for MiqAlert with a result of true" do
-        @alert.miq_alert_statuses.find_by(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).result.should be_true
+        expect(@alert.miq_alert_statuses.find_by(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).result).to be_truthy
       end
 
       it "should have a link from the Vm to the miq alert status" do
-        @vm.miq_alert_statuses.count(:conditions => {:miq_alert_id => @alert.id}).should == 1
+        expect(@vm.miq_alert_statuses.count(:conditions => {:miq_alert_id => @alert.id})).to eq(1)
       end
 
       it "should have a miq alert status for Vm with a result of true" do
-        @vm.miq_alert_statuses.find_by(:miq_alert_id => @alert.id).result.should be_true
+        expect(@vm.miq_alert_statuses.find_by(:miq_alert_id => @alert.id).result).to be_truthy
       end
 
       context "with the alert now evaluated to false" do
@@ -126,19 +126,19 @@ describe MiqAlert do
         end
 
         it "should have had the MiqAlert's miq_alert_statuses" do
-          @alert.miq_alert_statuses.count(:conditions => {:resource_type => @vm.class.base_class.name, :resource_id => @vm.id}).should == 1
+          expect(@alert.miq_alert_statuses.count(:conditions => {:resource_type => @vm.class.base_class.name, :resource_id => @vm.id})).to eq(1)
         end
 
         it "should have a miq alert status for MiqAlert with a result of false" do
-          @alert.miq_alert_statuses.find_by(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).result.should be_false
+          expect(@alert.miq_alert_statuses.find_by(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).result).to be_falsey
         end
 
         it "should have the Vm's miq_alert_statuses" do
-          @vm.miq_alert_statuses.count(:conditions => {:miq_alert_id => @alert.id}).should == 1
+          expect(@vm.miq_alert_statuses.count(:conditions => {:miq_alert_id => @alert.id})).to eq(1)
         end
 
         it "should have a miq alert status for Vm with a result of false" do
-          @vm.miq_alert_statuses.find_by(:miq_alert_id => @alert.id).result.should be_false
+          expect(@vm.miq_alert_statuses.find_by(:miq_alert_id => @alert.id).result).to be_falsey
         end
       end
 
@@ -151,13 +151,13 @@ describe MiqAlert do
 
         it "should retry evaluation (after 10 minutes)" do
           Timecop.travel 10.minutes do
-            @alert.postpone_evaluation?(@vm).should be_false
+            expect(@alert.postpone_evaluation?(@vm)).to be_falsey
           end
         end
 
         it "should skip evaluation (after 4 minutes)" do
           Timecop.travel 4.minutes do
-            @alert.postpone_evaluation?(@vm).should be_true
+            expect(@alert.postpone_evaluation?(@vm)).to be_truthy
           end
         end
       end
@@ -180,13 +180,13 @@ describe MiqAlert do
       end
 
       it "should still have alerts assigned to vm now" do
-        @assigned_now.length.should == @original_assigned.length
-        @assigned_all_now.length.should == @original_assigned_all.length
+        expect(@assigned_now.length).to eq(@original_assigned.length)
+        expect(@assigned_all_now.length).to eq(@original_assigned_all.length)
       end
 
       it "should not have any alerts assigned to vm later" do
-        @assigned_later.length.should == 0
-        @assigned_all_later.length.should == 0
+        expect(@assigned_later.length).to eq(0)
+        expect(@assigned_all_later.length).to eq(0)
       end
     end
   end
@@ -208,7 +208,7 @@ describe MiqAlert do
     end
 
     it "should get assignment by tagged VM" do
-      MiqAlert.assigned_to_target(@vm).should == [@alert]
+      expect(MiqAlert.assigned_to_target(@vm)).to eq([@alert])
     end
   end
 
@@ -223,7 +223,7 @@ describe MiqAlert do
     end
 
     it "should return true when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@vm).should be_true
+      expect(MiqAlert.target_needs_realtime_capture?(@vm)).to be_truthy
     end
   end
 
@@ -234,7 +234,7 @@ describe MiqAlert do
     end
 
     it "should return false when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@vm).should be_false
+      expect(MiqAlert.target_needs_realtime_capture?(@vm)).to be_falsey
     end
   end
 
@@ -249,7 +249,7 @@ describe MiqAlert do
     end
 
     it "should return true when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@host).should be_true
+      expect(MiqAlert.target_needs_realtime_capture?(@host)).to be_truthy
     end
   end
 
@@ -260,7 +260,7 @@ describe MiqAlert do
     end
 
     it "should return false when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@host).should be_false
+      expect(MiqAlert.target_needs_realtime_capture?(@host)).to be_falsey
     end
   end
 
@@ -278,7 +278,7 @@ describe MiqAlert do
     end
 
     it "should return true when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@vm).should be_true
+      expect(MiqAlert.target_needs_realtime_capture?(@vm)).to be_truthy
     end
   end
 
@@ -296,7 +296,7 @@ describe MiqAlert do
     end
 
     it "should return true when calling target_needs_realtime_capture?" do
-      MiqAlert.target_needs_realtime_capture?(@host).should be_true
+      expect(MiqAlert.target_needs_realtime_capture?(@host)).to be_truthy
     end
   end
 
@@ -316,7 +316,7 @@ describe MiqAlert do
       @alert_prof.mode = @ems.class.base_model.name
       @alert_prof.assign_to_objects(@ems.id, "ExtManagementSystem")
 
-      MiqAlert.should_receive(:evaluate_alerts).with(@ems, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).with(@ems, "_hourly_timer_")
       MiqAlert.evaluate_hourly_timer
     end
 
@@ -328,9 +328,9 @@ describe MiqAlert do
       @alert_prof.mode = vm_in_zone.class.base_model.name
       @alert_prof.assign_to_objects(vm_in_zone.id, "Vm")
 
-      MiqAlert.should_receive(:evaluate_alerts).once.with(vm_in_zone, "_hourly_timer_")
-      MiqAlert.should_receive(:evaluate_alerts).once.with(vm_no_ems, "_hourly_timer_")
-      MiqAlert.should_not_receive(:evaluate_alerts).with(vm_in_other, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).once.with(vm_in_zone, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).once.with(vm_no_ems, "_hourly_timer_")
+      expect(MiqAlert).not_to receive(:evaluate_alerts).with(vm_in_other, "_hourly_timer_")
       MiqAlert.evaluate_hourly_timer
     end
 
@@ -350,10 +350,10 @@ describe MiqAlert do
       @alert_prof.mode = storage_in_zone.class.base_model.name
       @alert_prof.assign_to_objects(storage_in_zone.id, "Storage")
 
-      MiqAlert.should_receive(:evaluate_alerts).once.with(storage_in_zone, "_hourly_timer_")
-      MiqAlert.should_receive(:evaluate_alerts).once.with(storage_in_host_no_ems, "_hourly_timer_")
-      MiqAlert.should_receive(:evaluate_alerts).once.with(storage_no_ems, "_hourly_timer_")
-      MiqAlert.should_not_receive(:evaluate_alerts).with(storage_in_another, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).once.with(storage_in_zone, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).once.with(storage_in_host_no_ems, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).once.with(storage_no_ems, "_hourly_timer_")
+      expect(MiqAlert).not_to receive(:evaluate_alerts).with(storage_in_another, "_hourly_timer_")
       MiqAlert.evaluate_hourly_timer
     end
   end

--- a/spec/models/miq_approval_spec.rb
+++ b/spec/models/miq_approval_spec.rb
@@ -5,13 +5,13 @@ describe MiqApproval do
     approval = FactoryGirl.build(:miq_approval)
     user     = FactoryGirl.create(:user)
 
-    approval.approver_name.should be_nil
+    expect(approval.approver_name).to be_nil
 
     approval.approver = user
-    approval.approver_name.should == user.name
+    expect(approval.approver_name).to eq(user.name)
 
     approval.approver = nil
-    approval.approver_name.should be_nil
+    expect(approval.approver_name).to be_nil
   end
 
   context "#approve" do
@@ -22,20 +22,20 @@ describe MiqApproval do
       approval = FactoryGirl.create(:miq_approval)
       reason   = "Why Not?"
 
-      approval.stub(:authorized?).and_return(false)
+      allow(approval).to receive(:authorized?).and_return(false)
       expect { approval.approve(approver, reason) }.to raise_error("not authorized")
 
       miq_request = FactoryGirl.create(:vm_migrate_request, :requester => user)
       approval.miq_request = miq_request
-      approval.stub(:authorized?).and_return(true)
+      allow(approval).to receive(:authorized?).and_return(true)
       Timecop.freeze do
-        miq_request.should_receive(:approval_approved).once
+        expect(miq_request).to receive(:approval_approved).once
         approval.approve(approver, reason)
-        approval.state.should == 'approved'
-        approval.reason.should == reason
-        approval.stamper.should == approver
-        approval.stamper_name.should == approver.name
-        approval.stamped_on.should == Time.now.utc
+        expect(approval.state).to eq('approved')
+        expect(approval.reason).to eq(reason)
+        expect(approval.stamper).to eq(approver)
+        expect(approval.stamper_name).to eq(approver.name)
+        expect(approval.stamped_on).to eq(Time.now.utc)
       end
     end
 
@@ -65,20 +65,20 @@ describe MiqApproval do
     approval = FactoryGirl.create(:miq_approval)
     reason   = "Why Not?"
 
-    approval.stub(:authorized?).and_return(false)
+    allow(approval).to receive(:authorized?).and_return(false)
     expect { approval.deny(approver, reason) }.to raise_error("not authorized")
 
     miq_request = FactoryGirl.create(:vm_migrate_request, :requester => user)
     approval.miq_request = miq_request
-    approval.stub(:authorized?).and_return(true)
+    allow(approval).to receive(:authorized?).and_return(true)
     Timecop.freeze do
-      miq_request.should_receive(:approval_denied).once
+      expect(miq_request).to receive(:approval_denied).once
       approval.deny(approver, reason)
-      approval.state.should == 'denied'
-      approval.reason.should == reason
-      approval.stamper.should == approver
-      approval.stamper_name.should == approver.name
-      approval.stamped_on.should == Time.now.utc
+      expect(approval.state).to eq('denied')
+      expect(approval.reason).to eq(reason)
+      expect(approval.stamper).to eq(approver)
+      expect(approval.stamper_name).to eq(approver.name)
+      expect(approval.stamped_on).to eq(Time.now.utc)
     end
   end
 
@@ -89,38 +89,38 @@ describe MiqApproval do
     let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
 
     it "with nil" do
-      approval.authorized?(nil).should be_false
+      expect(approval.authorized?(nil)).to be_falsey
     end
 
     it "with a user object without approval rights" do
-      approval.authorized?(user).should be_false
+      expect(approval.authorized?(user)).to be_falsey
     end
 
     it "with a user object with approval rights" do
-      approval.authorized?(approver).should be_true
+      expect(approval.authorized?(approver)).to be_truthy
     end
 
     it "with a userid without approval rights" do
-      approval.authorized?(user.userid).should be_false
+      expect(approval.authorized?(user.userid)).to be_falsey
     end
 
     it "with a userid with approval rights" do
-      approval.authorized?(approver.userid).should be_true
+      expect(approval.authorized?(approver.userid)).to be_truthy
     end
 
     context "with the approver property set to a specific user" do
       before { approval.approver = user }
 
       it "and passing the same user" do
-        approval.authorized?(user).should be_true
+        expect(approval.authorized?(user)).to be_truthy
       end
 
       it "and passing a different user with approval rights" do
-        approval.authorized?(approver).should be_true
+        expect(approval.authorized?(approver)).to be_truthy
       end
 
       it "and passing a different user without approval rights" do
-        approval.authorized?(user2).should be_false
+        expect(approval.authorized?(user2)).to be_falsey
       end
     end
   end

--- a/spec/models/miq_bulk_import_spec.rb
+++ b/spec/models/miq_bulk_import_spec.rb
@@ -8,9 +8,9 @@ describe MiqBulkImport do
 
     it ".upload with no vms" do
       ati = AssetTagImport.upload('VmOrTemplate', @file)
-      ati.stats[:bad].should == 1
-      ati.stats[:good].should == 0
-      ati.errors.all? { |attr,| attr.to_s.should == 'vmortemplatenotfound' }
+      expect(ati.stats[:bad]).to eq(1)
+      expect(ati.stats[:good]).to eq(0)
+      ati.errors.all? { |attr,| expect(attr.to_s).to eq('vmortemplatenotfound') }
     end
 
     it ".upload" do
@@ -19,7 +19,7 @@ describe MiqBulkImport do
       template = FactoryGirl.create(:template_vmware, :name => "JD-C-T4.0.1.43")
 
       ati = AssetTagImport.upload('VmOrTemplate', @file)
-      ati.stats[:good].should == 2
+      expect(ati.stats[:good]).to eq(2)
     end
 
     it "#apply" do
@@ -30,12 +30,12 @@ describe MiqBulkImport do
       ati.apply
 
       vm.reload
-      vm.custom_attributes.first.name.should == 'owner'
-      vm.custom_attributes.first.value.should == 'Joe'
+      expect(vm.custom_attributes.first.name).to eq('owner')
+      expect(vm.custom_attributes.first.value).to eq('Joe')
 
       template.reload
-      template.custom_attributes.first.name.should == 'owner'
-      template.custom_attributes.first.value.should == 'Jerry'
+      expect(template.custom_attributes.first.name).to eq('owner')
+      expect(template.custom_attributes.first.value).to eq('Jerry')
     end
   end
 
@@ -46,17 +46,17 @@ describe MiqBulkImport do
 
     it ".upload with no vms" do
       ci = ClassificationImport.upload(@file)
-      ci.stats[:bad].should == 1
-      ci.stats[:good].should == 0
-      ci.errors.all? { |attr,| attr.to_s.should == 'vmnotfound' }
+      expect(ci.stats[:bad]).to eq(1)
+      expect(ci.stats[:good]).to eq(0)
+      ci.errors.all? { |attr,| expect(attr.to_s).to eq('vmnotfound') }
     end
 
     it ".upload with no category" do
       vm = FactoryGirl.create(:vm_vmware, :name => "JD-C-T4.0.1.44")
       ci = ClassificationImport.upload(@file)
-      ci.stats[:bad].should == 1
-      ci.stats[:good].should == 0
-      ci.errors.all? { |attr,| attr.to_s.should == 'categorynotfound' }
+      expect(ci.stats[:bad]).to eq(1)
+      expect(ci.stats[:good]).to eq(0)
+      ci.errors.all? { |attr,| expect(attr.to_s).to eq('categorynotfound') }
     end
 
     it ".upload" do
@@ -66,9 +66,9 @@ describe MiqBulkImport do
       FactoryGirl.create(:vm_vmware, :name => "JD-C-T4.0.1.44")
       FactoryGirl.create(:template_vmware, :name => "JD-C-T4.0.1.43")
       ci = ClassificationImport.upload(@file)
-      ci.stats[:bad].should == 0
-      ci.stats[:good].should == 2
-      ci.errors.should be_empty
+      expect(ci.stats[:bad]).to eq(0)
+      expect(ci.stats[:good]).to eq(2)
+      expect(ci.errors).to be_empty
     end
 
     it "#apply" do
@@ -81,10 +81,10 @@ describe MiqBulkImport do
       ci.apply
 
       vm.reload
-      vm.is_tagged_with?("test", :cat => "environment", :ns => "/managed").should be_true
+      expect(vm.is_tagged_with?("test", :cat => "environment", :ns => "/managed")).to be_truthy
 
       template.reload
-      template.is_tagged_with?("test", :cat => "environment", :ns => "/managed").should be_true
+      expect(template.is_tagged_with?("test", :cat => "environment", :ns => "/managed")).to be_truthy
     end
   end
 end

--- a/spec/models/miq_compare_spec.rb
+++ b/spec/models/miq_compare_spec.rb
@@ -12,8 +12,8 @@ describe MiqCompare do
       compare = MiqCompare.new({:ids => [vm1.id, vm2.id]}, report)
 
       dumped = loaded = nil
-      -> { dumped = Marshal.dump(compare) }.should_not raise_error
-      -> { loaded = Marshal.load(dumped)  }.should_not raise_error
+      expect { dumped = Marshal.dump(compare) }.not_to raise_error
+      expect { loaded = Marshal.load(dumped)  }.not_to raise_error
     end
 
     it "with Hosts" do
@@ -27,8 +27,8 @@ describe MiqCompare do
       compare = MiqCompare.new({:ids => [host1.id, host2.id]}, report)
 
       dumped = loaded = nil
-      -> { dumped = Marshal.dump(compare) }.should_not raise_error
-      -> { loaded = Marshal.load(dumped)  }.should_not raise_error
+      expect { dumped = Marshal.dump(compare) }.not_to raise_error
+      expect { loaded = Marshal.load(dumped)  }.not_to raise_error
     end
   end
 end

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -67,20 +67,20 @@ describe MiqDatabase do
       MiqDatabase.seed
       EvmSpecHelper.create_guid_miq_server_zone
 
-      MiqTask.should_receive(:wait_for_taskid).and_return(FactoryGirl.create(:miq_task, :state => "Finished"))
+      expect(MiqTask).to receive(:wait_for_taskid).and_return(FactoryGirl.create(:miq_task, :state => "Finished"))
 
       MiqDatabase.first.verify_credentials(:registration)
     end
   end
 
-  pending("New model-based-rewrite") do
+  skip("New model-based-rewrite") do
     context "#vmdb_tables" do
       before(:each) do
         MiqDatabase.seed
         @db = MiqDatabase.first
 
         @expected_tables = %w(schema_migrations vms miq_databases)
-        VmdbTable.stub(:vmdb_table_names).and_return(@expected_tables)
+        allow(VmdbTable).to receive(:vmdb_table_names).and_return(@expected_tables)
       end
 
       after(:each) do
@@ -89,12 +89,12 @@ describe MiqDatabase do
 
       it "will fetch initial tables" do
         tables = @db.vmdb_tables
-        tables.collect(&:name).should match_array @expected_tables
+        expect(tables.collect(&:name)).to match_array @expected_tables
       end
 
       it "will create tables once" do
         @db.vmdb_tables
-        VmdbTable.should_receive(:new).never
+        expect(VmdbTable).to receive(:new).never
         @db.vmdb_tables
       end
     end

--- a/spec/models/miq_db_config_spec.rb
+++ b/spec/models/miq_db_config_spec.rb
@@ -40,9 +40,9 @@ describe MiqDbConfig do
     end
 
     it "exception" do
-      VmdbDatabaseConnection.stub(:all).and_raise("FAILURE")
+      allow(VmdbDatabaseConnection).to receive(:all).and_raise("FAILURE")
       MiqDbConfig.log_activity_statistics(@buffer)
-      @buffer.string.lines.first.should == "MIQ(DbConfig.log_activity_statistics) Unable to log stats, 'FAILURE'"
+      expect(@buffer.string.lines.first).to eq("MIQ(DbConfig.log_activity_statistics) Unable to log stats, 'FAILURE'")
     end
   end
 
@@ -53,7 +53,7 @@ describe MiqDbConfig do
       "postgresql"   => "External Postgres Database"
     }
 
-    MiqDbConfig.get_db_types.should == expected
+    expect(MiqDbConfig.get_db_types).to eq(expected)
   end
 
   context ".raw_config" do
@@ -73,17 +73,17 @@ EOF
 
     it "production" do
       Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
-      ERB.should_not_receive(:new)
+      expect(ERB).not_to receive(:new)
 
       expected = {"host" => "localhost", "username" => "root", "password" => "<%= MiqPassword.decrypt(\"#{enc_pass}\")%>"}
-      MiqDbConfig.raw_config["production"].should == expected
+      expect(MiqDbConfig.raw_config["production"]).to eq(expected)
     end
 
     it "non-production" do
-      ERB.should_receive(:new).and_call_original
+      expect(ERB).to receive(:new).and_call_original
 
       expected = {"host" => "localhost", "username" => "root", "password" => password}
-      MiqDbConfig.raw_config["production"].should == expected
+      expect(MiqDbConfig.raw_config["production"]).to eq(expected)
     end
   end
 
@@ -191,14 +191,14 @@ EOF
     subject { described_class.new(:name => "internal").save_internal }
 
     it "returns saved VMDB::Config" do
-      described_class.stub(:backup_file)
-      VMDB::Config.any_instance.should_receive(:save_file)
+      allow(described_class).to receive(:backup_file)
+      expect_any_instance_of(VMDB::Config).to receive(:save_file)
       expect(subject.config.fetch_path(:production, :host)).to be_nil
     end
 
     it "resets cache" do
-      described_class.stub(:backup_file)
-      VMDB::Config.any_instance.should_receive(:save_file)
+      allow(described_class).to receive(:backup_file)
+      expect_any_instance_of(VMDB::Config).to receive(:save_file)
       subject
       expect(described_class.raw_config.fetch_path('production')).to eq(
         "adapter"      => "postgresql",
@@ -214,8 +214,8 @@ EOF
       subject { described_class.new(:name => "internal", :host => 'localhost', :password => "x").save_internal }
 
       it "should save password to database.yml" do
-        described_class.stub(:backup_file)
-        VMDB::Config.any_instance.should_receive(:save_file)
+        allow(described_class).to receive(:backup_file)
+        expect_any_instance_of(VMDB::Config).to receive(:save_file)
         subject
         expect(described_class.raw_config.fetch_path('production')).to eq(
           "adapter"      => "postgresql",
@@ -233,19 +233,19 @@ EOF
 
   context "#save_common" do
     before do
-      described_class.should_receive(:backup_file)
-      VMDB::Config.any_instance.should_receive(:save_file)
+      expect(described_class).to receive(:backup_file)
+      expect_any_instance_of(VMDB::Config).to receive(:save_file)
 
       config = described_class.new({:name => "external_evm", :host => "abc"})
       @vmdb_config = config.save_common
     end
 
     it "returns saved VMDB::Config" do
-      @vmdb_config.config.fetch_path(:production, :host).should == "abc"
+      expect(@vmdb_config.config.fetch_path(:production, :host)).to eq("abc")
     end
 
     it "resets cache" do
-      described_class.raw_config.fetch_path('production', 'host').should == "abc"
+      expect(described_class.raw_config.fetch_path('production', 'host')).to eq("abc")
     end
   end
 

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -17,7 +17,7 @@ describe MiqEventDefinition do
 
         context 'seeding default event definitions from that csv' do
           before do
-            File.stub(:open).and_return(StringIO.new(csv))
+            allow(File).to receive(:open).and_return(StringIO.new(csv))
             MiqEventDefinition.seed_default_events
           end
 
@@ -38,7 +38,7 @@ describe MiqEventDefinition do
 
             context 'seeding again' do
               before do
-                File.stub(:open).and_return(StringIO.new(csv))
+                allow(File).to receive(:open).and_return(StringIO.new(csv))
                 MiqEventDefinition.seed_default_events
               end
 

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -5,37 +5,37 @@ describe MiqEvent do
     context ".raise_evm_job_event" do
       it "vm" do
         obj = FactoryGirl.create(:vm_redhat)
-        MiqEvent.should_receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "vm_scan_complete" }
+        expect(MiqEvent).to receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "vm_scan_complete" }
         MiqEvent.raise_evm_job_event(obj, {:type => "scan", :suffix => "complete"}, {})
       end
 
       it "host" do
         obj = FactoryGirl.create(:host_vmware)
-        MiqEvent.should_receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "host_scan_complete" }
+        expect(MiqEvent).to receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "host_scan_complete" }
         MiqEvent.raise_evm_job_event(obj, {:type => "scan", :suffix => "complete"}, {})
       end
     end
 
     it "will recognize known events" do
       FactoryGirl.create(:miq_event_definition, :name => "host_connect")
-      MiqEvent.normalize_event("host_connect").should_not == "unknown"
+      expect(MiqEvent.normalize_event("host_connect")).not_to eq("unknown")
 
       FactoryGirl.create(:miq_event_definition, :name => "evm_server_start")
-      MiqEvent.normalize_event("evm_server_start").should_not == "unknown"
+      expect(MiqEvent.normalize_event("evm_server_start")).not_to eq("unknown")
     end
 
     it "will mark unknown events" do
-      MiqEvent.normalize_event("xxx").should == "unknown"
-      MiqEvent.normalize_event("unknown").should == "unknown"
+      expect(MiqEvent.normalize_event("xxx")).to eq("unknown")
+      expect(MiqEvent.normalize_event("unknown")).to eq("unknown")
     end
 
     context ".event_name_for_target" do
       it "vm" do
-        MiqEvent.event_name_for_target(FactoryGirl.build(:vm_redhat),   "perf_complete").should == "vm_perf_complete"
+        expect(MiqEvent.event_name_for_target(FactoryGirl.build(:vm_redhat),   "perf_complete")).to eq("vm_perf_complete")
       end
 
       it "host" do
-        MiqEvent.event_name_for_target(FactoryGirl.build(:host_redhat), "perf_complete").should == "host_perf_complete"
+        expect(MiqEvent.event_name_for_target(FactoryGirl.build(:host_redhat), "perf_complete")).to eq("host_perf_complete")
       end
     end
 
@@ -47,7 +47,7 @@ describe MiqEvent do
       end
 
       it "will raise an error for missing target" do
-        -> { MiqEvent.raise_evm_event([:MiqServer, 30000], "some_event") }.should raise_error
+        expect { MiqEvent.raise_evm_event([:MiqServer, 30000], "some_event") }.to raise_error
       end
 
       it "will raise an error for nil target" do
@@ -57,14 +57,14 @@ describe MiqEvent do
       it "will raise the event to automate given target directly" do
         event = 'evm_server_start'
         FactoryGirl.create(:miq_event_definition, :name => event)
-        MiqAeEvent.should_receive(:raise_evm_event)
+        expect(MiqAeEvent).to receive(:raise_evm_event)
         MiqEvent.raise_evm_event(@miq_server, event)
       end
 
       it "will raise the event to automate given target type and id" do
         event = 'evm_server_start'
         FactoryGirl.create(:miq_event_definition, :name => event)
-        MiqAeEvent.should_receive(:raise_evm_event)
+        expect(MiqAeEvent).to receive(:raise_evm_event)
         MiqEvent.raise_evm_event([:MiqServer, @miq_server.id], event)
       end
 
@@ -93,12 +93,12 @@ describe MiqEvent do
         FactoryGirl.create(:miq_event, :event_type => event, :target => @cluster)
         target_class = @cluster.class.name
 
-        MiqPolicy.should_receive(:enforce_policy).with(@cluster, event, :type => target_class)
-        MiqAlert.should_receive(:evaluate_alerts).with(@cluster, event, :type => target_class)
-        MiqEvent.should_receive(:raise_event_for_children).with(@cluster, event, :type => target_class)
+        expect(MiqPolicy).to receive(:enforce_policy).with(@cluster, event, :type => target_class)
+        expect(MiqAlert).to receive(:evaluate_alerts).with(@cluster, event, :type => target_class)
+        expect(MiqEvent).to receive(:raise_event_for_children).with(@cluster, event, :type => target_class)
 
         results = MiqEvent.first.process_evm_event
-        results.keys.should match_array([:policy, :alert, :children_events])
+        expect(results.keys).to match_array([:policy, :alert, :children_events])
       end
 
       it "will not raise to automate for supported policy target" do
@@ -106,7 +106,7 @@ describe MiqEvent do
         FactoryGirl.create(:miq_event_definition, :name => raw_event)
         FactoryGirl.create(:miq_event, :event_type => raw_event, :target => @miq_server)
 
-        MiqAeEvent.should_receive(:raise_evm_event).never
+        expect(MiqAeEvent).to receive(:raise_evm_event).never
         MiqEvent.first.process_evm_event
       end
 
@@ -114,9 +114,9 @@ describe MiqEvent do
         FactoryGirl.create(:miq_event_definition, :name => "some_event")
         FactoryGirl.create(:miq_event, :event_type => "some_event", :target => @zone)
 
-        MiqPolicy.should_receive(:enforce_policy).never
-        MiqAlert.should_receive(:evaluate_alerts).never
-        MiqEvent.should_receive(:raise_event_for_children).never
+        expect(MiqPolicy).to receive(:enforce_policy).never
+        expect(MiqAlert).to receive(:evaluate_alerts).never
+        expect(MiqEvent).to receive(:raise_event_for_children).never
         MiqEvent.first.process_evm_event
       end
     end
@@ -125,7 +125,7 @@ describe MiqEvent do
       it "uses base_model to build event name" do
         host = FactoryGirl.create(:host_vmware_esx)
         vm = FactoryGirl.create(:vm_vmware, :host => host)
-        MiqEvent.should_receive(:raise_evm_event_queue).with { |target, child_event, _inputs| target == vm && child_event == "assigned_company_tag_parent_host" }
+        expect(MiqEvent).to receive(:raise_evm_event_queue).with { |target, child_event, _inputs| target == vm && child_event == "assigned_company_tag_parent_host" }
         MiqEvent.raise_event_for_children(host, "assigned_company_tag")
       end
     end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -10,7 +10,7 @@ describe MiqGroup do
       it "normal" do
         expected = {:test => "test filter"}
         @miq_group.filters = expected
-        @miq_group.get_filters.should == expected
+        expect(@miq_group.get_filters).to eq(expected)
       end
 
       it "when nil" do
@@ -20,7 +20,7 @@ describe MiqGroup do
 
       it "when {}" do
         @miq_group.filters = {}
-        @miq_group.get_filters.should == {}
+        expect(@miq_group.get_filters).to eq({})
       end
     end
 
@@ -53,50 +53,50 @@ describe MiqGroup do
         it "normal" do
           expected = {type => "test filter"}
           @miq_group.filters = expected
-          @miq_group.public_send(method).should == expected[type]
+          expect(@miq_group.public_send(method)).to eq(expected[type])
         end
 
         it "when nil" do
           @miq_group.filters = nil
-          @miq_group.public_send(method).should == []
+          expect(@miq_group.public_send(method)).to eq([])
         end
 
         it "when []" do
           @miq_group.filters = []
-          @miq_group.public_send(method).should == []
+          expect(@miq_group.public_send(method)).to eq([])
         end
 
         it "missing the #{type} key" do
           expected = {"something" => "test filter"}
           @miq_group.filters = expected
-          @miq_group.public_send(method).should == []
+          expect(@miq_group.public_send(method)).to eq([])
         end
       end
 
       it "#set_#{type}_filters" do
         filters = {type => "test"}
         @miq_group.public_send("set_#{type}_filters", filters[type])
-        @miq_group.public_send("get_#{type}_filters").should == filters[type]
-        @miq_group.get_filters.should == filters
+        expect(@miq_group.public_send("get_#{type}_filters")).to eq(filters[type])
+        expect(@miq_group.get_filters).to eq(filters)
       end
     end
 
     it "should return user role name" do
-      @miq_group.miq_user_role_name.should == "EvmRole-super_administrator"
+      expect(@miq_group.miq_user_role_name).to eq("EvmRole-super_administrator")
     end
 
     it "should set group type to 'system' " do
-      @miq_group.group_type.should == "system"
+      expect(@miq_group.group_type).to eq("system")
     end
 
     it "should return user count" do
       # TODO: - add more users to check for proper user count...
-      @miq_group.user_count.should == 0
+      expect(@miq_group.user_count).to eq(0)
     end
 
     it "should strip group description of leading and trailing spaces" do
       @miq_group.description = "      leading and trailing white spaces     "
-      @miq_group.description.should == "leading and trailing white spaces"
+      expect(@miq_group.description).to eq("leading and trailing white spaces")
     end
   end
 
@@ -108,19 +108,19 @@ describe MiqGroup do
       ifp_object  = double('ifp_object')
       @ifp_interface = double('ifp_interface')
 
-      DBus.stub(:system_bus).and_return(sysbus)
-      sysbus.stub(:[]).with("org.freedesktop.sssd.infopipe").and_return(ifp_service)
-      ifp_service.stub(:object).with("/org/freedesktop/sssd/infopipe").and_return(ifp_object)
-      ifp_object.stub(:introspect)
-      ifp_object.stub(:[]).with("org.freedesktop.sssd.infopipe").and_return(@ifp_interface)
+      allow(DBus).to receive(:system_bus).and_return(sysbus)
+      allow(sysbus).to receive(:[]).with("org.freedesktop.sssd.infopipe").and_return(ifp_service)
+      allow(ifp_service).to receive(:object).with("/org/freedesktop/sssd/infopipe").and_return(ifp_object)
+      allow(ifp_object).to receive(:introspect)
+      allow(ifp_object).to receive(:[]).with("org.freedesktop.sssd.infopipe").and_return(@ifp_interface)
     end
 
     it "should return groups by user name with external authentication" do
       memberships = [%w(foo bar)]
 
-      @ifp_interface.stub(:GetUserGroups).with('user').and_return(memberships)
+      allow(@ifp_interface).to receive(:GetUserGroups).with('user').and_return(memberships)
 
-      MiqGroup.get_httpd_groups_by_user('user').should == memberships.first
+      expect(MiqGroup.get_httpd_groups_by_user('user')).to eq(memberships.first)
     end
   end
 
@@ -134,11 +134,11 @@ describe MiqGroup do
                         :bind            => true,
                         :get_user_object => 'user object',
                         :get_memberships => %w(foo bar))
-      MiqLdap.stub(:new).and_return(miq_ldap)
+      allow(MiqLdap).to receive(:new).and_return(miq_ldap)
     end
 
     it "should return LDAP groups by user name" do
-      MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password').should == %w(foo bar)
+      expect(MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password')).to eq(%w(foo bar))
     end
 
     it "should issue an error message when user name could not be bound to LDAP" do
@@ -201,28 +201,28 @@ describe MiqGroup do
     end
 
     it "#active_vms" do
-      @miq_group.active_vms.should match_array([@active_vm])
+      expect(@miq_group.active_vms).to match_array([@active_vm])
     end
 
     it "#allocated_memory" do
-      @miq_group.allocated_memory.should == @ram_size.megabyte
+      expect(@miq_group.allocated_memory).to eq(@ram_size.megabyte)
     end
 
     it "#allocated_vcpu" do
-      @miq_group.allocated_vcpu.should == @num_cpu
+      expect(@miq_group.allocated_vcpu).to eq(@num_cpu)
     end
 
     it "#allocated_storage" do
-      @miq_group.allocated_storage.should == @disk_size
+      expect(@miq_group.allocated_storage).to eq(@disk_size)
     end
 
     it "#provisioned_storage" do
-      @miq_group.provisioned_storage.should == @ram_size.megabyte + @disk_size
+      expect(@miq_group.provisioned_storage).to eq(@ram_size.megabyte + @disk_size)
     end
 
     %w(allocated_memory allocated_vcpu allocated_storage provisioned_storage).each do |vcol|
       it "should have virtual column #{vcol} " do
-        described_class.should have_virtual_column "#{vcol}", :integer
+        expect(described_class).to have_virtual_column "#{vcol}", :integer
       end
     end
 
@@ -234,7 +234,7 @@ describe MiqGroup do
                          :ems_id       => @ems.id,
                          :storage_id   => @storage.id,
                          :hardware     => hw)
-      @miq_group.allocated_storage.should == @disk_size
+      expect(@miq_group.allocated_storage).to eq(@disk_size)
     end
   end
 

--- a/spec/models/miq_host_provision_spec.rb
+++ b/spec/models/miq_host_provision_spec.rb
@@ -5,7 +5,7 @@ describe MiqHostProvision do
     host_name = "fred"
     host = FactoryGirl.create(:host, :name => host_name)
     mhp  = MiqHostProvision.create(:host => host)
-    mhp.host_name.should == host_name
+    expect(mhp.host_name).to eq(host_name)
   end
 
   it "#host_rediscovered?" do
@@ -13,14 +13,14 @@ describe MiqHostProvision do
     pxe_image = FactoryGirl.create(:pxe_image, :pxe_image_type => pxe_image_type)
 
     mhp = MiqHostProvision.create
-    mhp.stub(:pxe_image).and_return(pxe_image)
-    mhp.host_rediscovered?.should be_false
+    allow(mhp).to receive(:pxe_image).and_return(pxe_image)
+    expect(mhp.host_rediscovered?).to be_falsey
 
     mhp.host = FactoryGirl.create(:host, :vmm_vendor => 'unknown')
-    mhp.host_rediscovered?.should be_false
+    expect(mhp.host_rediscovered?).to be_falsey
 
     mhp.host.vmm_vendor = 'vmware'
-    mhp.host_rediscovered?.should be_true
+    expect(mhp.host_rediscovered?).to be_truthy
   end
 
   context "with default server and zone" do
@@ -34,12 +34,12 @@ describe MiqHostProvision do
 
       it "#reset_host_credentials" do
         password = 'secret'
-        mhp.stub(:get_option).with(:root_password).and_return(password)
-        mhp.should_receive(:signal).with(:create_pxe_configuration_files)
+        allow(mhp).to receive(:get_option).with(:root_password).and_return(password)
+        expect(mhp).to receive(:signal).with(:create_pxe_configuration_files)
         mhp.reset_host_credentials
-        mhp.host.authentications.length.should == 1
-        mhp.host.authentication_userid(:default).should == 'root'
-        mhp.host.authentication_password(:default).should == password
+        expect(mhp.host.authentications.length).to eq(1)
+        expect(mhp.host.authentication_userid(:default)).to eq('root')
+        expect(mhp.host.authentication_password(:default)).to eq(password)
       end
 
       it "#reset_host_in_vmdb" do
@@ -55,30 +55,30 @@ describe MiqHostProvision do
         host.update_authentication(:ipmi    => {:userid => ipmi_userid,    :password => ipmi_password})
         host.update_authentication(:default => {:userid => default_userid, :password => default_password})
 
-        mhp.host.should be_kind_of(ManageIQ::Providers::Vmware::InfraManager::HostEsx)
-        mhp.stub(:get_option).with(:root_password).and_return(dialog_password)
-        mhp.should_receive(:signal).with(:reset_host_credentials)
+        expect(mhp.host).to be_kind_of(ManageIQ::Providers::Vmware::InfraManager::HostEsx)
+        allow(mhp).to receive(:get_option).with(:root_password).and_return(dialog_password)
+        expect(mhp).to receive(:signal).with(:reset_host_credentials)
         mhp.reset_host_in_vmdb
 
-        mhp.host.should be_kind_of(Host)
-        mhp.host.operating_system.should be_nil
+        expect(mhp.host).to be_kind_of(Host)
+        expect(mhp.host.operating_system).to be_nil
 
-        mhp.host.authentications.length.should == 2
-        mhp.host.authentication_userid(:ipmi).should == ipmi_userid
-        mhp.host.authentication_password(:ipmi).should == ipmi_password
+        expect(mhp.host.authentications.length).to eq(2)
+        expect(mhp.host.authentication_userid(:ipmi)).to eq(ipmi_userid)
+        expect(mhp.host.authentication_password(:ipmi)).to eq(ipmi_password)
 
-        mhp.host.authentication_userid(:default).should == dialog_userid
-        mhp.host.authentication_password(:default).should == dialog_password
+        expect(mhp.host.authentication_userid(:default)).to eq(dialog_userid)
+        expect(mhp.host.authentication_password(:default)).to eq(dialog_password)
       end
 
       it "#provision_completed" do
-        mhp.should_receive(:signal).with(:post_install_callback)
+        expect(mhp).to receive(:signal).with(:post_install_callback)
         mhp.provision_completed
       end
 
       it "#post_install_callback" do
-        mhp.should_receive(:update_and_notify_parent)
-        mhp.should_receive(:signal).with(:delete_pxe_configuration_files)
+        expect(mhp).to receive(:update_and_notify_parent)
+        expect(mhp).to receive(:signal).with(:delete_pxe_configuration_files)
         mhp.post_install_callback
       end
     end

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -23,8 +23,8 @@ describe MiqHostProvisionWorkflow do
       context "Without a Valid IPMI Host," do
         it "should not create an MiqRequest when calling from_ws" do
           lambda do
-            MiqHostProvisionWorkflow.from_ws("1.1", user, @template_fields, @host_fields, @requester, false, nil, nil)
-              .should raise_error(RuntimeError)
+            expect(MiqHostProvisionWorkflow.from_ws("1.1", user, @template_fields, @host_fields, @requester, false, nil, nil))
+              .to raise_error(RuntimeError)
           end
         end
       end
@@ -48,7 +48,7 @@ describe MiqHostProvisionWorkflow do
                                                      @template_fields,
                                                      @host_fields,
                                                      @requester, false, nil, nil)
-          request.should be_a_kind_of(MiqRequest)
+          expect(request).to be_a_kind_of(MiqRequest)
           request.options
         end
       end

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -14,8 +14,8 @@ describe MiqPolicy do
     end
 
     it "should return the correct conditions" do
-      @ps.miq_policies.first.conditions.should == []
-      @p.conditions.should == []
+      expect(@ps.miq_policies.first.conditions).to eq([])
+      expect(@p.conditions).to eq([])
     end
   end
 
@@ -24,18 +24,18 @@ describe MiqPolicy do
 
     it "should keep the description < 255" do
       @description = "a" * 30
-      subject.description.length.should == 30
+      expect(subject.description.length).to eq(30)
     end
 
     it "should raise an error with empty description" do
       @description = nil
-      -> { subject.description }.should raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
+      expect { subject.description }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
     end
 
     it "should raise an error when description is reset to empty" do
       @description = "a" * 30
       subject.description = nil
-      -> { subject.save! }.should raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
+      expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
     end
   end
 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -26,7 +26,7 @@ describe MiqProductFeature do
       expect(status_seed1[:unchanged]).to match_array []
 
       status_seed2 = MiqProductFeature.seed
-      MiqProductFeature.count.should eq(expected_feature_count)
+      expect(MiqProductFeature.count).to eq(expected_feature_count)
       expect(status_seed2[:created]).to match_array []
       expect(status_seed2[:updated]).to match_array []
       expect(status_seed2[:unchanged]).to match_array status_seed1[:created]
@@ -70,8 +70,8 @@ describe MiqProductFeature do
 
       MiqProductFeature.seed_features(feature_path)
       expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      changed.reload.name.should == "One"
-      unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at
+      expect(changed.reload.name).to eq("One")
+      expect(unchanged.reload.updated_at).to be_same_time_as unchanged_orig_updated_at
     end
 
     it "additional yaml feature" do
@@ -87,7 +87,7 @@ describe MiqProductFeature do
       additional_file.close
 
       status_seed = MiqProductFeature.seed_features(feature_path)
-      MiqProductFeature.count.should eq(3)
+      expect(MiqProductFeature.count).to eq(3)
       expect(status_seed[:created]).to match_array %w(everything one two)
 
       additional_file.unlink

--- a/spec/models/miq_provision/automate_spec.rb
+++ b/spec/models/miq_provision/automate_spec.rb
@@ -12,9 +12,9 @@ describe MiqProvision do
     let(:prov) { FactoryGirl.build(:miq_provision, :tenant => t1) }
 
     def stub_method
-      MiqAeEngine.should_receive(:resolve_automation_object).with do |uri, _, _, _|
-        uri.should eq('REQUEST')
-      end.and_return(workspace)
+      expect(MiqAeEngine).to receive(:resolve_automation_object).with { |uri, _, _, _|
+        expect(uri).to eq('REQUEST')
+      }.and_return(workspace)
     end
 
     context "with password" do

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -21,13 +21,13 @@ describe MiqProvision do
 
     context "#prepare_provision" do
       before do
-        task.stub(:update_and_notify_parent)
+        allow(task).to receive(:update_and_notify_parent)
         task.stub(:instance_type => flavor)
       end
 
       it "sets default :clone_options" do
-        task.should_receive(:signal).with(:prepare_provision).and_call_original
-        task.should_receive(:signal).with(:start_clone_task)
+        expect(task).to receive(:signal).with(:prepare_provision).and_call_original
+        expect(task).to receive(:signal).with(:start_clone_task)
 
         task.signal(:prepare_provision)
 
@@ -43,8 +43,8 @@ describe MiqProvision do
         options[:clone_options] = {:security_groups => ["test_sg"], :test_key => "test_value"}
         task.update_attributes(:options => options)
 
-        task.should_receive(:signal).with(:prepare_provision).and_call_original
-        task.should_receive(:signal).with(:start_clone_task)
+        expect(task).to receive(:signal).with(:prepare_provision).and_call_original
+        expect(task).to receive(:signal).with(:start_clone_task)
 
         task.signal(:prepare_provision)
 
@@ -61,8 +61,8 @@ describe MiqProvision do
         options[:clone_options] = {:image_ref => nil, :test_key => "test_value"}
         task.update_attributes(:options => options)
 
-        task.should_receive(:signal).with(:prepare_provision).and_call_original
-        task.should_receive(:signal).with(:start_clone_task)
+        expect(task).to receive(:signal).with(:prepare_provision).and_call_original
+        expect(task).to receive(:signal).with(:start_clone_task)
 
         task.signal(:prepare_provision)
 
@@ -82,7 +82,7 @@ describe MiqProvision do
         options[:vm_description] = description = "foo bar"
         task.update_attributes(:options => options)
 
-        task.should_receive(:mark_as_completed)
+        expect(task).to receive(:mark_as_completed)
 
         task.signal(:post_create_destination)
 
@@ -98,7 +98,7 @@ describe MiqProvision do
         options[:owner_group] = group_owner.description
         task.update_attributes(:options => options)
 
-        task.should_receive(:mark_as_completed)
+        expect(task).to receive(:mark_as_completed)
 
         task.signal(:post_create_destination)
 
@@ -114,14 +114,14 @@ describe MiqProvision do
           retires_on           = (Time.now.utc + retirement).to_date
           task.update_attributes(:options => options)
 
-          task.should_receive(:mark_as_completed)
+          expect(task).to receive(:mark_as_completed)
 
           task.signal(:post_create_destination)
 
           expect(task.destination.retires_on).to eq(retires_on)
           expect(vm.reload.retires_on).to        eq(retires_on)
           expect(vm.retirement_warn).to          eq(0)
-          expect(vm.retired).to                  be_false
+          expect(vm.retired).to                  be_falsey
         end
 
         it "with :retirement_time option" do
@@ -132,19 +132,19 @@ describe MiqProvision do
           retires_on                = retirement_time.to_date
           task.update_attributes(:options => options)
 
-          task.should_receive(:mark_as_completed)
+          expect(task).to receive(:mark_as_completed)
 
           task.signal(:post_create_destination)
 
           expect(task.destination.retires_on).to eq(retires_on)
           expect(vm.reload.retires_on).to        eq(retires_on)
           expect(vm.retirement_warn).to          eq(retirement_warn_days)
-          expect(vm.retired).to                  be_false
+          expect(vm.retired).to                  be_falsey
         end
       end
 
       it "sets genealogy" do
-        task.should_receive(:mark_as_completed)
+        expect(task).to receive(:mark_as_completed)
 
         task.signal(:post_create_destination)
 

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -21,7 +21,7 @@ describe MiqProvisionRequest do
   end
 
   context "A new provision request," do
-    before            { User.any_instance.stub(:role).and_return("admin") }
+    before            { allow_any_instance_of(User).to receive(:role).and_return("admin") }
     let(:approver)    { FactoryGirl.create(:user_miq_request_approver) }
     let(:user)        { FactoryGirl.create(:user) }
     let(:ems)         { FactoryGirl.create(:ems_vmware) }
@@ -33,7 +33,7 @@ describe MiqProvisionRequest do
     end
 
     it "should not be created with an invalid userid being specified" do
-      -> { FactoryGirl.create(:miq_provision_request, :userid => 'barney', :src_vm_id => vm_template.id) }.should raise_error(ActiveRecord::RecordInvalid)
+      expect { FactoryGirl.create(:miq_provision_request, :userid => 'barney', :src_vm_id => vm_template.id) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should not be created with a valid userid but no vm being specified" do
@@ -56,27 +56,27 @@ describe MiqProvisionRequest do
       end
 
       it "should create an MiqProvisionRequest" do
-        MiqProvisionRequest.count.should == 1
-        MiqProvisionRequest.first.should == @pr
-        @pr.valid?.should be_true
-        @pr.approved?.should be_false
+        expect(MiqProvisionRequest.count).to eq(1)
+        expect(MiqProvisionRequest.first).to eq(@pr)
+        expect(@pr.valid?).to be_truthy
+        expect(@pr.approved?).to be_falsey
       end
 
       it "should create a valid MiqRequest" do
-        @pr.miq_request.should == MiqRequest.first
-        @pr.miq_request.valid?.should be_true
-        @pr.miq_request.approval_state.should == "pending_approval"
-        @pr.miq_request.resource.should == @pr
-        @pr.miq_request.requester_userid.should == user.userid
-        @pr.miq_request.stamped_on.should be_nil
+        expect(@pr.miq_request).to eq(MiqRequest.first)
+        expect(@pr.miq_request.valid?).to be_truthy
+        expect(@pr.miq_request.approval_state).to eq("pending_approval")
+        expect(@pr.miq_request.resource).to eq(@pr)
+        expect(@pr.miq_request.requester_userid).to eq(user.userid)
+        expect(@pr.miq_request.stamped_on).to be_nil
 
-        @pr.miq_request.approved?.should be_false
-        MiqApproval.count.should == 1
-        @pr.miq_request.first_approval.should == MiqApproval.first
+        expect(@pr.miq_request.approved?).to be_falsey
+        expect(MiqApproval.count).to eq(1)
+        expect(@pr.miq_request.first_approval).to eq(MiqApproval.first)
       end
 
       it "should return a workflow class" do
-        @pr.workflow_class.should == ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow
+        expect(@pr.workflow_class).to eq(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow)
       end
 
       context "when calling call_automate_event_queue" do
@@ -86,13 +86,13 @@ describe MiqProvisionRequest do
         end
 
         it "should create proper MiqQueue item" do
-          MiqQueue.count.should == 1
+          expect(MiqQueue.count).to eq(1)
           q = MiqQueue.first
-          q.class_name.should == @pr.miq_request.class.name
-          q.instance_id.should == @pr.miq_request.id
-          q.method_name.should == "call_automate_event"
-          q.args.should == [@event_name]
-          q.zone.should == ems.zone.name
+          expect(q.class_name).to eq(@pr.miq_request.class.name)
+          expect(q.instance_id).to eq(@pr.miq_request.id)
+          expect(q.method_name).to eq("call_automate_event")
+          expect(q.args).to eq([@event_name])
+          expect(q.zone).to eq(ems.zone.name)
         end
       end
 
@@ -100,15 +100,15 @@ describe MiqProvisionRequest do
         before { @request.destroy }
 
         it "should delete MiqProvisionRequest" do
-          MiqProvisionRequest.count.should == 0
+          expect(MiqProvisionRequest.count).to eq(0)
         end
 
         it "should delete MiqApproval" do
-          MiqApproval.count.should == 0
+          expect(MiqApproval.count).to eq(0)
         end
 
         it "should not delete Approver" do
-          -> { approver.reload }.should_not raise_error
+          expect { approver.reload }.not_to raise_error
         end
       end
 
@@ -118,7 +118,7 @@ describe MiqProvisionRequest do
         it "should return a hash for quota methods" do
           [:vms_by_group, :vms_by_owner, :retired_vms_by_group, :retired_vms_by_owner, :provisions_by_group, :provisions_by_owner,
            :requests_by_group, :requests_by_owner, :active_provisions_by_group, :active_provisions_by_owner, :active_provisions].each do |quota_method|
-            @pr.check_quota(quota_method).should be_kind_of(Hash)
+            expect(@pr.check_quota(quota_method)).to be_kind_of(Hash)
           end
         end
 
@@ -128,13 +128,13 @@ describe MiqProvisionRequest do
 
           #:requests_by_group
           stats = @pr.check_quota(:requests_by_owner)
-          stats.should be_kind_of(Hash)
+          expect(stats).to be_kind_of(Hash)
 
-          stats[:class_name].should == "MiqProvisionRequest"
-          stats[:count].should == 2
-          stats[:memory].should == 2048
-          stats[:cpu].should == 4
-          stats.fetch_path(:active, :class_name).should == "MiqProvision"
+          expect(stats[:class_name]).to eq("MiqProvisionRequest")
+          expect(stats[:count]).to eq(2)
+          expect(stats[:memory]).to eq(2048)
+          expect(stats[:cpu]).to eq(4)
+          expect(stats.fetch_path(:active, :class_name)).to eq("MiqProvision")
         end
       end
 
@@ -142,72 +142,72 @@ describe MiqProvisionRequest do
         before { FactoryGirl.create(:classification_department_with_tags) }
 
         it "should add and delete tags from a request" do
-          @pr.get_tags.length.should == 0
+          expect(@pr.get_tags.length).to eq(0)
 
           t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
-          @pr.get_tags[t.name.to_sym].should be_kind_of(String) # Single tag returns as a String
-          @pr.get_tags[t.name.to_sym].should == t.children.first.name
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(String) # Single tag returns as a String
+          expect(@pr.get_tags[t.name.to_sym]).to eq(t.children.first.name)
 
           # Adding the same tag again should not increase the tag count
           @pr.add_tag(t.name, t.children.first.name)
-          @pr.get_tags[t.name.to_sym].should be_kind_of(String) # Single tag returns as a String
-          @pr.get_tags[t.name.to_sym].should == t.children.first.name
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(String) # Single tag returns as a String
+          expect(@pr.get_tags[t.name.to_sym]).to eq(t.children.first.name)
 
           # Verify that #get_tag with classification returns the single child tag name
-          @pr.get_tags[t.name.to_sym].should == @pr.get_tag(t.name)
+          expect(@pr.get_tags[t.name.to_sym]).to eq(@pr.get_tag(t.name))
 
           t.children.each { |c| @pr.add_tag(t.name, c.name) }
-          @pr.get_tags[t.name.to_sym].should be_kind_of(Array)
-          @pr.get_tags[t.name.to_sym].length.should == t.children.length
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(Array)
+          expect(@pr.get_tags[t.name.to_sym].length).to eq(t.children.length)
 
           child_names = t.children.collect(&:name)
           # Make sure each child name is yield from the tag method
           @pr.tags { |tag_name, _classification| child_names.delete(tag_name) }
-          child_names.should be_empty
+          expect(child_names).to be_empty
 
           tags = @pr.get_classification(t.name)
-          tags.should be_kind_of(Array)
+          expect(tags).to be_kind_of(Array)
           classification = tags.first
-          classification.should be_kind_of(Hash)
-          classification.keys.should include(:name)
-          classification.keys.should include(:description)
+          expect(classification).to be_kind_of(Hash)
+          expect(classification.keys).to include(:name)
+          expect(classification.keys).to include(:description)
 
           child_names = t.children.collect(&:name)
 
           @pr.clear_tag(t.name, child_names[0])
-          @pr.get_tags[t.name.to_sym].should be_kind_of(Array) # Multiple tags return as an Array
-          @pr.get_tags[t.name.to_sym].length.should == t.children.length - 1
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(Array) # Multiple tags return as an Array
+          expect(@pr.get_tags[t.name.to_sym].length).to eq(t.children.length - 1)
 
           @pr.clear_tag(t.name, child_names[1])
-          @pr.get_tags[t.name.to_sym].should be_kind_of(String) # Single tag returns as a String
-          @pr.get_tags[t.name.to_sym].should == child_names[2]
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(String) # Single tag returns as a String
+          expect(@pr.get_tags[t.name.to_sym]).to eq(child_names[2])
 
           @pr.clear_tag(t.name)
-          @pr.get_tags[t.name.to_sym].should be_nil # No tags returns as nil
-          @pr.get_tags.length.should == 0
+          expect(@pr.get_tags[t.name.to_sym]).to be_nil # No tags returns as nil
+          expect(@pr.get_tags.length).to eq(0)
         end
 
         it "should return classifications for tags" do
-          @pr.get_tags.length.should == 0
+          expect(@pr.get_tags.length).to eq(0)
 
           t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
           @pr.add_tag(t.name, t.children.first.name)
-          @pr.get_tags[t.name.to_sym].should be_kind_of(String)
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(String)
 
           classification = @pr.get_classification(t.name)
-          classification.should be_kind_of(Hash)
-          classification.keys.should include(:name)
-          classification.keys.should include(:description)
+          expect(classification).to be_kind_of(Hash)
+          expect(classification.keys).to include(:name)
+          expect(classification.keys).to include(:description)
 
           @pr.add_tag(t.name, t.children[1].name)
-          @pr.get_tags[t.name.to_sym].should be_kind_of(Array)
+          expect(@pr.get_tags[t.name.to_sym]).to be_kind_of(Array)
 
           classification = @pr.get_classification(t.name)
-          classification.should be_kind_of(Array)
+          expect(classification).to be_kind_of(Array)
           first = classification.first
-          first.keys.should include(:name)
-          first.keys.should include(:description)
+          expect(first.keys).to include(:name)
+          expect(first.keys).to include(:description)
         end
       end
     end

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -30,8 +30,8 @@ describe MiqProvisionRequestTemplate do
   describe '#create_tasks_for_service' do
     before do
       MiqRegion.seed
-      ManageIQ::Providers::Vmware::InfraManager::Provision.any_instance.stub(:get_hostname).and_return('hostname')
-      MiqAeEngine.stub(:resolve_automation_object).and_return(double(:root => 'miq'))
+      allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Provision).to receive(:get_hostname).and_return('hostname')
+      allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'miq'))
     end
 
     it 'should only call get_next_vm_name once' do

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -30,48 +30,48 @@ describe MiqProvision do
         end
 
         it "should get values out of an arrays in the options hash" do
-          @vm_prov.options[:src_vm_id].should be_kind_of(Array)
-          @vm_prov.get_option(:src_vm_id).should == @vm_template.id
-          @vm_prov.get_option_last(:src_vm_id).should == @vm_template.name
-          @vm_prov.get_option_last(:number_of_vms).should == 1
-          @vm_prov.get_option(nil, @vm_prov.options[:src_vm_id]).should == @vm_template.id
+          expect(@vm_prov.options[:src_vm_id]).to be_kind_of(Array)
+          expect(@vm_prov.get_option(:src_vm_id)).to eq(@vm_template.id)
+          expect(@vm_prov.get_option_last(:src_vm_id)).to eq(@vm_template.name)
+          expect(@vm_prov.get_option_last(:number_of_vms)).to eq(1)
+          expect(@vm_prov.get_option(nil, @vm_prov.options[:src_vm_id])).to eq(@vm_template.id)
         end
 
         it "should return a user object" do
           user = @vm_prov.get_user
-          user.should be_kind_of(User)
-          user.should == @admin
+          expect(user).to be_kind_of(User)
+          expect(user).to eq(@admin)
         end
 
         it "should return a description" do
-          @vm_prov.class.get_description(@vm_prov, nil).should_not be_blank
+          expect(@vm_prov.class.get_description(@vm_prov, nil)).not_to be_blank
         end
 
         it "should populate description, target_name and target_hostname" do
           @vm_prov.after_request_task_create
-          @vm_prov.description.should_not be_nil
-          @vm_prov.get_option(:vm_target_name).should_not be_nil
-          @vm_prov.get_option(:vm_target_hostname).should_not be_nil
+          expect(@vm_prov.description).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_name)).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_hostname)).not_to be_nil
         end
 
         it "should create a valid target_name and hostname" do
           MiqRegion.seed
           @vm_prov.after_request_task_create
-          @vm_prov.get_option(:vm_target_name).should == @target_vm_name
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(@target_vm_name)
 
           @vm_prov.options[:number_of_vms] = 2
           @vm_prov.after_request_task_create
           name_001 = "#{@target_vm_name}001"
-          @vm_prov.get_option(:vm_target_name).should == name_001
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_001)
           # Hostname cannot contain spaces or underscores, they should be replaces with (-)
-          @vm_prov.get_option(:vm_target_hostname).should == name_001.gsub(/ +|_+/, "-")
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_001.gsub(/ +|_+/, "-"))
 
           @vm_prov.options[:pass] = 2
           @vm_prov.after_request_task_create
           name_002 = "#{@target_vm_name}002"
-          @vm_prov.get_option(:vm_target_name).should == name_002
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_002)
           # Hostname cannot contain spaces or underscores, they should be replaces with (-)
-          @vm_prov.get_option(:vm_target_hostname).should == name_002.gsub(/ +|_+/, "-")
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_002.gsub(/ +|_+/, "-"))
         end
 
         context "when auto naming sequence exceeds the range" do
@@ -84,11 +84,11 @@ describe MiqProvision do
           it "should advance to next range but based on the existing sequence number for the new range" do
             @vm_prov.options[:number_of_vms] = 2
             @vm_prov.after_request_task_create
-            @vm_prov.get_option(:vm_target_name).should == "#{@target_vm_name}999"  # 3 digits
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
 
             @vm_prov.options[:pass] = 2
             @vm_prov.after_request_task_create
-            @vm_prov.get_option(:vm_target_name).should == "#{@target_vm_name}0011" # 4 digits
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}0011") # 4 digits
           end
         end
 
@@ -99,41 +99,41 @@ describe MiqProvision do
           #                                      1         2         3         4         5         6
           @vm_prov.options[:vm_name] = '123456789012345678901234567890123456789012345678901234567890123456789'
           @vm_prov.after_request_task_create
-          @vm_prov.get_option(:vm_target_hostname).length.should == 15
+          expect(@vm_prov.get_option(:vm_target_hostname).length).to eq(15)
 
           os_linux = OperatingSystem.new(:product_name => 'linux')
           @vm_prov.source.operating_system = os_linux
           @vm_prov.after_request_task_create
-          @vm_prov.get_option(:vm_target_hostname).length.should == 63
+          expect(@vm_prov.get_option(:vm_target_hostname).length).to eq(63)
         end
 
         it "should select a different IP address for multiple provisions" do
-          @vm_prov.set_static_ip_address(1).should be_nil
+          expect(@vm_prov.set_static_ip_address(1)).to be_nil
           @vm_prov.options[:ip_addr] = '127.0.0.100'
           @vm_prov.set_static_ip_address(1)
-          @vm_prov.get_option(:ip_addr).should == '127.0.0.100'
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.100')
           x = @vm_prov.set_static_ip_address(2)
-          @vm_prov.get_option(:ip_addr).should == '127.0.0.101'
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.101')
         end
 
         it "should skip post-provisioning if the request is finished or in error" do
-          @vm_prov.prematurely_finished?.should be_false
+          expect(@vm_prov.prematurely_finished?).to be_falsey
 
           init_state = @vm_prov.state
           @vm_prov.state = 'finished'
-          @vm_prov.prematurely_finished?.should be_true
+          expect(@vm_prov.prematurely_finished?).to be_truthy
 
           @vm_prov.state = init_state
           @vm_prov.status = 'Error'
-          @vm_prov.prematurely_finished?.should be_true
+          expect(@vm_prov.prematurely_finished?).to be_truthy
 
           @vm_prov.state = 'finished'
-          @vm_prov.prematurely_finished?.should be_true
+          expect(@vm_prov.prematurely_finished?).to be_truthy
         end
 
         it "#my_zone" do
-          @vm_prov.source.class.any_instance.should_receive(:my_zone).once
-          @pr.class.any_instance.should_receive(:my_zone).never
+          expect_any_instance_of(@vm_prov.source.class).to receive(:my_zone).once
+          expect_any_instance_of(@pr.class).to receive(:my_zone).never
 
           @vm_prov.my_zone
         end
@@ -147,12 +147,12 @@ describe MiqProvision do
       host     = active_record_instance_double('Host', :id => 1, :name => 'my_host')
       workflow = auto_loaded_instance_double("MiqProvisionWorkflow", :allowed_hosts => [host])
 
-      prov.should_receive(:eligible_resource_lookup).and_return(host)
+      expect(prov).to receive(:eligible_resource_lookup).and_return(host)
 
-      prov.should_receive(:workflow).with do |options, flags|
-        options[:placement_auto].should eq([false, 0])
-        flags[:skip_dialog_load].should be_true
-      end.and_return(workflow)
+      expect(prov).to receive(:workflow).with { |options, flags|
+        expect(options[:placement_auto]).to eq([false, 0])
+        expect(flags[:skip_dialog_load]).to be_truthy
+      }.and_return(workflow)
 
       prov.eligible_resources(:hosts)
     end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -15,20 +15,20 @@ describe MiqProvisionVirtWorkflow do
 
     context "exit_pre_dialog" do
       it "doesn't exit when not running" do
-        workflow.should_not_receive(:exit_pre_dialog)
+        expect(workflow).not_to receive(:exit_pre_dialog)
 
-        expect(workflow.continue_request({})).to be_true
+        expect(workflow.continue_request({})).to be_truthy
       end
 
       it "exits when running" do
         workflow.instance_variable_set(:@running_pre_dialog, true)
         new_values = workflow.instance_variable_get(:@values)
 
-        workflow.should_receive(:exit_pre_dialog).once.and_call_original
+        expect(workflow).to receive(:exit_pre_dialog).once.and_call_original
 
-        expect(workflow.continue_request({})).to                        be_true
+        expect(workflow.continue_request({})).to                        be_truthy
         expect(workflow.instance_variable_get(:@last_vm_id)).to         eq(123)
-        expect(workflow.instance_variable_get(:@running_pre_dialog)).to be_false
+        expect(workflow.instance_variable_get(:@running_pre_dialog)).to be_falsey
         expect(workflow.instance_variable_get(:@tags)).to               be_nil
         expect(new_values[:forced_sysprep_enabled]).to                  eq('fields')
         expect(new_values[:forced_sysprep_domain_name]).to              eq([sdn])
@@ -43,11 +43,11 @@ describe MiqProvisionVirtWorkflow do
       @ems    = FactoryGirl.create(:ems_vmware)
       @host1  = FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
       @src_vm = FactoryGirl.create(:vm_vmware, :host => @host1, :ems_id => @ems.id)
-      Rbac.stub(:search) do |hash|
+      allow(Rbac).to receive(:search) do |hash|
         [Array.wrap(hash[:targets])]
       end
-      VmOrTemplate.any_instance.stub(:archived?).with(no_args).and_return(false)
-      VmOrTemplate.any_instance.stub(:orphaned?).with(no_args).and_return(false)
+      allow_any_instance_of(VmOrTemplate).to receive(:archived?).with(no_args).and_return(false)
+      allow_any_instance_of(VmOrTemplate).to receive(:orphaned?).with(no_args).and_return(false)
       workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id)
       workflow.instance_variable_set(:@target_resource, nil)
     end
@@ -64,11 +64,11 @@ describe MiqProvisionVirtWorkflow do
       end
 
       it '#allowed_vlans' do
-        workflow.stub(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(@host1)])
+        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(@host1)])
         vlans = workflow.allowed_vlans(:vlans => true, :dvs => false)
         lan_keys = [@lan11.name, @lan13.name, @lan12.name]
-        vlans.keys.should match_array(lan_keys)
-        vlans.values.should match_array(lan_keys)
+        expect(vlans.keys).to match_array(lan_keys)
+        expect(vlans.values).to match_array(lan_keys)
       end
     end
 
@@ -77,8 +77,8 @@ describe MiqProvisionVirtWorkflow do
         @host1_dvs = {'pg1' => ['switch1'], 'pg2' => ['switch2']}
         @host1_dvs_hash = {'dvs_pg1' => 'pg1 (switch1)',
                            'dvs_pg2' => 'pg2 (switch2)'}
-        ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:connect)
-        workflow.stub(:get_host_dvs).with(@host1, nil).and_return(@host1_dvs)
+        allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:connect)
+        allow(workflow).to receive(:get_host_dvs).with(@host1, nil).and_return(@host1_dvs)
       end
 
       it '#allowed_dvs single host' do
@@ -89,14 +89,14 @@ describe MiqProvisionVirtWorkflow do
                                        :ems     => workflow.ci_to_hash_struct(@ems),
                                        :host_id => @host1.id)
         dvs = workflow.allowed_dvs({}, nil)
-        dvs.should eql(@host1_dvs_hash)
+        expect(dvs).to eql(@host1_dvs_hash)
       end
 
       context "#allowed_dvs" do
         before do
           @host2 = FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
           @host2_dvs = {'pg1' => ['switch21'], 'pg2' => ['switch2'], 'pg3' => ['switch23']}
-          workflow.stub(:get_host_dvs).with(@host2, nil).and_return(@host2_dvs)
+          allow(workflow).to receive(:get_host_dvs).with(@host2, nil).and_return(@host2_dvs)
           workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id,
                                         :placement_auto => true)
 
@@ -107,7 +107,7 @@ describe MiqProvisionVirtWorkflow do
 
         it 'multiple hosts auto placement' do
           dvs = workflow.allowed_dvs({}, nil)
-          dvs.should eql(@combined_dvs_hash)
+          expect(dvs).to eql(@combined_dvs_hash)
         end
 
         it 'cached filtering' do
@@ -121,7 +121,7 @@ describe MiqProvisionVirtWorkflow do
                                          :ems     => workflow.ci_to_hash_struct(@ems),
                                          :host_id => @host1.id)
           dvs = workflow.allowed_dvs({}, nil)
-          dvs.should eql(@host1_dvs_hash)
+          expect(dvs).to eql(@host1_dvs_hash)
         end
       end
     end
@@ -169,8 +169,8 @@ describe MiqProvisionVirtWorkflow do
     let(:show_hide_iso_pxe) { {:hide => [], :edit => []} }
     describe "supports iso" do
       before do
-        workflow.stub(:supports_iso?).and_return(true)
-        workflow.stub(:supports_pxe?).and_return(false)
+        allow(workflow).to receive(:supports_iso?).and_return(true)
+        allow(workflow).to receive(:supports_pxe?).and_return(false)
       end
 
       it "sets iso_image_id as a validated key" do
@@ -184,8 +184,8 @@ describe MiqProvisionVirtWorkflow do
 
     describe "supports pxe" do
       before do
-        workflow.stub(:supports_iso?).and_return(false)
-        workflow.stub(:supports_pxe?).and_return(true)
+        allow(workflow).to receive(:supports_iso?).and_return(false)
+        allow(workflow).to receive(:supports_pxe?).and_return(true)
       end
 
       it "sets pxe_server_id and pxe_image_id as validated keys" do
@@ -212,7 +212,7 @@ describe MiqProvisionVirtWorkflow do
     it "invalid size" do
       error = "Memory Reservation is larger than VM Memory"
 
-      workflow.should_receive(:required_description).and_return("Memory")
+      expect(workflow).to receive(:required_description).and_return("Memory")
       expect(workflow.validate_memory_reservation(nil, values.merge(:memory_reserve => 2048), {}, {}, nil)).to eq(error)
     end
   end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -43,7 +43,7 @@ describe MiqProvisionWorkflow do
           FactoryGirl.create(:classification_cost_center_with_tags)
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
             "1.0", admin, "template", "target", false, "cc|001|environment|test", "")
-          request.should be_a_kind_of(MiqRequest)
+          expect(request).to be_a_kind_of(MiqRequest)
 
           expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
         end
@@ -53,7 +53,7 @@ describe MiqProvisionWorkflow do
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
             "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test'}, nil,
             {'cc' => '001', 'environment' => 'test'}, nil, nil, nil)
-          request.should be_a_kind_of(MiqRequest)
+          expect(request).to be_a_kind_of(MiqRequest)
 
           expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
         end
@@ -65,8 +65,8 @@ describe MiqProvisionWorkflow do
             {'owner_email' => 'admin'}, {'owner_first_name' => 'test'},
             {'owner_last_name' => 'test'}, nil, nil, nil, nil)
 
-          MiqPassword.encrypted?(request.options[:root_password]).should be_true
-          MiqPassword.decrypt(request.options[:root_password]).should == password_input
+          expect(MiqPassword.encrypted?(request.options[:root_password])).to be_truthy
+          expect(MiqPassword.decrypt(request.options[:root_password])).to eq(password_input)
         end
 
         it "should set values when extra '|' are passed in for multiple values" do
@@ -102,8 +102,8 @@ describe MiqProvisionWorkflow do
         it "should show PXE fields when customization supported" do
           fields = {'key' => 'value'}
           wf = MiqProvisionVirtWorkflow.new({}, admin)
-          wf.should_receive(:supports_customization_template?).and_return(true)
-          wf.should_receive(:show_customize_fields_pxe).with(fields)
+          expect(wf).to receive(:supports_customization_template?).and_return(true)
+          expect(wf).to receive(:show_customize_fields_pxe).with(fields)
           wf.show_customize_fields(fields, 'linux')
         end
       end
@@ -112,7 +112,7 @@ describe MiqProvisionWorkflow do
 
   context ".encrypted_options_fields" do
     MiqProvisionWorkflow.descendants.each do |sub_klass|
-      it("with class #{sub_klass}") { sub_klass.encrypted_options_fields.should include(:root_password) }
+      it("with class #{sub_klass}") { expect(sub_klass.encrypted_options_fields).to include(:root_password) }
     end
   end
 
@@ -127,13 +127,13 @@ describe MiqProvisionWorkflow do
     end
 
     it 'with orphaned source' do
-      template.stub(:storage).and_return([])
-      expect(template.orphaned?).to be_true
+      allow(template).to receive(:storage).and_return([])
+      expect(template.orphaned?).to be_truthy
       expect(described_class.class_for_source(template.id)).to eq(workflow_class)
     end
 
     it 'with archived source' do
-      expect(template.archived?).to be_true
+      expect(template.archived?).to be_truthy
       expect(described_class.class_for_source(template.id)).to eq(workflow_class)
     end
   end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe MiqQueue do
-  specify { FactoryGirl.build(:miq_queue).should be_valid }
+  specify { expect(FactoryGirl.build(:miq_queue)).to be_valid }
 
   context "#deliver" do
     before do
@@ -10,45 +10,45 @@ describe MiqQueue do
 
     it "works with deliver_on" do
       deliver_on = Time.now.utc + 1.minute
-      Storage.stub(:foobar).and_raise(MiqException::MiqQueueRetryLater.new(:deliver_on => deliver_on))
+      allow(Storage).to receive(:foobar).and_raise(MiqException::MiqQueueRetryLater.new(:deliver_on => deliver_on))
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'Storage', :method_name => 'foobar')
       status, message, result = msg.deliver
 
-      status.should == MiqQueue::STATUS_RETRY
-      msg.state.should == MiqQueue::STATE_READY
-      msg.handler.should    be_nil
-      msg.deliver_on.should == deliver_on
+      expect(status).to eq(MiqQueue::STATUS_RETRY)
+      expect(msg.state).to eq(MiqQueue::STATE_READY)
+      expect(msg.handler).to    be_nil
+      expect(msg.deliver_on).to eq(deliver_on)
 
-      Storage.stub(:foobar).and_raise(MiqException::MiqQueueRetryLater.new)
+      allow(Storage).to receive(:foobar).and_raise(MiqException::MiqQueueRetryLater.new)
       msg.state   = MiqQueue::STATE_DEQUEUE
       msg.handler = @miq_server
       status, message, result = msg.deliver
 
-      status.should == MiqQueue::STATUS_RETRY
-      msg.state.should == MiqQueue::STATE_READY
-      msg.handler.should be_nil
+      expect(status).to eq(MiqQueue::STATUS_RETRY)
+      expect(msg.state).to eq(MiqQueue::STATE_READY)
+      expect(msg.handler).to be_nil
     end
 
     it "works with expires_on" do
-      MiqServer.stub(:foobar).and_return(0)
+      allow(MiqServer).to receive(:foobar).and_return(0)
 
       expires_on = 1.minute.from_now.utc
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar', :expires_on => expires_on)
       status, message, result = msg.deliver
-      status.should == MiqQueue::STATUS_OK
+      expect(status).to eq(MiqQueue::STATUS_OK)
 
       expires_on = 1.minute.ago.utc
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar', :expires_on => expires_on)
       status, message, result = msg.deliver
-      status.should == MiqQueue::STATUS_EXPIRED
+      expect(status).to eq(MiqQueue::STATUS_EXPIRED)
     end
 
     it "sets last_exception on raised Exception" do
-      MiqServer.stub(:foobar).and_raise(Exception)
+      allow(MiqServer).to receive(:foobar).and_raise(Exception)
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar')
       status, message, result = msg.deliver
-      status.should == MiqQueue::STATUS_ERROR
-      msg.last_exception.should be_kind_of(Exception)
+      expect(status).to eq(MiqQueue::STATUS_ERROR)
+      expect(msg.last_exception).to be_kind_of(Exception)
     end
   end
 
@@ -71,8 +71,8 @@ describe MiqQueue do
         @msg.update_attributes(:msg_timeout => 1.minutes)
         begin
           Timecop.travel 10.minute
-          $log.should_receive(:warn)
-          @msg.should_receive(:destroy)
+          expect($log).to receive(:warn)
+          expect(@msg).to receive(:destroy)
           @msg.check_for_timeout
         ensure
           Timecop.return
@@ -83,7 +83,7 @@ describe MiqQueue do
         MiqQueue.atStartup
 
         @msg.reload
-        @msg.state.should == MiqQueue::STATE_ERROR
+        expect(@msg.state).to eq(MiqQueue::STATE_ERROR)
       end
     end
 
@@ -96,7 +96,7 @@ describe MiqQueue do
         MiqQueue.atStartup
 
         @msg.reload
-        @msg.state.should == MiqQueue::STATE_DEQUEUE
+        expect(@msg.state).to eq(MiqQueue::STATE_DEQUEUE)
       end
     end
 
@@ -109,7 +109,7 @@ describe MiqQueue do
         MiqQueue.atStartup
 
         @msg.reload
-        @msg.state.should == MiqQueue::STATE_ERROR
+        expect(@msg.state).to eq(MiqQueue::STATE_ERROR)
       end
     end
   end
@@ -137,8 +137,8 @@ describe MiqQueue do
     message_parms.each do |mparms|
       msg = FactoryGirl.create(:miq_queue)
       mparms.each { |k, v| msg.send("#{k}=", v) }
-      MiqQueue.format_short_log_msg(msg).should == "Message id: [#{msg.id}]"
-      MiqQueue.format_full_log_msg(msg).should == "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{msg.args.inspect}"
+      expect(MiqQueue.format_short_log_msg(msg)).to eq("Message id: [#{msg.id}]")
+      expect(MiqQueue.format_full_log_msg(msg)).to eq("Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{msg.args.inspect}")
     end
   end
 
@@ -174,43 +174,43 @@ describe MiqQueue do
 
     message_parms.each do |mparms|
       msg = FactoryGirl.create(:miq_queue, mparms)
-      MiqQueue.format_short_log_msg(msg).should == "Message id: [#{msg.id}]"
-      MiqQueue.format_full_log_msg(msg).should == "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{args_cleaned_password.inspect}"
+      expect(MiqQueue.format_short_log_msg(msg)).to eq("Message id: [#{msg.id}]")
+      expect(MiqQueue.format_full_log_msg(msg)).to eq("Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{args_cleaned_password.inspect}")
     end
   end
 
   context "executing priority" do
     it "should return adjusted value" do
-      MiqQueue.priority(:max).should == MiqQueue::MAX_PRIORITY
-      MiqQueue.priority(:high).should == MiqQueue::HIGH_PRIORITY
-      MiqQueue.priority(:normal).should == MiqQueue::NORMAL_PRIORITY
-      MiqQueue.priority(:low).should == MiqQueue::LOW_PRIORITY
-      MiqQueue.priority(:min).should == MiqQueue::MIN_PRIORITY
+      expect(MiqQueue.priority(:max)).to eq(MiqQueue::MAX_PRIORITY)
+      expect(MiqQueue.priority(:high)).to eq(MiqQueue::HIGH_PRIORITY)
+      expect(MiqQueue.priority(:normal)).to eq(MiqQueue::NORMAL_PRIORITY)
+      expect(MiqQueue.priority(:low)).to eq(MiqQueue::LOW_PRIORITY)
+      expect(MiqQueue.priority(:min)).to eq(MiqQueue::MIN_PRIORITY)
 
-      MiqQueue.priority(5000).should == MiqQueue::MIN_PRIORITY
-      MiqQueue.priority(-5000).should == MiqQueue::MAX_PRIORITY
-      MiqQueue.priority(100).should == 100
+      expect(MiqQueue.priority(5000)).to eq(MiqQueue::MIN_PRIORITY)
+      expect(MiqQueue.priority(-5000)).to eq(MiqQueue::MAX_PRIORITY)
+      expect(MiqQueue.priority(100)).to eq(100)
 
-      -> { MiqQueue.priority(:other)        }.should raise_error(ArgumentError)
-      -> { MiqQueue.priority(:high, :other) }.should raise_error(ArgumentError)
+      expect { MiqQueue.priority(:other)        }.to raise_error(ArgumentError)
+      expect { MiqQueue.priority(:high, :other) }.to raise_error(ArgumentError)
 
-      MiqQueue.priority(:normal, :higher, 10).should == MiqQueue::NORMAL_PRIORITY - 10
-      MiqQueue.priority(:normal, :lower,  10).should == MiqQueue::NORMAL_PRIORITY + 10
+      expect(MiqQueue.priority(:normal, :higher, 10)).to eq(MiqQueue::NORMAL_PRIORITY - 10)
+      expect(MiqQueue.priority(:normal, :lower,  10)).to eq(MiqQueue::NORMAL_PRIORITY + 10)
 
-      MiqQueue.priority(:min, :lower,  1).should == MiqQueue::MIN_PRIORITY
-      MiqQueue.priority(:max, :higher, 1).should == MiqQueue::MAX_PRIORITY
+      expect(MiqQueue.priority(:min, :lower,  1)).to eq(MiqQueue::MIN_PRIORITY)
+      expect(MiqQueue.priority(:max, :higher, 1)).to eq(MiqQueue::MAX_PRIORITY)
     end
 
     it "should validate comparisons" do
-      MiqQueue.higher_priority(MiqQueue::MIN_PRIORITY, MiqQueue::MAX_PRIORITY).should == MiqQueue::MAX_PRIORITY
-      MiqQueue.higher_priority(MiqQueue::MAX_PRIORITY, MiqQueue::MIN_PRIORITY).should == MiqQueue::MAX_PRIORITY
-      MiqQueue.higher_priority?(MiqQueue::MIN_PRIORITY, MiqQueue::MAX_PRIORITY).should be_false
-      MiqQueue.higher_priority?(MiqQueue::MAX_PRIORITY, MiqQueue::MIN_PRIORITY).should be_true
+      expect(MiqQueue.higher_priority(MiqQueue::MIN_PRIORITY, MiqQueue::MAX_PRIORITY)).to eq(MiqQueue::MAX_PRIORITY)
+      expect(MiqQueue.higher_priority(MiqQueue::MAX_PRIORITY, MiqQueue::MIN_PRIORITY)).to eq(MiqQueue::MAX_PRIORITY)
+      expect(MiqQueue.higher_priority?(MiqQueue::MIN_PRIORITY, MiqQueue::MAX_PRIORITY)).to be_falsey
+      expect(MiqQueue.higher_priority?(MiqQueue::MAX_PRIORITY, MiqQueue::MIN_PRIORITY)).to be_truthy
 
-      MiqQueue.lower_priority(MiqQueue::MIN_PRIORITY,  MiqQueue::MAX_PRIORITY).should == MiqQueue::MIN_PRIORITY
-      MiqQueue.lower_priority(MiqQueue::MAX_PRIORITY,  MiqQueue::MIN_PRIORITY).should == MiqQueue::MIN_PRIORITY
-      MiqQueue.lower_priority?(MiqQueue::MIN_PRIORITY,  MiqQueue::MAX_PRIORITY).should be_true
-      MiqQueue.lower_priority?(MiqQueue::MAX_PRIORITY,  MiqQueue::MIN_PRIORITY).should be_false
+      expect(MiqQueue.lower_priority(MiqQueue::MIN_PRIORITY,  MiqQueue::MAX_PRIORITY)).to eq(MiqQueue::MIN_PRIORITY)
+      expect(MiqQueue.lower_priority(MiqQueue::MAX_PRIORITY,  MiqQueue::MIN_PRIORITY)).to eq(MiqQueue::MIN_PRIORITY)
+      expect(MiqQueue.lower_priority?(MiqQueue::MIN_PRIORITY,  MiqQueue::MAX_PRIORITY)).to be_truthy
+      expect(MiqQueue.lower_priority?(MiqQueue::MAX_PRIORITY,  MiqQueue::MIN_PRIORITY)).to be_falsey
     end
   end
 
@@ -245,10 +245,10 @@ describe MiqQueue do
 
     it "should calculate wait times" do
       cor = MiqQueue.wait_times_by_role
-      cor.should == {
+      expect(cor).to eq({
         "role1" => {:next => (Time.now - @t3), :last => (Time.now - @t1)},
         "role3" => {:next => (Time.now - @t3), :last => (Time.now - @t3)}
-      }
+      })
     end
   end
 
@@ -275,7 +275,7 @@ describe MiqQueue do
       @new_msg = @msg.requeue(options)
       @new_msg_id = @new_msg.id
 
-      @msg.id.should_not == @msg.requeue(options).id
+      expect(@msg.id).not_to eq(@msg.requeue(options).id)
     end
 
     it "should requeue a message with message id higher last" do
@@ -293,13 +293,13 @@ describe MiqQueue do
       @new_msg = @msg.requeue(options)
       @new_msg_id = @new_msg.id
 
-      @msg.requeue(options).id.should be > @msg.id
+      expect(@msg.requeue(options).id).to be > @msg.id
     end
 
     it "should requeue a message" do
       hash_value = "test_string_2_05312011"
       @msg.data = hash_value
-      @msg.data.should == "test_string_2_05312011"
+      expect(@msg.data).to eq("test_string_2_05312011")
     end
   end
 
@@ -312,11 +312,11 @@ describe MiqQueue do
     end
 
     it "should find a message by task id" do
-      MiqQueue.get_worker("task123").should == @worker
+      expect(MiqQueue.get_worker("task123")).to eq(@worker)
     end
 
     it "should return worker handler" do
-      @msg.get_worker.should == @worker
+      expect(@msg.get_worker).to eq(@worker)
     end
   end
 

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -7,10 +7,10 @@ describe MiqRegion do
     end
 
     it "should increment naming sequence number after each call" do
-      MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming").should == 1
-      MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming").should == 2
-      MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming").should == 1
-      MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming").should == 2
+      expect(MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming")).to eq(1)
+      expect(MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming")).to eq(2)
+      expect(MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming")).to eq(1)
+      expect(MiqRegion.my_region.next_naming_sequence("anothertest$n{3}", "naming")).to eq(2)
     end
 
     context "with cloud and infra EMSes" do
@@ -27,13 +27,13 @@ describe MiqRegion do
       end
 
       it "should be able to return the list of ems_clouds" do
-        @region.ems_clouds.should include(*@ems_clouds)
-        @region.ems_clouds.should_not include(*@ems_infras)
+        expect(@region.ems_clouds).to include(*@ems_clouds)
+        expect(@region.ems_clouds).not_to include(*@ems_infras)
       end
 
       it "should be able to return the list of ems_infras" do
-        @region.ems_infras.should include(*@ems_infras)
-        @region.ems_infras.should_not include(*@ems_clouds)
+        expect(@region.ems_infras).to include(*@ems_infras)
+        expect(@region.ems_infras).not_to include(*@ems_clouds)
       end
     end
   end
@@ -53,15 +53,15 @@ describe MiqRegion do
 
     it "replaces deleted current region" do
       MiqRegion.where(:region => @region_number).destroy_all
-      MiqRegion.count.should == 0
+      expect(MiqRegion.count).to eq(0)
       MiqRegion.seed
-      MiqRegion.first.region.should == @region_number
+      expect(MiqRegion.first.region).to eq(@region_number)
     end
 
     it "raises Exception if db region_id doesn't match my_region_number" do
       @db = FactoryGirl.create(:miq_database)
       MiqRegion.stub(:my_region_number => @region_number + 1)
-      -> { MiqRegion.seed }.should raise_error(Exception)
+      expect { MiqRegion.seed }.to raise_error(Exception)
     end
   end
 end

--- a/spec/models/miq_replication_worker/runner_spec.rb
+++ b/spec/models/miq_replication_worker/runner_spec.rb
@@ -2,37 +2,37 @@ require "spec_helper"
 
 describe MiqReplicationWorker::Runner do
   before do
-    MiqReplicationWorker::Runner.any_instance.stub(:worker_initialization)
+    allow_any_instance_of(MiqReplicationWorker::Runner).to receive(:worker_initialization)
     @worker = MiqReplicationWorker::Runner.new
   end
 
   context "testing rubyrep_alive?" do
     before do
-      Process.stub(:waitpid2)
-      @worker.stub(:child_process_recently_active?).and_return(true)
+      allow(Process).to receive(:waitpid2)
+      allow(@worker).to receive(:child_process_recently_active?).and_return(true)
       @worker.instance_variable_set(:@pid, 123)
     end
 
     it "should be alive if process is alive" do
-      MiqProcess.stub(:state).and_return(:sleeping)
-      expect(@worker.rubyrep_alive?).to be_true
+      allow(MiqProcess).to receive(:state).and_return(:sleeping)
+      expect(@worker.rubyrep_alive?).to be_truthy
     end
 
     it "should not be alive if process is zombie" do
-      MiqProcess.stub(:state).and_return(:zombie)
-      expect(@worker.rubyrep_alive?).to be_false
+      allow(MiqProcess).to receive(:state).and_return(:zombie)
+      expect(@worker.rubyrep_alive?).to be_falsey
     end
   end
 
   context "testing child process heartbeat" do
     it "should be alive if heartbeat within threshold" do
       @worker.stub(:child_process_last_heartbeat => 1.second.ago.utc)
-      expect(@worker.child_process_recently_active?).to be_true
+      expect(@worker.child_process_recently_active?).to be_truthy
     end
 
     it "should not be alive if heartbeat beyond threshold" do
       @worker.stub(:child_process_last_heartbeat => 6.minutes.ago.utc)
-      expect(@worker.child_process_recently_active?).to be_false
+      expect(@worker.child_process_recently_active?).to be_falsey
     end
   end
 end

--- a/spec/models/miq_replication_worker_spec.rb
+++ b/spec/models/miq_replication_worker_spec.rb
@@ -3,14 +3,14 @@ require "spec_helper"
 describe MiqReplicationWorker do
   context "#check_status" do
     def should_handle_check_status(rr_pending_count, rr_pending_last_id, expected_status)
-      RrPendingChange.stub(:count).and_return(rr_pending_count)
-      RrPendingChange.stub(:last_id).and_return(rr_pending_last_id)
+      allow(RrPendingChange).to receive(:count).and_return(rr_pending_count)
+      allow(RrPendingChange).to receive(:last_id).and_return(rr_pending_last_id)
 
-      MiqReplicationWorker.check_status.should == expected_status
+      expect(MiqReplicationWorker.check_status).to eq(expected_status)
 
       db = MiqDatabase.first
-      db.last_replication_count.should == rr_pending_count
-      db.last_replication_id.should == rr_pending_last_id
+      expect(db.last_replication_count).to eq(rr_pending_count)
+      expect(db.last_replication_id).to eq(rr_pending_last_id)
     end
 
     before(:each) do

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -18,7 +18,7 @@ describe MiqReport do
     @show_title   = true
     @options = MiqReport.graph_options(600, 400)
 
-    Charting.stub(:detect_available_plugin).and_return(JqplotCharting)
+    allow(Charting).to receive(:detect_available_plugin).and_return(JqplotCharting)
   end
 
   context 'graph_options' do

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -30,15 +30,15 @@ describe MiqReport::ImportExport do
       it "preview" do
         _, result = subject
 
-        result[:status].should == :add
-        MiqReport.count.should == 0
+        expect(result[:status]).to eq(:add)
+        expect(MiqReport.count).to eq(0)
       end
 
       it "import" do
         @options[:save] = true
         _, result = subject
-        result[:status].should == :add
-        MiqReport.count.should == 1
+        expect(result[:status]).to eq(:add)
+        expect(MiqReport.count).to eq(1)
       end
     end
 
@@ -48,15 +48,15 @@ describe MiqReport::ImportExport do
       context "overwrite" do
         it "preview" do
           _, result = subject
-          result[:status].should == :update
-          MiqReport.first.tz.should == "UTC"
+          expect(result[:status]).to eq(:update)
+          expect(MiqReport.first.tz).to eq("UTC")
         end
 
         it "import" do
           @options[:save] = true
           _, result = subject
-          result[:status].should == :update
-          MiqReport.first.tz.should == "Eastern Time (US & Canada)"
+          expect(result[:status]).to eq(:update)
+          expect(MiqReport.first.tz).to eq("Eastern Time (US & Canada)")
         end
       end
 
@@ -65,15 +65,15 @@ describe MiqReport::ImportExport do
 
         it "preview" do
           _, result = subject
-          result[:status].should == :keep
-          MiqReport.first.tz.should == "UTC"
+          expect(result[:status]).to eq(:keep)
+          expect(MiqReport.first.tz).to eq("UTC")
         end
 
         it "import" do
           @options[:save] = true
           _, result = subject
-          result[:status].should == :keep
-          MiqReport.first.tz.should == "UTC"
+          expect(result[:status]).to eq(:keep)
+          expect(MiqReport.first.tz).to eq("UTC")
         end
       end
     end
@@ -83,7 +83,7 @@ describe MiqReport::ImportExport do
         @new_report = @new_report["MiqReport"]
 
         _, result = subject
-        result[:status].should == :update
+        expect(result[:status]).to eq(:update)
       end
     end
   end

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -9,37 +9,37 @@ describe MiqReport do
     context "#get_order_info" do
       it "works when there is no sortby specified" do
         apply_sortby_in_search, order = @miq_report.get_order_info
-        apply_sortby_in_search.should be_true
-        order.should be_nil
+        expect(apply_sortby_in_search).to be_truthy
+        expect(order).to be_nil
       end
 
       it "works when there is a column specified as string in sortby" do
         @miq_report.sortby = "name"
         apply_sortby_in_search, order = @miq_report.get_order_info
-        apply_sortby_in_search.should be_true
-        order.should == "LOWER(vms.name)"
+        expect(apply_sortby_in_search).to be_truthy
+        expect(order).to eq("LOWER(vms.name)")
       end
 
       it "works when there is a column specified as array in sortby" do
         @miq_report.sortby = ["name"]
         apply_sortby_in_search, order = @miq_report.get_order_info
-        apply_sortby_in_search.should be_true
-        order.should == "LOWER(vms.name)"
+        expect(apply_sortby_in_search).to be_truthy
+        expect(order).to eq("LOWER(vms.name)")
       end
 
       context "works when there are columns from other tables specified in sortby" do
         it "works with association where table_name can be guessed at" do
           @miq_report.sortby = ["name", "operating_system.product_name"]
           apply_sortby_in_search, order = @miq_report.get_order_info
-          apply_sortby_in_search.should be_true
-          order.should == "LOWER(vms.name),LOWER(operating_systems.product_name)"
+          expect(apply_sortby_in_search).to be_truthy
+          expect(order).to eq("LOWER(vms.name),LOWER(operating_systems.product_name)")
         end
 
         it "works with association where table_name can not be guessed at" do
           @miq_report.sortby = ["name", "linux_initprocesses.name", "evm_owner.name"]
           apply_sortby_in_search, order = @miq_report.get_order_info
-          apply_sortby_in_search.should be_true
-          order.should == "LOWER(vms.name),LOWER(system_services.name),LOWER(users.name)"
+          expect(apply_sortby_in_search).to be_truthy
+          expect(order).to eq("LOWER(vms.name),LOWER(system_services.name),LOWER(users.name)")
         end
       end
     end

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -31,20 +31,20 @@ describe MiqReportResult do
       it "with missing config value" do
         @vmdb_config.delete_path(:reporting, :history, :keep_reports)
         Timecop.freeze(Time.now) do
-          described_class.purge_mode_and_value.should == [:date, 6.months.to_i.seconds.ago.utc]
+          expect(described_class.purge_mode_and_value).to eq([:date, 6.months.to_i.seconds.ago.utc])
         end
       end
 
       it "with date" do
         @vmdb_config.store_path(:reporting, :history, :keep_reports, "1.day")
         Timecop.freeze(Time.now) do
-          described_class.purge_mode_and_value.should == [:date, 1.day.to_i.seconds.ago.utc]
+          expect(described_class.purge_mode_and_value).to eq([:date, 1.day.to_i.seconds.ago.utc])
         end
       end
 
       it "with count" do
         @vmdb_config.store_path(:reporting, :history, :keep_reports, 50)
-        described_class.purge_mode_and_value.should == [:remaining, 50]
+        expect(described_class.purge_mode_and_value).to eq([:remaining, 50])
       end
     end
 
@@ -52,14 +52,14 @@ describe MiqReportResult do
       it "with missing config value" do
         @vmdb_config.delete_path(:reporting, :history, :purge_window_size)
         Timecop.freeze(Time.now) do
-          described_class.purge_window_size.should == 100
+          expect(described_class.purge_window_size).to eq(100)
         end
       end
 
       it "with value" do
         @vmdb_config.store_path(:reporting, :history, :purge_window_size, 1000)
         Timecop.freeze(Time.now) do
-          described_class.purge_window_size.should == 1000
+          expect(described_class.purge_window_size).to eq(1000)
         end
       end
     end
@@ -71,14 +71,14 @@ describe MiqReportResult do
         described_class.purge_timer
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge"
         )
 
-        q.first.args[0].should == :date
-        q.first.args[1].should be_same_time_as 6.months.to_i.seconds.ago.utc
+        expect(q.first.args[0]).to eq(:date)
+        expect(q.first.args[1]).to be_same_time_as 6.months.to_i.seconds.ago.utc
       end
     end
 
@@ -90,8 +90,8 @@ describe MiqReportResult do
 
       it "with nothing in the queue" do
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 1]
@@ -102,8 +102,8 @@ describe MiqReportResult do
         described_class.purge_queue(:remaining, 2)
 
         q = MiqQueue.all
-        q.length.should == 1
-        q.first.should have_attributes(
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
           :class_name  => described_class.name,
           :method_name => "purge",
           :args        => [:remaining, 2]
@@ -112,36 +112,36 @@ describe MiqReportResult do
     end
 
     it "#purge_ids_for_remaining" do
-      described_class.send(:purge_ids_for_remaining, 1).should == {1 => @rr1.last.id, 2 => @rr2.last.id}
+      expect(described_class.send(:purge_ids_for_remaining, 1)).to eq({1 => @rr1.last.id, 2 => @rr2.last.id})
     end
 
     it "#purge_counts_for_remaining" do
-      described_class.send(:purge_counts_for_remaining, 1).should == {1 => 1, 2 => 2}
+      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({1 => 1, 2 => 2})
     end
 
     context "#purge_count" do
       it "by remaining" do
-        described_class.purge_count(:remaining, 1).should == 3
+        expect(described_class.purge_count(:remaining, 1)).to eq(3)
       end
 
       it "by date" do
-        described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc).should == 3
+        expect(described_class.purge_count(:date, 6.months.to_i.seconds.ago.utc)).to eq(3)
       end
     end
 
     context "#purge" do
       it "by remaining" do
         described_class.purge(:remaining, 1)
-        described_class.where(:miq_report_id => 1).should == [@rr1.last]
-        described_class.where(:miq_report_id => 2).should == [@rr2.last]
-        described_class.where(:miq_report_id => nil).should == @rr_orphaned
+        expect(described_class.where(:miq_report_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:miq_report_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:miq_report_id => nil)).to eq(@rr_orphaned)
       end
 
       it "by date" do
         described_class.purge(:date, 6.months.to_i.seconds.ago.utc)
-        described_class.where(:miq_report_id => 1).should == [@rr1.last]
-        described_class.where(:miq_report_id => 2).should == [@rr2.last]
-        described_class.where(:miq_report_id => nil).should == @rr_orphaned
+        expect(described_class.where(:miq_report_id => 1)).to eq([@rr1.last])
+        expect(described_class.where(:miq_report_id => 2)).to eq([@rr2.last])
+        expect(described_class.where(:miq_report_id => nil)).to eq(@rr_orphaned)
       end
     end
   end

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -18,7 +18,7 @@ describe MiqReportResult do
       @show_title   = true
       @options = MiqReport.graph_options(600, 400)
 
-      Charting.stub(:detect_available_plugin).and_return(JqplotCharting)
+      allow(Charting).to receive(:detect_available_plugin).and_return(JqplotCharting)
     end
 
     it "should save the original report metadata and the generated table as a binary blob" do
@@ -29,12 +29,12 @@ describe MiqReportResult do
 
       report_result.reload
 
-      report_result.should_not be_nil
-      report_result.report.kind_of?(MiqReport).should be_true
-      report_result.binary_blob.should_not be_nil
-      report_result.report_results.kind_of?(MiqReport).should be_true
-      report_result.report_results.table.should_not be_nil
-      report_result.report_results.table.data.should_not be_nil
+      expect(report_result).not_to be_nil
+      expect(report_result.report.kind_of?(MiqReport)).to be_truthy
+      expect(report_result.binary_blob).not_to be_nil
+      expect(report_result.report_results.kind_of?(MiqReport)).to be_truthy
+      expect(report_result.report_results.table).not_to be_nil
+      expect(report_result.report_results.table.data).not_to be_nil
     end
 
     context "for miq_report_result is used different miq_group_id than user's current id" do

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -8,7 +8,7 @@ describe MiqReport do
     before = MiqReport.new
     before.table = fake_ruport_data_table
     after = YAML.load(YAML.dump(before))
-    after.table.should == fake_ruport_data_table
+    expect(after.table).to eq(fake_ruport_data_table)
   end
 
   it '.get_expressions_by_model' do
@@ -148,8 +148,8 @@ describe MiqReport do
       expect(results.length).to eq 1
       expect(results.data.collect(&:name)).to eq [vm1.name]
       expect(report.table.length).to eq 1
-      expect(attrs[:apply_sortby_in_search]).to be_true
-      expect(attrs[:apply_limit_in_sql]).to be_true
+      expect(attrs[:apply_sortby_in_search]).to be_truthy
+      expect(attrs[:apply_limit_in_sql]).to be_truthy
       expect(attrs[:auth_count]).to eq 1
       expect(attrs[:user_filters]["managed"]).to eq [["/managed/environment/prod"]]
       expect(attrs[:total_count]).to eq 2
@@ -180,8 +180,8 @@ describe MiqReport do
       expect(results.data.first["name"]).to eq "VA"
       expect(results.data.first["storage.name"]).to eq "SA"
       expect(report.table.length).to eq 2
-      expect(attrs[:apply_sortby_in_search]).to be_true
-      expect(attrs[:apply_limit_in_sql]).to be_true
+      expect(attrs[:apply_sortby_in_search]).to be_truthy
+      expect(attrs[:apply_limit_in_sql]).to be_truthy
       expect(attrs[:auth_count]).to eq 2
       expect(attrs[:user_filters]["managed"]).to eq [[tag]]
       expect(attrs[:total_count]).to eq 2

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -39,7 +39,7 @@ describe MiqRequest do
     context "#set_description" do
       it "should set a description when nil" do
         expect(host_request.description).to be_nil
-        host_request.should_receive(:update_attributes).with(:description => "PXE install on [] from image []")
+        expect(host_request).to receive(:update_attributes).with(:description => "PXE install on [] from image []")
 
         host_request.set_description
       end
@@ -53,14 +53,14 @@ describe MiqRequest do
 
       it "should set description when :force => true" do
         host_request.description = "test description"
-        host_request.should_receive(:update_attributes).with(:description => "PXE install on [] from image []")
+        expect(host_request).to receive(:update_attributes).with(:description => "PXE install on [] from image []")
 
         host_request.set_description(true)
       end
     end
 
     it "#call_automate_event_queue" do
-      MiqServer.stub(:my_zone).and_return("New York")
+      allow(MiqServer).to receive(:my_zone).and_return("New York")
 
       expect(MiqQueue.count).to eq(0)
 
@@ -78,13 +78,13 @@ describe MiqRequest do
 
     context "#call_automate_event_sync" do
       it "successful" do
-        MiqAeEvent.stub(:raise_evm_event).and_return("foo")
+        allow(MiqAeEvent).to receive(:raise_evm_event).and_return("foo")
 
         expect(request.call_automate_event_sync(event_name)).to eq("foo")
       end
 
       it "re-raises exceptions" do
-        MiqAeEvent.stub(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
+        allow(MiqAeEvent).to receive(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
 
         expect { request.call_automate_event_sync(event_name) }.to raise_error(MiqAeException::Error, "bogus automate error")
       end
@@ -92,24 +92,24 @@ describe MiqRequest do
 
     context "#call_automate_event" do
       it "successful" do
-        MiqAeEvent.should_receive(:raise_evm_event)
+        expect(MiqAeEvent).to receive(:raise_evm_event)
         request.call_automate_event(event_name)
       end
 
       it "re-raises exceptions" do
-        MiqAeEvent.stub(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
+        allow(MiqAeEvent).to receive(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
         expect { request.call_automate_event(event_name) }.to raise_error(MiqAeException::Error, "bogus automate error")
       end
     end
 
     it "#pending" do
-      request.should_receive(:call_automate_event_queue).with("request_pending").once
+      expect(request).to receive(:call_automate_event_queue).with("request_pending").once
 
       request.pending
     end
 
     it "#approval_denied" do
-      request.should_receive(:call_automate_event_queue).with("request_denied").once
+      expect(request).to receive(:call_automate_event_queue).with("request_denied").once
 
       request.approval_denied
 
@@ -126,16 +126,16 @@ describe MiqRequest do
 
       context "#approval_approved" do
         it "not approved" do
-          provision_request.stub(:approved?).and_return(false)
+          allow(provision_request).to receive(:approved?).and_return(false)
 
-          expect(provision_request.approval_approved).to be_false
+          expect(provision_request.approval_approved).to be_falsey
         end
 
         it "approved" do
-          provision_request.stub(:approved?).and_return(true)
+          allow(provision_request).to receive(:approved?).and_return(true)
 
-          provision_request.should_receive(:call_automate_event_queue).with("request_approved").once
-          provision_request.resource.should_receive(:execute).once
+          expect(provision_request).to receive(:call_automate_event_queue).with("request_approved").once
+          expect(provision_request.resource).to receive(:execute).once
 
           provision_request.approval_approved
 
@@ -236,15 +236,15 @@ describe MiqRequest do
         end
 
         it "#approve" do
-          request.stub(:approved?).and_return(true, false)
+          allow(request).to receive(:approved?).and_return(true, false)
 
-          fred_approval.should_receive(:approve).once
+          expect(fred_approval).to receive(:approve).once
 
           2.times { request.approve(fred, reason) }
         end
 
         it "#deny" do
-          fred_approval.should_receive(:deny).once
+          expect(fred_approval).to receive(:deny).once
 
           request.deny(fred, reason)
         end
@@ -283,13 +283,13 @@ describe MiqRequest do
       end
 
       it 'with 0 tasks' do
-        request.stub(:requested_task_idx).and_return([])
+        allow(request).to receive(:requested_task_idx).and_return([])
         request.post_create_request_tasks
         expect(request.description).to eq(description)
       end
 
       it 'with >1 tasks' do
-        request.stub(:requested_task_idx).and_return([1, 2])
+        allow(request).to receive(:requested_task_idx).and_return([1, 2])
         request.post_create_request_tasks
         expect(request.description).to eq(description)
       end

--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -7,15 +7,15 @@ describe MiqRequestTask do
         task = FactoryGirl.create(:miq_request_task)
         task.stub(:miq_request => double("MiqRequest").as_null_object)
         exception = String.xxx rescue $!
-        task.stub(:some_state).and_raise(exception)
+        allow(task).to receive(:some_state).and_raise(exception)
 
-        $log.should_receive(:error).with(/#{exception.class.name}/)
-        $log.should_receive(:error).with(exception.backtrace.join("\n"))
-        task.should_receive(:finish)
+        expect($log).to receive(:error).with(/#{exception.class.name}/)
+        expect($log).to receive(:error).with(exception.backtrace.join("\n"))
+        expect(task).to receive(:finish)
 
         task.signal(:some_state)
 
-        task.status.should == "Error"
+        expect(task.status).to eq("Error")
       end
     end
   end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -61,15 +61,15 @@ describe MiqScheduleWorker::Runner do
 
       it "check_for_dispatch calls check_for_timeout with triple threshold for active worker" do
         @worker1.update_attribute(:status, MiqWorker::STATUS_STARTED)
-        MiqQueue.any_instance.should_receive(:check_for_timeout).once do |_instance, _prefix, _grace, timeout|
-          timeout.should == @stale_timeout * 3
+        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |instance, _instance, _prefix, _grace, timeout|
+          expect(timeout).to eq(@stale_timeout * 3)
         end
         MiqScheduleWorker::Jobs.new.check_for_stuck_dispatch(@stale_timeout)
       end
 
       it "check_for_dispatch calls check_for_timeout with threshold for inactive worker" do
-        MiqQueue.any_instance.should_receive(:check_for_timeout).once do |_instance, _prefix, _grace, timeout|
-          timeout.should == @stale_timeout
+        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |instance, _instance, _prefix, _grace, timeout|
+          expect(timeout).to eq(@stale_timeout)
         end
         MiqScheduleWorker::Jobs.new.check_for_stuck_dispatch(@stale_timeout)
       end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -61,14 +61,14 @@ describe MiqScheduleWorker::Runner do
 
       it "check_for_dispatch calls check_for_timeout with triple threshold for active worker" do
         @worker1.update_attribute(:status, MiqWorker::STATUS_STARTED)
-        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |instance, _instance, _prefix, _grace, timeout|
+        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |_instance, _prefix, _grace, timeout|
           expect(timeout).to eq(@stale_timeout * 3)
         end
         MiqScheduleWorker::Jobs.new.check_for_stuck_dispatch(@stale_timeout)
       end
 
       it "check_for_dispatch calls check_for_timeout with threshold for inactive worker" do
-        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |instance, _instance, _prefix, _grace, timeout|
+        expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).once do |_instance, _prefix, _grace, timeout|
           expect(timeout).to eq(@stale_timeout)
         end
         MiqScheduleWorker::Jobs.new.check_for_stuck_dispatch(@stale_timeout)

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
 def stub_vmdb_util_methods_for_collection_log
-  VMDB::Util.stub(:zip_logs)
-  VMDB::Util.stub(:compressed_log_patterns).and_return(["log/evm.1122.gz"])
-  VMDB::Util.stub(:get_evm_log_for_date).and_return("20151209_141429_20151217_140845")
-  VMDB::Util.stub(:get_log_start_end_times).and_return([Time.zone.now, Time.zone.now])
+  allow(VMDB::Util).to receive(:zip_logs)
+  allow(VMDB::Util).to receive(:compressed_log_patterns).and_return(["log/evm.1122.gz"])
+  allow(VMDB::Util).to receive(:get_evm_log_for_date).and_return("20151209_141429_20151217_140845")
+  allow(VMDB::Util).to receive(:get_log_start_end_times).and_return([Time.zone.now, Time.zone.now])
 end
 
 shared_examples "post_[type_of_log]_logs" do |type, type_of_log|

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -7,10 +7,10 @@ describe MiqTask do
     end
 
     it "should initialize properly" do
-      @miq_task.state.should == MiqTask::STATE_INITIALIZED
-      @miq_task.status.should == MiqTask::STATUS_OK
-      @miq_task.message.should == MiqTask::DEFAULT_MESSAGE
-      @miq_task.userid.should == MiqTask::DEFAULT_USERID
+      expect(@miq_task.state).to eq(MiqTask::STATE_INITIALIZED)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_OK)
+      expect(@miq_task.message).to eq(MiqTask::DEFAULT_MESSAGE)
+      expect(@miq_task.userid).to eq(MiqTask::DEFAULT_USERID)
     end
 
     it "should respond to update_status class method properly" do
@@ -19,9 +19,9 @@ describe MiqTask do
       message = 'This is only a class test'
       MiqTask.update_status(@miq_task.id, state, status, message)
       @miq_task.reload
-      @miq_task.state.should == state
-      @miq_task.status.should == status
-      @miq_task.message.should == message
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(status)
+      expect(@miq_task.message).to eq(message)
     end
 
     it "should respond to update_status instance method properly" do
@@ -29,37 +29,37 @@ describe MiqTask do
       status  = MiqTask::STATUS_OK
       message = 'This is only a test'
       @miq_task.update_status(state, status, message)
-      @miq_task.state.should == state
-      @miq_task.status.should == status
-      @miq_task.message.should == message
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(status)
+      expect(@miq_task.message).to eq(message)
 
-      -> { @miq_task.update_status("FOO", status, message) }.should raise_error(ActiveRecord::RecordInvalid)
-      -> { @miq_task.update_status(state, "FOO",  message) }.should raise_error(ActiveRecord::RecordInvalid)
+      expect { @miq_task.update_status("FOO", status, message) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { @miq_task.update_status(state, "FOO",  message) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should trim long message to 255" do
       message = ("So there I was sitting in a rabbit's suit" * 100).freeze
       @miq_task.message = message
-      @miq_task.message.length.should == 255
-      @miq_task.message[252, 3].should == "..."
+      expect(@miq_task.message.length).to eq(255)
+      expect(@miq_task.message[252, 3]).to eq("...")
 
       @miq_task.update_attributes(:message => message)
-      @miq_task.message.length.should == 255
-      @miq_task.message[252, 3].should == "..."
+      expect(@miq_task.message.length).to eq(255)
+      expect(@miq_task.message[252, 3]).to eq("...")
     end
 
     it "should update context upon request" do
       context = {:a => 1, :b => 2}
       @miq_task.update_context(context)
-      @miq_task.context_data.should == context
+      expect(@miq_task.context_data).to eq(context)
     end
 
     it "should respond to info instance method properly" do
       message      = "Hello World"
       pct_complete = 19
       @miq_task.info(message, pct_complete)
-      @miq_task.message.should == message
-      @miq_task.pct_complete.should == pct_complete
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.pct_complete).to eq(pct_complete)
     end
 
     it "should respond to info class method properly" do
@@ -67,89 +67,89 @@ describe MiqTask do
       pct_complete = 29
       MiqTask.info(@miq_task.id, message, pct_complete)
       @miq_task.reload
-      @miq_task.message.should == message
-      @miq_task.pct_complete.should == pct_complete
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.pct_complete).to eq(pct_complete)
     end
 
     it "should respond to warn instance method properly" do
       message      = "There may be a fire on your floor"
       @miq_task.warn(message)
-      @miq_task.message.should == message
-      @miq_task.status.should == MiqTask::STATUS_WARNING
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_WARNING)
     end
 
     it "should respond to warn class method properly" do
       message      = "There may be a fire on your floor (class)"
       MiqTask.warn(@miq_task.id, message)
       @miq_task.reload
-      @miq_task.message.should == message
-      @miq_task.status.should == MiqTask::STATUS_WARNING
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_WARNING)
     end
 
     it "should respond to error instance method properly" do
       message      = "Red Alert"
       @miq_task.error(message)
-      @miq_task.message.should == message
-      @miq_task.status.should == MiqTask::STATUS_ERROR
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_ERROR)
     end
 
     it "should respond to error class method properly" do
       message      = "Red Alert (class)"
       MiqTask.error(@miq_task.id, message)
       @miq_task.reload
-      @miq_task.message.should == message
-      @miq_task.status.should == MiqTask::STATUS_ERROR
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_ERROR)
     end
 
     it "should respond to state_initialized instance method properly" do
       @miq_task.state_initialized
-      @miq_task.state.should == MiqTask::STATE_INITIALIZED
+      expect(@miq_task.state).to eq(MiqTask::STATE_INITIALIZED)
     end
 
     it "should respond to state_initialized class method properly" do
       MiqTask.state_initialized(@miq_task.id)
       @miq_task.reload
-      @miq_task.state.should == MiqTask::STATE_INITIALIZED
+      expect(@miq_task.state).to eq(MiqTask::STATE_INITIALIZED)
     end
 
     it "should respond to state_queued instance method properly" do
       @miq_task.state_queued
-      @miq_task.state.should == MiqTask::STATE_QUEUED
+      expect(@miq_task.state).to eq(MiqTask::STATE_QUEUED)
     end
 
     it "should respond to state_queued class method properly" do
       MiqTask.state_queued(@miq_task.id)
       @miq_task.reload
-      @miq_task.state.should == MiqTask::STATE_QUEUED
+      expect(@miq_task.state).to eq(MiqTask::STATE_QUEUED)
     end
 
     it "should respond to state_active instance method properly" do
       @miq_task.state_active
-      @miq_task.state.should == MiqTask::STATE_ACTIVE
+      expect(@miq_task.state).to eq(MiqTask::STATE_ACTIVE)
     end
 
     it "should respond to state_active class method properly" do
       MiqTask.state_active(@miq_task.id)
       @miq_task.reload
-      @miq_task.state.should == MiqTask::STATE_ACTIVE
+      expect(@miq_task.state).to eq(MiqTask::STATE_ACTIVE)
     end
 
     it "should respond to state_finished instance method properly" do
       @miq_task.state_finished
-      @miq_task.state.should == MiqTask::STATE_FINISHED
+      expect(@miq_task.state).to eq(MiqTask::STATE_FINISHED)
     end
 
     it "should respond to state_finished class method properly" do
       MiqTask.state_finished(@miq_task.id)
       @miq_task.reload
-      @miq_task.state.should == MiqTask::STATE_FINISHED
+      expect(@miq_task.state).to eq(MiqTask::STATE_FINISHED)
     end
 
     it "should get/set task_results properly" do
       results = {:a => 1, :b => 2}
       @miq_task.task_results = results
       @miq_task.save
-      @miq_task.task_results.should == results
+      expect(@miq_task.task_results).to eq(results)
     end
 
     it "should queue callback properly" do
@@ -157,24 +157,24 @@ describe MiqTask do
       message = 'Message for testing: queue_callback'
       result  = {:a => 1, :b => 2}
       @miq_task.queue_callback(state, 'ok', message, result)
-      @miq_task.state.should == state
-      @miq_task.status.should == MiqTask::STATUS_OK
-      @miq_task.message.should == MiqTask::MESSAGE_TASK_COMPLETED_SUCCESSFULLY
-      @miq_task.task_results.should == result
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_OK)
+      expect(@miq_task.message).to eq(MiqTask::MESSAGE_TASK_COMPLETED_SUCCESSFULLY)
+      expect(@miq_task.task_results).to eq(result)
 
       status  = MiqTask::STATUS_ERROR
       @miq_task.queue_callback(state, status, "", result)
-      @miq_task.state.should == state
-      @miq_task.status.should == status
-      @miq_task.message.should == MiqTask::MESSAGE_TASK_COMPLETED_UNSUCCESSFULLY
-      @miq_task.task_results.should == result
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(status)
+      expect(@miq_task.message).to eq(MiqTask::MESSAGE_TASK_COMPLETED_UNSUCCESSFULLY)
+      expect(@miq_task.task_results).to eq(result)
 
       result  = {:c => 1, :d => 2}
       @miq_task.queue_callback(state, status, message, result)
-      @miq_task.state.should == state
-      @miq_task.status.should == status
-      @miq_task.message.should == message
-      @miq_task.task_results.should == result
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(status)
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.task_results).to eq(result)
     end
 
     it "should queue callback on exceptions properly" do
@@ -182,21 +182,21 @@ describe MiqTask do
       message = 'Message for testing: queue_callback_on_exceptions'
       result  = {:a => 1, :b => 2}
       @miq_task.queue_callback_on_exceptions(state, 'ok', message, result)
-      @miq_task.state.should == MiqTask::STATE_INITIALIZED
-      @miq_task.status.should == MiqTask::STATUS_OK
-      @miq_task.message.should == MiqTask::DEFAULT_MESSAGE
-      @miq_task.task_results.should be_nil
+      expect(@miq_task.state).to eq(MiqTask::STATE_INITIALIZED)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_OK)
+      expect(@miq_task.message).to eq(MiqTask::DEFAULT_MESSAGE)
+      expect(@miq_task.task_results).to be_nil
 
       @miq_task.queue_callback_on_exceptions(state, "MAYDAY", message, result)
-      @miq_task.state.should == state
-      @miq_task.status.should == MiqTask::STATUS_ERROR
-      @miq_task.message.should == message
-      @miq_task.task_results.should == result
+      expect(@miq_task.state).to eq(state)
+      expect(@miq_task.status).to eq(MiqTask::STATUS_ERROR)
+      expect(@miq_task.message).to eq(message)
+      expect(@miq_task.task_results).to eq(result)
     end
 
     it "should properly process MiqTask#generic_action_with_callback" do
       zone = 'New York'
-      MiqServer.stub(:my_zone).and_return(zone)
+      allow(MiqServer).to receive(:my_zone).and_return(zone)
       opts = {
         :action => 'Feed',
         :userid => 'Flintstone'
@@ -208,18 +208,18 @@ describe MiqTask do
       }
       tid = MiqTask.generic_action_with_callback(opts, qopts)
       task = MiqTask.find_by_id(tid)
-      task.state.should == MiqTask::STATE_QUEUED
-      task.status.should == MiqTask::STATUS_OK
-      task.userid.should == "Flintstone"
-      task.name.should == "Feed"
-      task.message.should == "Queued the action: [#{task.name}] being run for user: [#{task.userid}]"
+      expect(task.state).to eq(MiqTask::STATE_QUEUED)
+      expect(task.status).to eq(MiqTask::STATUS_OK)
+      expect(task.userid).to eq("Flintstone")
+      expect(task.name).to eq("Feed")
+      expect(task.message).to eq("Queued the action: [#{task.name}] being run for user: [#{task.userid}]")
 
-      MiqQueue.count.should == 1
+      expect(MiqQueue.count).to eq(1)
       message = MiqQueue.first
-      message.class_name.should == "MyClass"
-      message.method_name.should == "my_method"
-      message.args.should == [1, 2, 3]
-      message.zone.should == zone
+      expect(message.class_name).to eq("MyClass")
+      expect(message.method_name).to eq("my_method")
+      expect(message.args).to eq([1, 2, 3])
+      expect(message.zone).to eq(zone)
     end
   end
 
@@ -229,20 +229,20 @@ describe MiqTask do
       @miq_task2 = FactoryGirl.create(:miq_task_plain)
       @miq_task3 = FactoryGirl.create(:miq_task_plain)
       @zone = 'New York'
-      MiqServer.stub(:my_zone).and_return(@zone)
+      allow(MiqServer).to receive(:my_zone).and_return(@zone)
     end
 
     it "should queue up deletes when calling MiqTask.delete_by_id" do
       MiqTask.delete_by_id([@miq_task1.id, @miq_task3.id])
-      MiqQueue.count.should == 1
+      expect(MiqQueue.count).to eq(1)
       message = MiqQueue.first
 
-      message.class_name.should == "MiqTask"
+      expect(message.class_name).to eq("MiqTask")
       expect(message.method_name).to eq("destroy")
-      message.args.should        be_kind_of(Array)
-      message.args.length.should == 1
+      expect(message.args).to        be_kind_of(Array)
+      expect(message.args.length).to eq(1)
       expect(message.args.first).to match_array([@miq_task1.id, @miq_task3.id])
-      message.zone.should == @zone
+      expect(message.zone).to eq(@zone)
     end
 
     it "should queue up proper deletes when calling MiqTask.delete_older" do
@@ -250,29 +250,29 @@ describe MiqTask do
       Timecop.travel(12.minutes.ago) { @miq_task3.state_queued }
       MiqTask.delete_older(5.minutes.ago.utc, nil)
 
-      MiqQueue.count.should == 1
+      expect(MiqQueue.count).to eq(1)
       message = MiqQueue.first
 
-      message.class_name.should == "MiqTask"
+      expect(message.class_name).to eq("MiqTask")
       expect(message.method_name).to eq("destroy")
-      message.args.should        be_kind_of(Array)
-      message.args.length.should == 1
+      expect(message.args).to        be_kind_of(Array)
+      expect(message.args.length).to eq(1)
       expect(message.args.first).to match_array([@miq_task2.id, @miq_task3.id])
-      message.zone.should == @zone
+      expect(message.zone).to eq(@zone)
 
       message.destroy
 
       MiqTask.delete_older(11.minutes.ago.utc, nil)
 
-      MiqQueue.count.should == 1
+      expect(MiqQueue.count).to eq(1)
       message = MiqQueue.first
 
-      message.class_name.should == "MiqTask"
-      message.method_name.should == "destroy"
-      message.args.should        be_kind_of(Array)
-      message.args.length.should == 1
+      expect(message.class_name).to eq("MiqTask")
+      expect(message.method_name).to eq("destroy")
+      expect(message.args).to        be_kind_of(Array)
+      expect(message.args.length).to eq(1)
       expect(message.args.first).to eq([@miq_task3.id])
-      message.zone.should == @zone
+      expect(message.zone).to eq(@zone)
     end
   end
 end

--- a/spec/models/miq_template_spec.rb
+++ b/spec/models/miq_template_spec.rb
@@ -2,15 +2,15 @@ require "spec_helper"
 
 describe MiqTemplate do
   it ".corresponding_model" do
-    described_class.corresponding_model.should == Vm
-    ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_model.should == ManageIQ::Providers::Vmware::InfraManager::Vm
-    ManageIQ::Providers::Redhat::InfraManager::Template.corresponding_model.should == ManageIQ::Providers::Redhat::InfraManager::Vm
+    expect(described_class.corresponding_model).to eq(Vm)
+    expect(ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm)
+    expect(ManageIQ::Providers::Redhat::InfraManager::Template.corresponding_model).to eq(ManageIQ::Providers::Redhat::InfraManager::Vm)
   end
 
   it ".corresponding_vm_model" do
-    described_class.corresponding_vm_model.should == Vm
-    ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_vm_model.should == ManageIQ::Providers::Vmware::InfraManager::Vm
-    ManageIQ::Providers::Redhat::InfraManager::Template.corresponding_vm_model.should == ManageIQ::Providers::Redhat::InfraManager::Vm
+    expect(described_class.corresponding_vm_model).to eq(Vm)
+    expect(ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_vm_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm)
+    expect(ManageIQ::Providers::Redhat::InfraManager::Template.corresponding_vm_model).to eq(ManageIQ::Providers::Redhat::InfraManager::Vm)
   end
 
   context "#template=" do
@@ -18,32 +18,32 @@ describe MiqTemplate do
 
     it "true" do
       @template.update_attribute(:template, true)
-      @template.type.should == "ManageIQ::Providers::Vmware::InfraManager::Template"
-      @template.template.should == true
-      @template.state.should == "never"
-      -> { @template.reload }.should_not raise_error
-      -> { ManageIQ::Providers::Vmware::InfraManager::Vm.find(@template.id) }.should raise_error ActiveRecord::RecordNotFound
+      expect(@template.type).to eq("ManageIQ::Providers::Vmware::InfraManager::Template")
+      expect(@template.template).to eq(true)
+      expect(@template.state).to eq("never")
+      expect { @template.reload }.not_to raise_error
+      expect { ManageIQ::Providers::Vmware::InfraManager::Vm.find(@template.id) }.to raise_error ActiveRecord::RecordNotFound
     end
 
     it "false" do
       @template.update_attribute(:template, false)
-      @template.type.should == "ManageIQ::Providers::Vmware::InfraManager::Vm"
-      @template.template.should == false
-      @template.state.should == "unknown"
-      -> { @template.reload }.should raise_error ActiveRecord::RecordNotFound
-      -> { ManageIQ::Providers::Vmware::InfraManager::Vm.find(@template.id) }.should_not raise_error
+      expect(@template.type).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
+      expect(@template.template).to eq(false)
+      expect(@template.state).to eq("unknown")
+      expect { @template.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { ManageIQ::Providers::Vmware::InfraManager::Vm.find(@template.id) }.not_to raise_error
     end
   end
 
   it ".supports_kickstart_provisioning?" do
-    ManageIQ::Providers::Amazon::CloudManager::Template.supports_kickstart_provisioning?.should be_false
-    ManageIQ::Providers::Redhat::InfraManager::Template.supports_kickstart_provisioning?.should be_true
-    ManageIQ::Providers::Vmware::InfraManager::Template.supports_kickstart_provisioning?.should be_false
+    expect(ManageIQ::Providers::Amazon::CloudManager::Template.supports_kickstart_provisioning?).to be_falsey
+    expect(ManageIQ::Providers::Redhat::InfraManager::Template.supports_kickstart_provisioning?).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::Template.supports_kickstart_provisioning?).to be_falsey
   end
 
   it "#supports_kickstart_provisioning?" do
-    ManageIQ::Providers::Amazon::CloudManager::Template.new.supports_kickstart_provisioning?.should be_false
-    ManageIQ::Providers::Redhat::InfraManager::Template.new.supports_kickstart_provisioning?.should be_true
-    ManageIQ::Providers::Vmware::InfraManager::Template.new.supports_kickstart_provisioning?.should be_false
+    expect(ManageIQ::Providers::Amazon::CloudManager::Template.new.supports_kickstart_provisioning?).to be_falsey
+    expect(ManageIQ::Providers::Redhat::InfraManager::Template.new.supports_kickstart_provisioning?).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::Template.new.supports_kickstart_provisioning?).to be_falsey
   end
 end

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -7,13 +7,13 @@ describe MiqUserRole do
   context ".seed" do
     it "empty table" do
       MiqUserRole.seed
-      MiqUserRole.count.should == @expected_user_role_count
+      expect(MiqUserRole.count).to eq(@expected_user_role_count)
     end
 
     it "run twice" do
       MiqUserRole.seed
       MiqUserRole.seed
-      MiqUserRole.count.should == @expected_user_role_count
+      expect(MiqUserRole.count).to eq(@expected_user_role_count)
     end
 
     it "with existing records" do
@@ -23,9 +23,9 @@ describe MiqUserRole do
 
       MiqUserRole.seed
 
-      MiqUserRole.count.should == @expected_user_role_count + 1
-      changed.reload.read_only.should    be_true
-      unchanged.reload.updated_at.should be_same_time_as unchanged_orig_updated_at
+      expect(MiqUserRole.count).to eq(@expected_user_role_count + 1)
+      expect(changed.reload.read_only).to    be_truthy
+      expect(unchanged.reload.updated_at).to be_same_time_as unchanged_orig_updated_at
     end
   end
 
@@ -59,55 +59,55 @@ describe MiqUserRole do
     end
 
     it "should return the correct answer calling allows? when requested feature is directly assigned or a descendant of a feature in a role" do
-      MiqUserRole.allows?(@role1.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows?(@role1.name, :identifier => "dashboard_add").should == true
-      MiqUserRole.allows?(@role1.name, :identifier => "dashboard_view").should == false
-      MiqUserRole.allows?(@role1.name, :identifier => "policy").should == false
+      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_admin")).to eq(true)
+      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_add")).to eq(true)
+      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_view")).to eq(false)
+      expect(MiqUserRole.allows?(@role1.name, :identifier => "policy")).to eq(false)
 
-      MiqUserRole.allows?(@role2.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows?(@role2.name, :identifier => "dashboard_add").should == true
-      MiqUserRole.allows?(@role2.name, :identifier => "dashboard_view").should == true
-      MiqUserRole.allows?(@role2.name, :identifier => "policy").should == true
+      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_admin")).to eq(true)
+      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_add")).to eq(true)
+      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_view")).to eq(true)
+      expect(MiqUserRole.allows?(@role2.name, :identifier => "policy")).to eq(true)
 
       # Test calling with an id of a role
       ident = MiqProductFeature.find_by_identifier("dashboard_admin")
-      MiqUserRole.allows?(@role1.id, :identifier => ident).should == true
+      expect(MiqUserRole.allows?(@role1.id, :identifier => ident)).to eq(true)
     end
 
     it "should return the correct answer calling allows_any? with scope => :base)" do
-      MiqUserRole.allows_any?(@role1.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
+      expect(MiqUserRole.allows_any?(@role1.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      MiqUserRole.allows_any?(@role2.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
+      expect(MiqUserRole.allows_any?(@role2.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["host_view"]).should == false
-      MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["everything"]).should == false
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["host_view"])).to eq(false)
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["vm"])).to eq(false)
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["everything"])).to eq(false)
     end
 
     it "should return the correct answer calling allows_any? with scope => :one)" do
-      MiqUserRole.allows_any?(@role1.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
+      expect(MiqUserRole.allows_any?(@role1.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      MiqUserRole.allows_any?(@role2.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
+      expect(MiqUserRole.allows_any?(@role2.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["host_view"]).should == true
-      MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["everything"]).should == false
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["host_view"])).to eq(true)
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["vm"])).to eq(false)
+      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["everything"])).to eq(false)
     end
 
     it "should return the correct answer calling allows_any? with default scope => :sub" do
-      MiqUserRole.allows_any?(@role1.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_any?(@role2.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"]).should == true
-      MiqUserRole.allows_any?(@role3.name, :identifiers => ["host_view"]).should == true
-      MiqUserRole.allows_any?(@role3.name, :identifiers => ["vm"]).should == false
-      MiqUserRole.allows_any?(@role3.name, :identifiers => ["everything"]).should == true
+      expect(MiqUserRole.allows_any?(@role1.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(MiqUserRole.allows_any?(@role2.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["host_view"])).to eq(true)
+      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["vm"])).to eq(false)
+      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["everything"])).to eq(true)
     end
 
     it "should return the correct answer calling allows_any_children?" do
-      MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows_any_children?(@role2.name, :identifier => "dashboard_admin").should == true
-      MiqUserRole.allows_any_children?(@role2.name, :identifier => "everything").should == true
-      MiqUserRole.allows_any_children?(@role1.name, :identifier => "everything").should == true
-      MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard").should == true
+      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard_admin")).to eq(true)
+      expect(MiqUserRole.allows_any_children?(@role2.name, :identifier => "dashboard_admin")).to eq(true)
+      expect(MiqUserRole.allows_any_children?(@role2.name, :identifier => "everything")).to eq(true)
+      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "everything")).to eq(true)
+      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard")).to eq(true)
     end
   end
 

--- a/spec/models/miq_user_scope_spec.rb
+++ b/spec/models/miq_user_scope_spec.rb
@@ -8,9 +8,9 @@ describe MiqUserScope do
     it "should return the correct converted scope instance" do
       filters = {"managed" => [["/managed/function/desktop"]], "belongsto" => []}
       scope = MiqUserScope.hash_to_scope(filters)
-      scope.view.should == {:managed => {:_all_ => [["/managed/function/desktop"]]}}
-      scope.admin.should.nil?
-      scope.control.should.nil?
+      expect(scope.view).to eq({:managed => {:_all_ => [["/managed/function/desktop"]]}})
+      expect(scope.admin).to.nil?
+      expect(scope.control).to.nil?
     end
   end
 
@@ -57,7 +57,7 @@ describe MiqUserScope do
     end
 
     it "should return the correct filters for search" do
-      @scope1.get_filters(:class => Vm, :feature_type => :view).should == {
+      expect(@scope1.get_filters(:class => Vm, :feature_type => :view)).to eq({
         :belongsto  =>
                        ["/belongsto/ExtManagementSystem|VC1/EmsFolder|Datacenters/EmsFolder|DataCenter1/EmsFolder|host/EmsCluster|Cluster1",
                         "/belongsto/ExtManagementSystem|VC1/EmsFolder|Datacenters/EmsFolder|DataCenter2/EmsFolder|host/EmsCluster|Cluster3"],
@@ -66,25 +66,25 @@ describe MiqUserScope do
                         ["/managed/location/london", "/managed/location/ny"],
                         ["/managed/service_level/gold", "/managed/service_level/platinum"]],
         :expression => nil
-      }
-      @scope1.get_filters(:class => Vm, :feature_type => :admin).should == {:expression => nil, :belongsto => nil, :managed => nil}
-      @scope1.get_filters(:class => Vm, :feature_type => :control).should == {:expression => nil, :belongsto => nil, :managed => nil}
+      })
+      expect(@scope1.get_filters(:class => Vm, :feature_type => :admin)).to eq({:expression => nil, :belongsto => nil, :managed => nil})
+      expect(@scope1.get_filters(:class => Vm, :feature_type => :control)).to eq({:expression => nil, :belongsto => nil, :managed => nil})
 
-      @scope2.get_filters(:class => Vm, :feature_type => :view).should == {
+      expect(@scope2.get_filters(:class => Vm, :feature_type => :view)).to eq({
         :belongsto  =>
                        ["/belongsto/ExtManagementSystem|VC4 IP 14/EmsFolder|Datacenters/EmsFolder|Prod/EmsFolder|vm/EmsFolder|Discovered virtual machine"],
         :managed    =>
                        [["/managed/location/chicago", "/managed/location/ny"], ["/managed/environment/dev"]],
         :expression => nil
-      }
+      })
 
       filters = @scope2.get_filters(:class => Storage, :feature_type => :view)
-      filters[:belongsto].should.nil?
-      filters[:managed].should == [["/managed/location/chicago", "/managed/location/ny"]]
-      filters[:expression].should == @scope2_exp
+      expect(filters[:belongsto]).to.nil?
+      expect(filters[:managed]).to eq([["/managed/location/chicago", "/managed/location/ny"]])
+      expect(filters[:expression]).to eq(@scope2_exp)
 
-      @scope2.get_filters(:class => Vm, :feature_type => :control).should == {:expression => nil, :belongsto => nil, :managed => [["/managed/location/chicago"]]}
-      @scope2.get_filters(:class => Vm, :feature_type => :admin).should == {:expression => nil, :belongsto => nil, :managed => [["/managed/location/ny"]]}
+      expect(@scope2.get_filters(:class => Vm, :feature_type => :control)).to eq({:expression => nil, :belongsto => nil, :managed => [["/managed/location/chicago"]]})
+      expect(@scope2.get_filters(:class => Vm, :feature_type => :admin)).to eq({:expression => nil, :belongsto => nil, :managed => [["/managed/location/ny"]]})
     end
   end
 
@@ -113,21 +113,21 @@ describe MiqUserScope do
 
     it "should correctly merge managed filters" do
       filters = @scope.get_filters(:class => Vm, :feature_type => :view)
-      filters[:managed].should == [["/managed/location/chicago", "/managed/location/ny"]]
+      expect(filters[:managed]).to eq([["/managed/location/chicago", "/managed/location/ny"]])
 
       filters = @scope.get_filters(:class => Host, :feature_type => :view)
-      filters[:managed].should == [["/managed/location/chicago", "/managed/location/ny", "/managed/location/london"], ["/managed/environment/prod"]]
+      expect(filters[:managed]).to eq([["/managed/location/chicago", "/managed/location/ny", "/managed/location/london"], ["/managed/environment/prod"]])
     end
 
     it "should correctly merge belongsto filters" do
       filters = @scope.get_filters(:class => Vm, :feature_type => :view)
-      filters[:belongsto].should == ["/belongsto/ExtManagementSystem|VC1", "/belongsto/ExtManagementSystem|VC4", "/belongsto/ExtManagementSystem|VC4/EmsFolder|Datacenters/EmsFolder|Prod/EmsFolder|vm/EmsFolder|Discovered virtual machine"]
+      expect(filters[:belongsto]).to eq(["/belongsto/ExtManagementSystem|VC1", "/belongsto/ExtManagementSystem|VC4", "/belongsto/ExtManagementSystem|VC4/EmsFolder|Datacenters/EmsFolder|Prod/EmsFolder|vm/EmsFolder|Discovered virtual machine"])
       # filters[:belongsto].should == ["/belongsto/ExtManagementSystem|VC1", "/belongsto/ExtManagementSystem|VC4"]
     end
 
     it "should correctly merge expression filters" do
       filters = @scope.get_filters(:class => Vm, :feature_type => :view)
-      filters[:expression].exp.should == {"or" => [@exp1, @exp2]}
+      expect(filters[:expression].exp).to eq({"or" => [@exp1, @exp2]})
     end
   end
 end

--- a/spec/models/miq_user_scope_spec.rb
+++ b/spec/models/miq_user_scope_spec.rb
@@ -9,8 +9,8 @@ describe MiqUserScope do
       filters = {"managed" => [["/managed/function/desktop"]], "belongsto" => []}
       scope = MiqUserScope.hash_to_scope(filters)
       expect(scope.view).to eq({:managed => {:_all_ => [["/managed/function/desktop"]]}})
-      expect(scope.admin).to.nil?
-      expect(scope.control).to.nil?
+      expect(scope.admin).to be_nil
+      expect(scope.control).to be_nil
     end
   end
 
@@ -79,7 +79,7 @@ describe MiqUserScope do
       })
 
       filters = @scope2.get_filters(:class => Storage, :feature_type => :view)
-      expect(filters[:belongsto]).to.nil?
+      expect(filters[:belongsto]).to be_nil
       expect(filters[:managed]).to eq([["/managed/location/chicago", "/managed/location/ny"]])
       expect(filters[:expression]).to eq(@scope2_exp)
 

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -13,64 +13,64 @@ describe MiqVimBrokerWorker::Runner do
     @worker_guid = MiqUUID.new_guid
     @worker_record = FactoryGirl.create(:miq_vim_broker_worker, :guid => @worker_guid, :miq_server_id => server.id)
     @drb_uri = "drb://127.0.0.1:12345"
-    DRb.stub(:uri).and_return(@drb_uri)
-    described_class.any_instance.stub(:sync_active_roles)
-    described_class.any_instance.stub(:sync_config)
-    described_class.any_instance.stub(:set_connection_pool_size)
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_check).and_return([true, ""])
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_status_ok?).and_return(true)
+    allow(DRb).to receive(:uri).and_return(@drb_uri)
+    allow_any_instance_of(described_class).to receive(:sync_active_roles)
+    allow_any_instance_of(described_class).to receive(:sync_config)
+    allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_status_ok?).and_return(true)
   end
 
   it "#after_initialize" do
-    described_class.any_instance.should_receive(:start_broker_server).once
-    described_class.any_instance.should_receive(:reset_broker_update_notification).once
-    described_class.any_instance.should_receive(:reset_broker_update_sleep_interval).once
+    expect_any_instance_of(described_class).to receive(:start_broker_server).once
+    expect_any_instance_of(described_class).to receive(:reset_broker_update_notification).once
+    expect_any_instance_of(described_class).to receive(:reset_broker_update_sleep_interval).once
     vim_broker_worker = described_class.new({:guid => @worker_guid})
 
-    vim_broker_worker.instance_variable_get(:@initial_emses_to_monitor).should match_array @zone.ext_management_systems
+    expect(vim_broker_worker.instance_variable_get(:@initial_emses_to_monitor)).to match_array @zone.ext_management_systems
 
     @worker_record.reload
-    @worker_record.uri.should == @drb_uri
-    @worker_record.status.should == 'starting'
+    expect(@worker_record.uri).to eq(@drb_uri)
+    expect(@worker_record.status).to eq('starting')
   end
 
   context "with a worker created" do
     before(:each) do
-      described_class.any_instance.should_receive(:after_initialize).once
+      expect_any_instance_of(described_class).to receive(:after_initialize).once
       @vim_broker_worker = described_class.new({:guid => @worker_guid})
     end
 
     context "#start_broker_server" do
       it "starts MiqVimBroker" do
-        @vim_broker_worker.should_receive(:create_miq_vim_broker_server).once
+        expect(@vim_broker_worker).to receive(:create_miq_vim_broker_server).once
         @vim_broker_worker.start_broker_server
       end
 
       it "does not prime when no EMSes specified" do
-        @vim_broker_worker.stub(:create_miq_vim_broker_server)
-        @vim_broker_worker.should_receive(:prime_all_ems).never
+        allow(@vim_broker_worker).to receive(:create_miq_vim_broker_server)
+        expect(@vim_broker_worker).to receive(:prime_all_ems).never
         @vim_broker_worker.start_broker_server
       end
 
       it "primes specified EMSes" do
-        @vim_broker_worker.stub(:create_miq_vim_broker_server)
+        allow(@vim_broker_worker).to receive(:create_miq_vim_broker_server)
         emses_to_prime = @zone.ext_management_systems
-        @vim_broker_worker.should_receive(:prime_all_ems).with(emses_to_prime).once
+        expect(@vim_broker_worker).to receive(:prime_all_ems).with(emses_to_prime).once
         @vim_broker_worker.start_broker_server(emses_to_prime)
       end
 
       it "should not raise error when MiqVimBroker.getMiqVim raises HTTPClient::ConnectTimeoutError" do
         require 'httpclient'  # needed for exception classes
         @miq_vim_broker = double('miq_vim_broker')
-        MiqVimBroker.stub(:new).and_return(@miq_vim_broker)
-        @miq_vim_broker.stub(:getMiqVim).and_raise(HTTPClient::ConnectTimeoutError)
-        -> { @vim_broker_worker.start_broker_server(@worker_record.class.emses_to_monitor) }.should_not raise_error
+        allow(MiqVimBroker).to receive(:new).and_return(@miq_vim_broker)
+        allow(@miq_vim_broker).to receive(:getMiqVim).and_raise(HTTPClient::ConnectTimeoutError)
+        expect { @vim_broker_worker.start_broker_server(@worker_record.class.emses_to_monitor) }.not_to raise_error
       end
     end
 
     it "#after_sync_config" do
       @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('miq_vim_broker'))
-      @vim_broker_worker.should_receive(:reset_broker_update_sleep_interval).once
+      expect(@vim_broker_worker).to receive(:reset_broker_update_sleep_interval).once
       @vim_broker_worker.after_sync_config
     end
 
@@ -80,7 +80,7 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('miq_vim_broker'))
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
 
-        -> { @vim_broker_worker.after_sync_active_roles }.should_not raise_error
+        expect { @vim_broker_worker.after_sync_active_roles }.not_to raise_error
       end
 
       it "with role change not including 'ems_inventory' role" do
@@ -88,7 +88,7 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('miq_vim_broker'))
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
 
-        -> { @vim_broker_worker.after_sync_active_roles }.should_not raise_error
+        expect { @vim_broker_worker.after_sync_active_roles }.not_to raise_error
       end
 
       it "adding 'ems_inventory' role" do
@@ -96,7 +96,7 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('miq_vim_broker'))
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar', 'ems_inventory'])
 
-        -> { @vim_broker_worker.after_sync_active_roles }.should raise_error(SystemExit)
+        expect { @vim_broker_worker.after_sync_active_roles }.to raise_error(SystemExit)
       end
 
       it "removing 'ems_inventory' role" do
@@ -104,27 +104,27 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('miq_vim_broker'))
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
 
-        -> { @vim_broker_worker.after_sync_active_roles }.should raise_error(SystemExit)
+        expect { @vim_broker_worker.after_sync_active_roles }.to raise_error(SystemExit)
       end
     end
 
     it "#do_heartbeat_work" do
-      @vim_broker_worker.should_receive(:check_broker_server).once
-      @vim_broker_worker.should_receive(:log_status).once
+      expect(@vim_broker_worker).to receive(:check_broker_server).once
+      expect(@vim_broker_worker).to receive(:log_status).once
       @vim_broker_worker.do_heartbeat_work
     end
 
     context "#do_before_work_loop" do
       it "should do nothing when active roles does not include 'ems_inventory'" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
-        EmsRefresh.should_receive(:queue_refresh).never
+        expect(EmsRefresh).to receive(:queue_refresh).never
         @vim_broker_worker.do_before_work_loop
       end
 
       it "should do nothing when active roles includes 'ems_inventory' and there are no EMSes to monitor" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar', 'ems_inventory'])
         @vim_broker_worker.instance_variable_set(:@initial_emses_to_monitor, [])
-        EmsRefresh.should_receive(:queue_refresh).never
+        expect(EmsRefresh).to receive(:queue_refresh).never
         @vim_broker_worker.do_before_work_loop
       end
 
@@ -132,7 +132,7 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar', 'ems_inventory'])
         emses = @zone.ext_management_systems
         @vim_broker_worker.instance_variable_set(:@initial_emses_to_monitor, emses)
-        EmsRefresh.should_receive(:queue_refresh).with(emses).once
+        expect(EmsRefresh).to receive(:queue_refresh).with(emses).once
         @vim_broker_worker.do_before_work_loop
       end
     end
@@ -140,33 +140,33 @@ describe MiqVimBrokerWorker::Runner do
     context "#create_miq_vim_broker_server" do
       it "with ems_inventory role" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
-        MiqVimBroker.should_receive(:new).with(:server, 0).once
+        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
         @vim_broker_worker.create_miq_vim_broker_server
-        MiqVimBroker.cacheScope.should == :cache_scope_ems_refresh
+        expect(MiqVimBroker.cacheScope).to eq(:cache_scope_ems_refresh)
       end
 
       it "without ems_inventory role" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_operations'])
-        MiqVimBroker.should_receive(:new).with(:server, 0).once
+        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
         @vim_broker_worker.create_miq_vim_broker_server
-        MiqVimBroker.cacheScope.should == :cache_scope_core
+        expect(MiqVimBroker.cacheScope).to eq(:cache_scope_core)
       end
     end
 
     it "#prime_all_ems" do
       emses = @zone.ext_management_systems
-      emses.each { |ems| @vim_broker_worker.should_receive(:prime_ems).with(ems).once }
+      emses.each { |ems| expect(@vim_broker_worker).to receive(:prime_ems).with(ems).once }
       @vim_broker_worker.prime_all_ems(emses)
     end
 
     it "#prime_ems" do
-      @vim_broker_worker.should_receive(:preload).with(@ems).once
+      expect(@vim_broker_worker).to receive(:preload).with(@ems).once
       @vim_broker_worker.prime_ems(@ems)
     end
 
     it "#reconnect_ems" do
-      @vim_broker_worker.should_receive(:preload).with(@ems).once
-      EmsRefresh.should_receive(:queue_refresh).with(@ems).once
+      expect(@vim_broker_worker).to receive(:preload).with(@ems).once
+      expect(EmsRefresh).to receive(:queue_refresh).with(@ems).once
       @vim_broker_worker.reconnect_ems(@ems)
     end
 
@@ -174,23 +174,23 @@ describe MiqVimBrokerWorker::Runner do
       @miq_vim_broker = double('miq_vim_broker')
       @vim_handle     = double('vim_handle')
       @vim_broker_worker.instance_variable_set(:@vim_broker_server, @miq_vim_broker)
-      @miq_vim_broker.should_receive(:getMiqVim).once.with(@ems.address, *@ems.auth_user_pwd).and_return(@vim_handle)
-      @vim_handle.should_receive(:disconnect).once
+      expect(@miq_vim_broker).to receive(:getMiqVim).once.with(@ems.address, *@ems.auth_user_pwd).and_return(@vim_handle)
+      expect(@vim_handle).to receive(:disconnect).once
       @vim_broker_worker.preload(@ems)
     end
 
     context "#reset_broker_update_notification" do
       it "calls enable_broker_update_notification when active roles includes 'ems_inventory'" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
-        @vim_broker_worker.should_receive(:enable_broker_update_notification).once
-        @vim_broker_worker.should_receive(:disable_broker_update_notification).never
+        expect(@vim_broker_worker).to receive(:enable_broker_update_notification).once
+        expect(@vim_broker_worker).to receive(:disable_broker_update_notification).never
         @vim_broker_worker.reset_broker_update_notification
       end
 
       it "calls disable_broker_update_notification when active roles does not include 'ems_inventory'" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
-        @vim_broker_worker.should_receive(:enable_broker_update_notification).never
-        @vim_broker_worker.should_receive(:disable_broker_update_notification).once
+        expect(@vim_broker_worker).to receive(:enable_broker_update_notification).never
+        expect(@vim_broker_worker).to receive(:disable_broker_update_notification).once
         @vim_broker_worker.reset_broker_update_notification
       end
     end
@@ -219,11 +219,11 @@ describe MiqVimBrokerWorker::Runner do
           @vim_broker_worker.instance_variable_get(:@queue).enq(event.dup)
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 1
+          expect(MiqQueue.count).to eq(1)
           q = MiqQueue.first
-          q.class_name.should == "EmsRefresh"
-          q.method_name.should == "vc_update"
-          q.args.should == [@ems.id, event]
+          expect(q.class_name).to eq("EmsRefresh")
+          expect(q.method_name).to eq("vc_update")
+          expect(q.args).to eq([@ems.id, event])
         end
 
         it "will handle queued Host updates properly" do
@@ -241,11 +241,11 @@ describe MiqVimBrokerWorker::Runner do
           @vim_broker_worker.instance_variable_get(:@queue).enq(event.dup)
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 1
+          expect(MiqQueue.count).to eq(1)
           q = MiqQueue.first
-          q.class_name.should == "EmsRefresh"
-          q.method_name.should == "vc_update"
-          q.args.should == [@ems.id, event]
+          expect(q.class_name).to eq("EmsRefresh")
+          expect(q.method_name).to eq("vc_update")
+          expect(q.args).to eq([@ems.id, event])
         end
 
         it "will ignore updates to unknown properties" do
@@ -260,7 +260,7 @@ describe MiqVimBrokerWorker::Runner do
                                                                 :changeSet    => [{"name" => "test.property", "op" => "assign", "val" => "test"}])
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 0
+          expect(MiqQueue.count).to eq(0)
         end
 
         it "will ignore updates to excluded properties" do
@@ -277,7 +277,7 @@ describe MiqVimBrokerWorker::Runner do
                                                                 :changeSet    => [{"name" => "summary.runtime.powerState", "op" => "assign", "val" => "poweredOn"}])
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 0
+          expect(MiqQueue.count).to eq(0)
         end
 
         it "will ignore updates to unknown connections" do
@@ -292,7 +292,7 @@ describe MiqVimBrokerWorker::Runner do
                                                                 :changeSet    => [{"name" => "summary.runtime.powerState", "op" => "assign", "val" => "poweredOn"}])
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 0
+          expect(MiqQueue.count).to eq(0)
         end
 
         it "will handle updates to valid connections that it previously did not know about" do
@@ -312,11 +312,11 @@ describe MiqVimBrokerWorker::Runner do
           @vim_broker_worker.instance_variable_get(:@queue).enq(event.dup)
 
           @vim_broker_worker.drain_event
-          MiqQueue.count.should == 1
+          expect(MiqQueue.count).to eq(1)
           q = MiqQueue.first
-          q.class_name.should == "EmsRefresh"
-          q.method_name.should == "vc_update"
-          q.args.should == [ems2.id, event]
+          expect(q.class_name).to eq("EmsRefresh")
+          expect(q.method_name).to eq("vc_update")
+          expect(q.args).to eq([ems2.id, event])
         end
       end
     end

--- a/spec/models/miq_vim_broker_worker_spec.rb
+++ b/spec/models/miq_vim_broker_worker_spec.rb
@@ -9,6 +9,6 @@ describe MiqVimBrokerWorker do
   end
 
   it ".emses_to_monitor" do
-    described_class.emses_to_monitor.should match_array @zone.ext_management_systems
+    expect(described_class.emses_to_monitor).to match_array @zone.ext_management_systems
   end
 end


### PR DESCRIPTION
Converts the remaining models specs under the pattern miq_* that haven't
already been converted to the newer `expect` syntax