### PR TITLE
Remove block expectactions with unsupported matchers

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -26,7 +26,7 @@ describe CatalogController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -137,7 +137,7 @@ describe MiqAeCustomizationController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -237,7 +237,7 @@ describe MiqPolicyController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -19,7 +19,7 @@ describe OpsController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -17,7 +17,7 @@ describe PxeController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
 
     it "Pressing Refresh button should show display name in the flash message" do

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -871,7 +871,7 @@ describe ReportController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -44,7 +44,7 @@ describe ServiceController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
   end
 

--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -29,7 +29,7 @@ describe VmOrTemplateController do
 
     it 'exception is raised for unknown action' do
       get :x_button, :pressed => 'random_dude', :format => :html
-      expect { response }.to render_template('layouts/exception')
+      expect(response).to render_template('layouts/exception')
     end
 
     context "x_button method check" do


### PR DESCRIPTION
Using a matcher in a block expectation expression (e.g. `expect { }.to
matcher`) that does not implement `supports_block_expectations?` is
deprecated. This removes all cases of that as no matchers we use that
use a block expectation need to use them.