### PR TITLE
Remove ui_lookup_for_host_types() and replace it with gettext

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -877,7 +877,7 @@ module ApplicationController::CiProcessing
 
   def set_discover_title(type, controller)
     if type == "hosts"
-      return ui_lookup(:host_types => "hosts")
+      return _("Hosts / Nodes")
     else
       return ui_lookup(:tables => controller)
     end

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -112,7 +112,7 @@ module MiqAeCustomizationController::CustomButtons
         # selected button is under assigned folder
         kls = case @nodetype[1]
               when "Host"
-                ui_lookup(:host_types => "host")
+                _("Host / Node")
               when "EmsCluster"
                 ui_lookup(:ems_cluster_types => "cluster")
               else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1181,15 +1181,14 @@ module ApplicationHelper
   end
 
   def title_for_host(plural = false)
-    key = case Host.node_types
-          when :non_openstack
-            "host_infra"
-          when :openstack
-            "host_openstack"
-          else
-            "host"
-          end
-    ui_lookup(:host_types => plural ? key.pluralize : key)
+    case Host.node_types
+    when :non_openstack
+      plural ? _("Hosts") : _("Host")
+    when :openstack
+      plural ? _("Nodes") : _("Node")
+    else
+      plural ? _("Hosts / Nodes") : _("Host / Node")
+    end
   end
 
   def title_for_clusters
@@ -1209,7 +1208,7 @@ module ApplicationHelper
   end
 
   def title_for_host_record(record)
-    record.openstack_host? ? ui_lookup(:host_types => 'host_openstack') : ui_lookup(:host_types => 'host_infra')
+    record.openstack_host? ? _("Node") : _("Host")
   end
 
   def title_for_cluster_record(record)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -819,14 +819,6 @@ en:
       linux_generic:   Linux
       windows_generic: Windows
 
-    host_types:
-      host:            Host / Node
-      hosts:           Hosts / Nodes
-      host_infra:      Host
-      host_infras:     Hosts
-      host_openstack:  Node
-      host_openstacks: Nodes
-
     model:
       AuditEvent:               EVM Audit Event
       AvailabilityZone:         Availability Zone

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -78,8 +78,6 @@ module Vmdb
         ui_lookup_for_model(options[:model]).singularize
       elsif options[:models]
         ui_lookup_for_model(options[:models]).pluralize
-      elsif options[:host_types]
-        ui_lookup_for_host_types(options[:host_types])
       elsif options[:ems_cluster_types]
         ui_lookup_for_ems_cluster_types(options[:ems_cluster_types])
       elsif options[:ui_title]
@@ -96,10 +94,6 @@ module Vmdb
 
     def ui_lookup_for_model(text)
       Dictionary.gettext(text, :type => :model, :notfound => :titleize)
-    end
-
-    def ui_lookup_for_host_types(text)
-      Dictionary.gettext(text, :type => :host_types, :notfound => :titleize)
     end
 
     def ui_lookup_for_ems_cluster_types(text)


### PR DESCRIPTION
This is part of effort leading to minimizing / removal of ui_lookup()
and replacing it with gettext.