### PR TITLE
Vmdb::Loggers reorganization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,11 +23,13 @@ CyclomaticComplexity:
 GlobalVars:
   AllowedVariables:
   # Loggers
+  - $audit_log
   - $api_log
   - $aws_log
   - $fog_log
   - $log
   - $miq_ae_logger
+  - $policy_log
   - $rails_log
   - $rhevm_log
   - $kube_log

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,28 +84,33 @@ module Vmdb
     # Defaults to every folder in the app directory of the application.
     config.eager_load_paths = []
 
-    require_relative 'environments/patches/database_configuration'
+    # This must be done outside of initialization blocks
+    #   as Vmdb::Logging is needed very early
+    require 'vmdb/logging'
+
+    config.before_initialize do
+      require_relative 'environments/patches/database_configuration'
+
+      Vmdb::Loggers.init
+      config.logger = Vmdb.rails_logger
+      config.colorize_logging = false
+
+      # To evaluate ERB from database.yml containing encrypted passwords
+      require 'miq-password'
+      MiqPassword.key_root = Rails.root.join("certs")
+
+      require 'vmdb_helper'
+    end
+
+    config.after_initialize do
+      Vmdb::Initializer.init
+      ActiveRecord::Base.connection_pool.release_connection
+    end
 
     console do
       Rails::ConsoleMethods.class_eval do
         include Vmdb::ConsoleMethods
       end
-    end
-
-    # logging requires configuration which requires encryption
-    require 'miq-password'
-    MiqPassword.key_root = Rails.root.join("certs")
-
-    require 'vmdb/logging'
-    Vmdb::Loggers.init
-    config.logger = Vmdb.rails_logger
-    config.colorize_logging = false
-
-    require 'vmdb_helper'
-
-    config.after_initialize do
-      Vmdb::Initializer.init
-      ActiveRecord::Base.connection_pool.release_connection
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,6 +101,8 @@ module Vmdb
     config.logger = Vmdb.rails_logger
     config.colorize_logging = false
 
+    require 'vmdb_helper'
+
     config.after_initialize do
       Vmdb::Initializer.init
       ActiveRecord::Base.connection_pool.release_connection

--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -3,9 +3,6 @@ GEMS_PENDING_ROOT = File.expand_path(File.join(__dir__, %w(.. gems pending)))
 $LOAD_PATH << GEMS_PENDING_ROOT
 $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "util")
 
-# To evaluate ERB from database.yml containing encrypted passwords
-require 'miq-password'
-
 # Optional logging of requires
 if ENV["REQUIRE_LOG"]
   $req_log_path = File.join(File.dirname(__FILE__), %w(.. log))

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -134,7 +134,6 @@ log:
   level_scvmm_in_evm: error
   level_vim: warn
   level_vim_in_evm: error
-  path:
 log_depot:
   password:
   uri:

--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -18,8 +18,8 @@ module VMDB
 
       private
 
-      def log(_data)
-        Vmdb::Loggers.init
+      def log(data)
+        Vmdb::Loggers.apply_config(data)
       end
 
       def session(data)

--- a/lib/vmdb/config/validator.rb
+++ b/lib/vmdb/config/validator.rb
@@ -84,10 +84,10 @@ module VMDB
         valid, errors = true, []
 
         # validate level
-        data.keys.each do |key|
+        data.each_pair do |key, value|
           next unless key.to_s.start_with?("level")
 
-          level = data[key].to_s.upcase.to_sym
+          level = value.to_s.upcase.to_sym
           unless VMDBLogger::Severity.constants.include?(level)
             valid = false; errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{VMDBLogger::Severity.constants.join(", ")}"]
           end

--- a/lib/vmdb/config/validator.rb
+++ b/lib/vmdb/config/validator.rb
@@ -81,8 +81,29 @@ module VMDB
       end
 
       def log(data)
-        data = data.instance_variable_get(:@table) if data.kind_of?(OpenStruct)
-        Vmdb::Loggers.validate_config(data)
+        valid, errors = true, []
+
+        # validate level
+        Vmdb::Loggers::LEVEL_CONFIG_KEYS.each do |key|
+          level = data[key].to_s.upcase.to_sym
+          unless VMDBLogger::Severity.constants.include?(level)
+            valid = false; errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{VMDBLogger::Severity.constants.join(", ")}"]
+          end
+        end
+
+        # validate path
+        path = data.path.to_s
+        unless path.blank?
+          unless File.exist?(File.dirname(path))
+            valid = false; errors << [:path, "path, \"#{path}\", is invalid, directory does not exist"]
+          end
+
+          if File.extname(path).downcase != ".log"
+            valid = false; errors << [:path, "path, \"#{path}\", is invalid, must be in the form of <directory path>/<log file name>.log"]
+          end
+        end
+
+        return valid, errors
       end
 
       def session(data)

