### PR TITLE
Dashboard widgets - remove useless #test id from dashboard widgets

### DIFF
--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,7 +1,7 @@
 -# Parameters:
 -# widget MiqWidget object
 %div{:id => "w_#{presenter.widget.id}"}
-  .panel.panel-default#test
+  .panel.panel-default
     .panel-heading
       %h3.dropdown.panel-title{:style => "cursor:move"}
         = h(presenter.widget.title)

--- a/app/views/report/_widget_form_menu.html.haml
+++ b/app/views/report/_widget_form_menu.html.haml
@@ -17,7 +17,7 @@
     - @edit[:new][:shortcuts].each do |s_id, s_desc|
       -# :shortcuts is a hash of s.id => s.miq_widget_shortcut.description
       %div{:id => "s_#{s_id}", :title => _("Drag this Shortcut to a new location")}
-        .panel.panel-default#test
+        .panel.panel-default
           .panel-header
             %h3.panel-title{:style => @edit ? "cursor: move;" : ""}
               %a{:class => "#{@widget.content_type}box"}


### PR DESCRIPTION
Remove useless #test id from dashboard widgets.

```diff
-  .panel.panel-default#test
+  .panel.panel-default
```

has no reason to be there, never selected on..