### PR TITLE
Remove support.select.prompt key from en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,11 +123,6 @@ en:
         # The variable :count is also available
         body: "There were problems with the following fields:"
 
-  support:
-    select:
-      # default value for :prompt => true in FormOptionsHelper
-      prompt: "Please select"
-
   model_name:
     miq_policy_set: Policy Profile
     miq_event_definition: Event


### PR DESCRIPTION
This same key and same (default) value is provided by rails.