### PR TITLE
Fix where condition in VmOrTemplate model for ems_custom_attributes

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -29,7 +29,8 @@ class VmOrTemplate < ActiveRecord::Base
   include ProcessTasksMixin
   include TenancyMixin
 
-  has_many :ems_custom_attributes, -> { where "source = 'VC'" }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy,
+           :class_name => "CustomAttribute"
 
   VENDOR_TYPES = {
     # DB            Displayed


### PR DESCRIPTION
It caused badly generated sql when custom report is generated. This report must contain custom attributtes for VM.

error in log:
```
[----] E, [2016-01-05T19:29:20.611648 #88085:3fddbc45e1f4] ERROR -- : [ActiveRecord::StatementInvalid]: PG::AmbiguousColumn: ERROR:  column reference "source" is ambiguous
LINE 1: ...m_attributes_vms"."resource_id" = "vms"."id" AND (source = '...
                                                             ^
: SELECT COUNT(DISTINCT "vms"."id") FROM "vms" LEFT OUTER JOIN "custom_attributes" ON "custom_attributes"."resource_id" = "vms"."id" AND "custom_attributes"."source" = $1 AND "custom_attributes"."resource_type" = $2 LEFT OUTER JOIN "custom_attributes" "ems_custom_attributes_vms" ON "ems_custom_attributes_vms"."resource_id" = "vms"."id" AND (source = 'VCa') AND "ems_custom_attributes_vms"."resource_type" = $3 WHERE "vms"."type" IN ('ManageIQ::Providers::InfraManager::Vm', 'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Vmware::InfraManager::Vm', 'VmXen') AND "vms"."template" = $4  Method:[rescue in deliver]
[----] E, [2016-01-05T19:29:20.611924 #88085:3fddbc45e1f4] ERROR -- : /usr/local/opt/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb:637:in `prepare'
/usr/local/opt/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb:637:in `prepare_statement'
/usr/local/opt/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb:596:in `exec_cache'
/usr/local/opt/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb:585:in `execute_and_clear'
```
it is done as it is in https://github.com/ManageIQ/manageiq/blob/master/app/models/host.rb#L100 now
