### PR TITLE
Removed require 'recursive_openstruct' from tests

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'recursive-open-struct'
 
 describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
   let(:parser)  { described_class.new }

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'recursive-open-struct'
 
 describe ContainerDashboardService do
   context "providers" do


### PR DESCRIPTION
Theres no need for these after #5955 was merged
fyi @himdel @simon3z @zakiva 