### PR TITLE
Remove .have(n).error_on(:thing) deprecations

### DIFF
--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -155,7 +155,7 @@ describe Classification do
         cat = Classification.new(:name => name, :parent_id => 0)
 
         expect(cat).to_not be_valid
-        expect(cat).to     have(1).error_on(:name)
+        expect(cat.errors[:name].size).to eq(1)
       end
     end
 


### PR DESCRIPTION
For RSpec 3 compatibility