### PR TITLE
GCE provision instance 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,6 +136,7 @@ class CatalogController < ApplicationController
       "amazon"                => "Amazon",
       "generic"               => "Generic",
       "generic_orchestration" => "Orchestration",
+      "google"                => "Google",
       "microsoft"             => "SCVMM",
       "openstack"             => "OpenStack",
       "redhat"                => "RHEV",

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -88,6 +88,10 @@ class EmsEvent < EventStream
     add(ems_id, ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, ems_id))
   end
 
+  def self.add_google(ems_id, event)
+    add(ems_id, ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, ems_id))
+  end
+
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, "event_type must be set in event" if event_type.nil?

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -3,7 +3,8 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
 
   def self.eligible_for_provisioning
     super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
-                            ManageIQ::Providers::Openstack::CloudManager::Template))
+                            ManageIQ::Providers::Openstack::CloudManager::Template
+                            ManageIQ::Providers::Google::CloudManager::Template))
   end
 
   private

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -1,6 +1,9 @@
 class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AvailabilityZone
+  require_nested :EventParser
   require_nested :Flavor
+  require_nested :Provision
+  require_nested :ProvisionWorkflow
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher

--- a/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_parser.rb
@@ -1,0 +1,18 @@
+module ManageIQ::Providers::Google::CloudManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
+
+    _log.debug { "#{log_header}event: [#{event["eventType"]}]" }
+
+    event_hash = {
+      :event_type => event["eventType"],
+      :source     => "GOOGLE",
+      :message    => event["configurationItemDiff"],
+      :timestamp  => event["notificationCreationTime"],
+      :full_data  => event,
+      :ems_id     => ems_id
+    }
+
+    event_hash
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Google::CloudManager::Provision < ::MiqProvisionCloud
+  include_concern 'Cloning'
+end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -1,0 +1,49 @@
+module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
+  def do_clone_task_check(clone_task_ref)
+    source.with_provider_connection do |google|
+      instance = google.servers.all.detect { |s| s.id == clone_task_ref }
+
+      return true if instance.ready?
+      return false, instance.status_message
+    end
+  end
+
+  def create_disk
+    source.with_provider_connection do |google|
+      return google.disks.create(
+        :name         => dest_name,
+        :size_gb      => get_option(:boot_disk_size).to_i,
+        :zone_name    => dest_availability_zone.ems_ref,
+        :source_image => source.name)
+    end
+  end
+
+  def prepare_for_clone_task
+    clone_options = super
+
+    clone_options[:name] = dest_name
+    clone_options[:disks] = [create_disk.get_as_boot_disk(true, true)]
+    clone_options[:machine_type] = instance_type.ems_ref
+    clone_options[:zone_name] = dest_availability_zone.ems_ref
+
+    clone_options
+  end
+
+  def log_clone_options(clone_options)
+    _log.info("Provisioning:                  [#{clone_options[:name]}]")
+    _log.info("Root Disk:                     [#{clone_options[:disks]}]")
+    _log.info("Destination Availability Zone: [#{clone_options[:zone_name]}]")
+    _log.info("Machine Type:                  [#{clone_options[:machine_type]}]")
+
+    dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
+    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info,
+            :protected => {:path => workflow_class.encrypted_options_field_regs})
+  end
+
+  def start_clone(clone_options)
+    source.with_provider_connection do |google|
+      instance = google.servers.create(clone_options)
+      return instance.id
+    end
+  end
+end

--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvisionCloudWorkflow
+  def allowed_instance_types(_options = {})
+    source = load_ar_obj(get_source_vm)
+    ems = get_targets_for_ems(source, :cloud_filter, Flavor, 'flavors')
+    ems.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
+  end
+
+  private
+
+  def dialog_name_from_automate(message = 'get_dialog_name')
+    super(message, {'platform' => 'google'})
+  end
+
+  def self.provider_model
+    ManageIQ::Providers::Google::CloudManager
+  end
+end

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -31,7 +31,7 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUPPORTED_EMS_CLASSES = %w(ManageIQ::Providers::Vmware::InfraManager ManageIQ::Providers::Redhat::InfraManager ManageIQ::Providers::Amazon::CloudManager ManageIQ::Providers::Openstack::CloudManager ManageIQ::Providers::Microsoft::InfraManager)
+  SUPPORTED_EMS_CLASSES = %w(ManageIQ::Providers::Vmware::InfraManager ManageIQ::Providers::Redhat::InfraManager ManageIQ::Providers::Amazon::CloudManager ManageIQ::Providers::Openstack::CloudManager ManageIQ::Providers::Microsoft::InfraManager ManageIQ::Providers::Google::CloudManager)
 
   def self.base_model
     MiqProvision

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -241,7 +241,8 @@
                :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
                :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
