### PR TITLE
Remove all number.format keys from en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,17 +95,6 @@ en:
     model_for_record: '%{model} for "%{name}"'
     name: '"%{name}"'
 
-  number:
-    # Used in number_with_delimiter()
-    # These are also the defaults for 'currency', 'percentage', 'precision', and 'human'
-    format:
-      # Sets the separator between the units, for more precision (e.g. 1.0 / 2.0 == 0.5)
-      separator: "."
-      # Delimets thousands (e.g. 1,000,000 is a million) (always in groups of three)
-      delimiter: ","
-      # Number of decimals, behind the separator (the number 1 with a precision of 2 gives: 1.00)
-      precision: 3
-
   activerecord:
     attributes:
       ems_cloud:


### PR DESCRIPTION
These keys are now all provided by rails-i18n gem.