--- a/lib/vmdb/config/validator.rb
+++ b/lib/vmdb/config/validator.rb
@@ -93,18 +93,6 @@ module VMDB
           end
         end
 
-        # validate path
-        path = data.path.to_s
-        unless path.blank?
-          unless File.exist?(File.dirname(path))
-            valid = false; errors << [:path, "path, \"#{path}\", is invalid, directory does not exist"]
-          end
-
-          if File.extname(path).downcase != ".log"
-            valid = false; errors << [:path, "path, \"#{path}\", is invalid, must be in the form of <directory path>/<log file name>.log"]
-          end
-        end
-
         return valid, errors
       end
 

--- a/lib/vmdb/config/validator.rb
+++ b/lib/vmdb/config/validator.rb
@@ -84,7 +84,9 @@ module VMDB
         valid, errors = true, []
 
         # validate level
-        Vmdb::Loggers::LEVEL_CONFIG_KEYS.each do |key|
+        data.keys.each do |key|
+          next unless key.to_s.start_with?("level")
+
           level = data[key].to_s.upcase.to_sym
           unless VMDBLogger::Severity.constants.include?(level)
             valid = false; errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{VMDBLogger::Severity.constants.join(", ")}"]

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -3,6 +3,8 @@ module Vmdb
     def self.init
       _log.info "- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['MIQ_GUID']: #{ENV['MIQ_GUID']}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}"
 
+      Vmdb::Loggers.apply_config
+
       if MiqEnvironment::Process.is_web_server_worker?
         require 'hamlit-rails'
 

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -26,7 +26,6 @@ module Vmdb
       #
       ####################################################
       if MiqEnvironment::Process.is_ui_worker_via_command_line?
-        Vmdb::Loggers.apply_config
         EvmDatabase.seed_primordial
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -14,7 +14,6 @@ module Vmdb
 
   module Loggers
     DEFAULT_LOG_LEVEL = "INFO"
-    DEFAULT_LOG_PATH  = Rails.root.join("log", "#{Rails.env}.log")
 
     def self.init
       return if @initialized
@@ -44,27 +43,25 @@ module Vmdb
     end
 
     def self.create_loggers
-      config   = get_config
-      path     = config[:path] || DEFAULT_LOG_PATH
-      path_dir = File.dirname(path)
-
       if ENV.key?("CI")
         $log = $rails_log = $audit_log = $fog_log = $policy_log = $vim_log =
           $rhevm_log = $aws_log = $kube_log = $scvmm_log = $api_log =
           $miq_ae_logger = LogProxy.null_logger
       else
-        $log           = VMDBLogger.new(File.join(path_dir, "evm.log"))
-        $rails_log     = VMDBLogger.new(path)
-        $audit_log     = AuditLogger.new(File.join(path_dir, "audit.log"))
-        $fog_log       = FogLogger.new(File.join(path_dir, "fog.log"))
-        $policy_log    = MirroredLogger.new(File.join(path_dir, "policy.log"),     "<PolicyEngine> ")
-        $vim_log       = MirroredLogger.new(File.join(path_dir, "vim.log"),        "<VIM> ")
-        $rhevm_log     = MirroredLogger.new(File.join(path_dir, "rhevm.log"),      "<RHEVM> ")
-        $aws_log       = MirroredLogger.new(File.join(path_dir, "aws.log"),        "<AWS> ")
-        $kube_log      = MirroredLogger.new(File.join(path_dir, "kubernetes.log"), "<KUBERNETES> ")
-        $scvmm_log     = MirroredLogger.new(File.join(path_dir, "scvmm.log"),      "<SCVMM> ")
-        $api_log       = MirroredLogger.new(File.join(path_dir, "api.log"),        "<API> ")
-        $miq_ae_logger = MirroredLogger.new(File.join(path_dir, "automation.log"), "<AutomationEngine> ")
+        path_dir = Rails.root.join("log")
+
+        $log           = VMDBLogger.new(path_dir.join("evm.log"))
+        $rails_log     = VMDBLogger.new(path_dir.join("#{Rails.env}.log"))
+        $audit_log     = AuditLogger.new(path_dir.join("audit.log"))
+        $fog_log       = FogLogger.new(path_dir.join("fog.log"))
+        $policy_log    = MirroredLogger.new(path_dir.join("policy.log"),     "<PolicyEngine> ")
+        $vim_log       = MirroredLogger.new(path_dir.join("vim.log"),        "<VIM> ")
+        $rhevm_log     = MirroredLogger.new(path_dir.join("rhevm.log"),      "<RHEVM> ")
+        $aws_log       = MirroredLogger.new(path_dir.join("aws.log"),        "<AWS> ")
+        $kube_log      = MirroredLogger.new(path_dir.join("kubernetes.log"), "<KUBERNETES> ")
+        $scvmm_log     = MirroredLogger.new(path_dir.join("scvmm.log"),      "<SCVMM> ")
+        $api_log       = MirroredLogger.new(path_dir.join("api.log"),        "<API> ")
+        $miq_ae_logger = MirroredLogger.new(path_dir.join("automation.log"), "<AutomationEngine> ")
         $miq_ae_logger.mirror_level = VMDBLogger::INFO
       end
 

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -16,25 +16,6 @@ module Vmdb
     DEFAULT_LOG_LEVEL = "INFO"
     DEFAULT_LOG_PATH  = Rails.root.join("log", "#{Rails.env}.log")
 
