### PR TITLE
Fix Containers Timelines

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -93,7 +93,7 @@ class ContainerController < ApplicationController
   def explorer
     @explorer   = true
     @lastaction = "explorer"
-
+    @timeline = @timeline_filter = true    # need to set these to load timelines on container show screen
 
     # if AJAX request, replace right cell, and return
     if request.xml_http_request?


### PR DESCRIPTION
Timelines for containers cannot be displayed.
This was introduced as part of a refactor in container controller, in which two variables were not set in the explorer while needed for the rendered layout.