### PR TITLE
Ensure that ldap object returns correctly

### DIFF
--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -12,13 +12,11 @@ module Authenticator
     private
 
     def ldap
-      @ldap ||= ldap_bind(config[:bind_dn], config[:bind_pwd])
+      @ldap = MiqLdap.new(:auth => config)
     end
 
     def ldap_bind(username, password)
-      ldap = MiqLdap.new(:auth => config)
       ldap if ldap.bind(username, password)
-      return ldap
     end
 
     def find_or_create_by_ldap(username)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -18,6 +18,7 @@ module Authenticator
     def ldap_bind(username, password)
       ldap = MiqLdap.new(:auth => config)
       ldap if ldap.bind(username, password)
+      return ldap
     end
 
     def find_or_create_by_ldap(username)


### PR DESCRIPTION
If conditional failed `ldap_bind` was returning a nil object, this ensures that `ldap_bind` always
returns correctly.