### PR TITLE
[api] category updates should return the virtual name attribute

### DIFF
--- a/app/controllers/api_controller/categories.rb
+++ b/app/controllers/api_controller/categories.rb
@@ -5,18 +5,25 @@ class ApiController
     #
     #
     def show_categories
-      @req[:additional_attributes] = %w(name)
+      request_additional_attributes
       show_generic(:categories)
     end
 
     def edit_resource_categories(type, id, data = {})
       raise ApiController::Forbidden if Category.find(id).read_only?
+      request_additional_attributes
       edit_resource(type, id, data)
     end
 
     def delete_resource_categories(type, id, data = {})
       raise ApiController::Forbidden if Category.find(id).read_only?
       delete_resource(type, id, data)
+    end
+
+    private
+
+    def request_additional_attributes
+      @req[:additional_attributes] = %w(name)
     end
   end
 end

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe "categories API" do
       end.to change { category.reload.description }.to("New description")
 
       expect_request_success
+      expect_result_to_have_keys(%w(id description name))
     end
 
     it "can delete a category through POST" do


### PR DESCRIPTION
Updates of categories should return the name attributes just as we ask for it during GET's.

Fixes #5974 