### PR TITLE
expose approve/deny a provision_request in the API

### DIFF
--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -18,5 +18,21 @@ class ApiController
       MiqProvisionVirtWorkflow.from_ws(version_str, @auth_user_obj, template_fields, vm_fields, requester, tags,
                                        additional_values, ems_custom_attrs, miq_custom_attrs)
     end
+
+    def deny_resource_provision_requests(type, id, data)
+      provreq = resource_search(id, type, collection_class(:provision_requests))
+      raise BadRequestError, "A reason is required for this action" if data['reason'].nil?
+      reason = data['reason']
+      provreq.deny(@auth_user_obj.userid, reason)
+      provreq
+    end
+
+    def approve_resource_provision_requests(type, id, data)
+      provreq = resource_search(id, type, collection_class(:provision_requests))
+      raise BadRequestError, "A reason is required for this action" if data['reason'].nil?
+      reason = data['reason']
+      provreq.approve(@auth_user_obj.userid, reason)
+      provreq
+    end
   end
 end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -22,7 +22,9 @@ class ApiController
     def deny_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
       provreq.deny(@auth_user, data['reason'])
-      action_result(true, 'Provision request denied')
+      res = action_result(true, "Provision request #{id} denied")
+      add_href_to_result(res, type, id)
+      res
     rescue => err
       action_result(false, err.to_s)
     end
@@ -30,7 +32,9 @@ class ApiController
     def approve_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
       provreq.approve(@auth_user, data['reason'])
-      action_result(true, 'Provision request approved')
+      res = action_result(true, "Provision request #{id} approved")
+      add_href_to_result(res, type, id)
+      res
     rescue => err
       action_result(false, err.to_s)
     end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -20,21 +20,21 @@ class ApiController
     end
 
     def deny_resource_provision_requests(type, id, data)
-      provreq = resource_search(id, type, collection_class(:provision_requests))
-      provreq.deny(@auth_user, data['reason'])
-      res = action_result(true, "Provision request #{id} denied")
-      add_href_to_result(res, type, id)
-      res
+      api_action(type, id) do |klass|
+        provreq = resource_search(id, type, klass)
+        provreq.deny(@auth_user, data['reason'])
+        action_result(true, "Provision request #{id} denied")
+      end
     rescue => err
       action_result(false, err.to_s)
     end
 
     def approve_resource_provision_requests(type, id, data)
-      provreq = resource_search(id, type, collection_class(:provision_requests))
-      provreq.approve(@auth_user, data['reason'])
-      res = action_result(true, "Provision request #{id} approved")
-      add_href_to_result(res, type, id)
-      res
+      api_action(type, id) do |klass|
+        provreq = resource_search(id, type, klass)
+        provreq.approve(@auth_user, data['reason'])
+        action_result(true, "Provision request #{id} approved")
+      end
     rescue => err
       action_result(false, err.to_s)
     end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -22,13 +22,17 @@ class ApiController
     def deny_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
       provreq.deny(@auth_user, data['reason'])
-      provreq
+      action_result(true, 'Provision request denied')
+    rescue => err
+      action_result(false, err.to_s)
     end
 
     def approve_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
       provreq.approve(@auth_user, data['reason'])
-      provreq
+      action_result(true, 'Provision request approved')
+    rescue => err
+      action_result(false, err.to_s)
     end
   end
 end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -21,17 +21,13 @@ class ApiController
 
     def deny_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
-      raise BadRequestError, "A reason is required for this action" if data['reason'].nil?
-      reason = data['reason']
-      provreq.deny(@auth_user_obj.userid, reason)
+      provreq.deny(@auth_user, data['reason'])
       provreq
     end
 
     def approve_resource_provision_requests(type, id, data)
       provreq = resource_search(id, type, collection_class(:provision_requests))
-      raise BadRequestError, "A reason is required for this action" if data['reason'].nil?
-      reason = data['reason']
-      provreq.approve(@auth_user_obj.userid, reason)
+      provreq.approve(@auth_user, data['reason'])
       provreq
     end
   end

--- a/config/api.yml
+++ b/config/api.yml
@@ -498,6 +498,10 @@
       :post:
       - :name: create
         :identifier: vm_miq_request_new
+      - :name: approve
+        :identifier: vm_miq_request_approve
+      - :name: deny
+        :identifier: vm_miq_request_deny
     :resource_actions:
       :post:
       - :name: approve

--- a/config/api.yml
+++ b/config/api.yml
@@ -498,6 +498,12 @@
       :post:
       - :name: create
         :identifier: vm_miq_request_new
+    :resource_actions:
+      :post:
+      - :name: approve
+        :identifier: vm_miq_request_approve
+      - :name: deny
+        :identifier: vm_miq_request_deny
   :rates:
     :description: Chargeback Rates
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -499,15 +499,15 @@
       - :name: create
         :identifier: vm_miq_request_new
       - :name: approve
-        :identifier: vm_miq_request_approve
+        :identifier: miq_request_approval
       - :name: deny
-        :identifier: vm_miq_request_deny
+        :identifier: miq_request_approval
     :resource_actions:
       :post:
       - :name: approve
-        :identifier: vm_miq_request_approve
+        :identifier: miq_request_approval
       - :name: deny
-        :identifier: vm_miq_request_deny
+        :identifier: miq_request_approval
   :rates:
     :description: Chargeback Rates
     :options:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3962,14 +3962,6 @@
         :description: Request to Provision VMs
         :feature_type: admin
         :identifier: vm_miq_request_new