-               :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, :vm_maximum_memory].include?(field)
+               :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, 
+               :vm_maximum_memory, :boot_disk_size].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
         - multiple = field == :security_groups

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -142,7 +142,7 @@
   - when :hardware
     - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
-              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory]
+              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? "Properties" : "Hardware"
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-provision.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Google_CloudManager_Provision < MiqAeServiceManageIQ_Providers_CloudManager_Provision
+  end
+end

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -1,0 +1,294 @@
+---
+:name: miq_provision_google_dialogs_template
+:description: Sample Google Instance Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_availability_zone:
+          :values_from:
+            :method: :allowed_availability_zones
+          :auto_select_single: false
+          :description: Availability Zones
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+          :required_description: Availability Zone Name
+        :cloud_network:
+          :values_from:
+            :method: :allowed_cloud_networks
+          :description: Cloud Network
+          :auto_select_single: false
+          :required: true
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: Instance Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: Instance Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: Instance Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: s:retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :hardware:
+      :description: Properties
+      :fields:
+        :boot_disk_size:
+          :description: Boot Disk Size (GB)
+          :values:
+            10.GB: 10 GB
+            50.GB: 50 GB
+            200.GB: 200 GB
+            500.GB: 500 GB
+            1024.GB: 1 TB
+            5120.GB: 5 TB
+            10240.GB: 10 TB
+          :required: true
+          :display: :edit
+          :data_type: string
+        :instance_type:
+          :values_from:
+            :method: :allowed_instance_types
+          :description: Instance Type
+          :required: true
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :schedule

--- a/spec/factories/availability_zone.rb
+++ b/spec/factories/availability_zone.rb
@@ -12,6 +12,9 @@ FactoryGirl.define do
   factory :availability_zone_openstack_null, :parent => :availability_zone_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull" do
   end
 
+  factory :availability_zone_google, :parent => :availability_zone, :class => "ManageIQ::Providers::Google::CloudManager::AvailabilityZone" do
+  end
+
   factory :availability_zone_target, :parent => :availability_zone do
     after(:create) do |x|
       x.perf_capture_enabled = true

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -103,6 +103,12 @@ FactoryGirl.define do
     provider_region "us-central1"
   end
 
+  factory :ems_google_with_authentication, :parent => :ems_google do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication, :userid => "0123456789ABCDEFGHIJ", :password => "ABCDEFGHIJKLMNO1234567890abcdefghijklmno")
+    end
+  end
+
   # Leaf classes for ems_container
 
   factory :ems_kubernetes, :aliases => ["manageiq/providers/kubernetes/container_manager"], :class => "ManageIQ::Providers::Kubernetes::ContainerManager", :parent => :ems_container do

--- a/spec/factories/flavor.rb
+++ b/spec/factories/flavor.rb
@@ -7,4 +7,7 @@ FactoryGirl.define do
 
   factory :flavor_openstack, :parent => :flavor, :class => "ManageIQ::Providers::Openstack::CloudManager::Flavor" do
   end
+
+  factory :flavor_google, :parent => :flavor, :class => "ManageIQ::Providers::Google::CloudManager::Flavor" do
+  end
 end

--- a/spec/factories/miq_provision_google.rb
+++ b/spec/factories/miq_provision_google.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_provision_google, :class => "ManageIQ::Providers::Google::CloudManager::Provision" do
+  end
+end

--- a/spec/factories/template_google.rb
+++ b/spec/factories/template_google.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory(:template_google, :class => "ManageIQ::Providers::Google::CloudManager::Template", :parent => :template_cloud) { vendor "google" }
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
   describe MiqAeMethodService::MiqAeServiceMiqProvision do
-    %w(amazon openstack).each  do |t|
+    %w(amazon openstack google).each do |t|
       context "for #{t}" do
         before do
           @provider      = FactoryGirl.create("ems_#{t}_with_authentication")
@@ -138,28 +138,30 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
           end
         end
 
