### PR TITLE
Adding context menus to container topology

### DIFF
--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -143,3 +143,33 @@ kubernetes-topology-icon svg {
     font-family: icomoon;
     fill: #0088ce;
 }
+
+.container_topology .canvas {
+    position: absolute;
+}
+
+.container_topology .popup {
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: #fff;
+    width: 180px;
+    border: 1px #ccc solid;
+    border-radius: 6px;
+    box-shadow: #333 2px 2px 4px;
+    padding: 6px;
+    font-size: 14px;
+}
+
+.container_topology .popup h5 {
+    font-weight: bold;
+}
+
+.container_topology .popup p {
+    margin: 0 0 4px;
+}
+
+.container_topology .popup p:hover {
+   color : #0099cc;
+   cursor: pointer;
+}

--- a/spec/javascripts/controllers/containers/container_topology_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_topology_controller_spec.js
@@ -48,15 +48,16 @@ describe('containerTopologyController', function() {
       });
     });
 
-    describe('the dbl click gets correct navigation', function() {
+    describe('the dbl click gets correct navigation url', function() {
       it('to entity pages', function() {
         var d = { id:"2",  item:{display_kind:"Openshift", kind:"ContainerManager", id:"2", miq_id:"37"}};
-        expect($controller.dblclick(d)).toEqual("/ems_container/show/37");
+        expect($controller.geturl(d)).toEqual("/ems_container/show/37");
         d = { id:"3",  item:{display_kind:"Pod", kind:"ContainerGroup", id:"3", miq_id:"30"}};
-        expect($controller.dblclick(d)).toEqual("/container_group/show/30");
+        expect($controller.geturl(d)).toEqual("/container_group/show/30");
         d = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4", miq_id:"25"}};
-        expect($controller.dblclick(d)).toEqual("/vm/show/25");
-        expect($controller.dblclick(replicator)).toEqual("/container_replicator/show/10");
+        expect($controller.geturl(d)).toEqual("/vm/show/25");
+        expect($controller.geturl(replicator)).toEqual("/container_replicator/show/10");
+
       });
     });
 


### PR DESCRIPTION
Introducing right click options menu to elements on topology graph.
This commit introduces "go to summary page" for all entities,
and "refresh provider" for Openshift and Kubernetes provider entities.

cc @stefwalter @serenamarie125 @itamarh