### PR TITLE
Remove `.with` used to validate arguments

### DIFF
--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -11,11 +11,11 @@ describe ApplicationController do
     context "with a resource_action dialog" do
       it "Vm button" do
         controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
-        expect(controller).to receive(:dialog_initialize).with { |action, options|
+        expect(controller).to receive(:dialog_initialize) do |action, options|
           expect(action).to eq(resource_action)
           expect(options[:target_id]).to eq(vm.id)
           expect(options[:target_kls]).to eq(vm.class.name)
-        }
+        end
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(vm.name)
@@ -26,11 +26,11 @@ describe ApplicationController do
         button.update_attributes(:applies_to_class => "MiqTemplate")
         controller.instance_variable_set(:@_params, :id => template.id, :button_id => button.id)
 
-        expect(controller).to receive(:dialog_initialize).with { |action, options|
+        expect(controller).to receive(:dialog_initialize) do |action, options|
           expect(action).to eq(resource_action)
           expect(options[:target_id]).to eq(template.id)
           expect(options[:target_kls]).to eq(template.class.name)
-        }
+        end
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(template.name)

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -25,14 +25,18 @@ describe MiqRequestController do
 
     it "MiqRequest-created_on" do
       content = {"value" => "9 Days Ago", "field" => "MiqRequest-created_on"}
-      expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 0, "AFTER")).to eq(content) }
+      expect(MiqExpression).to receive(:new) do |h|
+        expect(h.fetch_path("and", 0, "AFTER")).to eq(content)
+      end
       controller.send(:prov_condition, :time_period => 9)
     end
 
     context "MiqRequest-requester_id set based on user_id" do
       it "user with approver priveleges" do
         content = {"value" => user.id, "field" => "MiqRequest-requester_id"}
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 1, "=")).to eq(content) }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path("and", 1, "=")).to eq(content)
+        end
         controller.send(:prov_condition, {})
       end
 
@@ -40,7 +44,9 @@ describe MiqRequestController do
         user             = FactoryGirl.create(:user)
         login_as user
         content          = {"value" => user.id, "field" => "MiqRequest-requester_id"}
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 1, "=")).to eq(content) }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path("and", 1, "=")).to eq(content)
+        end
         controller.send(:prov_condition, {})
       end
     end
@@ -49,19 +55,25 @@ describe MiqRequestController do
       let(:path) { ["and", 2, "=", "value"] }
 
       it "selected 'all'" do
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path(path) == "all").to be_falsey }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path(path) == "all").to be_falsey
+        end
         controller.send(:prov_condition, :user_choice => "all")
       end
 
       it "selected '1'" do
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path(path) == 1).to be_truthy }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path(path) == 1).to be_truthy
+        end
         controller.send(:prov_condition, :user_choice => 1)
       end
     end
 
     it "MiqRequest-approval_state set with :applied_states" do
       content = [{"=" => {"value" => "state", "field" => "MiqRequest-approval_state"}}, {"=" => {"value" => "state 2", "field" => "MiqRequest-approval_state"}}]
-      expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 2, "or")).to eq(content) }
+      expect(MiqExpression).to receive(:new) do |h|
+        expect(h.fetch_path("and", 2, "or")).to eq(content)
+      end
       controller.send(:prov_condition, :applied_states => ["state", "state 2"])
     end
 
@@ -70,7 +82,9 @@ describe MiqRequestController do
         {"=" => {"value" => type, "field" => "MiqRequest-resource_type"}}
       end
 
-      expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 2, "or")).to eq(content) }
+      expect(MiqExpression).to receive(:new) do |h|
+        expect(h.fetch_path("and", 2, "or")).to eq(content)
+      end
       controller.send(:prov_condition, {})
     end
 
@@ -78,28 +92,34 @@ describe MiqRequestController do
       let(:path) { ["and", 3, "=", "value"] }
 
       it "selected 'all'" do
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path(path)).to be_nil }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path(path)).to be_nil
+        end
         controller.send(:prov_condition, :type_choice => "all")
       end
 
       it "selected '1'" do
-        expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path(path)).to eq(1) }
+        expect(MiqExpression).to receive(:new) do |h|
+          expect(h.fetch_path(path)).to eq(1)
+        end
         controller.send(:prov_condition, :type_choice => 1)
       end
     end
 
     it "MiqRequest-reason_text" do
       content = {"value" => "just because", "field" => "MiqRequest-reason"}
-      expect(MiqExpression).to receive(:new).with { |h| expect(h.fetch_path("and", 3, "INCLUDES")).to eq(content) }
+      expect(MiqExpression).to receive(:new) do |h|
+        expect(h.fetch_path("and", 3, "INCLUDES")).to eq(content)
+      end
       controller.send(:prov_condition, :reason_text => "just because")
     end
 
     it "empty options hash" do
