### PR TITLE
RSpec 3 conversion: Remaining specs

### DIFF
--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -149,13 +149,13 @@ describe CatalogController do
 
     it "redirects to requests show list after dialog is submitted" do
       controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
-      controller.stub(:role_allows).and_return(true)
-      wf.stub(:submit_request).and_return({})
-      page = mock('page')
-      page.should_receive(:redirect_to).with(:controller => "miq_request",
+      allow(controller).to receive(:role_allows).and_return(true)
+      allow(wf).to receive(:submit_request).and_return({})
+      page = double('page')
+      expect(page).to receive(:redirect_to).with(:controller => "miq_request",
                                              :action     => "show_list",
                                              :flash_msg  => "Order Request was Submitted")
-      controller.should_receive(:render).with(:update).and_yield(page)
+      expect(controller).to receive(:render).with(:update).and_yield(page)
       controller.send(:dialog_form_button_pressed)
     end
   end

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -81,7 +81,7 @@ describe ContainerController do
                                :name            => "container-01",
                                :container_group => container_group
                               )
-      controller.stub(:x_node).and_return("cnt_#{controller.to_cid(@ct.id)}")
+      allow(controller).to receive(:x_node).and_return("cnt_#{controller.to_cid(@ct.id)}")
       controller.instance_variable_set(:@record, @ct)
       FactoryGirl.create(:ems_event, :container_id => @ct.id)
     end
@@ -95,8 +95,8 @@ describe ContainerController do
            :pressed => "container_timeline",
            :id      => @ct.id,
            :display => 'timeline'
-      response.should render_template('layouts/_tl_show')
-      response.should render_template('layouts/_tl_detail')
+      expect(response).to render_template('layouts/_tl_show')
+      expect(response).to render_template('layouts/_tl_detail')
     end
 
     it "renders utilization views" do
@@ -104,8 +104,8 @@ describe ContainerController do
            :pressed => "container_perf",
            :id      => @ct.id,
            :display => 'performance'
-      response.should render_template('layouts/_perf_options')
-      response.should render_template('layouts/_perf_charts')
+      expect(response).to render_template('layouts/_perf_options')
+      expect(response).to render_template('layouts/_perf_charts')
     end
   end
 end

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -108,9 +108,9 @@ describe MiqAeCustomizationController do
         }
         controller.instance_variable_set(:@lastaction, "replace_right_cell")
         assigns(:edit)[:new] = new_hash
-        controller.stub(:get_node_info)
-        controller.stub(:replace_right_cell)
-        controller.stub(:render_flash)
+        allow(controller).to receive(:get_node_info)
+        allow(controller).to receive(:replace_right_cell)
+        allow(controller).to receive(:render_flash)
         controller.instance_variable_set(:@_params, :button => "add")
         controller.send(:dialog_edit)
         expect(assigns(:flash_array).first[:message]).to include("Validation failed:"\
@@ -152,9 +152,9 @@ describe MiqAeCustomizationController do
         }
         controller.instance_variable_set(:@lastaction, "replace_right_cell")
         assigns(:edit)[:new] = new_hash
