### PR TITLE
Move topology element icons from png to textual

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -96,21 +96,23 @@ angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
       return dblclick(d);
     });
 
-    added.append("image")
-      .attr("xlink:href", function(d) {
-        return d.item.icon;
-      })
+    added.append("text")
+        .text(function(d) {
+          return getIcon(d);
+        })
+      .attr('class', function(d) {
+          switch(d.item.kind) {
+            case 'ContainerManager':
+              return 'icon '+ d.item.display_kind;
+            default:
+              return 'icon';
+          }
+        })
       .attr("y", function(d) {
         return getDimensions(d).y;
       })
       .attr("x", function(d) {
         return getDimensions(d).x;
-      })
-      .attr("height", function(d) {
-        return getDimensions(d).height;
-      })
-      .attr("width", function(d) {
-        return getDimensions(d).width;
       });
 
     added.append("text")
@@ -187,18 +189,53 @@ angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
     window.location.assign(url);
   }
 
+  function getIcon(d) {
+    switch (d.item.kind) {
+      case 'Container':
+        return '\uF1B2'; // fa-cube
+      case "ContainerNode":
+        return '\uE621';  // pficon-container-node
+      case "ContainerRoute":
+        return '\uE625'; // pficon-route
+      case "ContainerService":
+        return '\uE61E'; // pficon-service
+      case "Vm":
+        return '\uE600'; // pficon-screen
+      case "Host":
+        return '\uE620'; // pficon-cluster
+      case "ContainerGroup":
+        return '\uF1B3'; // fa-cubes
+      case "ContainerReplicator":
+        return '\uE624'; // pficon-replicator
+      case "ContainerManager":
+        switch (d.item.display_kind) {
+          case "Kubernetes":
+            return '\uE627'; // pficon-kubernetes
+          case "Openshift":
+          case "OpenshiftEnterprise":
+            return '\uE626';  // pficon-openshift
+          case "Atomic":
+            return '\uE62c'; // vendor-atomic
+          case "AtomicEnterprise":
+            return '\uE62d'; //vendor-atomic-enterprise
+        }
+    }
+  }
+
   function getDimensions(d) {
     switch (d.item.kind) {
       case "ContainerManager":
-        return { x: -20, y: -20, height: 40, width: 40, r: 28 };
+        return { x: 0, y: 16, r: 28 };
       case "Container":
-        return { x: -7, y: -7, height: 14, width: 14, r: 13 };
+        return { x: 1, y: 5, r: 13 };
+      case "ContainerGroup":
+        return { x: 0, y: 6, r: 17 };
       case "ContainerNode":
       case "Vm":
       case "Host":
-        return { x: -12, y: -12, height: 23, width: 23, r: 19 };
+        return { x: 0, y: 9, r: 21 };
       default:
-        return { x: -9, y: -9, height: 18, width: 18, r: 17 };
+        return { x: 0, y: 9, r: 17 };
     }
   }
 

--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -125,3 +125,51 @@ kubernetes-topology-icon svg {
     font-size: 12px;
     fill: black;
 }
+
+.kube-topology g text.icon {
+    font-size: 20px;
+    fill: #1186C1;
+    font-family: PatternFlyIcons-webfont;
+}
+
+.kube-topology g.Container text.icon {
+    font-family: FontAwesome;
+    font-size: 15px;
+}
+
+.kube-topology g.ContainerGroup text.icon {
+    font-family: FontAwesome;
+    font-size: 18px;
+}
+
+.kube-topology g.Vm text.icon, .kube-topology g.Host text.icon {
+    fill: #636363;
+}
+
+.kube-topology g.ContainerNode text.icon {
+    font-size: 25px;
+}
+
+.kube-topology g.ContainerManager text.icon {
+    font-size: 38px;
+}
+
+.kube-topology g.ContainerManager text.icon.Kubernetes {
+    fill: #326de6;
+}
+
+.kube-topology g.ContainerManager text.icon.Openshift, .kube-topology g.ContainerManager text.icon.OpenshiftEnterprise {
+    fill: #da2430;
+}
+
+.kube-topology g.ContainerManager text.icon.Atomic {
+    font-family: icomoon;
+    fill: #666666;
+}
+
+.kube-topology g.ContainerManager text.icon.AtomicEnterprise  {
+    font-family: icomoon;
+    fill: #0088ce;
+}
+
+

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -61,7 +61,7 @@ class ContainerTopologyService
     topology[:kinds] = build_kinds
     topology
   end