-        context "security_groups" do
-          it "workflow exposes allowed_security_groups" do
-            expect(workflow_klass.instance_methods).to include(:allowed_security_groups)
-          end
-
-          context "with a security_group" do
-            before do
-              @ci = FactoryGirl.create("security_group_#{t}")
-              allow_any_instance_of(workflow_klass).to receive(:allowed_security_groups).and_return(@ci.id => @ci.name)
+        if t != "google"
+          context "security_groups" do
+            it "workflow exposes allowed_security_groups" do
+              expect(workflow_klass.instance_methods).to include(:allowed_security_groups)
             end
 
-            it "#eligible_security_groups" do
-              result = ae_svc_prov.eligible_security_groups
+            context "with a security_group" do
+              before do
+                @ci = FactoryGirl.create("security_group_#{t}")
+                allow_any_instance_of(workflow_klass).to receive(:allowed_security_groups).and_return(@ci.id => @ci.name)
+              end
 
-              expect(result).to be_kind_of(Array)
-              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
-            end
+              it "#eligible_security_groups" do
+                result = ae_svc_prov.eligible_security_groups
 
-            it "#set_security_group" do
-              ae_svc_prov.eligible_security_groups.each { |rsc| ae_svc_prov.set_security_group(rsc) }
+                expect(result).to be_kind_of(Array)
+                expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              end
 
-              expect(@miq_provision.reload.options[:security_groups]).to eq([@ci.id])
+              it "#set_security_group" do
+                ae_svc_prov.eligible_security_groups.each { |rsc| ae_svc_prov.set_security_group(rsc) }
+
+                expect(@miq_provision.reload.options[:security_groups]).to eq([@ci.id])
+              end
             end
           end
         end
@@ -190,80 +192,86 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
           end
         end
 
-        context "cloud_subnets" do
-          it "workflow exposes allowed_cloud_subnets" do
-            expect(workflow_klass.instance_methods).to include(:allowed_cloud_subnets)
-          end
-
-          context "with a cloud_subnet" do
-            before do
-              @ci = FactoryGirl.create(:cloud_subnet)
-              allow_any_instance_of(workflow_klass).to receive(:allowed_cloud_subnets).and_return(@ci.id => @ci.name)
+        if t != "google"
+          context "cloud_subnets" do
+            it "workflow exposes allowed_cloud_subnets" do
+              expect(workflow_klass.instance_methods).to include(:allowed_cloud_subnets)
             end
 
-            it "#eligible_cloud_subnets" do
-              result = ae_svc_prov.eligible_cloud_subnets
+            context "with a cloud_subnet" do
+              before do
+                @ci = FactoryGirl.create(:cloud_subnet)
+                allow_any_instance_of(workflow_klass).to receive(:allowed_cloud_subnets).and_return(@ci.id => @ci.name)
+              end
 
-              expect(result).to be_kind_of(Array)
-              expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCloudSubnet)
-            end
+              it "#eligible_cloud_subnets" do
+                result = ae_svc_prov.eligible_cloud_subnets
 
-            it "#set_cloud_subnet" do
-              ae_svc_prov.eligible_cloud_subnets.each { |rsc| ae_svc_prov.set_cloud_subnet(rsc) }
+                expect(result).to be_kind_of(Array)
+                expect(result.first.class).to eq(MiqAeMethodService::MiqAeServiceCloudSubnet)
+              end
 
-              expect(@miq_provision.reload.options[:cloud_subnet]).to eq([@ci.id, @ci.name])
-            end
-          end
-        end
+              it "#set_cloud_subnet" do
+                ae_svc_prov.eligible_cloud_subnets.each { |rsc| ae_svc_prov.set_cloud_subnet(rsc) }
 
-        context "floating_ip_addresses" do
-          it "workflow exposes allowed_floating_ip_addresses" do
-            expect(workflow_klass.instance_methods).to include(:allowed_floating_ip_addresses)
-          end
-
-          context "with a floating_ip_address" do
-            before do
-              @ci = FactoryGirl.create("floating_ip_#{t}")
-              allow_any_instance_of(workflow_klass).to receive(:allowed_floating_ip_addresses).and_return(@ci.id => @ci.address)
-            end
-
-            it "#eligible_floating_ip_addresses" do
-              result = ae_svc_prov.eligible_floating_ip_addresses
-
-              expect(result).to be_kind_of(Array)
-              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
-            end
-
-            it "#set_floating_ip_address" do
-              ae_svc_prov.eligible_floating_ip_addresses.each { |rsc| ae_svc_prov.set_floating_ip_address(rsc) }
-
-              expect(@miq_provision.reload.options[:floating_ip_address]).to eq([@ci.id, @ci.address])
+                expect(@miq_provision.reload.options[:cloud_subnet]).to eq([@ci.id, @ci.name])
+              end
             end
           end
         end
 