-        controller.stub(:get_node_info)
-        controller.stub(:replace_right_cell)
-        controller.stub(:render_flash)
+        allow(controller).to receive(:get_node_info)
+        allow(controller).to receive(:replace_right_cell)
+        allow(controller).to receive(:render_flash)
         controller.instance_variable_set(:@_params, :button => "add")
         controller.send(:dialog_edit)
         expect(assigns(:flash_array).first[:message]).to include("Validation failed:"\

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -105,16 +105,16 @@ describe ReportController do
         allow(User).to receive(:server_timezone).and_return("UTC")
 
         login_as user
-        User.any_instance.stub(:role_allows?).and_return(true)
+        allow_any_instance_of(User).to receive(:role_allows?).and_return(true)
 
-        controller.stub(:check_privileges).and_return(true)
-        controller.stub(:load_edit).and_return(true)
+        allow(controller).to receive(:check_privileges).and_return(true)
+        allow(controller).to receive(:load_edit).and_return(true)
 
-        controller.stub(:replace_right_cell)
+        allow(controller).to receive(:replace_right_cell)
 
         post :miq_report_edit, :id => rep.id, :button => 'reset'
-        assigns(:sb)[:miq_tab].should eq("edit_1")
-        assigns(:tabs).should include(["edit_1", ""])
+        expect(assigns(:sb)[:miq_tab]).to eq("edit_1")
+        expect(assigns(:tabs)).to include(["edit_1", ""])
       end
     end
   end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1318,7 +1318,7 @@ describe ReportController do
           controller.instance_variable_set(:@_params, :id => controller.to_cid(report_result_id),
                                                       :controller => "report", :action => "explorer")
           controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
-          controller.stub(:get_all_reps)
+          allow(controller).to receive(:get_all_reps)
           controller.send(:show_saved_report)
           fetched_report_result = controller.instance_variable_get(:@report_result)
           expect(fetched_report_result.id).to eq(@rpt.miq_report_results.first.id)

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -74,7 +74,7 @@ describe StorageController do
 
         host = FactoryGirl.create(:host)
         command = button.split('_', 2)[1]
-        Host.any_instance.stub(:is_available?).with(command).and_return(true)
+        allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
 
         controller.instance_variable_set(:@_params, :pressed => button, :miq_grid_checks => "#{host.id}")
         controller.instance_variable_set(:@lastaction, "show_list")

--- a/spec/models/lan_spec.rb
+++ b/spec/models/lan_spec.rb
@@ -8,14 +8,14 @@ describe Lan do
   end
 
   it "#vms_and_templates" do
-    @lan.vms_and_templates.should match_array [@vm, @template]
+    expect(@lan.vms_and_templates).to match_array [@vm, @template]
   end
 
   it "#vms" do
-    @lan.vms.should == [@vm]
+    expect(@lan.vms).to eq([@vm])
   end
 
   it "#miq_templates" do
-    @lan.miq_templates.should == [@template]
+    expect(@lan.miq_templates).to eq([@template])
   end
 end

--- a/spec/models/ldap_domain_spec.rb
+++ b/spec/models/ldap_domain_spec.rb
@@ -12,17 +12,17 @@ describe LdapDomain do
   end
 
   it "should create proper AR relationships" do
-    @ldap_server.ldap_domain.should == @ldap_domain
-    @ldap_user.ldap_domain.should == @ldap_domain
-    @ldap_group.ldap_domain.should == @ldap_domain
+    expect(@ldap_server.ldap_domain).to eq(@ldap_domain)
+    expect(@ldap_user.ldap_domain).to eq(@ldap_domain)
+    expect(@ldap_group.ldap_domain).to eq(@ldap_domain)
 
-    @ldap_domain.ldap_region.should == @ldap_region
-    @ldap_region.zone.should == @zone
+    expect(@ldap_domain.ldap_region).to eq(@ldap_region)
+    expect(@ldap_region.zone).to eq(@zone)
 
-    @zone.ldap_regions.count.should == 1
-    @ldap_region.ldap_domains.count.should == 1
-    @ldap_domain.ldap_servers.count.should == 1
-    @ldap_domain.ldap_users.count.should == 1
-    @ldap_domain.ldap_groups.count.should == 1
+    expect(@zone.ldap_regions.count).to eq(1)
+    expect(@ldap_region.ldap_domains.count).to eq(1)
+    expect(@ldap_domain.ldap_servers.count).to eq(1)
+    expect(@ldap_domain.ldap_users.count).to eq(1)
+    expect(@ldap_domain.ldap_groups.count).to eq(1)
   end
 end

--- a/spec/models/ldap_server_spec.rb
+++ b/spec/models/ldap_server_spec.rb
@@ -10,21 +10,21 @@ describe LdapServer do
 
   context "#verify_credentials" do
     it "when LdapDomain#connect returns nil" do
-      LdapDomain.any_instance.stub(:connect).with(@ldap_server).and_return(nil)
-      -> { @ldap_server.verify_credentials }.should raise_error(MiqException::Error, "Authentication failed")
+      allow_any_instance_of(LdapDomain).to receive(:connect).with(@ldap_server).and_return(nil)
+      expect { @ldap_server.verify_credentials }.to raise_error(MiqException::Error, "Authentication failed")
     end
 
     it "when LdapDomain#connect returns connection handle" do
       handle = double("handle")
-      LdapDomain.any_instance.stub(:connect).with(@ldap_server).and_return(handle)
-      @ldap_server.verify_credentials.should == handle
+      allow_any_instance_of(LdapDomain).to receive(:connect).with(@ldap_server).and_return(handle)
+      expect(@ldap_server.verify_credentials).to eq(handle)
     end
 
     it "when LdapDomain#connect returns an error" do
       msg = "Invalid socket"
       err = SocketError.new(msg)
-      LdapDomain.any_instance.stub(:connect).with(@ldap_server).and_raise(err)
-      -> { @ldap_server.verify_credentials }.should raise_error(MiqException::Error, msg)
+      allow_any_instance_of(LdapDomain).to receive(:connect).with(@ldap_server).and_raise(err)
+      expect { @ldap_server.verify_credentials }.to raise_error(MiqException::Error, msg)
     end
   end
 end

--- a/spec/models/ldap_user_spec.rb
+++ b/spec/models/ldap_user_spec.rb
@@ -12,11 +12,11 @@ describe LdapUser do
 
       lm.direct_reports << lu
 
-      lm.direct_reports.should have(1).thing
-      lm.managers.should have(0).thing
+      expect(lm.direct_reports.size).to eq(1)
+      expect(lm.managers.size).to eq(0)
 
-      lu.managers.should have(1).thing
-      lu.direct_reports.should have(0).thing
+      expect(lu.managers.size).to eq(1)
+      expect(lu.direct_reports.size).to eq(0)
     end
   end
 end

--- a/spec/models/log_collection_spec.rb
+++ b/spec/models/log_collection_spec.rb
@@ -22,8 +22,8 @@ describe "LogCollection" do
     it { expect(@zone).to       be_log_collection_active_recently }
 
     context "21 minutes ago" do
-      it { expect(@miq_server.log_collection_active_recently?(21.minutes.ago.utc)).to be_true }
-      it { expect(@zone.log_collection_active_recently?(21.minutes.ago.utc)).to       be_true }
+      it { expect(@miq_server.log_collection_active_recently?(21.minutes.ago.utc)).to be_truthy }
+      it { expect(@zone.log_collection_active_recently?(21.minutes.ago.utc)).to       be_truthy }
     end
 
     context "jumping ahead in time 20 minutes" do
@@ -48,7 +48,7 @@ describe "LogCollection" do
       @region            = FactoryGirl.create(:miq_region)
       @timestamp         = "2010"
       @fname             = "/test.zip"
-      LogFile.any_instance.stub(:format_log_time).and_return(@timestamp)
+      allow_any_instance_of(LogFile).to receive(:format_log_time).and_return(@timestamp)
     end
 
     context "with a nil region column" do
@@ -64,7 +64,7 @@ describe "LogCollection" do
 
     context "with my_region nil" do
       before do
-        MiqRegion.stub(:my_region).and_return(nil)
+        allow(MiqRegion).to receive(:my_region).and_return(nil)
       end
 
       it "using a historical log file should raise no errors with a nil region association" do
@@ -75,7 +75,7 @@ describe "LogCollection" do
 
     context "using a historical log file" do
       before do
-        MiqRegion.stub(:my_region).and_return(@region)
+        allow(MiqRegion).to receive(:my_region).and_return(@region)
         @log_file.update_attributes(:historical => true)
       end
 
@@ -94,7 +94,7 @@ describe "LogCollection" do
 
     context "using a current log file" do
       before do
-        MiqRegion.stub(:my_region).and_return(@region)
+        allow(MiqRegion).to receive(:my_region).and_return(@region)
         @log_file.update_attributes(:historical => false)
       end
 
@@ -115,7 +115,7 @@ describe "LogCollection" do
   context "queue item and task item creation are atomic" do
     context "with error creating task" do
       before do
-        MiqTask.stub(:new).and_raise("some error message")
+        allow(MiqTask).to receive(:new).and_raise("some error message")
         LogFile.logs_from_server(@miq_server.id) rescue nil
       end
 
@@ -125,7 +125,7 @@ describe "LogCollection" do
 
     context "with error creating queue message" do
       before do
-        MiqQueue.stub(:put).and_raise("some error message")
+        allow(MiqQueue).to receive(:put).and_raise("some error message")
         LogFile.logs_from_server(@miq_server.id) rescue nil
       end
 

--- a/spec/models/log_file_spec.rb
+++ b/spec/models/log_file_spec.rb
@@ -79,7 +79,7 @@ describe LogFile do
 
       it "delivering MiqServer._request_logs message should call _post_my_logs with correct args" do
         expected_options = {:timeout => described_class::LOG_REQUEST_TIMEOUT, :taskid => @task.id, :callback => {:instance_id => @task.id, :class_name => 'MiqTask', :method_name => :queue_callback_on_exceptions, :args => ['Finished']}}
-        MiqServer.any_instance.should_receive(:_post_my_logs).with(expected_options)
+        expect_any_instance_of(MiqServer).to receive(:_post_my_logs).with(expected_options)
 
         @message.delivered(*@message.deliver)
       end
@@ -101,23 +101,23 @@ describe LogFile do
           it "#post_logs will only post current logs if flag enabled" do
             message.deliver
             message.args.first[:only_current] = true
-            MiqServer.any_instance.should_receive(:post_historical_logs).never
-            MiqServer.any_instance.should_receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_historical_logs).never
+            expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
             message.delivered(*message.deliver)
           end
 
           it "#post_logs will post both historical and current logs if flag nil" do
             message.deliver
-            MiqServer.any_instance.should_receive(:post_historical_logs).once
-            MiqServer.any_instance.should_receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_historical_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
             message.delivered(*message.deliver)
           end
 
           it "#post_logs will post both historical and current logs if flag false" do
             message.deliver
             message.args.first[:only_current] = false
-            MiqServer.any_instance.should_receive(:post_historical_logs).once
-            MiqServer.any_instance.should_receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_historical_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
             message.delivered(*message.deliver)
           end
         end
@@ -125,7 +125,7 @@ describe LogFile do
 
       context "with MiqServer _post_my_logs raising exception" do
         before do
-          MiqServer.any_instance.stub(:_post_my_logs).and_raise
+          allow_any_instance_of(MiqServer).to receive(:_post_my_logs).and_raise
           @message.delivered(*@message.deliver)
         end
 
@@ -135,7 +135,7 @@ describe LogFile do
 
       context "with MiqServer _post_my_logs raising timeout exception" do
         before do
