### PR TITLE
Opt-in to Marshal dump mocking

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,13 +50,20 @@ RSpec.configure do |config|
   # so we're temporarily adding the method for now
   config.expose_current_running_example_as :example
 
-  # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
-  # instance as the first block argument to allow the implementation block to use
-  # the state of the receiver. This opts-in to the behavior now and can be removed
-  # once the upgrade is complete.
   config.mock_with :rspec do |mocks|
+    # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
+    # instance as the first block argument to allow the implementation block to use
+    # the state of the receiver. This opts-in to the behavior now and can be removed
+    # once the upgrade is complete.
     mocks.yield_receiver_to_any_instance_implementation_blocks = true
+
+    # Monkey-patch Marshal.dump to enable dumping of mocked or stubbed objects. By
+    # default this will not work since RSpec mocks works by adding singleton methods
+    # that cannot be serialized. This patch removes these singleton methods before
+    # serialization. Potentially but unlikely to be removed post upgrade.
+    mocks.patch_marshal_to_support_partial_doubles = true
   end
+
   # =====================
 
   # config.before(:all) do


### PR DESCRIPTION
Monkey-patch `Marshal.dump` to enable dumping of mocked or stubbed objects. By default this will not work since RSpec mocks works by adding singleton methods that cannot be serialized. This patch removes these singleton methods before serialization.

Potentially but unlikely to be removed post upgrade.