### PR TITLE
Correct name of class in old_dialogs_edit_delete.rb

### DIFF
--- a/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
+++ b/app/helpers/application_helper/button/old_dialogs_edit_delete.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::OrchestrationOldDialogsEditDelete < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::OldDialogsEditDelete < ApplicationHelper::Button::Basic
   def calculate_properties
     super
     if @view_context.x_active_tree == :old_dialogs_tree && @record && @record[:default]


### PR DESCRIPTION
clicking on Automate -> Customization
causes error:

![screen shot 2016-01-04 at 13 38 46](https://cloud.githubusercontent.com/assets/14937244/12089768/8adc7924-b2e8-11e5-96ca-ee65b2c07571.png)

cc @martinpovolny 