### PR TITLE
Remove Explorer#x_button_response

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -127,16 +127,13 @@ module ApplicationController::Explorer
     return if performed?
     # no need to render anything, method will render flash message when async task is completed
 
-    x_button_response(model, action)
-  end
-
-  def x_button_response(model, action)
     if @refresh_partial == "layouts/flash_msg"
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     elsif @refresh_partial
-      replace_right_cell unless action == 'download_pdf' # no need to render anything when download_pdf button is pressed on summary screen
+      # no need to render anything when download_pdf button is pressed on summary screen
+      replace_right_cell unless action == 'download_pdf'
     else
       add_flash(_("Button not yet implemented") + " #{model}:#{action}", :error) unless @flash_array
       render :update do |page|

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -22,7 +22,6 @@ describe VmCloudController do
           actual_method = [:s1, :s2].include?(method) ? actual_action : method.to_s
 
           it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
-            allow(controller).to receive(:x_button_response)
             expect(controller).to receive(actual_method)
             get :x_button, :id => nil, :pressed => actual_action
           end

--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -20,7 +20,6 @@ describe VmOrTemplateController do
         actual_method = [:s1, :s2].include?(method) ? actual_action : method.to_s
 
         it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
-          allow(controller).to receive(:x_button_response)
           expect(controller).to receive(actual_method)
           get :x_button, :id => nil, :pressed => actual_action
         end


### PR DESCRIPTION
This was added in 5c873cff80fa1fcdae3abb7a3d6eb04d3bdf6d29

It needn't be, ~~and actually makes things a bit more complex in RSpec3 as with this method mocked the controller doesn't respond at times and causes errors.~~ I actually fixed the RSpec 3 issue another way but I believe this PR is still valid; this doesn't need to be a separate method just for RSpec's sake and makes things less complicated.