-      - :name: Approve Provision VMs
-        :description: Approve Request to Provision VMs
-        :feature_type: admin
-        :identifier: vm_miq_request_approve
-      - :name: Deny Provision VMs
-        :description: Deny Request to Provision VMs
-        :feature_type: admin
-        :identifier: vm_miq_request_deny
       - :name: Clone VMs
         :description: Clone VMs
         :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3962,6 +3962,14 @@
         :description: Request to Provision VMs
         :feature_type: admin
         :identifier: vm_miq_request_new
+      - :name: Approve Provision VMs
+        :description: Approve Request to Provision VMs
+        :feature_type: admin
+        :identifier: vm_miq_request_approve
+      - :name: Deny Provision VMs
+        :description: Deny Request to Provision VMs
+        :feature_type: admin
+        :identifier: vm_miq_request_deny
       - :name: Clone VMs
         :description: Clone VMs
         :feature_type: admin

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -106,16 +106,11 @@ describe ApiController do
   end
 
   context "Provision requests approval" do
-    let(:user)      { FactoryGirl.create(:user) }
-    let(:template)  { FactoryGirl.create(:template_amazon) }
-    let(:provreq1)  { FactoryGirl.create(:miq_provision_request,
-                                         :requester   => user,
-                                         :source_type => 'VmOrTemplate',
-                                         :source_id   => template.id) }
-    let(:provreq2)  { FactoryGirl.create(:miq_provision_request,
-                                         :requester   => user,
-                                         :source_type => 'VmOrTemplate',
-                                         :source_id   => template.id) }
+    let(:user)          { FactoryGirl.create(:user) }
+    let(:template)      { FactoryGirl.create(:template_amazon) }
+    let(:provreqbody)   { {:requester => user, :source_type => 'VmOrTemplate', :source_id => template.id} }
+    let(:provreq1)      { FactoryGirl.create(:miq_provision_request, provreqbody) }
+    let(:provreq2)      { FactoryGirl.create(:miq_provision_request, provreqbody) }
     let(:provreq1_url)  { provision_requests_url(provreq1.id) }
     let(:provreq2_url)  { provision_requests_url(provreq2.id) }
     let(:provreqs_list) { [provreq1_url, provreq2_url] }
@@ -125,7 +120,8 @@ describe ApiController do
 
       run_post(provreq1_url, gen_request(:approve))
 
-      expect_single_action_result(:success => true, :message => "Provision request #{provreq1.id} approved", :href => :provreq1_url)
+      expected_msg = "Provision request #{provreq1.id} approved"
+      expect_single_action_result(:success => true, :message => expected_msg, :href => :provreq1_url)
     end
 
     it "supports denying a request" do
@@ -133,7 +129,8 @@ describe ApiController do
 
       run_post(provreq2_url, gen_request(:deny))
 
-      expect_single_action_result(:success => true, :message => "Provision request #{provreq2.id} denied", :href => :provreq2_url)
+      expected_msg = "Provision request #{provreq2.id} denied"
+      expect_single_action_result(:success => true, :message => expected_msg, :href => :provreq2_url)
     end
 
     it "supports approving multiple requests" do

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -104,4 +104,64 @@ describe ApiController do
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end
   end
+
+  context "Provision requests approval" do
+    let(:user)      { FactoryGirl.create(:user) }
+    let(:template)  { FactoryGirl.create(:template_amazon) }
+    let(:provreq1)  { FactoryGirl.create(:miq_provision_request,
+                                         :requester   => user,
+                                         :source_type => 'VmOrTemplate',
+                                         :source_id   => template.id) }
+    let(:provreq2)  { FactoryGirl.create(:miq_provision_request,
+                                         :requester   => user,
+                                         :source_type => 'VmOrTemplate',
+                                         :source_id   => template.id) }
+    let(:provreq1_url)  { provision_requests_url(provreq1.id) }
+    let(:provreq2_url)  { provision_requests_url(provreq2.id) }
+    let(:provreqs_list) { [provreq1_url, provreq2_url] }
+
+    it "supports approving a request" do
+      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+
+      run_post(provreq1_url, gen_request(:approve))
+
+      expect_single_action_result(:success => true, :message => "Provision request #{provreq1.id} approved", :href => :provreq1_url)
+    end
+
+    it "supports denying a request" do
+      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+
+      run_post(provreq2_url, gen_request(:deny))
+
+      expect_single_action_result(:success => true, :message => "Provision request #{provreq2.id} denied", :href => :provreq2_url)
+    end
+
+    it "supports approving multiple requests" do
+      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+
+      run_post(provision_requests_url, gen_request(:approve, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
+
+      expect_multiple_action_result(2)
+      expect_result_resources_to_include_hrefs("results", :provreqs_list)
+      expect_result_resources_to_match_key_data(
+        "results",
+        "message",
+        [/Provision request #{provreq1.id} approved/i, /Provision request #{provreq2.id} approved/i]
+      )
+    end
+
+    it "supports denying multiple requests" do
+      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+
+      run_post(provision_requests_url, gen_request(:deny, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
+
+      expect_multiple_action_result(2)
+      expect_result_resources_to_include_hrefs("results", :provreqs_list)
+      expect_result_resources_to_match_key_data(
+        "results",
+        "message",
+        [/Provision request #{provreq1.id} denied/i, /Provision request #{provreq2.id} denied/i]
+      )
+    end
+  end
 end


### PR DESCRIPTION
Hi guys,

I guess this one is for @abellotti .
We found ourselves in the need for approving/denying a provision_request via the API.
This PR is not done yet (no tests at least).
Would you guys be ok with something like this ?

Thanks !