### PR TITLE
miq_debug - add Ctrl+Shift+Z to trigger a check for duplicate element ids in DOM

### DIFF
--- a/app/assets/javascripts/miq_debug.js
+++ b/app/assets/javascripts/miq_debug.js
@@ -1,2 +1,24 @@
 // CTRL+SHIFT+X stops the spinner
 $(document).bind('keyup', 'ctrl+shift+x', miqSparkleOff);
+
+// CTRL+SHIFT+Z checks for duplicate element ids
+$(document).bind('keyup', 'ctrl+shift+z', function() {
+  var ids = {};
+
+  $('[id]').each(function(_i, e) {
+    var id = $(e).attr('id');
+    if (id in ids) {
+      ids[id]++;
+    } else {
+      ids[id] = 1;
+    }
+  });
+
+  _.keys(ids).forEach(function(id) {
+    if (ids[id] <= 1)
+      return;
+
+    console.log('duplicate id', id, ids[id], $('[id="' + id + '"]'));
+  });
+  console.log('done');
+});


### PR DESCRIPTION
(miq_debug is only included in development environment)

outputs something like:

```
duplicate id test 4 [div#test.panel.panel-default, div#test.panel.panel-default, div#test.panel.panel-default, div#test.panel.panel-default, ...]
done
```