-          MiqServer.any_instance.stub(:_post_my_logs).and_raise(Timeout::Error)
+          allow_any_instance_of(MiqServer).to receive(:_post_my_logs).and_raise(Timeout::Error)
           @message.delivered(*@message.deliver)
         end
 
@@ -145,7 +145,7 @@ describe LogFile do
 
       context "with MiqServer.post_logs raising missing log_depot settings exception" do
         before do
-          MiqServer.any_instance.stub(:log_depot).and_return(nil)
+          allow_any_instance_of(MiqServer).to receive(:log_depot).and_return(nil)
           @message.delivered(*@message.deliver)
 
           @message = MiqQueue.where(:class_name => "MiqServer", :method_name => "post_logs").first
@@ -160,15 +160,15 @@ describe LogFile do
         before do
           @message.delivered(*@message.deliver)
           @message = MiqQueue.where(:class_name => "MiqServer", :method_name => "post_logs").first
-          VMDB::Util.stub(:zip_logs).and_return('/tmp/blah')
-          VMDB::Util.stub(:get_evm_log_for_date).and_return('/tmp/blah')
-          VMDB::Util.stub(:get_log_start_end_times).and_return((Time.now.utc - 600), Time.now.utc)
-          described_class.any_instance.stub(:add).and_return("smb://blah.com/share1")
+          allow(VMDB::Util).to receive(:zip_logs).and_return('/tmp/blah')
+          allow(VMDB::Util).to receive(:get_evm_log_for_date).and_return('/tmp/blah')
+          allow(VMDB::Util).to receive(:get_log_start_end_times).and_return((Time.now.utc - 600), Time.now.utc)
+          allow_any_instance_of(described_class).to receive(:add).and_return("smb://blah.com/share1")
         end
 
         context "with VMDB::Util.zip_logs raising exception" do
           before do
-            VMDB::Util.stub(:zip_logs).and_raise("some error message")
+            allow(VMDB::Util).to receive(:zip_logs).and_raise("some error message")
             @message.delivered(*@message.deliver)
           end
 
@@ -178,7 +178,7 @@ describe LogFile do
 
         context "with VMDB::Util.zip_logs raising timeout exception" do
           before do
-            VMDB::Util.stub(:zip_logs).and_raise(Timeout::Error)
+            allow(VMDB::Util).to receive(:zip_logs).and_raise(Timeout::Error)
             @message.delivered(*@message.deliver)
           end
 
@@ -188,7 +188,7 @@ describe LogFile do
 
         context "with MiqServer delete_old_requested_logs raising timeout exception" do
           before do
-            MiqServer.any_instance.stub(:delete_old_requested_logs).and_raise(Timeout::Error)
+            allow_any_instance_of(MiqServer).to receive(:delete_old_requested_logs).and_raise(Timeout::Error)
             @message.delivered(*@message.deliver)
           end
 
@@ -198,7 +198,7 @@ describe LogFile do
 
         context "with MiqServer delete_old_requested_logs raising exception" do
           before do
-            MiqServer.any_instance.stub(:delete_old_requested_logs).and_raise("some error message")
+            allow_any_instance_of(MiqServer).to receive(:delete_old_requested_logs).and_raise("some error message")
             @message.delivered(*@message.deliver)
           end
 
@@ -208,7 +208,7 @@ describe LogFile do
 
         context "with MiqServer base_zip_log_name raising exception" do
           before do
-            MiqServer.any_instance.stub(:base_zip_log_name).and_raise("some error message")
+            allow_any_instance_of(MiqServer).to receive(:base_zip_log_name).and_raise("some error message")
             @message.delivered(*@message.deliver)
           end
 
@@ -218,7 +218,7 @@ describe LogFile do
 
         context "with MiqServer base_zip_log_name raising timeout exception" do
           before do
-            MiqServer.any_instance.stub(:base_zip_log_name).and_raise(Timeout::Error)
+            allow_any_instance_of(MiqServer).to receive(:base_zip_log_name).and_raise(Timeout::Error)
             @message.delivered(*@message.deliver)
           end
 
@@ -228,7 +228,7 @@ describe LogFile do
 
         context "with MiqServer format_log_time raising exception" do
           before do
-            MiqServer.any_instance.stub(:format_log_time).and_raise("some error message")
+            allow_any_instance_of(MiqServer).to receive(:format_log_time).and_raise("some error message")
             @message.delivered(*@message.deliver)
           end
 
@@ -238,7 +238,7 @@ describe LogFile do
 
         context "with MiqServer format_log_time raising timeout exception" do
           before do
-            MiqServer.any_instance.stub(:format_log_time).and_raise(Timeout::Error)
+            allow_any_instance_of(MiqServer).to receive(:format_log_time).and_raise(Timeout::Error)
             @message.delivered(*@message.deliver)
           end
 

--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
     @ems.update_attributes(:project => "civil-tube-113314")
 
     # A true thread may fail the test with VCR
-    Thread.stub(:new) do |*args, &block|
+    allow(Thread).to receive(:new) do |*args, &block|
       block.call(*args)
       Class.new do
         def join; end
@@ -38,32 +38,32 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
   end
 
   def assert_table_counts
-    ExtManagementSystem.count.should eql(1)
-    Flavor.count.should              eql(18)
-    AvailabilityZone.count.should    eql(13)
-    VmOrTemplate.count.should        eql(347)
-    Vm.count.should                  eql(2)
-    MiqTemplate.count.should         eql(345)
-    Disk.count.should                eql(0)
-    GuestDevice.count.should         eql(0)
-    Hardware.count.should            eql(2)
-    Network.count.should             eql(0)
-    OperatingSystem.count.should     eql(345)
-    Relationship.count.should        eql(0)
-    MiqQueue.count.should            eql(347)
+    expect(ExtManagementSystem.count).to eql(1)
+    expect(Flavor.count).to              eql(18)
+    expect(AvailabilityZone.count).to    eql(13)
+    expect(VmOrTemplate.count).to        eql(347)
+    expect(Vm.count).to                  eql(2)
+    expect(MiqTemplate.count).to         eql(345)
+    expect(Disk.count).to                eql(0)
+    expect(GuestDevice.count).to         eql(0)
+    expect(Hardware.count).to            eql(2)
+    expect(Network.count).to             eql(0)
+    expect(OperatingSystem.count).to     eql(345)
+    expect(Relationship.count).to        eql(0)
+    expect(MiqQueue.count).to            eql(347)
   end
 
   def assert_ems
-    @ems.flavors.size.should            eql(18)
-    @ems.availability_zones.size.should eql(13)
-    @ems.vms_and_templates.size.should  eql(347)
-    @ems.vms.size.should                eql(2)
-    @ems.miq_templates.size.should      eq(345)
+    expect(@ems.flavors.size).to            eql(18)
+    expect(@ems.availability_zones.size).to eql(13)
+    expect(@ems.vms_and_templates.size).to  eql(347)
+    expect(@ems.vms.size).to                eql(2)
+    expect(@ems.miq_templates.size).to      eq(345)
   end
 
   def assert_specific_zone
     @zone = ManageIQ::Providers::Google::CloudManager::AvailabilityZone.find_by_ems_ref("us-east1-b")
