### PR TITLE
Add Terminate and Soft Reboot for GCE Instances

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -109,8 +109,9 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_restart(vm, _options = {})
-    vm.provider_object.restart
-    vm.update_attributes!(:raw_power_state => "VM starting")
+  def vm_reboot_guest(vm, _options = {})
+    vm.reboot_guest
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -103,6 +103,12 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     vm.update_attributes!(:raw_power_state => "VM stopping")
   end
 
+  def vm_destroy(vm, _options = {})
+    vm.vm_destroy
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
   def vm_restart(vm, _options = {})
     vm.provider_object.restart
     vm.update_attributes!(:raw_power_state => "VM starting")

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -94,13 +94,15 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   # Operations
 
   def vm_start(vm, _options = {})
-    vm.provider_object.start
-    vm.update_attributes!(:raw_power_state => "VM starting")
+    vm.start
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
   def vm_stop(vm, _options = {})
-    vm.provider_object.stop
-    vm.update_attributes!(:raw_power_state => "VM stopping")
+    vm.stop
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
   def vm_destroy(vm, _options = {})

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -1,4 +1,5 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations
+  include_concern 'Guest'
   include_concern 'Power'
 
   def raw_destroy

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -1,3 +1,9 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations
   include_concern 'Power'
+
+  def raw_destroy
+    raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
+    with_provider_object(&:destroy)
+    self.update_attributes!(:raw_power_state => "DELETED")
+  end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -1,0 +1,10 @@
+module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
+  def validate_reboot_guest
+    validate_vm_control_powered_on
+  end
+
+  def raw_reboot_guest
+    with_provider_object(&:reboot)
+    self.update_attributes!(:raw_power_state => "reboot") # show state as suspended
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
@@ -6,4 +6,14 @@ module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Power
   def validate_pause
     validate_unsupported("Pause Operation")
   end
+
+  def raw_start
+    with_provider_object(&:start)
+    self.update_attributes!(:raw_power_state => "starting")
+  end
+
+  def raw_stop
+    with_provider_object(&:stop)
+    self.update_attributes!(:raw_power_state => "stopping")
+  end
 end


### PR DESCRIPTION
Add Terminate and Soft Reboot to GCE Instance Power Ops, and migrate vm_start and vm_stop to be run through VmOrTemplate so that the right policy checks are done.

/cc @blomquisg 