-        context "guest_access_key_pairs" do
-          it "workflow exposes allowed_guest_access_key_pairs" do
-            expect(workflow_klass.instance_methods).to include(:allowed_guest_access_key_pairs)
+        if t != "google"
+          context "floating_ip_addresses" do
+            it "workflow exposes allowed_floating_ip_addresses" do
+              expect(workflow_klass.instance_methods).to include(:allowed_floating_ip_addresses)
+            end
+
+            context "with a floating_ip_address" do
+              before do
+                @ci = FactoryGirl.create("floating_ip_#{t}")
+                allow_any_instance_of(workflow_klass).to receive(:allowed_floating_ip_addresses).and_return(@ci.id => @ci.address)
+              end
+
+              it "#eligible_floating_ip_addresses" do
+                result = ae_svc_prov.eligible_floating_ip_addresses
+
+                expect(result).to be_kind_of(Array)
+                expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              end
+
+              it "#set_floating_ip_address" do
+                ae_svc_prov.eligible_floating_ip_addresses.each { |rsc| ae_svc_prov.set_floating_ip_address(rsc) }
+
+                expect(@miq_provision.reload.options[:floating_ip_address]).to eq([@ci.id, @ci.address])
+              end
+            end
           end
+        end
 
-          context "with a key_pairs" do
-            before do
-              @ci = FactoryGirl.create("auth_key_pair_#{t}")
-              allow_any_instance_of(workflow_klass).to receive(:allowed_guest_access_key_pairs).and_return(@ci.id => @ci.name)
+        if t != "google"
+          context "guest_access_key_pairs" do
+            it "workflow exposes allowed_guest_access_key_pairs" do
+              expect(workflow_klass.instance_methods).to include(:allowed_guest_access_key_pairs)
             end
 
-            it "#eligible_guest_access_key_pairs" do
-              result = ae_svc_prov.eligible_guest_access_key_pairs
+            context "with a key_pairs" do
+              before do
+                @ci = FactoryGirl.create("auth_key_pair_#{t}")
+                allow_any_instance_of(workflow_klass).to receive(:allowed_guest_access_key_pairs).and_return(@ci.id => @ci.name)
+              end
 
-              expect(result).to be_kind_of(Array)
-              expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
-            end
+              it "#eligible_guest_access_key_pairs" do
+                result = ae_svc_prov.eligible_guest_access_key_pairs
 
-            it "#set_guest_access_key_pairs" do
-              ae_svc_prov.eligible_guest_access_key_pairs.each { |rsc| ae_svc_prov.set_guest_access_key_pair(rsc) }
+                expect(result).to be_kind_of(Array)
+                expect(result.first.class).to eq("MiqAeMethodService::MiqAeService#{@ci.class.name.gsub(/::/, '_')}".constantize)
+              end
 
-              expect(@miq_provision.reload.options[:guest_access_key_pair]).to eq([@ci.id, @ci.name])
+              it "#set_guest_access_key_pairs" do
+                ae_svc_prov.eligible_guest_access_key_pairs.each { |rsc| ae_svc_prov.set_guest_access_key_pair(rsc) }
+
+                expect(@miq_provision.reload.options[:guest_access_key_pair]).to eq([@ci.id, @ci.name])
+              end
             end
           end
         end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 module MiqAeServiceVmOpenstackSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm do
-    ["openstack", "amazon"].each  do |t|
+    ["openstack", "amazon", "google"].each do |t|
       context "for #{t}" do
         define_method(:service_class_for) do |part|
           "MiqAeMethodService::MiqAeServiceManageIQ_Providers_#{t.camelize}_CloudManager_#{part.to_s.camelize}".constantize
@@ -14,7 +14,11 @@ module MiqAeServiceVmOpenstackSpec
           vm                   =  FactoryGirl.create("vm_#{t}".to_sym)
           vm.availability_zone =  FactoryGirl.create("availability_zone_#{t}".to_sym)
           vm.flavor            =  FactoryGirl.create("flavor_#{t}".to_sym)
