### PR TITLE
miqGridCheckedRows - handle checkboxes where the id is a part of the name, not value

### DIFF
--- a/app/assets/javascripts/miq_list_grid.js
+++ b/app/assets/javascripts/miq_list_grid.js
@@ -10,15 +10,29 @@ function miqRowClick(row_id, row_url, row_url_ajax) {
   }
 }
 
+function checkboxItemId($elem) {
+  var val = $elem.val()
+  var name = $elem.attr('name');
+
+  if (_.startsWith(name, 'check_')) {
+    return name.substr(6);
+  }
+
+  return val;
+}
+
 // returns a list of checked row ids
 function miqGridGetCheckedRows(grid) {
   grid = grid || 'list_grid';
   var crows = [];
 
   $('#' + grid + ' .list-grid-checkbox').each(function(_idx, elem) {
-    if ($(elem).prop('checked')) {
-      crows.push($(elem).val());
+    if (! $(elem).prop('checked')) {
+      return;
     }
+
+    var item_id = checkboxItemId($(elem));
+    crows.push(item_id);
   });
 
   return crows;

--- a/spec/javascripts/miq_list_grid_spec.js
+++ b/spec/javascripts/miq_list_grid_spec.js
@@ -1,8 +1,49 @@
-describe('Calling miqGridSort', function() {
-  it('returns url fwith no double id', function() {
-    ManageIQ.actionUrl = 'show/1000000000015';
-    ManageIQ.record.parentClass = 'ems_infra';
-    ManageIQ.record.parentId = '1000000000015';
-    expect(miqGetSortUrl(1)).toEqual('/ems_infra/show/1000000000015?sortby=1&');
+describe('miq_list_grid.js', function() {
+  describe('#miqGridSort', function() {
+    it('returns url with no double id', function() {
+      ManageIQ.actionUrl = 'show/1000000000015';
+      ManageIQ.record.parentClass = 'ems_infra';
+      ManageIQ.record.parentId = '1000000000015';
+      expect(miqGetSortUrl(1)).toEqual('/ems_infra/show/1000000000015?sortby=1&');
+    });
+  });
+
+  describe('#checkboxItemId', function() {
+    // helper to create a fake jquery object
+    var kvToElem = function(name, value) {
+      return {
+        attr: _.constant(name),
+        val: _.constant(value),
+      };
+    };
+
+    it('correctly parses name=check_#{id} checkboxes', function() {
+      expect(checkboxItemId(kvToElem('check_1r2345', '1'))).toEqual('1r2345');
+      expect(checkboxItemId(kvToElem('check_12345', '12345'))).toEqual('12345');
+      expect(checkboxItemId(kvToElem('check_1', '0'))).toEqual('1');
+    });
+
+    it('correctly parses value=#{id} checkboxes', function() {
+      expect(checkboxItemId(kvToElem('whatever', '1r2345'))).toEqual('1r2345');
+      expect(checkboxItemId(kvToElem('whatever', '12345'))).toEqual('12345');
+      expect(checkboxItemId(kvToElem('whatever', '0'))).toEqual('0');
+    });
+  });
+
+  describe('#miqGridGetCheckedRows', function() {
+    beforeEach(function() {
+      var html = "";
+      html += '<div id="test_grid_1">';
+      html += '  <input type="checkbox" class="list-grid-checkbox" name="check_1r2345" value="1" checked>';
+      html += '  <input type="checkbox" class="list-grid-checkbox" name="check_12345" value="1" checked>';
+      html += '  <input type="checkbox" class="list-grid-checkbox" name="check_1" value="1" checked>';
+      html += '  <input type="checkbox" class="list-grid-checkbox" name="check_123" value="1">';
+      html += '</div>';
+      setFixtures(html);
+    });
+
+    it("picks checked checkboxes from the chosen grid", function() {
+      expect(miqGridGetCheckedRows('test_grid_1')).toEqual(['1r2345', '12345', '1']);
+    });
   });
 });


### PR DESCRIPTION
This makes miqGridCheckedRows be able to handle not only `whatever: 1r123` but also `check_1r123: 1`, fixing a bug introduced by #5532.

I'd like to get rid of the concept of putting ids in the checkbox name, but that warrants a separate PR.

@lgalis could you please verify?