### PR TITLE
Set RAILS_ENV/Rails.env before, not in-between rake tasks

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -9,6 +9,12 @@ namespace :test do
   end
 
   task :verify_no_db_access_loading_rails_environment do
+    # If this gets merged, we can use the attr_reader:
+    # https://github.com/ruby/rake/pull/93
+    if Rake::Task['environment'].instance_variable_get(:@already_invoked)
+      raise "Failed to verify database access when loading rails because the 'environment' rake task has already been invoked!"
+    end
+
     EvmRakeHelper.with_dummy_database_url_configuration do
       begin
         puts "** Confirming rails environment does not connect to the database"

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -4,7 +4,7 @@ if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :vmdb do
     desc "Setup environment for vmdb specs"
-    task :setup => [:verify_no_db_access_loading_rails_environment, :setup_db]
+    task :setup => [:initialize, :verify_no_db_access_loading_rails_environment, :setup_db]
   end
 
   desc "Run all core specs (excludes automation, migrations, replication, etc)"


### PR DESCRIPTION
Even though this wasn't causing an obvious problem, invoking
`test:vmdb:setup` was causing "environment" to be loaded in dev mode
before we switched to test and reset the database.  That's probably
not a good thing to do.

Before:

```
be rake --trace test:vmdb:setup
** Invoke test:vmdb:setup (first_time)
** Invoke test:verify_no_db_access_loading_rails_environment (first_time)
** Execute test:verify_no_db_access_loading_rails_environment
nil
development
** Confirming rails environment does not connect to the database
** Invoke environment (first_time)
** Execute environment
** Invoke test:setup_db (first_time)
** Invoke test:initialize (first_time)
** Execute test:initialize
** Execute test:setup_db
test
test
** Preparing database
** Invoke evm:db:reset (first_time)
** Invoke evm:db:destroy (first_time)
** Execute evm:db:destroy
** Invoke environment
** Invoke db:drop (first_time)
...
```

After:

```
be rake --trace test:vmdb:setup
** Invoke test:vmdb:setup (first_time)
** Invoke test:initialize (first_time)
** Execute test:initialize
** Invoke test:verify_no_db_access_loading_rails_environment (first_time)
** Execute test:verify_no_db_access_loading_rails_environment
test
test
** Confirming rails environment does not connect to the database
** Invoke environment (first_time)
** Execute environment
** Invoke test:setup_db (first_time)
** Invoke test:initialize
** Execute test:setup_db
test
test
** Preparing database
** Invoke evm:db:reset (first_time)
** Invoke evm:db:destroy (first_time)
** Execute evm:db:destroy
** Invoke environment
** Invoke db:drop (first_time)
** Invoke db:load_config (first_time)
...
```