-      expect(MiqExpression).to receive(:new).with { |h|
+      expect(MiqExpression).to receive(:new) do |h|
         expect(h.fetch_path("and", 2, "or", 0, "=", "field") == "MiqRequest-approval_state")
           .to be_falsey # Doesn't set approval_states
         expect(h.fetch_path("and", 3, "INCLUDES")).to be_nil # Doesn't set reason_text
-      }
+      end
       controller.send(:prov_condition, {})
     end
   end

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -70,11 +70,11 @@ describe EmsRefresh do
       ems = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
       vm1 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems)
       vm2 = FactoryGirl.create(:vm_vmware, :name => "vm_vmware2", :ext_management_system => ems)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh).with { |args|
+      expect(ManageIQ::Providers::Vmware::InfraManager::Refresher).to receive(:refresh) do |args|
         # Refresh code doesn't care about args order so neither does the test
         # TODO: use array_including in rspec 3
         (args - [vm2, vm1]).empty?
-      }
+      end
 
       EmsRefresh.refresh([
         [vm1.class, vm1.id],

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -18,18 +18,18 @@ describe ManageIQ::Providers::Azure::CloudManager do
 
     context "#connect " do
       it "defaults" do
-        expect(described_class).to receive(:raw_connect).with { |clientid, clientkey|
+        expect(described_class).to receive(:raw_connect) do |clientid, clientkey|
           expect(clientid).to eq("klmnopqrst")
           expect(clientkey).to eq("1234567890")
-        }
+        end
         @e.connect
       end
 
       it "accepts overrides" do
-        expect(described_class).to receive(:raw_connect).with { |clientid, clientkey|
+        expect(described_class).to receive(:raw_connect) do |clientid, clientkey|
           expect(clientid).to eq("user")
           expect(clientkey).to eq("pass")
-        }
+        end
         @e.connect(:user => "user", :pass => "pass")
       end
     end

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -20,10 +20,10 @@ describe ManageIQ::Providers::Google::CloudManager do
 
     context "#connect " do
       it "defaults" do
-        expect(described_class).to receive(:raw_connect).with { |project, auth_key|
+        expect(described_class).to receive(:raw_connect) do |project, auth_key|
           expect(project).to eq(@google_project)
           expect(auth_key).to eq(@google_json_key)
-        }
+        end
         @e.connect
       end
     end

--- a/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
@@ -20,23 +20,23 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
         expect(url).to match(/host/)
         expect(protocol).to eq("ssl")
         expect(creds[:user]).to eq("user")
         expect(creds[:pass]).to eq("pass")
-      }
+      end
 
       @e.connect
     end
 
     it "accepts overrides" do
-      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
         expect(url).to match(/host2/)
         expect(protocol).to eq("ssl")
         expect(creds[:user]).to eq("user2")
         expect(creds[:pass]).to eq("pass2")
-      }
+      end
 
       @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
     end
@@ -49,25 +49,25 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "defaults" do
-      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
         expect(url).to match(/host/)
         expect(protocol).to eq("kerberos")
         expect(creds[:user]).to eq("user")
         expect(creds[:pass]).to eq("pass")
         expect(creds[:realm]).to eq("pretendrealm")
-      }
+      end
 
       @e.connect
     end
 
     it "accepts overrides" do
-      expect(described_class).to receive(:raw_connect).with { |url, protocol, creds|
+      expect(described_class).to receive(:raw_connect) do |url, protocol, creds|
         expect(url).to match(/host2/)
         expect(protocol).to eq("kerberos")
         expect(creds[:user]).to eq("user2")
         expect(creds[:pass]).to eq("pass2")
         expect(creds[:realm]).to eq("pretendrealm")
-      }
+      end
 
       @e.connect(:user => "user2", :pass => "pass2", :hostname => "host2")
     end

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -5,13 +5,17 @@ describe MiqEvent do
     context ".raise_evm_job_event" do
       it "vm" do
         obj = FactoryGirl.create(:vm_redhat)
-        expect(MiqEvent).to receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "vm_scan_complete" }
+        expect(MiqEvent).to receive(:raise_evm_event) do |target, raw_event, _inputs|
+          target == obj && raw_event == "vm_scan_complete"
+        end
         MiqEvent.raise_evm_job_event(obj, {:type => "scan", :suffix => "complete"}, {})
       end
 
       it "host" do
         obj = FactoryGirl.create(:host_vmware)
-        expect(MiqEvent).to receive(:raise_evm_event).with { |target, raw_event, _inputs| target == obj && raw_event == "host_scan_complete" }
+        expect(MiqEvent).to receive(:raise_evm_event) do |target, raw_event, _inputs|
+          target == obj && raw_event == "host_scan_complete"
+        end
         MiqEvent.raise_evm_job_event(obj, {:type => "scan", :suffix => "complete"}, {})
       end
     end
@@ -125,7 +129,9 @@ describe MiqEvent do
       it "uses base_model to build event name" do
         host = FactoryGirl.create(:host_vmware_esx)
         vm = FactoryGirl.create(:vm_vmware, :host => host)
-        expect(MiqEvent).to receive(:raise_evm_event_queue).with { |target, child_event, _inputs| target == vm && child_event == "assigned_company_tag_parent_host" }
+        expect(MiqEvent).to receive(:raise_evm_event_queue) do |target, child_event, _inputs|
+          target == vm && child_event == "assigned_company_tag_parent_host"
+        end
         MiqEvent.raise_event_for_children(host, "assigned_company_tag")
       end
     end

--- a/spec/models/miq_provision/automate_spec.rb
+++ b/spec/models/miq_provision/automate_spec.rb
@@ -12,9 +12,9 @@ describe MiqProvision do
     let(:prov) { FactoryGirl.build(:miq_provision, :tenant => t1) }
 
     def stub_method
-      expect(MiqAeEngine).to receive(:resolve_automation_object).with { |uri, _, _, _|
-        expect(uri).to eq('REQUEST')
-      }.and_return(workspace)
+      expect(MiqAeEngine)
+        .to receive(:resolve_automation_object) { |uri, _, _, _| expect(uri).to eq('REQUEST') }
+        .and_return(workspace)
     end
 
     context "with password" do

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -149,7 +149,7 @@ describe MiqProvision do
 
       expect(prov).to receive(:eligible_resource_lookup).and_return(host)
 
-      expect(prov).to receive(:workflow).with { |options, flags|
+      expect(prov).to receive(:workflow) { |options, flags|
         expect(options[:placement_auto]).to eq([false, 0])
         expect(flags[:skip_dialog_load]).to be_truthy
       }.and_return(workflow)


### PR DESCRIPTION
Using the return value of a `with` block to validate passed arguments rather than as an implementation is deprecated in RSpec 3.