### PR TITLE
Event scopes

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -40,7 +40,7 @@ class AvailabilityZone < ActiveRecord::Base
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.availability_zone_id = ?", id]
+  def event_where_clause(scope, assoc = :ems_events)
+    scope.where(events_table_name(assoc) => {:availability_zone_id => id})
   end
 end

--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -101,11 +101,11 @@ class BottleneckEvent < ActiveRecord::Base
     result
   end
 
-  def self.event_where_clause(obj)
+  def self.event_where_clause(scope, obj)
     ids_hash = child_types_and_ids(obj)
-    result = ["(resource_type = '#{obj.class.base_class.name}' AND resource_id = #{obj.id})"]
-    ids_hash.each { |k, v| result.push("(resource_type = '#{k}' AND resource_id in (#{v.join(",")}))") }
-    result.join(" OR ")
+    result = ids_hash.map { |k, v| "(resource_type = '#{k}' AND resource_id in (#{v.join(",")}))" }
+    result << "(resource_type = '#{obj.class.base_class.name}' AND resource_id = #{obj.id})"
+    scope.where(result.join(" OR "))
   end
 
   def self.child_types_and_ids(obj)

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -26,15 +26,18 @@ class Container < ActiveRecord::Base
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ? AND container_name = ?",
-       container_project.name, ext_management_system.id, name]
+      scope.where(:container_namespace     => container_project.name,
+                  events_table_name(assoc) => {:ems_id => ext_management_system.id},
+                  :container_name          => name)
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ext_management_system.id]
+      scope.where(events_table_name(assoc) => {:ems_id => ext_management_system.id})
+    else
+      scope
     end
   end
 

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -55,15 +55,18 @@ class ContainerGroup < ActiveRecord::Base
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_namespace = ? AND container_group_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
-       container_project.name, name, ems_id]
+      scope.where(:container_namespace     => container_project.name,
+                  :container_group_name    => name,
+                  events_table_name(assoc) => {:ems_id => ems_id})
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
+      scope.where(events_table_name(assoc) => {:ems_id => ems_id})
+    else
+      scope
     end
   end
 

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -46,14 +46,17 @@ class ContainerNode < ActiveRecord::Base
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_node_name = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
+      scope.where(:container_node_name     => name,
+                  events_table_name(assoc) => {:ems_id => ems_id})
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
+      scope.where(events_table_name(assoc) => {:ems_id => ems_id})
+    else
+      scope
     end
   end
 

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -54,14 +54,17 @@ class ContainerProject < ActiveRecord::Base
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
+      scope.where(:container_namespace     => name,
+                  events_table_name(assoc) => {:ems_id => ems_id})
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["ems_id = ?", ems_id]
+      scope.where("ems_id" => ems_id)
+    else
+      scope
     end
   end
 

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -22,15 +22,18 @@ class ContainerReplicator < ActiveRecord::Base
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
       # TODO: improve relationship using the id
-      ["container_namespace = ? AND container_replicator_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
-       container_project.name, name, ems_id]
+      scope.where("container_namespace"       => container_project.name,
+                  "container_replicator_name" => name,
+                  events_table_name(assoc)    => {:ems_id => ems_id})
     when :policy_events
       # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
+      scope.where(events_table_name(assoc) => {:ems_id => ems_id})
+    else
+      scope
     end
   end
 

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -247,7 +247,7 @@ class EmsCluster < ActiveRecord::Base
   end
 
   def event_where_clause(assoc = :ems_events)
-    return ["ems_cluster_id = ?", id] if assoc.to_sym == :policy_events
+    return scope.where("ems_cluster_id" => id) if assoc.to_sym == :policy_events
 
     cond = ["ems_cluster_id = ?"]
     cond_params = [id]
@@ -264,14 +264,11 @@ class EmsCluster < ActiveRecord::Base
       cond_params += [ids, ids]
     end
 
-    cond_params.unshift(cond.join(" OR ")) unless cond.empty?
-    cond_params
+    scope.where(cond.join(" OR "), cond_params)
   end
 
   def ems_events
-    ewc = event_where_clause
-    return [] if ewc.blank?
-    EmsEvent.where(ewc).order("timestamp").to_a
+    event_where_clause(self.class).order("timestamp").to_a
   end
 
   def scan

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -365,8 +365,8 @@ class ExtManagementSystem < ActiveRecord::Base
     end
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.ems_id = ?", id]
+  def event_where_clause(scope, assoc = :ems_events)
+    scope.where(events_table_name(assoc) => {:ems_id => id})
   end
 
   def total_vms_and_templates

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1632,12 +1632,14 @@ class Host < ActiveRecord::Base
     !(vmm_vendor == VENDOR_TYPES["vmware"] && vmm_product == "Workstation")
   end
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
-      ["host_id = ? OR dest_host_id = ?", id, id]
+      scope.where("host_id = ? OR dest_host_id = ?", id, id)
     when :policy_events
-      ["host_id = ?", id]
+      scope.where("host_id" => id)
+    else
+      scope
     end
   end
 

--- a/app/models/mixins/event_mixin.rb
+++ b/app/models/mixins/event_mixin.rb
@@ -19,7 +19,7 @@ module EventMixin
     # It should be considered for removal.
     @has_events ||= {}
     return @has_events[assoc] if @has_events.key?(assoc)
-    @has_events[assoc] = events_assoc_class(assoc).where(event_where_clause(assoc)).exists?
+    @has_events[assoc] = event_where_clause(events_assoc_class(assoc), assoc).exists?
   end
 
   def events_assoc_class(assoc)
@@ -33,7 +33,6 @@ module EventMixin
   private
 
   def find_one_event(assoc, order)
-    ewc = event_where_clause(assoc)
-    events_assoc_class(assoc).where(ewc).order(order).first unless ewc.blank?
+    event_where_clause(events_assoc_class(assoc), assoc).order(order).first
   end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1421,12 +1421,14 @@ class VmOrTemplate < ActiveRecord::Base
     ent
   end
 
-  def event_where_clause(assoc = :ems_events)
+  def event_where_clause(scope, assoc = :ems_events)
     case assoc.to_sym
     when :ems_events
-      return ["vm_or_template_id = ? OR dest_vm_or_template_id = ? ", id, id]
+      scope.where("vm_or_template_id = ? OR dest_vm_or_template_id = ? ", id, id)
     when :policy_events
-      return ["target_id = ? and target_class = ? ", id, self.class.base_class.name]
+      scope.where("target_id" => id, "target_class" => self.class.base_class.name)
+    else
+      scope
     end
   end
 


### PR DESCRIPTION
High level: Picking off entries that are building sql when they could use scopes

This targets event where clause. Instead of returning string sql, it builds it up using a scope.
There are a few spots that use `OR`, so the `where-or` gem is introduced. @matthewd will delete this once we are on rails 5.

Need some help sanity checking these entries.
Probably need to revisit specs around these specific cases.


/cc @matthewd you seem to find the spots where I slip on this type of work.