### PR TITLE
Azure refresh parser - fix bugs in add_instance_disk method

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -275,7 +275,7 @@ module ManageIQ::Providers
       end
 
       def add_instance_disk(disks, size, name, location)
-        super(disks, size, name, location, "azure")
+        super(disks, size, location, name, "azure")
       end
 
       def populate_hardware_hash_with_networks(networks_array, instance)
@@ -313,7 +313,7 @@ module ManageIQ::Providers
         os_disk = instance.properties.storage_profile.os_disk
         sz      = series[:root_disk_size]
 
-        add_instance_disk(hardware_hash[:disks], sz, os_disk.name, os_disk.vhd) unless sz.zero?
+        add_instance_disk(hardware_hash[:disks], sz, os_disk.name, os_disk.vhd.uri) unless sz.zero?
 
         # No data availbale on swap disk? Called temp or resource disk.
       end

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -38,6 +38,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       assert_specific_az
       assert_specific_cloud_network
       assert_specific_flavor
+      assert_specific_disk
       assert_specific_vm_powered_on
       assert_specific_vm_powered_off
       assert_specific_template
@@ -191,11 +192,10 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     expect(v.hardware.guest_devices.size).to eql(0)
     expect(v.hardware.nics.size).to eql(0)
 
-    assert_specific_vm_powered_on_hardware_networks(v)
-    assert_specific_vm_powered_disk(v)
+    assert_specific_hardware_networks(v)
   end
 
-  def assert_specific_vm_powered_on_hardware_networks(v)
+  def assert_specific_hardware_networks(v)
     expect(v.hardware.networks.size).to eql(2)
     network = v.hardware.networks.where(:description => "public").first
     expect(network).to have_attributes(
@@ -211,11 +211,9 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     )
   end
 
-  def assert_specific_vm_powered_disk(v)
-    expect(v.hardware.disks.size).to eql(1)
-    disk = v.hardware.disks.first
+  def assert_specific_disk
+    disk = ManageIQ::Providers::Azure::CloudManager::Disk.where(:device_name => "Chef-Prod").first
     expect(disk).to have_attributes(
-      :device_name => "Chef-Prod",
       :location    => "http://chefprod5120.blob.core.windows.net/vhds/Chef-Prod.vhd",
       :size        => 1023.megabyte
     )

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -188,11 +188,11 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :virtualization_type => nil
     )
 
-    expect(v.hardware.disks.size).to eql(1) # TODO: Change to a flavor that has disks
     expect(v.hardware.guest_devices.size).to eql(0)
     expect(v.hardware.nics.size).to eql(0)
 
     assert_specific_vm_powered_on_hardware_networks(v)
+    assert_specific_vm_powered_disk(v)
   end
 
   def assert_specific_vm_powered_on_hardware_networks(v)
@@ -208,6 +208,16 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :description => "private",
       :ipaddress   => "10.2.0.4",
       :hostname    => "ipconfig1"
+    )
+  end
+
+  def assert_specific_vm_powered_disk(v)
+    expect(v.hardware.disks.size).to eql(1)
+    disk = v.hardware.disks.first
+    expect(disk).to have_attributes(
+      :device_name => "Chef-Prod",
+      :location    => "http://chefprod5120.blob.core.windows.net/vhds/Chef-Prod.vhd",
+      :size        => 1023.megabyte
     )
   end
 


### PR DESCRIPTION
Reorder parameters to add_instance_disk so they match parent class method signature
Set disk location to be the uri string, not the hash containing the uri string
Added a new spec test for VM disks