### PR TITLE
Fix navigation to container entity from the topology graph

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -180,6 +180,7 @@ angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
 
   function dblclick(d) {
     var entity_url = "";
+    var action = '/show/' + d.item.miq_id;
     switch (d.item.kind) {
       case "Kubernetes":
       case "Openshift":
@@ -188,11 +189,14 @@ angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
       case "AtomicEnterprise":
         entity_url = "ems_container";
         break;
+      case "Container":
+        entity_url = class_name(d);
+        action = '/explorer';
       default :
         entity_url = class_name(d);
     }
 
-    var url = '/' + entity_url + '/show/' + d.item.miq_id;
+    var url = '/' + entity_url + action;
     window.location.assign(url);
   }
 


### PR DESCRIPTION
The container entity has an explorer unlike other container
related entities, hence the navigation to the show/id action was
failing prior to this fix.