### PR TITLE
Support where method for service models

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -29,7 +29,7 @@ module MiqAeMethodService
 
     # Expose the ActiveRecord find, all, count, and first
     def self.class_method_exposed?(m)
-      m.to_s.starts_with?('find_') || [:find, :all, :count, :first].include?(m)
+      m.to_s.starts_with?('find_') || [:where, :find, :all, :count, :first].include?(m)
     end
     private_class_method :class_method_exposed?
 

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -94,4 +94,12 @@ module MiqAeServiceModelSpec
       end
     end
   end
+
+  describe MiqAeMethodService::MiqAeServiceVmOrTemplate do
+    it '#where' do
+      vm = FactoryGirl.create(:vm_vmware, :name => 'fred')
+      svc_vm = MiqAeMethodService::MiqAeServiceVmOrTemplate.where(:name => 'fred').first
+      expect(svc_vm.id).to eq(vm.id)
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1295927

Starting in Rails 4 the where method should be used instead
of find when accessing ActiveRecord Objects. The Automate
Service Model wraps the ActiveRecord objects and wasn't exposing
the class method where.