-          vm.key_pairs << FactoryGirl.create("auth_key_pair_#{t}".to_sym)
+          if t != "google"
+            vm.key_pairs << FactoryGirl.create("auth_key_pair_#{t}".to_sym)
+            vm.floating_ip = FactoryGirl.create("floating_ip_#{t}".to_sym)
+            vm.security_groups << FactoryGirl.create("security_group_#{t}".to_sym)
+          end
           case t
           when "openstack"
             network = FactoryGirl.create(:cloud_network)
@@ -23,14 +27,14 @@ module MiqAeServiceVmOpenstackSpec
                                                    :device        => vm,
                                                    :cloud_network => network,
                                                    :cloud_subnet  => subnet)
+          when "google"
+            vm.cloud_network = FactoryGirl.create(:cloud_network)
           else
             # TODO(lsmola) when ready, all providers should act as openstack
             vm.cloud_network = FactoryGirl.create(:cloud_network)
             vm.cloud_subnet  = FactoryGirl.create(:cloud_subnet)
           end
 
-          vm.floating_ip       =  FactoryGirl.create("floating_ip_#{t}".to_sym)
-          vm.security_groups << FactoryGirl.create("security_group_#{t}".to_sym)
           vm.save!
           @vm                  = service_class_for(:vm).find(vm.id)
         end
@@ -47,20 +51,22 @@ module MiqAeServiceVmOpenstackSpec
           expect(@vm.cloud_network).to be_kind_of(MiqAeMethodService::MiqAeServiceCloudNetwork)
         end
 
-        it "#cloud_subnet" do
-          expect(@vm.cloud_subnet).to be_kind_of(MiqAeMethodService::MiqAeServiceCloudSubnet)
-        end
+        if t != "google"
+          it "#cloud_subnet" do
+            expect(@vm.cloud_subnet).to be_kind_of(MiqAeMethodService::MiqAeServiceCloudSubnet)
+          end
 
-        it "#floating_ip" do
-          expect(@vm.floating_ip).to be_kind_of(service_class_for :floating_ip)
-        end
+          it "#floating_ip" do
+            expect(@vm.floating_ip).to be_kind_of(service_class_for :floating_ip)
+          end
 
-        it "#security_groups" do
-          expect(@vm.security_groups.first).to be_kind_of(service_class_for :security_group)
-        end
+          it "#security_groups" do
+            expect(@vm.security_groups.first).to be_kind_of(service_class_for :security_group)
+          end
 
-        it "#key_pairs" do
-          expect(@vm.key_pairs.first).to be_kind_of(service_class_for :auth_key_pair)
+          it "#key_pairs" do
+            expect(@vm.key_pairs.first).to be_kind_of(service_class_for :auth_key_pair)
+          end
         end
       end
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-google-cloud_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-google-cloud_manager_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+module MiqAeServiceManageIQ_Providers_Google_CloudManagerSpec
+  include MiqAeEngine
+  describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Google_CloudManager do
+    before(:each) do
+      @ems                    = FactoryGirl.create(:ems_google)
+      @flavor                 = FactoryGirl.create(:flavor)
+      @availability_zone      = FactoryGirl.create(:availability_zone)
+      @ems.availability_zones << @availability_zone
+      @ems.flavors << @flavor
+      @ems_google = MiqAeMethodService::MiqAeServiceManageIQ_Providers_Google_CloudManager.find(@ems.id)
+    end
+
+    it "#flavors" do
+      flavor = @ems_google.flavors.first
+      expect(flavor).to be_kind_of(MiqAeMethodService::MiqAeServiceFlavor)
+    end
+
+    it "#availability_zones" do
+      availability_zone = @ems_google.availability_zones.first
+      expect(availability_zone).to be_kind_of(MiqAeMethodService::MiqAeServiceAvailabilityZone)
+    end
+  end
+end


### PR DESCRIPTION
This PR allows a user to provision a GCE VM using the Clouds > Instances > Lifecycle > Provision Instances workflow. The user needs to specify the machine type, image, region, network and root disk size for the request to succeed. 

However, I am having trouble getting the new `root_disk_size` attribute from the user facing form to the GCE API, could @gmcculloug or @agrare take a look for me? I feel like I'm missing something small. Thank you for all the help so far!

