### PR TITLE
Made all fields visible on the form.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -370,8 +370,7 @@ class CatalogController < ApplicationController
       if @edit[:new][:selected_resources].empty?
         add_flash(_("%s must be selected") % "Resource", :error)
       end
-      add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:display] &&
-                                                                             @edit[:new][:fqname].blank?
+      add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:fqname].blank?
       dialog_catalog_check
 
       if @flash_array
@@ -860,8 +859,7 @@ class CatalogController < ApplicationController
       # check for service template required fields before creating a request
       add_flash(_("%s is required") % "Name", :error)
     end
-    add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:display] &&
-                                                                           @edit[:new][:fqname].blank?
+    add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:fqname].blank?
 
     # Check for a Dialog if Display in Catalog is selected
     dialog_catalog_check
@@ -910,12 +908,8 @@ class CatalogController < ApplicationController
     st.long_description = @edit[:new][:display] ? @edit[:new][:long_description] : nil
     st.provision_cost = @edit[:new][:provision_cost]
     st.display = @edit[:new][:display]
-    if @edit[:new][:display]
-      stc = @edit[:new][:catalog_id].nil? ? nil : ServiceTemplateCatalog.find_by_id(@edit[:new][:catalog_id])
-      st.service_template_catalog = stc
-    else
-      st.service_template_catalog = nil
-    end
+    stc = @edit[:new][:catalog_id].nil? ? nil : ServiceTemplateCatalog.find_by_id(@edit[:new][:catalog_id])
+    st.service_template_catalog = stc
     add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
     st.service_type = "atomic"
     st.prov_type = @edit[:new][:st_prov_type]

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -26,33 +26,32 @@
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
           = _('Display in Catalog')
     = javascript_tag(javascript_focus('name'))
-    - if @edit[:new][:display]
-      .form-group
-        %label.col-md-2.control-label
-          = _('Catalog')
-        .col-md-4
-          - available_catalogs = @edit[:new][:available_catalogs]
-          - catalog_id = @edit[:new][:catalog_id]
-          = select_tag('catalog_id',
-                       options_for_select(([["<#{_('Unassigned')}>", nil]]) + available_catalogs, catalog_id),
-                       "data-miq_sparkle_on" => true,
-                       :class                => "selectpicker")
+    .form-group
+      %label.col-md-2.control-label
+        = _('Catalog')
+      .col-md-4
+        - available_catalogs = @edit[:new][:available_catalogs]
+        - catalog_id = @edit[:new][:catalog_id]
+        = select_tag('catalog_id',
+                     options_for_select(([["<#{_('Unassigned')}>", nil]]) + available_catalogs, catalog_id),
+                     "data-miq_sparkle_on" => true,
+                     :class                => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('catalog_id', '#{url}')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Dialog')
+      .col-md-4
+        %p.form-control-static
+          - available_dialogs =  @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
+          - options = [["<#{_('No Dialog')}>", nil]] + available_dialogs
+          = select_tag('dialog_id',
+                        options_for_select(options, @edit[:new][:dialog_id]),
+                        "data-miq_sparkle_on" => true,
+                        :class                => "selectpicker")
           :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('catalog_id', '#{url}')
-      .form-group
-        %label.col-md-2.control-label
-          = _('Dialog')
-        .col-md-4
-          %p.form-control-static
-            - available_dialogs =  @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
-            - options = [["<#{_('No Dialog')}>", nil]] + available_dialogs
-            = select_tag('dialog_id',
-                          options_for_select(options, @edit[:new][:dialog_id]),
-                          "data-miq_sparkle_on" => true,
-                          :class                => "selectpicker")
-            :javascript
-              miqSelectPickerEvent('dialog_id', '#{url}')
+            miqSelectPickerEvent('dialog_id', '#{url}')
 
       - if @edit[:new][:st_prov_type] == "generic_orchestration"
         - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
@@ -78,74 +77,74 @@
                            :class               => "selectpicker")
               :javascript
                 miqSelectPickerEvent('manager_id', '#{url}')
