### PR TITLE
Rspec 3: Remove `visit` in controller specs

### DIFF
--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -9,7 +9,7 @@ describe PictureController do
 
     EvmSpecHelper.create_guid_miq_server_zone
 
-    picture.content = picture_content
+    picture.content = picture_content.dup # dup because destructive operation
     picture.save
   end
 

--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -14,26 +14,26 @@ describe PictureController do
   end
 
   it 'can serve a picture directly from the database' do
-    visit "/pictures/#{picture.compressed_id}.#{picture.extension}"
-    expect(page.status_code).to eq(200)
+    get :show, :basename => "#{picture.compressed_id}.#{picture.extension}"
+    expect(response.status).to eq(200)
     expect(response.body).to eq(picture_content)
   end
 
   it 'can serve a picture directly from the database using the uncompressed id' do
-    visit "/pictures/#{picture.id}.#{picture.extension}"
-    expect(page.status_code).to eq(200)
+    get :show, :basename => "#{picture.compressed_id}.#{picture.extension}"
+    expect(response.status).to eq(200)
     expect(response.body).to eq(picture_content)
   end
 
   it "responds with a Not Found with pictures of incorrect extension" do
-    visit "/pictures/#{picture.compressed_id}.png"
-    expect(page.status_code).to eq(404)
+    get :show, :basename => "#{picture.compressed_id}.png"
+    expect(response.status).to eq(404)
     expect(response.body).to be_blank
   end
 
   it "responds with a Not Found with unknown pictures" do
-    visit "/pictures/bogusimage.gif"
-    expect(page.status_code).to eq(404)
+    get :show, :basename => "bogusimage.gif"
+    expect(response.status).to eq(404)
     expect(response.body).to be_blank
   end
 end


### PR DESCRIPTION
* Using the capybara method `visit` in controller specs is deprecated and removed in RSpec 3
* Also, Picture#content= is a destructive operation because binary. All of these specs were previously just testing "" == ""