### PR TITLE
fix DEBUG_PRECOMPILE option

### DIFF
--- a/lib/vmdb/productization.rb
+++ b/lib/vmdb/productization.rb
@@ -31,7 +31,7 @@ module Vmdb
             path =~ /(?:\/|\\|\A)(application|productization)\.(css|js)$/
 
           if ENV["DEBUG_PRECOMPILE"]
-            resolved = Rails.application.assets.resolve(path)
+            resolved = Pathname.new(Rails.application.assets.resolve(path))
             resolved = resolved.relative_path_from(Rails.root) if resolved.to_s.start_with?(Rails.root.to_s)
             puts " #{file ? "+" : "-"} #{resolved}"
           end


### PR DESCRIPTION
`assets.resolve` sometimes returns strings for gem `sprockets-rails` 3.0.
This works around that so the debug option will still work.

```
DEBUG_PRECOMPILE=true bundle exec rspec ./spec/controllers/chargeback_controller_spec.rb:79
```

was generating:

```
Failure/Error: get :explorer
     ActionView::Template::Error:
       undefined method `relative_path_from' for "/Users/kbrock/src/manageiq/app/assets/fonts/icomoon.eot":String
     # ./lib/vmdb/productization.rb:35:in `block in prepare_asset_precompilation'
```

/cc @Fryguy This was failing for me, not sure if you still use this option