-      .form-group
-        %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
-          = _('Provisioning Entry Point')
-          %br
-          = _('State Machine (NS/Cls/Inst)')
-        .col-md-8{:title => @edit[:new][:fqname]}
-          .input-group
-            = text_field_tag("fqname",
-                             @edit[:new][:fqname],
-                             :class   => "form-control",
-                             :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
-            %span.input-group-btn
-              #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "provision"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm-ujs"     => _("Are you sure you want to remove this Provisioning Entry Point?"),
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Provisioning Entry Point")) do
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
-      .form-group
-        %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
-          = _('Reconfigure Entry Point')
-          %br
-          = _('State Machine (NS/Cls/Inst)')
-        .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
-          .input-group
-            = text_field_tag("reconfigure_fqname",
-                             @edit[:new][:reconfigure_fqname],
-                             :class             => "form-control",
-                             :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
-                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %span.input-group-btn
-              #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "reconfigure"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm-ujs"     => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Reconfigure Entry Point")) do
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+    .form-group
+      %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
+        = _('Provisioning Entry Point')
+        %br
+        = _('State Machine (NS/Cls/Inst)')
+      .col-md-8{:title => @edit[:new][:fqname]}
+        .input-group
+          = text_field_tag("fqname",
+                           @edit[:new][:fqname],
+                           :class   => "form-control",
+                           :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
+          %span.input-group-btn
+            #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
+              = link_to({:action => 'ae_tree_select_discard',
+                         :typ => "provision"},
+                        "data-miq_sparkle_on"  => true,
+                        "data-miq_sparkle_off" => true,
+                        "data-confirm-ujs"     => _("Are you sure you want to remove this Provisioning Entry Point?"),
+                        :remote                => true,
+                        :class                 => "btn btn-default",
+                        :title                 => _("Remove this Provisioning Entry Point")) do
+                %i.pficon.pficon-close
+          %span.input-group-addon{:style => "visibility:hidden"}
+    .form-group
+      %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+        = _('Reconfigure Entry Point')
+        %br
+        = _('State Machine (NS/Cls/Inst)')
+      .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
+        .input-group
+          = text_field_tag("reconfigure_fqname",
+                           @edit[:new][:reconfigure_fqname],
+                           :class             => "form-control",
+                           :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
+                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+          %span.input-group-btn
+            #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
+              = link_to({:action => 'ae_tree_select_discard',
+                         :typ => "reconfigure"},
+                        "data-miq_sparkle_on"  => true,
+                        "data-miq_sparkle_off" => true,
+                        "data-confirm-ujs"     => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                        :remote                => true,
+                        :class                 => "btn btn-default",
+                        :title                 => _("Remove this Reconfigure Entry Point")) do
+                %i.pficon.pficon-close
+          %span.input-group-addon{:style => "visibility:hidden"}
 
-      .form-group
-        %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
-          = _('Retirement Entry Point')
-          %br
-          = _('State Machine (NS/Cls/Inst)')
-        .col-md-8{:title => @edit[:new][:retire_fqname]}
-          .input-group
-            = text_field_tag("retire_fqname",
-                             @edit[:new][:retire_fqname],
-                             :class   => "form-control",
-                             :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
-            %span.input-group-btn
-              #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "retire"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm-ujs"     => _("Are you sure you want to remove this Retirement Entry Point?"),
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Retirement Entry Point")) do
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+    .form-group
+      %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
+        = _('Retirement Entry Point')
+        %br
+        = _('State Machine (NS/Cls/Inst)')
+      .col-md-8{:title => @edit[:new][:retire_fqname]}
+        .input-group
+          = text_field_tag("retire_fqname",
+                           @edit[:new][:retire_fqname],
+                           :class   => "form-control",
+                           :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
+          %span.input-group-btn
+            #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
+              = link_to({:action => 'ae_tree_select_discard',
+                         :typ => "retire"},
+                        "data-miq_sparkle_on"  => true,
+                        "data-miq_sparkle_off" => true,
+                        "data-confirm-ujs"     => _("Are you sure you want to remove this Retirement Entry Point?"),
+                        :remote                => true,
+                        :class                 => "btn btn-default",
+                        :title                 => _("Remove this Retirement Entry Point")) do
+                %i.pficon.pficon-close
+          %span.input-group-addon{:style => "visibility:hidden"}

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -103,8 +103,14 @@ describe CatalogController do
       controller.instance_variable_set(:@_params, :button => "add")
       st = FactoryGirl.create(:service_template)
       controller.instance_variable_set(:@record, st)
+      provision_fqname = 'ns1/cls1/inst1'
       edit = {
-        :new    => {:name => "New Name", :description => "New Description", :selected_resources => [st.id], :rsc_groups => [[{:name => "Some name"}]]},
+        :new    => {:name               => "New Name",
+                    :description        => "New Description",
+                    :selected_resources => [st.id],
+                    :rsc_groups         => [[{:name => "Some name"}]],
+                    :fqname             => provision_fqname,
+                   },
         :key    => "st_edit__new",
         :rec_id => st.id,
       }


### PR DESCRIPTION
- Entry Point fields, Catalog & Dialog fields were only visible when user checked to Display Catalog ITem in the Catalog, changed to make all fields visible on the form.
- Change Provisioning Entry Point field to be required field even if Display in catalog is not selected.
- Dialog field is only required when user has selected to display in Catalog.

https://bugzilla.redhat.com/show_bug.cgi?id=1275712
https://bugzilla.redhat.com/show_bug.cgi?id=1291871

@dclarizio @gmcculloug please review/test