### PR TITLE
define miq_cim_metric derived metrics class

### DIFF
--- a/app/models/miq_cim_metric.rb
+++ b/app/models/miq_cim_metric.rb
@@ -3,8 +3,10 @@ require 'wbem'
 require 'net_app_manageability/types'
 
 class MiqCimMetric < MiqStorageMetric
+  DERIVED_METRICS_CLASS_NAME = "MiqCimDerivedMetric"
+
   has_many  :miq_derived_metrics, -> { order :position },
-            :class_name  => "MiqCimDerivedMetric",
+            :class_name  => DERIVED_METRICS_CLASS_NAME,
             :foreign_key => "miq_storage_metric_id",
             :dependent   => :destroy
 


### PR DESCRIPTION
Noticed that this was not defined like the other sub classes of `MiqStorageMetric`.

@roliveri Can you comment if this is needed, and if there needs to be a `METRICS_ROLLUP_CLASS_NAME` as well? (not sure what class would be there)