### PR TITLE
Add container entities ids to events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -99,6 +99,7 @@ class EmsEvent < EventStream
     process_host_in_event!(event_hash, :prefix => "dest_")
     process_availability_zone_in_event!(event_hash)
     process_cluster_in_event!(event_hash)
+    process_container_entities_in_event!(event_hash)
 
     # Write the event
     new_event = create_event(event_hash)
@@ -146,6 +147,13 @@ class EmsEvent < EventStream
 
   def self.process_host_in_event!(event, options = {})
     process_object_in_event!(Host, event, options)
+  end
+
+  def self.process_container_entities_in_event!(event, _options = {})
+    [ContainerNode, ContainerGroup, ContainerReplicator].each do |entity|
+      process_object_in_event!(entity, event, :ems_ref_key => :ems_ref)
+    end
+    event.except!(:ems_ref)
   end
 
   def self.process_availability_zone_in_event!(event, options = {})

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -52,7 +52,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
       :name      => event.object.involvedObject.name,
       :namespace => event.object.involvedObject['table'][:namespace],
       :reason    => event.object.reason,
-      :message   => event.object.message
+      :message   => event.object.message,
+      :uid       => event.object.involvedObject.uid
     }
 
     unless event.object.involvedObject.fieldPath.nil?

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_parser_mixin.rb
@@ -14,6 +14,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventParserMixin
         :container_replicator_name => event[:container_replicator_name],
         :container_namespace       => event[:container_namespace],
         :container_name            => event[:container_name],
+        :ems_ref                   => event[:uid],
         :full_data                 => event,
         :ems_id                    => ems_id
       }

--- a/spec/factories/container_replicator.rb
+++ b/spec/factories/container_replicator.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :container_replicator do
+    sequence(:name) { |n| "container_replicator_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -102,6 +102,62 @@ describe EmsEvent do
     end
   end
 
+  context ".process_container_entities_in_event!" do
+    before :each do
+      @ems = FactoryGirl.create(:ems_kubernetes)
+      @container_project = FactoryGirl.create(:container_project, :ext_management_system => @ems)
+      EMS_REF = "test_ems_ref"
+      @event_hash = {
+        :ems_ref => EMS_REF,
+        :ems_id  => @ems.id
+      }
+    end
+
+    context "process node in events" do
+      before :each do
+        @container_node = FactoryGirl.create(:container_node,
+                                             :ext_management_system => @ems,
+                                             :name                  => "Test Node",
+                                             :ems_ref               => EMS_REF)
+      end
+
+      it "should link node id to event" do
+        EmsEvent.process_container_entities_in_event!(@event_hash)
+        expect(@event_hash[:container_node_id]).to eq @container_node.id
+      end
+    end
+
+    context "process pods in events" do
+      before :each do
+        @container_group = FactoryGirl.create(:container_group,
+                                              :ext_management_system => @ems,
+                                              :container_project     => @container_project,
+                                              :name                  => "Test Group",
+                                              :ems_ref               => EMS_REF)
+      end
+
+      it "should link pod id to event" do
+        EmsEvent.process_container_entities_in_event!(@event_hash)
+        expect(@event_hash[:container_group_id]).to eq @container_group.id
+      end
+    end
+
+    context "process replicator in events" do
+      before :each do
+        @container_replicator = FactoryGirl.create(:container_replicator,
+                                                   :ext_management_system => @ems,
+                                                   :container_project     => @container_project,
+                                                   :name                  => "Test Replicator",
+                                                   :ems_ref               => EMS_REF)
+      end
+
+      it "should link replicator id to event" do
+        EmsEvent.process_container_entities_in_event!(@event_hash)
+        expect(@event_hash[:container_replicator_id]).to eq @container_replicator.id
+      end
+    end
+  end
+
   context "with availability zones" do
     before :each do
       @zone = FactoryGirl.create(:small_environment)


### PR DESCRIPTION
Add id to event for the following container entities:
* Pods
* Nodes
* Replicators

Linking entities ids for "creation events" will be handled in a
separate commit.