-
+  
   def entity_type(entity)
       entity.class.name.demodulize
   end
@@ -104,7 +104,6 @@ class ContainerTopologyService
            else
              entity.ems_ref
            end
-      icon = type.underscore.downcase
     end
 
     data = {:id           => id,
@@ -112,8 +111,7 @@ class ContainerTopologyService
             :status       => status,
             :kind         => type,
             :display_kind => entity_display_type(entity),
-            :miq_id       => entity.id,
-            :icon         => image_path("icons/new/#{icon}.png")}
+            :miq_id       => entity.id}
 
     if %w(Vm Host).include? type
       data.merge!(:provider => entity.ext_management_system.name)

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -5,10 +5,6 @@ describe ContainerTopologyService do
   let(:container_topology_service) { described_class.new(nil) }
   let(:long_id) { "3572afee-3a41-11e5-a79a-001a4a231290_ruby-helloworld-database_openshift\n/mysql-55-centos7:latest" }
 
-  def icon(f)
-    "/images/icons/new/#{f}.png"
-  end
-
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
       allow(container_topology_service).to receive(:retrieve_providers).and_return([FactoryGirl.create(:ems_kubernetes)])
@@ -46,8 +42,7 @@ describe ContainerTopologyService do
                                           :status       => "Unknown",
                                           :kind         => "ContainerManager",
                                           :display_kind => "Openshift",
-                                          :miq_id       => ems_openshift.id,
-                                          :icon         => icon('vendor-openshift')})
+                                          :miq_id       => ems_openshift.id})
 
     end
 
@@ -80,56 +75,49 @@ describe ContainerTopologyService do
                                                    :status       => "Error",
                                                    :kind         => "ContainerManager",
                                                    :display_kind => "Kubernetes",
-                                                   :miq_id       => ems_kube.id,
-                                                   :icon         => icon('vendor-kubernetes')},
+                                                   :miq_id       => ems_kube.id},
 
         "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_node.ems_ref,
                                                    :name         => container_node.name,
                                                    :status       => "Ready",
                                                    :kind         => "ContainerNode",
                                                    :display_kind => "Node",
-                                                   :miq_id       => container_node.id,
-                                                   :icon         => icon('container_node')},
+                                                   :miq_id       => container_node.id},
 
         "8f8ca74c-3a41-11e5-a79a-001a4a231290" => {:id           => container_replicator.ems_ref,
                                                    :name         => container_replicator.name,
                                                    :status       => "OK",
                                                    :kind         => "ContainerReplicator",
                                                    :display_kind => "Replicator",
-                                                   :miq_id       => container_replicator.id,
-                                                   :icon         => icon('container_replicator')},
+                                                   :miq_id       => container_replicator.id},
 
         "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_service.ems_ref,
                                                    :name         => container_service.name,
                                                    :status       => "Unknown",
                                                    :kind         => "ContainerService",
                                                    :display_kind => "Service",
-                                                   :miq_id       => container_service.id,
-                                                   :icon         => icon('container_service')},
+                                                   :miq_id       => container_service.id},
 
         "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_group.ems_ref,
                                                    :name         => container_group.name,
                                                    :status       => "Running",
                                                    :kind         => "ContainerGroup",
                                                    :display_kind => "Pod",
