### PR TITLE
One more fix for the toolbars.

### DIFF
--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -192,18 +192,16 @@ module ToolbarHelper
   #
   def data_hash_keys(props)
     %i(pressed popup window_url prompt explorer onwhen url_parms url).each_with_object({}) do |key, h|
-      h[key] = props[key] if props[key].present?
+      h["data-#{key}"] = props[key] if props[key].present?
     end
   end
 
   # Calculate common html tag keys and values from toolbar button definition
   #
   def prepare_tag_keys(props)
-    h = {
-      'data'       => data_hash_keys(props),
-      'title'      => _(props['title']),
-      'data-click' => props['id']
-    }
+    h = data_hash_keys(props)
+    h.update('title'      => _(props['title']),
+             'data-click' => props['id'])
     h['name']         = props[:name] if props.key?(:name)
     h['data-confirm'] = _("#{props[:confirm]}") if props.key?(:confirm)
     h

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -173,8 +173,13 @@ describe ToolbarHelper do
   describe "#data_hash_keys" do
     it "returns hash without elements with nil value" do
       output_hash = data_hash_keys(:pressed => nil, :explorer => true)
-      expect(output_hash[:explorer]).to be_truthy
-      expect(output_hash).not_to have_key(:pressed)
+      expect(output_hash['data-explorer']).to be_truthy
+      expect(output_hash).not_to have_key('data-pressed')
+    end
+
+    it "converts :url_parms do data-url_parms" do
+      output_hash = data_hash_keys(:url_parms => 'foobar')
+      expect(output_hash['data-url_parms']).to eq('foobar')
     end
   end
 end


### PR DESCRIPTION
The content_tag( ... :data => {... } ... ) converts underscores in hash
keys to dashes. So avoid using the :data key. Plus spec for that.