### PR TITLE
Skip rendering nil atributtes for toolbars

### DIFF
--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -192,7 +192,7 @@ module ToolbarHelper
   #
   def data_hash_keys(props)
     %i(pressed popup window_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
-      h[key] = props[key] if props.key?(key)
+      h[key] = props[key] if props[key].present?
     end
   end
 

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -169,4 +169,12 @@ describe ToolbarHelper do
       expect(subject).to have_selector('li a i.fa.fa-th')
     end
   end
+
+  describe "#data_hash_keys" do
+    it "returns hash without elements with nil value" do
+      output_hash = data_hash_keys(:pressed => nil, :explorer => true)
+      expect(output_hash[:explorer]).to be_truthy
+      expect(output_hash).not_to have_key(:pressed)
+    end
+  end
 end


### PR DESCRIPTION
for example:
Configure -> Configuration -> Access Control -> click on any group and press edit in Configuration toolbar button
before:
![screen shot 2016-01-05 at 15 22 18](https://cloud.githubusercontent.com/assets/14937244/12117298/2c64f4ce-b3c0-11e5-92b2-01048a6138e9.png)

after:
can edit

thanks @himdel - I slighlty rewrote condition, is it ok ?
cc @martinpovolny 
caused by https://github.com/ManageIQ/manageiq/pull/5959
 