### PR TITLE
Toolbar button classes 2

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1225,8 +1225,8 @@ function miqToolbarOnClick(e) {
     // to open console in a new window
     if (confirm(button.data('confirm'))) {
       if (button.data('popup') != "undefined" && button.data('popup')) {
-        if (button.data("console_url")) {
-          window.open(button.data('console_url'));
+        if (button.data("window_url")) {
+          window.open(button.data('window_url'));
         }
       }
     }
@@ -1234,8 +1234,8 @@ function miqToolbarOnClick(e) {
   } else if (!button.data("confirm") && button.data("popup")) {
     // to open readonly report in a new window, doesnt have confirm message
     if (button.data('popup')) {
-      if (button.data("console_url")) {
-        window.open(button.data('console_url'));
+      if (button.data("window_url")) {
+        window.open(button.data('window_url'));
       }
     }
     return;

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::Basic < Hash
     @view_context  = view_context
     @view_binding  = view_binding
 
-    props.each { |k, v| self[k] = v }
+    merge!(props)
 
     instance_data.each do |name, value|
       instance_variable_set(:"@#{name}", value)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -72,7 +72,7 @@ class ApplicationHelper::ToolbarBuilder
           "child_id" => bsi[:button],
           "id"       => bgi[:buttonSelect] + "__" + bsi[:button],
           "type"     => "button",
-          "img"      => img = "#{bsi[:image] ? bsi[:image] : bsi[:button]}.png",
+          "img"      => img = "#{bsi[:image] || bsi[:button]}.png",
           "imgdis"   => img,
           :icon      => bsi[:icon]
         )
@@ -138,7 +138,7 @@ class ApplicationHelper::ToolbarBuilder
       "id"     => bgi[:button],
       "type"   => "button",
       "img"    => "#{get_image(bgi[:image], bgi[:button]) ? get_image(bgi[:image], bgi[:button]) : bgi[:button]}.png",
-      "imgdis" => "#{bgi[:image] ? bgi[:image] : bgi[:button]}.png",
+      "imgdis" => "#{bgi[:image] || bgi[:button]}.png",
       :icon    => bgi[:icon]
     )
     apply_common_props(props, bgi)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -111,6 +111,11 @@ class ApplicationHelper::ToolbarBuilder
     button[:confirm]   = safer_eval(input[:confirm]) unless input[:confirm].blank?
     button[:url_parms] = update_url_parms(safer_eval(input[:url_parms])) unless input[:url_parms].blank?
 
+    if input[:popup] # special behavior: button opens window_url in a new window
+      button[:popup] = true
+      button[:window_url] = "/#{request.parameters["controller"]}#{input[:url]}"
+    end
+
     dis_title = build_toolbar_disable_button(button['id'])
     if dis_title
       button["enabled"] = "false"
@@ -1368,21 +1373,6 @@ class ApplicationHelper::ToolbarBuilder
   def build_toolbar_save_button(item, props)
     props[:url] = url_for_save_button(props['id'], item[:url], controller_restful?) if item[:url]
     props[:explorer] = true if @explorer && !item[:url] # Add explorer = true if ajax button
-
-    if item[:popup] # FIXME: move this code to button classes
-      props[:popup] = item[:popup]
-      if item[:url_parms] == "popup_only" # For readonly reports, they don't have confirm message
-        props[:console_url] = "/#{request.parameters["controller"]}#{item[:url]}"
-      else # Assuming at this point this is a console button
-        props[:console_url] =
-          if item[:url] == "vnc_console" # This is a VNC console button
-            "http://#{@record.ipaddresses[0]}:#{get_vmdb_config[:server][:vnc_port]}"
-          else # This is an MKS or VMRC VMware console button
-            "/#{request.parameters["controller"]}#{item[:url]}/#{@record.id}"
-          end
-      end
-    end
-
     props
   end
 

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -191,7 +191,7 @@ module ToolbarHelper
   # attributes in html
   #
   def data_hash_keys(props)
-    hsh = %i(pressed popup console_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
+    hsh = %i(pressed popup window_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
       h["data-#{key}"] = props[key] if props.key?(key)
     end
     hsh

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -191,19 +191,20 @@ module ToolbarHelper
   # attributes in html
   #
   def data_hash_keys(props)
-    hsh = %i(pressed popup window_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
-      h["data-#{key}"] = props[key] if props.key?(key)
+    %i(pressed popup window_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
+      h[key] = props[key] if props.key?(key)
     end
-    hsh
   end
 
   # Calculate common html tag keys and values from toolbar button definition
   #
   def prepare_tag_keys(props)
-    h = data_hash_keys(props)
+    h = {
+      'data'       => data_hash_keys(props),
+      'title'      => _(props['title']),
+      'data-click' => props['id']
+    }
     h['name']         = props[:name] if props.key?(:name)
-    h['title']        = _(props['title'])
-    h['data-click']   = props['id']
     h['data-confirm'] = _("#{props[:confirm]}") if props.key?(:confirm)
     h
   end

--- a/product/toolbars/chargeback_center_tb.yaml
+++ b/product/toolbars/chargeback_center_tb.yaml
@@ -28,8 +28,6 @@
   - :button: chargeback_report_only
     :image: reportonly
     :url: '/report_only'
-    #:url_parms: '?type=#{@ght_type}'
-    :url_parms: 'popup_only'
     :popup: true
     :title: "Show full screen report"
     :confirm: "This will show the entire report (all rows) in your browser.  Do you want to proceed?"

--- a/product/toolbars/saved_report_center_tb.yaml
+++ b/product/toolbars/saved_report_center_tb.yaml
@@ -16,7 +16,6 @@
       :text: "Show full screen Report"
       :title: "Show full screen Report"
       :url: "/report_only"
-      :url_parms: 'popup_only'
       :popup: true
       :confirm: 'This will show the entire report (all rows) in your browser.  Do you want to proceed?'
     - :button: saved_report_delete

--- a/product/toolbars/saved_reports_center_tb.yaml
+++ b/product/toolbars/saved_reports_center_tb.yaml
@@ -25,7 +25,6 @@
       :enabled: 'false'
       :onwhen: '1'
       :url: "/report_only"
-      :url_parms: 'popup_only'
       :popup: true
       :confirm: 'This will show the entire report (all rows) in your browser.  Do you want to proceed?'
     - :button: saved_report_delete


### PR DESCRIPTION
Work on top of #5783.

Deal with `popup` and `popup_only` options in the toolbar buttons.

The special case for consoles was actually a dead code so I could unify the behavior for reports with consoles. Also renamed the option for clarity.

Further code cleanups as @DNNX suggested included.