### PR TITLE
Partial fix BZ #1286486 - rmv topology from breadcrumbs

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -6,6 +6,10 @@ module ContainersCommonMixin
   end
 
   def show
+    # fix breadcrumbs - remove displaying 'topology' when navigating to any container related entity summary page
+    if @breadcrumbs.present? && (@breadcrumbs.last[:name].eql? 'Topology')
+      @breadcrumbs.clear
+    end
     @display = params[:display] || "main" unless control_selected?
     @lastaction = "show"
     @showtype = "main"


### PR DESCRIPTION
Remove the topology from breadcrumbs when navigated to an entity page from topology.
The change fixes a non working link to topology in breadcrumbs, and anyway, unlike other breadcrumbs, this is not a hierarchical breadcrumb (e.g. all pods->pod), but rather just a navigation from screen A to screen B, similar to what would happen when navigated from, for example, container registry to a VM (infra tab)