-    @zone.should have_attributes(
+    expect(@zone).to have_attributes(
       :name   => "us-east1-b",
       :ems_id => @ems.id
     )
@@ -71,7 +71,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
 
   def assert_specific_cloud_network
     @cn = CloudNetwork.where(:name => "default").first
-    @cn.should have_attributes(
+    expect(@cn).to have_attributes(
       :name    => "default",
       :ems_ref => "183954628405178359",
       :cidr    => "10.240.0.0/16",
@@ -82,7 +82,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
 
   def assert_specific_flavor
     @flavor = ManageIQ::Providers::Google::CloudManager::Flavor.where(:name => "f1-micro").first
-    @flavor.should have_attributes(
+    expect(@flavor).to have_attributes(
       :name        => "f1-micro",
       :ems_ref     => "f1-micro",
       :description => "1 vCPU (shared physical core) and 0.6 GB RAM",
@@ -92,12 +92,12 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :memory      => 643825664,
     )
 
-    @flavor.ext_management_system.should == @ems
+    expect(@flavor.ext_management_system).to eq(@ems)
   end
 
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Google::CloudManager::Vm.where(:name => "rhel7", :raw_power_state => "RUNNING").first
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "5220078748954475260",
       :ems_ref_obj           => nil,
@@ -122,18 +122,18 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    v.ext_management_system.should eql(@ems)
-    v.availability_zone.should eql(@zone)
+    expect(v.ext_management_system).to eql(@ems)
+    expect(v.availability_zone).to eql(@zone)
     #TODO parse instance flavor v.flavor.should eql(@flavor)
     #TODO parse instance OS v.operating_system.product_name.should eql("Red Hat Enterprise Linux")
-    v.custom_attributes.size.should eql(0)
-    v.snapshots.size.should         eql(0)
+    expect(v.custom_attributes.size).to eql(0)
+    expect(v.snapshots.size).to         eql(0)
 
     assert_specific_vm_powered_on_hardware(v)
   end
 
   def assert_specific_vm_powered_on_hardware(v)
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os            => nil,
       :guest_os_full_name  => nil,
       :bios                => nil,
@@ -144,15 +144,15 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :virtualization_type => nil
     )
 
-    v.hardware.disks.size.should         eql(0) # TODO: Change to a flavor that has disks
-    v.hardware.guest_devices.size.should eql(0)
-    v.hardware.nics.size.should          eql(0)
+    expect(v.hardware.disks.size).to         eql(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.guest_devices.size).to eql(0)
+    expect(v.hardware.nics.size).to          eql(0)
 
     assert_specific_vm_powered_on_hardware_networks(v)
   end
 
   def assert_specific_vm_powered_on_hardware_networks(v)
-    v.hardware.networks.size.should eql(0)
+    expect(v.hardware.networks.size).to eql(0)
     # TODO inventory network hardware
   end
 
@@ -165,20 +165,20 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
 
     assert_specific_vm_powered_off_attributes(v)
 
-    v.ext_management_system.should  eql(@ems)
-    v.availability_zone.should      eql(zone1)
-    v.floating_ip.should            be_nil
-    v.cloud_network.should          be_nil
-    v.cloud_subnet.should           be_nil
+    expect(v.ext_management_system).to  eql(@ems)
+    expect(v.availability_zone).to      eql(zone1)
+    expect(v.floating_ip).to            be_nil
+    expect(v.cloud_network).to          be_nil
+    expect(v.cloud_subnet).to           be_nil
     #TODO parse instance OS v.operating_system.product_name.should eql("Debian")
-    v.custom_attributes.size.should eql(0)
-    v.snapshots.size.should         eql(0)
+    expect(v.custom_attributes.size).to eql(0)
+    expect(v.snapshots.size).to         eql(0)
 
     assert_specific_vm_powered_off_hardware(v)
   end
 
   def assert_specific_vm_powered_off_attributes(v)
-    v.should have_attributes(
+    expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "17122958274615180727",
       :ems_ref_obj           => nil,
@@ -205,7 +205,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
   end
 
   def assert_specific_vm_powered_off_hardware(v)
-    v.hardware.should have_attributes(
+    expect(v.hardware).to have_attributes(
       :guest_os           => nil,
       :guest_os_full_name => nil,
       :bios               => nil,
@@ -215,16 +215,16 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :bitness            => nil
     )
 
-    v.hardware.disks.size.should         eql(0)
-    v.hardware.guest_devices.size.should eql(0)
-    v.hardware.nics.size.should          eql(0)
-    v.hardware.networks.size.should      eql(0)
+    expect(v.hardware.disks.size).to         eql(0)
+    expect(v.hardware.guest_devices.size).to eql(0)
+    expect(v.hardware.nics.size).to          eql(0)
+    expect(v.hardware.networks.size).to      eql(0)
   end
 
   def assert_specific_template
     name      = "rhel-7-v20151104"
     @template = ManageIQ::Providers::Google::CloudManager::Template.where(:name => name).first
-    @template.should have_attributes(
+    expect(@template).to have_attributes(
       :template              => true,
       :ems_ref               => "5670907071397924697",
       :ems_ref_obj           => nil,
@@ -249,9 +249,9 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    @template.ext_management_system.should         eq(@ems)
-    @template.operating_system.product_name.should eq("linux_redhat")
-    @template.custom_attributes.size.should        eq(0)
-    @template.snapshots.size.should                eq(0)
+    expect(@template.ext_management_system).to         eq(@ems)
+    expect(@template.operating_system.product_name).to eq("linux_redhat")
+    expect(@template.custom_attributes.size).to        eq(0)
+    expect(@template.snapshots.size).to                eq(0)
   end
 end

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe ManageIQ::Providers::Google::CloudManager do
   it ".ems_type" do
-    described_class.ems_type.should == 'gce'
+    expect(described_class.ems_type).to eq('gce')
   end
 
   it ".description" do
-    described_class.description.should == 'Google Compute Engine'
+    expect(described_class.description).to eq('Google Compute Engine')
   end
 
   context "#connectivity" do
@@ -20,17 +20,17 @@ describe ManageIQ::Providers::Google::CloudManager do
 
     context "#connect " do
       it "defaults" do
-        described_class.should_receive(:raw_connect).with do |project, auth_key|
-          project.should eq(@google_project)
-          auth_key.should eq(@google_json_key)
-        end
+        expect(described_class).to receive(:raw_connect).with { |project, auth_key|
+          expect(project).to eq(@google_project)
+          expect(auth_key).to eq(@google_json_key)
+        }
         @e.connect
       end
     end
 
     context "#validation" do
       it "handles incorrect password" do
-        ManageIQ::Providers::Google::CloudManager.stub(:connect).and_raise(StandardError)
+        allow(ManageIQ::Providers::Google::CloudManager).to receive(:connect).and_raise(StandardError)
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Invalid Google JSON*/)
       end
     end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -528,7 +528,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
 
   describe "parse_node" do
     it "handles node without capacity" do
-      parser.send(
+      expect(parser.send(
         :parse_node,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -547,7 +547,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             }
           }
         )
-      ).should == {
+      )).to eq({
         :name                       => 'test-node',
         :ems_ref                    => 'f0c1fe7e-9c09-11e5-bb22-28d2447dcefe',
         :creation_timestamp         => '2015-12-06T11:10:21Z',
@@ -575,11 +575,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         :namespace                  => nil,
         :resource_version           => '369104',
         :type                       => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode'
-      }
+      })
     end
 
     it "handles node without memory, cpu and pods" do
-      parser.send(
+      expect(parser.send(
         :parse_node,
         RecursiveOpenStruct.new(
           :metadata => {
@@ -599,7 +599,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
             :capacity => {}
           }
         )
-      ).should == {
+      )).to eq({
         :name                       => 'test-node',
         :ems_ref                    => 'f0c1fe7e-9c09-11e5-bb22-28d2447dcefe',
         :creation_timestamp         => '2015-12-06T11:10:21Z',
@@ -627,7 +627,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         :namespace                  => nil,
         :resource_version           => '3691041',
         :type                       => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode'
-      }
+      })
     end
   end
 end

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe "Message Timeout Handling" do
   before(:each) do
     @guid = MiqUUID.new_guid
-    MiqServer.stub(:my_guid).and_return(@guid)
+    allow(MiqServer).to receive(:my_guid).and_return(@guid)
 
     @zone       = FactoryGirl.create(:zone)
     @miq_server = FactoryGirl.create(:miq_server, :guid => @guid, :zone => @zone)
-    MiqServer.stub(:my_server).and_return(@miq_server)
+    allow(MiqServer).to receive(:my_server).and_return(@miq_server)
 
     @worker = FactoryGirl.create(:vmware_refresh_worker, :miq_server_id => @miq_server.id)
   end
@@ -28,8 +28,8 @@ describe "Message Timeout Handling" do
     it "should not be timed out after 15 minutes" do
       Timecop.travel(15.minutes) do
         time_threshold = @worker.current_timeout
-        time_threshold.should == 3600
-        time_threshold.seconds.ago.utc.should_not > @worker.last_heartbeat
+        expect(time_threshold).to eq(3600)
+        expect(time_threshold.seconds.ago.utc).not_to be > @worker.last_heartbeat
       end
     end
   end
@@ -55,8 +55,8 @@ describe "Message Timeout Handling" do
       @msg.update_attribute(:state, "dequeue")
       Timecop.travel(15.minutes) do
         time_threshold = @miq_server.get_time_threshold(@worker)
-        time_threshold.should == 3610
-        time_threshold.seconds.ago.utc.should_not > @worker.last_heartbeat
+        expect(time_threshold).to eq(3610)
+        expect(time_threshold.seconds.ago.utc).not_to be > @worker.last_heartbeat
       end
     end
 
@@ -64,8 +64,8 @@ describe "Message Timeout Handling" do
       @msg.update_attribute(:state, "error")
       Timecop.travel(15.minutes) do
         time_threshold = @miq_server.get_time_threshold(@worker)
-        time_threshold.should == 120
-        time_threshold.seconds.ago.utc.should > @worker.last_heartbeat
+        expect(time_threshold).to eq(120)
+        expect(time_threshold.seconds.ago.utc).to be > @worker.last_heartbeat
       end
     end
   end

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -7,10 +7,10 @@ describe "Service Retirement Management" do
   end
 
   it "#retirement_check" do
-    MiqEvent.should_receive(:raise_evm_event)
+    expect(MiqEvent).to receive(:raise_evm_event)
     @stack.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
     expect(@stack.retirement_last_warn).to be_nil
-    @stack.class.any_instance.should_receive(:retire_now).once
+    expect_any_instance_of(@stack.class).to receive(:retire_now).once
     @stack.retirement_check
     @stack.reload
     expect(@stack.retirement_last_warn).not_to be_nil
@@ -77,54 +77,54 @@ describe "Service Retirement Management" do
     expect(@stack.retirement_state).to be_nil
     @stack.finish_retirement
     @stack.reload
-    expect(@stack.retired).to be_true
+    expect(@stack.retired).to be_truthy
     expect(@stack.retires_on).to eq(Date.today)
     expect(@stack.retirement_state).to eq("retired")
   end
 
   it "#retiring - false" do
     expect(@stack.retirement_state).to be_nil
-    expect(@stack.retiring?).to be_false
+    expect(@stack.retiring?).to be_falsey
   end
 
   it "#retiring - true" do
     @stack.update_attributes(:retirement_state => 'retiring')
-    expect(@stack.retiring?).to be_true
+    expect(@stack.retiring?).to be_truthy
   end
 
   it "#error_retiring - false" do
     expect(@stack.retirement_state).to be_nil
-    expect(@stack.error_retiring?).to be_false
+    expect(@stack.error_retiring?).to be_falsey
   end
 
   it "#error_retiring - true" do
     @stack.update_attributes(:retirement_state => 'error')
-    expect(@stack.error_retiring?).to be_true
+    expect(@stack.error_retiring?).to be_truthy
   end
 
   it "#retires_on - today" do
-    expect(@stack.retirement_due?).to be_false
+    expect(@stack.retirement_due?).to be_falsey
     @stack.retires_on = Date.today
-    expect(@stack.retirement_due?).to be_true
+    expect(@stack.retirement_due?).to be_truthy
   end
 
   it "#retires_on - tomorrow" do
-    expect(@stack.retirement_due?).to be_false
+    expect(@stack.retirement_due?).to be_falsey
     @stack.retires_on = Date.today + 1
-    expect(@stack.retirement_due?).to be_false
+    expect(@stack.retirement_due?).to be_falsey
   end
 
   it "#retirement_due?" do
-    expect(@stack.retirement_due?).to be_false
+    expect(@stack.retirement_due?).to be_falsey
 
     @stack.update_attributes(:retires_on => Date.today + 1.day)
-    expect(@stack.retirement_due?).to be_false
+    expect(@stack.retirement_due?).to be_falsey
 
     @stack.update_attributes(:retires_on => Date.today)
-    expect(@stack.retirement_due?).to be_true
+    expect(@stack.retirement_due?).to be_truthy
 
     @stack.update_attributes(:retires_on => Date.today - 1.day)
-    expect(@stack.retirement_due?).to be_true
+    expect(@stack.retirement_due?).to be_truthy
   end
 
   it "#raise_retirement_event" do

--- a/spec/models/orchestration_stack_spec.rb
+++ b/spec/models/orchestration_stack_spec.rb
@@ -18,21 +18,21 @@ describe OrchestrationStack do
     end
 
     it 'defines a set of methods for vms' do
-      root_stack.direct_vms.size.should == 1
-      root_stack.vms.size.should == 2
-      root_stack.total_vms.should == 2
+      expect(root_stack.direct_vms.size).to eq(1)
+      expect(root_stack.vms.size).to eq(2)
+      expect(root_stack.total_vms).to eq(2)
     end
 
     it 'defines a set of methods for cloud_networks' do
-      root_stack.direct_cloud_networks.size.should == 1
-      root_stack.cloud_networks.size.should == 2
-      root_stack.total_cloud_networks.should == 2
+      expect(root_stack.direct_cloud_networks.size).to eq(1)
+      expect(root_stack.cloud_networks.size).to eq(2)
+      expect(root_stack.total_cloud_networks).to eq(2)
     end
 
     it 'defines a set of methods for security_groups' do
-      root_stack.direct_security_groups.size.should == 1
-      root_stack.security_groups.size.should == 2
-      root_stack.total_security_groups.should == 2
+      expect(root_stack.direct_security_groups.size).to eq(1)
+      expect(root_stack.security_groups.size).to eq(2)
+      expect(root_stack.total_security_groups).to eq(2)
     end
   end
 end

--- a/spec/models/orchestration_template_azure_spec.rb
+++ b/spec/models/orchestration_template_azure_spec.rb
@@ -4,7 +4,7 @@ describe OrchestrationTemplateAzure do
   describe ".eligible_manager_types" do
     it "lists the classes of eligible managers" do
       OrchestrationTemplateAzure.eligible_manager_types.each do |klass|
-        (klass <= ManageIQ::Providers::Azure::CloudManager).should be_true
+        expect(klass <= ManageIQ::Providers::Azure::CloudManager).to be_truthy
       end
     end
   end
@@ -14,11 +14,11 @@ describe OrchestrationTemplateAzure do
   context "when a raw template in JSON format is given" do
     it "parses parameters from a template" do
       groups = valid_template.parameter_groups
-      groups.size.should == 1
-      groups[0].label.should == "Parameters"
+      expect(groups.size).to eq(1)
+      expect(groups[0].label).to eq("Parameters")
 
       param_hash = groups[0].parameters.index_by(&:name)
-      param_hash.size.should == 3
+      expect(param_hash.size).to eq(3)
       assert_string_type(param_hash["adminUsername"])
       assert_secret_type(param_hash["adminPassword"])
       assert_allowed_values(param_hash["hostingPlanSku"])
@@ -26,7 +26,7 @@ describe OrchestrationTemplateAzure do
   end
 
   def assert_secret_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "adminPassword",
       :label         => "Admin Password",
       :description   => "Admin password",
@@ -38,7 +38,7 @@ describe OrchestrationTemplateAzure do
   end
 
   def assert_string_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "adminUsername",
       :label         => "Admin Username",
       :description   => "Administrator username",
@@ -50,7 +50,7 @@ describe OrchestrationTemplateAzure do
   end
 
   def assert_allowed_values(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "hostingPlanSku",
       :label         => "Hosting Plan Sku",
       :description   => nil,
@@ -59,10 +59,10 @@ describe OrchestrationTemplateAzure do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterAllowed
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterAllowed
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description    => nil,
       :allowed_values => ["Free", "Shared", "Basic", "Standard", "Premium"]
     )
@@ -71,16 +71,16 @@ describe OrchestrationTemplateAzure do
   describe '#validate_format' do
     it 'passes validation if no content' do
       template = OrchestrationTemplateAzure.new
-      template.validate_format.should be_nil
+      expect(template.validate_format).to be_nil
     end
 
     it 'passes validation with correct JSON content' do
-      valid_template.validate_format.should be_nil
+      expect(valid_template.validate_format).to be_nil
     end
 
     it 'fails validations with incorrect JSON content' do
       template = OrchestrationTemplateAzure.new(:content => "invalid string")
-      template.validate_format.should_not be_nil
+      expect(template.validate_format).not_to be_nil
     end
   end
 end

--- a/spec/models/orchestration_template_cfn_spec.rb
+++ b/spec/models/orchestration_template_cfn_spec.rb
@@ -4,7 +4,7 @@ describe OrchestrationTemplateCfn do
   describe ".eligible_manager_types" do
     it "lists the classes of eligible managers" do
       OrchestrationTemplateCfn.eligible_manager_types.each do |klass|
-        (klass <= ManageIQ::Providers::Amazon::CloudManager || klass <= ManageIQ::Providers::Openstack::CloudManager).should be_true
+        expect(klass <= ManageIQ::Providers::Amazon::CloudManager || klass <= ManageIQ::Providers::Openstack::CloudManager).to be_truthy
       end
     end
   end
@@ -14,11 +14,11 @@ describe OrchestrationTemplateCfn do
   context "when a raw template in JSON format is given" do
     it "parses parameters from a template" do
       groups = valid_template.parameter_groups
-      groups.size.should == 1
-      groups[0].label.should == "Parameters"
+      expect(groups.size).to eq(1)
+      expect(groups[0].label).to eq("Parameters")
 
       param_hash = groups[0].parameters.index_by(&:name)
-      param_hash.size.should == 6
+      expect(param_hash.size).to eq(6)
       assert_aws_type(param_hash["KeyName"])
       assert_list_aws_type(param_hash["Subnets"])
       assert_list_string_type(param_hash["AZs"])
@@ -29,7 +29,7 @@ describe OrchestrationTemplateCfn do
   end
 
   def assert_aws_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "KeyName",
       :label         => "Key Name",
       :description   => "Name of an existing EC2 KeyPair to enable SSH access to the instances",
@@ -41,7 +41,7 @@ describe OrchestrationTemplateCfn do
   end
 
   def assert_list_aws_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "Subnets",
       :label         => "Subnets",
       :description   => "The list of SubnetIds in your Virtual Private Cloud (VPC)",
@@ -53,7 +53,7 @@ describe OrchestrationTemplateCfn do
   end
 
   def assert_list_string_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "AZs",
       :label         => "A Zs",
       :description   => "The list of AvailabilityZones for your Virtual Private Cloud (VPC)",
@@ -65,7 +65,7 @@ describe OrchestrationTemplateCfn do
   end
 
   def assert_allowed_values(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "WebServerInstanceType",
       :label         => "Web Server Instance Type",
       :description   => "WebServer Server EC2 instance type",
@@ -74,17 +74,17 @@ describe OrchestrationTemplateCfn do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterAllowed
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterAllowed
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description    => "must be a valid EC2 instance type.",
       :allowed_values => ["t2.small", "t2.medium", "m1.small"]
     )
   end
 
   def assert_min_max_value(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "SecondaryIPAddressCount",
       :label         => "Secondary Ip Address Count",
       :description   => "Number of secondary IP addresses to assign to the network interface (1-5)",
@@ -93,10 +93,10 @@ describe OrchestrationTemplateCfn do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterRange
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterRange
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description => "must be a number from 1 to 5.",
       :min_value   => 1,
       :max_value   => 5
@@ -104,7 +104,7 @@ describe OrchestrationTemplateCfn do
   end
 
   def assert_hidden_length_pattern(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "MasterUserPassword",
       :label         => "Master User Password",
       :description   => "The password associated with the aster user account for the redshift cluster that is being created. ",
@@ -113,15 +113,15 @@ describe OrchestrationTemplateCfn do
       :hidden        => true,
     )
     constraints = parameter.constraints
-    constraints.size.should == 2
+    expect(constraints.size).to eq(2)
 
     constraint_hash = constraints.index_by(&:class)
-    constraint_hash[OrchestrationTemplate::OrchestrationParameterPattern].should have_attributes(
+    expect(constraint_hash[OrchestrationTemplate::OrchestrationParameterPattern]).to have_attributes(
       :description => "must contain only alphanumeric characters.",
       :pattern     => "[a-zA-Z0-9]*",
     )
 
-    constraint_hash[OrchestrationTemplate::OrchestrationParameterLength].should have_attributes(
+    expect(constraint_hash[OrchestrationTemplate::OrchestrationParameterLength]).to have_attributes(
       :description => "must contain only alphanumeric characters.",
       :min_length  => 1,
       :max_length  => 41
@@ -131,16 +131,16 @@ describe OrchestrationTemplateCfn do
   describe '#validate_format' do
     it 'passes validation if no content' do
       template = OrchestrationTemplateCfn.new
-      template.validate_format.should be_nil
+      expect(template.validate_format).to be_nil
     end
 
     it 'passes validation with correct JSON content' do
-      valid_template.validate_format.should be_nil
+      expect(valid_template.validate_format).to be_nil
     end
 
     it 'fails validations with incorrect JSON content' do
       template = OrchestrationTemplateCfn.new(:content => "invalid string")
-      template.validate_format.should_not be_nil
+      expect(template.validate_format).not_to be_nil
     end
   end
 end

--- a/spec/models/orchestration_template_hot_spec.rb
+++ b/spec/models/orchestration_template_hot_spec.rb
@@ -4,7 +4,7 @@ describe OrchestrationTemplateHot do
   describe ".eligible_manager_types" do
     it "lists the classes of eligible managers" do
       OrchestrationTemplateHot.eligible_manager_types.each do |klass|
-        (klass <= ManageIQ::Providers::Openstack::CloudManager).should be_true
+        expect(klass <= ManageIQ::Providers::Openstack::CloudManager).to be_truthy
       end
     end
   end
@@ -14,7 +14,7 @@ describe OrchestrationTemplateHot do
   context "when a raw template in YAML format is given" do
     it "parses parameters from a template" do
       groups = valid_template.parameter_groups
-      groups.size.should == 2
+      expect(groups.size).to eq(2)
 
       assert_general_group(groups[0])
       assert_db_group(groups[1])
@@ -22,8 +22,8 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_general_group(group)
-    group.label.should == "General parameters"
-    group.description.should == "General parameters"
+    expect(group.label).to eq("General parameters")
+    expect(group.description).to eq("General parameters")
 
     assert_custom_constraint(group.parameters[0])
     assert_allowed_values(group.parameters[1])
@@ -31,8 +31,8 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_db_group(group)
-    group.label.should == "DB parameters"
-    group.description.should == "Database related parameters"
+    expect(group.label).to eq("DB parameters")
+    expect(group.description).to eq("Database related parameters")
 
     assert_hidden_length_patterns(group.parameters[0])
     assert_min_max_value(group.parameters[1])
@@ -40,7 +40,7 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_custom_constraint(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "flavor",
       :label         => "Flavor",
       :description   => "Flavor for the instances to be created",
@@ -49,17 +49,17 @@ describe OrchestrationTemplateHot do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterCustom
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterCustom
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description       => "Must be a flavor known to Nova",
       :custom_constraint => "nova.flavor"
     )
   end
 
   def assert_list_string_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "cartridges",
       :label         => "Cartridges",
       :description   => "Cartridges to install. \"all\" for all cartridges; \"standard\" for all cartridges except for JBossEWS or JBossEAP\n",
@@ -71,7 +71,7 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_allowed_values(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "image_id",
       :label         => "Image", # String#titleize removes trailing id
       :description   => "ID of the image to use for the instance to be created.",
@@ -80,17 +80,17 @@ describe OrchestrationTemplateHot do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterAllowed
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterAllowed
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description    => "Image ID must be either F18-i386-cfntools or F18-x86_64-cfntools.",
       :allowed_values => ["F18-i386-cfntools", "F18-x86_64-cfntools"]
     )
   end
 
   def assert_min_max_value(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "db_port",
       :label         => "Port Number",  # provided by template
       :description   => "Database port number",
@@ -99,10 +99,10 @@ describe OrchestrationTemplateHot do
       :hidden        => false,
     )
     constraints = parameter.constraints
-    constraints.size.should == 1
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterRange
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints.size).to eq(1)
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterRange
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description => "Port number must be between 40000 and 60000",
       :min_value   => 40_000,
       :max_value   => 60_000
@@ -110,7 +110,7 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_hidden_length_patterns(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "admin_pass",
       :label         => "Admin Pass",
       :description   => "Admin password",
@@ -119,32 +119,32 @@ describe OrchestrationTemplateHot do
       :hidden        => true
     )
     constraints = parameter.constraints
-    constraints.size.should == 3
+    expect(constraints.size).to eq(3)
 
-    constraints[0].should be_a OrchestrationTemplate::OrchestrationParameterLength
-    constraints[0].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[0].should have_attributes(
+    expect(constraints[0]).to be_a OrchestrationTemplate::OrchestrationParameterLength
+    expect(constraints[0]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[0]).to have_attributes(
       :description => "Admin password must be between 6 and 8 characters long.\n",
       :min_length  => 6,
       :max_length  => 8
     )
 
-    constraints[1].should be_a OrchestrationTemplate::OrchestrationParameterPattern
-    constraints[1].should be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
-    constraints[1].should have_attributes(
+    expect(constraints[1]).to be_a OrchestrationTemplate::OrchestrationParameterPattern
+    expect(constraints[1]).to be_kind_of OrchestrationTemplate::OrchestrationParameterConstraint
+    expect(constraints[1]).to have_attributes(
       :description => "Password must consist of characters and numbers only",
       :pattern     => "[a-zA-Z0-9]+"
     )
 
-    constraints[2].should be_a OrchestrationTemplate::OrchestrationParameterPattern
-    constraints[2].should have_attributes(
+    expect(constraints[2]).to be_a OrchestrationTemplate::OrchestrationParameterPattern
+    expect(constraints[2]).to have_attributes(
       :description => "Password must start with an uppercase character",
       :pattern     => "[A-Z]+[a-zA-Z0-9]*"
     )
   end
 
   def assert_json_type(parameter)
-    parameter.should have_attributes(
+    expect(parameter).to have_attributes(
       :name          => "metadata",
       :label         => "Metadata",
       :description   => nil,
@@ -158,16 +158,16 @@ describe OrchestrationTemplateHot do
   describe '#validate_format' do
     it 'passes validation if no content' do
       template = OrchestrationTemplateHot.new
-      template.validate_format.should be_nil
+      expect(template.validate_format).to be_nil
     end
 
     it 'passes validation with correct YAML content' do
-      valid_template.validate_format.should be_nil
+      expect(valid_template.validate_format).to be_nil
     end
 
     it 'fails validations with incorrect YAML content' do
       template = OrchestrationTemplateHot.new(:content => ":-Invalid:\n-String")
-      template.validate_format.should_not be_nil
+      expect(template.validate_format).not_to be_nil
     end
   end
 end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -6,13 +6,13 @@ describe OrchestrationTemplate do
       let(:query_hash) { FactoryGirl.build(:orchestration_template).as_json.symbolize_keys }
 
       it "creates a new template" do
-        OrchestrationTemplate.count.should == 0
+        expect(OrchestrationTemplate.count).to eq(0)
         record = OrchestrationTemplate.find_or_create_by_contents(query_hash)[0]
-        OrchestrationTemplate.count.should == 1
-        record.name.should == query_hash[:name]
-        record.content.should == query_hash[:content]
-        record.description.should == query_hash[:description]
-        record.md5.should_not be_nil
+        expect(OrchestrationTemplate.count).to eq(1)
+        expect(record.name).to eq(query_hash[:name])
+        expect(record.content).to eq(query_hash[:content])
+        expect(record.description).to eq(query_hash[:description])
+        expect(record.md5).not_to be_nil
       end
     end
 
@@ -27,16 +27,16 @@ describe OrchestrationTemplate do
       end
 
       it "finds the existing template regardless the new name or description" do
-        OrchestrationTemplate.count.should == 1
-        @existing_record.should == OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0]
-        OrchestrationTemplate.count.should == 1
+        expect(OrchestrationTemplate.count).to eq(1)
+        expect(@existing_record).to eq(OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0])
+        expect(OrchestrationTemplate.count).to eq(1)
       end
 
       it "creates a draft template even though the content is a duplicate" do
-        OrchestrationTemplate.count.should == 1
+        expect(OrchestrationTemplate.count).to eq(1)
         @query_hash[:draft] = true
-        @existing_record.should_not == OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0]
-        OrchestrationTemplate.count.should == 2
+        expect(@existing_record).not_to eq(OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0])
+        expect(OrchestrationTemplate.count).to eq(2)
       end
     end
   end
@@ -50,24 +50,24 @@ describe OrchestrationTemplate do
 
     describe "#in_use?" do
       it "knows whether a template is in use" do
-        @template_alone.in_use?.should      be_false
-        @template_with_stack.in_use?.should be_true
+        expect(@template_alone.in_use?).to      be_falsey
+        expect(@template_with_stack.in_use?).to be_truthy
       end
     end
 
     describe ".in_use" do
       it "finds all templates that are in use" do
         inused_templates = OrchestrationTemplate.in_use
-        inused_templates.size.should == 1
-        inused_templates[0].should == @template_with_stack
+        expect(inused_templates.size).to eq(1)
+        expect(inused_templates[0]).to eq(@template_with_stack)
       end
     end
 
     describe ".not_in_use" do
       it "finds all templates that are never deployed" do
         alone_templates = OrchestrationTemplate.not_in_use
-        alone_templates.size.should == 1
-        alone_templates[0].should == @template_alone
+        expect(alone_templates.size).to eq(1)
+        expect(alone_templates[0]).to eq(@template_alone)
       end
     end
   end
@@ -81,7 +81,7 @@ describe OrchestrationTemplate do
     end
 
     it "lists all eligible managers for a template" do
-      @template.eligible_managers.should =~ [@aws, @openstack]
+      expect(@template.eligible_managers).to match_array([@aws, @openstack])
     end
   end
 
@@ -93,17 +93,17 @@ describe OrchestrationTemplate do
     end
 
     it "uses caller provided manager to do validation" do
-      @template.validate_content(@manager).should == "Validation Message"
+      expect(@template.validate_content(@manager)).to eq("Validation Message")
     end
 
     it "uses all eligible managers to do validation" do
       @template.stub(:eligible_managers => [@manager])
-      @template.validate_content.should == "Validation Message"
+      expect(@template.validate_content).to eq("Validation Message")
     end
 
     it "gets an error message if no eligible managers" do
       @template.stub(:eligible_managers => ["Invalid Object"])
-      @template.validate_content.should match(/No (.*) is capable to validate the template/)
+      expect(@template.validate_content).to match(/No (.*) is capable to validate the template/)
     end
   end
 
@@ -144,7 +144,7 @@ describe OrchestrationTemplate do
       allow(Digest::MD5).to receive(:hexdigest).and_return(existing_template.md5)
 
       result = OrchestrationTemplate.find_with_content("#{existing_template.content} content changed")
-      result.should == existing_template
+      expect(result).to eq(existing_template)
     end
   end
 
@@ -154,18 +154,18 @@ describe OrchestrationTemplate do
     let(:existing_template) { FactoryGirl.create(:orchestration_template, :content => raw_text) }
 
     it "stores content with universal newlines" do
-      existing_template.content.should == content
+      expect(existing_template.content).to eq(content)
     end
 
     it "is retrievable through either raw or normalized content" do
-      existing_template.should == OrchestrationTemplate.find_with_content(raw_text)
-      existing_template.should == OrchestrationTemplate.find_with_content(content)
+      expect(existing_template).to eq(OrchestrationTemplate.find_with_content(raw_text))
+      expect(existing_template).to eq(OrchestrationTemplate.find_with_content(content))
     end
 
     it "does not save a new template if the request has either the raw or normalized content" do
-      existing_template.should == OrchestrationTemplate.find_or_create_by_contents(:content => raw_text)[0]
-      existing_template.should == OrchestrationTemplate.find_or_create_by_contents(:content => content)[0]
-      OrchestrationTemplate.count.should == 1
+      expect(existing_template).to eq(OrchestrationTemplate.find_or_create_by_contents(:content => raw_text)[0])
+      expect(existing_template).to eq(OrchestrationTemplate.find_or_create_by_contents(:content => content)[0])
+      expect(OrchestrationTemplate.count).to eq(1)
     end
   end
 
@@ -183,7 +183,7 @@ describe OrchestrationTemplate do
     context "when format validation passes" do
       it "saves the template" do
         template.stub(:validate_format => nil)
-        template.save_with_format_validation!.should be_true
+        expect(template.save_with_format_validation!).to be_truthy
       end
     end
 
@@ -191,7 +191,7 @@ describe OrchestrationTemplate do
       it "always saves the template" do
         template.draft = true
         template.stub(:validate_format => "format is invalid")
-        template.save_with_format_validation!.should be_true
+        expect(template.save_with_format_validation!).to be_truthy
       end
     end
   end
@@ -202,7 +202,7 @@ describe OrchestrationTemplate do
     context "the first time seeding" do
       it "adds templates from default location" do
         OrchestrationTemplate.seed
-        OrchestrationTemplate.where(:name => azure_template).count.should == 1
+        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
       end
     end
 
@@ -215,25 +215,25 @@ describe OrchestrationTemplate do
 
       it "does not add new templates from following runs" do
         OrchestrationTemplate.seed
-        OrchestrationTemplate.where(:name => azure_template).count.should == 1
+        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
       end
 
       it "does not add new template if the original template has been only renamed" do
         seeded_template.update_attributes(:name => 'other')
         OrchestrationTemplate.seed
-        OrchestrationTemplate.where(:name => azure_template).count.should == 0
+        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(0)
       end
 
       it "does not add new template if the original template has modified content" do
         seeded_template.update_attributes(:content => '{}')
         OrchestrationTemplate.seed
-        OrchestrationTemplate.where(:name => azure_template).count.should == 1
+        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
       end
 
       it "adds new template if the original template has been renamed and modified" do
         seeded_template.update_attributes(:name => 'other', :content => '{}')
         OrchestrationTemplate.seed
-        OrchestrationTemplate.where(:name => azure_template).count.should == 1
+        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,7 +98,7 @@ describe User do
       password    = @user.password
       newpassword = "newpassword"
       @user.change_password(password, newpassword)
-      @user.password.should == newpassword
+      expect(@user.password).to eq(newpassword)
     end
 
     it "should raise an error when asked to change user password" do

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -40,7 +40,7 @@ describe ApiController do
   def expect_result_to_have_provision_dialog
     expect_result_to_have_keys(%w(id href provision_dialog))
     provision_dialog = @result["provision_dialog"]
-    provision_dialog.should be_kind_of(Hash)
+    expect(provision_dialog).to be_kind_of(Hash)
     expect(provision_dialog).to have_key("label")
     expect(provision_dialog).to have_key("dialog_tabs")
     expect(provision_dialog["label"]).to eq(provision_dialog1.label)

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "/static/*" do
   context "foo" do
     before :each do
-      ApplicationController.any_instance.stub(:set_user_time_zone)
+      allow_any_instance_of(ApplicationController).to receive(:set_user_time_zone)
     end
 
     it "returns test template" do


### PR DESCRIPTION
The very last of the remaining spec, converted to the newer `expect` syntax. :tada:

After this, fixes of specific deprecations need to be handled across the board and then
we can officially move to the RSpec 3 gem.