### PR TITLE
Remove deprecated uses of `mock_model`

### DIFF
--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -217,7 +217,7 @@ describe EmsCloudController do
   end
 
   context "#build_credentials only contains credentials that it supports and has a username for in params" do
-    let(:mocked_ems)    { mock_model(ManageIQ::Providers::Openstack::CloudManager) }
+    let(:mocked_ems)    { double(ManageIQ::Providers::Openstack::CloudManager) }
     let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
     let(:amqp_creds)    { {:userid => "amqp_userid",    :password => "amqp_password"} }
 
@@ -247,7 +247,7 @@ describe EmsCloudController do
   end
 
   context "#update_ems_button_validate" do
-    let(:mocked_ems) { mock_model(ManageIQ::Providers::Openstack::CloudManager) }
+    let(:mocked_ems) { double(ManageIQ::Providers::Openstack::CloudManager, id: 1) }
     it "calls authentication_check with save = true if validation is done for an existing record" do
       allow(controller).to receive(:set_ems_record_vars)
       allow(controller).to receive(:render)

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -93,7 +93,7 @@ describe EmsCloudController do
 
     context "#update_button_validate" do
       context "when authentication_check" do
-        let(:mocked_ems_cloud) { mock_model(EmsCloud) }
+        let(:mocked_ems_cloud) { double(EmsCloud) }
         before(:each) do
           controller.instance_variable_set(:@_params, :id => "42", :type => "amqp")
           expect(controller).to receive(:find_by_id_filtered).with(EmsCloud, "42").and_return(mocked_ems_cloud)
@@ -235,7 +235,7 @@ end
 
 describe EmsInfraController do
   context "#show_link" do
-    let(:ems) { mock_model(EmsInfra) }
+    let(:ems) { double(EmsInfra, id: 1) }
     it "sets relative url" do
       controller.instance_variable_set(:@table_name, "ems_infra")
       link = controller.send(:show_link, ems, :display => "vms")

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -174,7 +174,7 @@ describe HostController do
   end
 
   context "#set_credentials" do
-    let(:mocked_host) { mock_model(Host) }
+    let(:mocked_host) { double(Host) }
     it "uses params[:default_password] for validation if one exists" do
       controller.instance_variable_set(:@_params,
                                        :default_userid   => "default_userid",

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -81,7 +81,7 @@ describe OpsController do
     end
   end
   context "#build_uri_settings" do
-    let(:mocked_filedepot) { mock_model(FileDepotSmb) }
+    let(:mocked_filedepot) { double(FileDepotSmb) }
     it "uses params[:log_password] for validation if one exists" do
       controller.instance_variable_set(:@_params,
                                        :log_userid   => "userid",

--- a/spec/controllers/storage_manager_controller_spec.rb
+++ b/spec/controllers/storage_manager_controller_spec.rb
@@ -50,7 +50,7 @@ describe StorageManagerController do
   end
 
   context "Validate" do
-    let(:mocked_sm) { mock_model(StorageManager) }
+    let(:mocked_sm) { double(StorageManager) }
 
     it "uses @edit password value for validation" do
       Zone.create(:name => "default", :description => "default")

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_copy_spec.rb
@@ -103,7 +103,7 @@ describe MiqAeClassCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       miq_ae_class_copy = double(MiqAeClassCopy)
-      miq_ae_class = mock_model(MiqAeClass)
+      miq_ae_class = double(MiqAeClass, id: 1)
       new_ids = [miq_ae_class.id] * ids.length
       expect(miq_ae_class_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_class }
       expect(miq_ae_class).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_copy_spec.rb
@@ -100,7 +100,7 @@ describe MiqAeInstanceCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       ins_copy = double(MiqAeInstanceCopy)
-      ins = mock_model(MiqAeInstance)
+      ins = double(MiqAeInstance, id: 1)
       expect(ins_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { ins }
       new_ids = [ins.id] * ids.length
       expect(ins).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_copy_spec.rb
@@ -90,7 +90,7 @@ describe MiqAeMethodCopy do
       fqname = 'test1'
       ids    = [1, 2, 3]
       miq_ae_method_copy = double(MiqAeMethodCopy)
-      miq_ae_method = mock_model(MiqAeMethod)
+      miq_ae_method = double(MiqAeMethod, id: 1)
       expect(miq_ae_method_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_method }
       new_ids = [miq_ae_method.id] * ids.length
       expect(miq_ae_method).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }


### PR DESCRIPTION
`mock_model` is removed in RSpec 3. Rather than add `rspec-activemodel-mocks` to restore this functionality, this changes all of our uses of it to a typical named double, which should provide all the mocking we require anyway.