-                                                   :miq_id       => container_group.id,
-                                                   :icon         => icon('container_group')},
+                                                   :miq_id       => container_group.id},
 
         "ab5za74c-3a41-11e5-a79a-001a4a231290" => {:id           => container_route.ems_ref,
                                                    :name         => container_route.name,
                                                    :status       => "Unknown",
                                                    :kind         => "ContainerRoute",
                                                    :display_kind => "Route",
-                                                   :miq_id       => container_route.id,
-                                                   :icon         => icon('container_route')},
+                                                   :miq_id       => container_route.id},
 
         long_id                                => {:id           => container.ems_ref,
                                                    :name         => container.name,
                                                    :status       => "Running",
                                                    :kind         => "Container",
                                                    :display_kind => "Container",
-                                                   :miq_id       => container.id,
-                                                   :icon         => icon('container')},
+                                                   :miq_id       => container.id},
 
         "558d9a08-7b13-11e5-8546-129aa6621998" => {:id           => vm_rhev.uid_ems,
                                                    :name         => vm_rhev.name,
@@ -137,7 +125,6 @@ describe ContainerTopologyService do
                                                    :kind         => "Vm",
                                                    :display_kind => "VM",
                                                    :miq_id       => vm_rhev.id,
-                                                   :icon         => icon('vm'),
                                                    :provider     => ems_rhev.name},
 
         "abcd9a08-7b13-11e5-8546-129aa6621999" => {:id           => host.uid_ems,
@@ -146,7 +133,6 @@ describe ContainerTopologyService do
                                                    :kind         => "Host",
                                                    :display_kind => "Host",
                                                    :miq_id       => host.id,
-                                                   :icon         => icon('host'),
                                                    :provider     => ems_rhev.name}
       )
 
@@ -180,32 +166,28 @@ describe ContainerTopologyService do
                                                    :status       => "Ready",
                                                    :kind         => "ContainerNode",
                                                    :display_kind => "Node",
-                                                   :miq_id       => container_node.id,
-                                                   :icon         => icon('container_node')},
+                                                   :miq_id       => container_node.id},
 
         "95e49048-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_service.ems_ref,
                                                    :name         => container_service.name,
                                                    :status       => "Unknown",
                                                    :kind         => "ContainerService",
                                                    :display_kind => "Service",
-                                                   :miq_id       => container_service.id,
-                                                   :icon         => icon('container_service')},
+                                                   :miq_id       => container_service.id},
 
         "96c35ccd-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_group.ems_ref,
                                                    :name         => container_group.name,
                                                    :status       => "Running",
                                                    :kind         => "ContainerGroup",
                                                    :display_kind => "Pod",
-                                                   :miq_id       => container_group.id,
-                                                   :icon         => icon('container_group')},
+                                                   :miq_id       => container_group.id},
 
         long_id                                => {:id           => container.ems_ref,
                                                    :name         => container.name,
                                                    :status       => "Running",
                                                    :kind         => "Container",
                                                    :display_kind => "Container",
-                                                   :miq_id       => container.id,
-                                                   :icon         => icon('container')},
+                                                   :miq_id       => container.id},
 
         "558d9a08-7b13-11e5-8546-129aa6621998" => {:id           => vm_rhev.uid_ems,
                                                    :name         => vm_rhev.name,
@@ -213,7 +195,6 @@ describe ContainerTopologyService do
                                                    :kind         => "Vm",
                                                    :display_kind => "VM",
                                                    :miq_id       => vm_rhev.id,
-                                                   :icon         => icon('vm'),
                                                    :provider     => ems_rhev.name},
 
         ems_kube.id.to_s                       => {:id           => ems_kube.id.to_s,
@@ -221,8 +202,7 @@ describe ContainerTopologyService do
                                                    :status       => "Error",
                                                    :kind         => "ContainerManager",
                                                    :display_kind => "Kubernetes",
-                                                   :miq_id       => ems_kube.id,
-                                                   :icon         => icon('vendor-kubernetes')}
+                                                   :miq_id       => ems_kube.id}
       )
 
       expect(subject[:relations].size).to eq(5)


### PR DESCRIPTION
@miq-bot add_label ui, providers/containers, wip

pending the existence of a textual Atomic icon (has an incorrect temp placeholder in current patch, hence wip)
cc @epwinchell 