### PR TITLE
Remove `describe` double nesting with constant names

### DIFF
--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -1,25 +1,23 @@
 require "spec_helper"
 include UiConstants
 
-describe MiqAeCustomizationController do
-  describe ApplicationController::Automate do
-    context "#resolve" do
-      before(:each) do
-        set_user_privileges
-      end
-      it "Simulate button from custom buttons should redirect to resolve" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
-        target_classes = {}
-        CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
-        resolve = {
-          :new            => {:target_class => custom_button.applies_to_class},
-          :target_classes => target_classes
-        }
-        session[:resolve] = resolve
-        controller.instance_variable_set(:@resolve, resolve)
-        post :resolve, :button => "simulate", :id => custom_button.id
-        expect(response.body).to include("miq_ae_tools/resolve?escape=false&simulate=simulate")
-      end
+describe MiqAeCustomizationController, "ApplicationController::Automate" do
+  context "#resolve" do
+    before(:each) do
+      set_user_privileges
+    end
+    it "Simulate button from custom buttons should redirect to resolve" do
+      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+      target_classes = {}
+      CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
+      resolve = {
+        :new            => {:target_class => custom_button.applies_to_class},
+        :target_classes => target_classes
+      }
+      session[:resolve] = resolve
+      controller.instance_variable_set(:@resolve, resolve)
+      post :resolve, :button => "simulate", :id => custom_button.id
+      expect(response.body).to include("miq_ae_tools/resolve?escape=false&simulate=simulate")
     end
   end
 end


### PR DESCRIPTION
The semantics of `described_class` in a nested `describe <SomeClass>` example group are changing in RSpec 3. In RSpec 2.x, `described_class` would return the outermost described class (MiqAeCustomizationController).  In RSpec 3, it will return the innermost described class (ApplicationController::Automate, incorrectly)