-    LEVEL_CONFIG_KEYS = [
-      :level,
-      :level_rails,
-      :level_vim,
-      :level_vim_in_evm,
-      :level_rhevm,
-      :level_rhevm_in_evm,
-      :level_aws,
-      :level_aws_in_evm,
-      :level_kube,
-      :level_kube_in_evm,
-      :level_scvmm,
-      :level_scvmm_in_evm,
-      :level_api,
-      :level_api_in_evm,
-      :level_fog,
-      :level_fog_in_evm,
-    ]
-
     def self.init
       return if @initialized
       create_loggers

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -20,7 +20,7 @@ module Vmdb
 
     def self.apply_config(config = nil)
       config ||= VMDB::Config.new("vmdb").config
-      config = config[:log] if config.key?(:log)
+      config = config[:log] if config[:log]
 
       apply_config_value(config, $log,       :level)
       apply_config_value(config, $rails_log, :level_rails)

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,5 +1,4 @@
 require 'vmdb-logger'
-require 'vmdb_helper'  # TODO: eventually replace this with requiring Vmdb::Config directly
 
 Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }
 
@@ -13,8 +12,6 @@ module Vmdb
   end
 
   module Loggers
-    DEFAULT_LOG_LEVEL = "INFO"
-
     def self.init
       return if @initialized
       create_loggers
@@ -22,7 +19,7 @@ module Vmdb
     end
 
     def self.apply_config(config = nil)
-      config ||= get_config
+      config ||= VMDB::Config.new("vmdb").config
       config = config[:log] if config.key?(:log)
 
       apply_config_value(config, $log,       :level)
@@ -37,10 +34,6 @@ module Vmdb
     end
 
     private
-
-    def self.get_config
-      VMDB::Config.new("vmdb").config[:log]
-    end
 
     def self.create_loggers
       if ENV.key?("CI")
@@ -82,7 +75,7 @@ module Vmdb
 
     def self.apply_config_value_logged(config, logger, level_method, key)
       old_level = logger.send(level_method)
-      new_level_name = (config[key] || DEFAULT_LOG_LEVEL).to_s.upcase
+      new_level_name = (config[key] || "INFO").to_s.upcase
       new_level = VMDBLogger.const_get(new_level_name)
       if old_level != new_level
         $log.info("MIQ(#{name}.apply_config) Log level for #{File.basename(logger.filename)} has been changed to [#{new_level_name}]")

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -75,5 +75,3 @@ module Vmdb
 
   ::Module.send :include, ClassLogging
 end
-
-require 'vmdb/loggers'


### PR DESCRIPTION
This PR cleans up the initialization of the application with respect to the loggers.  This is a pre-requisite for the configuration revamp.

Loggers were defined extremely early (during Rails boot, before `config.before_initialize`) and were coupled with configuration.  Because of this, configuration itself was required extremely early, which makes changing the code very difficult, as it has to account for pre-boot conditions as well.

The only reason Loggers really needed configuration was because of the ability to configure the Rails log path.  However this feature is not used at all, and, in fact, if changed, may cause issues with the appliance.  The appliance has the ability to configure a separate disk for logs, so there is no need to change the default path as it is the mount point for the log disk.

So, this PR removes the path from the configuration, which allows us to decouple configuration from logging.  The log levels can still be configured, but instead of being applied immediately, they are applied during `Vmdb::Config#activate`, when all other configuration settings are applied.  As such, the code for activating and validating the configuration now lives in the Vmdb::Config code.

Additionally, once things cleared up in application.rb, I reorganized the application.rb code to properly leverage `config.before_initialize`.  This should make it very clear what is happening when and why.

@jrafanie Please review.