### PR TITLE
Fixed button visibility of buttons in automate explorer.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -694,7 +694,7 @@ class ApplicationHelper::ToolbarBuilder
         return true unless role_allows(:feature => "action_delete")
       end
     when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
-      return false if MIQ_AE_COPY_ACTIONS.include?(id) && MiqAeDomain.any_unlocked?
+      return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
       when "miq_ae_domain_lock"
         return true unless editable_domain?(@record)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -213,6 +213,10 @@ class Tenant < ActiveRecord::Base
     ae_domains.where(:system => false).order('priority DESC')
   end
 
+  def any_editable_domains?
+    ae_domains.where(:system => false).count > 0
+  end
+
   # The default tenant is the tenant to be used when
   # the url does not map to a known domain or subdomain
   #

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2928,6 +2928,16 @@ describe ApplicationHelper do
       expect(build_toolbar_hide_button('miq_ae_class_edit')).to be_truthy
     end
 
+    it "Enables copy button when there are Editable domains available" do
+      expect(build_toolbar_hide_button('miq_ae_class_copy')).to be_falsey
+    end
+
+    it "Disables copy button when there are no Editable domains available" do
+      @domain.update_attributes(:system => true)
+      @domain.reload
+      expect(build_toolbar_hide_button('miq_ae_class_copy')).to be_truthy
+    end
+
     def role_allows(_)
       true
     end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -488,6 +488,25 @@ describe Tenant do
       dom1
       expect(dom1.tenant.name).to eq(t1.name)
     end
+
+    it "no editable domains available for current tenant" do
+      t1_1
+      FactoryGirl.create(:miq_ae_domain,
+                         :name      => 'non_editable',
+                         :priority  => 3,
+                         :tenant_id => t1_1.id,
+                         :system    => true)
+      expect(t1_1.any_editable_domains?).to eq(false)
+    end
+
+    it "editable domains available for current_tenant" do
+      t1_1
+      FactoryGirl.create(:miq_ae_domain,
+                         :name      => 'editable',
+                         :priority  => 3,
+                         :tenant_id => t1_1.id)
+      expect(t1_1.any_editable_domains?).to eq(true)
+    end
   end
 
   describe ".set_quotas" do


### PR DESCRIPTION
Added code to only make certain buttons visible when user's current tenant has any editable domains.

https://bugzilla.redhat.com/show_bug.cgi?id=1288512
https://bugzilla.redhat.com/show_bug.cgi?id=1293741

@dclarizio please review.