### PR TITLE
Add search functionality to container topology

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -215,4 +215,37 @@ angular.module('topologyApp', ['kubernetesUI', 'ui.bootstrap'])
     }
   }
 
+  var d3 = window.d3;
+
+  function getSVG() {
+    var graph = d3.select("kubernetes-topology-graph");
+    var svg = graph.select('svg');
+    return svg;
+  }
+
+  $scope.searchNode = function() {
+    var svg = getSVG();
+    var query = $scope.search.query;
+
+    var nodes = svg.selectAll("g");
+    if (query != "") {
+      var selected = nodes.filter(function (d) {
+        return d.item.name != query;
+      });
+      selected.style("opacity", "0.2");
+      var links = svg.selectAll("line");
+      links.style("opacity", "0.2");
+    }
+  };
+
+  $scope.resetSearch = function() {
+    // Display all topology nodes and links
+    d3.selectAll("g, line").transition()
+        .duration(2000)
+        .style("opacity", 1);
+
+    // Reset the search term in search input
+    $scope.search.query = "";
+  };
+
 }]);

--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -46,6 +46,16 @@ kubernetes-topology-graph {
     position: relative;
 }
 
+.search-topology {
+    vertical-align: middle;
+    float: right;
+    margin-right: 15px;
+    text-align: center;
+}
+
+.search-topology .form-control {
+    font-size: 20px;
+}
 
 #selected {
     float: right;

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -7,7 +7,17 @@
         %input#box{'ng-change' => "show_hide_names(checkboxModel.value)",  'ng-model' => "checkboxModel.value", :type => "checkbox", 'ng-true-value' => 'true', 'ng-false-value' => 'false'}
         Display Names
       %i{'ng-click' => "refresh()", :class => "btn btn-default fa fa-refresh refresh-topology"}
-
+    .search-topology
+      %form.search-pf.has-button{:role => "form"}
+        .form-group.has-clear
+          .search-pf-input-group
+            %label.sr-only{:for => "search"} Search
+            %input#search.form-control{'placeholder' => "Search", 'type' => "search", "ng-model" => "search.query"}
+              %button.clear{"aria-hidden" => "true", :type => "button", "ng-click" => "resetSearch()"}
+                %span.pficon.pficon-close
+        .form-group
+          %button.btn.btn-default.search-topology-button{:type => "button",  "ng-click" => "searchNode()"}
+            %span.fa.fa-search
     .legend
       %label#selected
       %div{'ng-if' => "kinds"}


### PR DESCRIPTION
video at [this link](https://youtu.be/Q65z9oaqvUw)
another option with keeping the graph partially visible (whatever not relevant for search results) can be [seen here](https://youtu.be/ezBKdfVPFv8)

![searchtopology](https://cloud.githubusercontent.com/assets/6277245/12079529/43f15208-b245-11e5-94a7-86672f8265ce.png)

@miq-bot add_label ui, enhancement, wip, providers/containers
@himdel @martinpovolny please review
cc @stefwalter @itamarh @serenamarie125 @chessbyte @jonnyfiveiq 

Note: if this will be accepted, worth to consider for future enhancements: 
1. substring search (e.g. all entities that have hawkular as part of their name, not only entities whose name is hawkular)
2. autocomplete in the search box, although in large environments, it might become inefficient and not user friendly.