### PR TITLE
Priority wasn't being set for new fields

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2247,12 +2247,14 @@ class MiqAeClassController < ApplicationController
   # Set record variables to new values
   def set_field_vars(parent = nil)
     fields = parent_fields(parent)
+    highest_priority = fields.count
     @edit[:new][:fields].each_with_index do |fld, i|
       if fld['id'].nil?
         new_field = MiqAeField.new
+        highest_priority += 1
+        new_field.priority  = highest_priority
         if @ae_method
           new_field.method_id = @ae_method.id
-          new_field.priority  = i + 1
         else
           new_field.class_id = @ae_class.id
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1292791

The priority wasn't being set for the newly added fields, before
being saved the fields were sorted and the fields with nil priority
floated to the top. Set the fields to the highest priority if they
are new