### PR TITLE
[api] Respond 404 not found when deleting non-existent tag

### DIFF
--- a/app/controllers/api_controller/tags.rb
+++ b/app/controllers/api_controller/tags.rb
@@ -79,6 +79,8 @@ class ApiController
     def delete_resource_tags(_type, id, _data = {})
       destroy_tag_and_classification(id)
       action_result(true, "tags id: #{id} deleting")
+    rescue ActiveRecord::RecordNotFound
+      raise
     rescue => err
       action_result(false, err.to_s)
     end
@@ -94,13 +96,8 @@ class ApiController
     end
 
     def destroy_tag_and_classification(tag_id)
-      entry = Classification.find_by_tag_id(tag_id)
-      if entry
-        entry.destroy!
-      else
-        tag = Tag.find_by_id(tag_id)
-        tag.destroy! if tag
-      end
+      entry_or_tag = Classification.find_by_tag_id(tag_id) || Tag.find(tag_id)
+      entry_or_tag.destroy!
     end
 
     def tag_ident(tag_spec)

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -162,6 +162,28 @@ describe ApiController do
         expect_request_success_with_no_content
       end
 
+      it "will respond with 404 not found when deleting a non-existent tag through DELETE" do
+        api_basic_authorize action_identifier(:tags, :delete)
+        classification = FactoryGirl.create(:classification_tag)
+        tag_id = classification.tag.id
+        classification.destroy!
+
+        run_delete tags_url(tag_id)
+
+        expect_resource_not_found
+      end
+
+      it "will respond with 404 not found when deleting a non-existent tag through POST" do
+        api_basic_authorize action_identifier(:tags, :delete)
+        classification = FactoryGirl.create(:classification_tag)
+        tag_id = classification.tag.id
+        classification.destroy!
+
+        run_post tags_url(tag_id), :action => :delete
+
+        expect_resource_not_found
+      end
+
       it "can delete multiple tags within a category by id" do
         api_basic_authorize action_identifier(:tags, :delete)
         classification1 = FactoryGirl.create(:classification_tag)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1290783

@abellotti please review
@miq-bot add-label api, bug