### PR TITLE
Fix vmdb logging initialization (again)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -85,14 +85,15 @@ module Vmdb
     config.eager_load_paths = []
 
     # This must be done outside of initialization blocks
-    #   as Vmdb::Logging is needed very early
+    #   as the Vmdb::Logging constant is needed very early
     require 'vmdb/logging'
 
-    initializer :initialize_vmdb_logger, :before => :initialize_logger do
-      Vmdb::Loggers.init
-      config.logger = Vmdb.rails_logger
-      config.colorize_logging = false
-    end
+    # This must be done outside of initialization blocks
+    #   as rake tasks that do not use the environment still need to log
+    require 'vmdb/loggers'
+    Vmdb::Loggers.init
+    config.logger = Vmdb.rails_logger
+    config.colorize_logging = false
 
     config.before_initialize do
       require_relative 'environments/patches/database_configuration'

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -1,5 +1,3 @@
-require 'vmdb-logger'
-
 $LOAD_PATH << File.expand_path(__dir__)
 require 'util/postgres_admin'
 
@@ -11,9 +9,6 @@ class EvmDatabaseOps
   BACKUP_TMP_FILE = "/tmp/miq_backup"
 
   DEFAULT_OPTS = {:dbname => 'vmdb_production'}
-
-  LOGFILE = File.expand_path(File.join(__dir__, "../log/evm.log"))
-  $log ||= VMDBLogger.new(LOGFILE)
 
   def self.backup_destination_free_space(file_location)
     require 'fileutils'

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -7,6 +7,10 @@ module Vmdb
     $log
   end
 
+  def self.null_logger
+    @null_logger ||= Loggers::NullLogger.new
+  end
+
   def self.rails_logger
     $rails_log
   end
@@ -39,7 +43,7 @@ module Vmdb
       if ENV.key?("CI")
         $log = $rails_log = $audit_log = $fog_log = $policy_log = $vim_log =
           $rhevm_log = $aws_log = $kube_log = $scvmm_log = $api_log =
-          $miq_ae_logger = LogProxy.null_logger
+          $miq_ae_logger = Vmdb.null_logger
       else
         path_dir = Rails.root.join("log")
 
@@ -68,7 +72,7 @@ module Vmdb
     private_class_method :configure_external_loggers
 
     def self.apply_config_value(config, logger, key, mirror_key = nil)
-      return if logger == LogProxy.null_logger
+      return if logger == Vmdb.null_logger
       apply_config_value_logged(config, logger, :level, key)
       apply_config_value_logged(config, logger, :mirror_level, mirror_key) if mirror_key
     end

--- a/lib/vmdb/loggers/null_logger.rb
+++ b/lib/vmdb/loggers/null_logger.rb
@@ -1,0 +1,22 @@
+module Vmdb::Loggers
+  class NullLogger < Logger
+    def initialize(*)
+      super('/dev/null')
+      self.level = Logger::UNKNOWN
+    end
+
+    def filename(*); end
+
+    def log_backtrace(*); end
+
+    def log_hashes(*); end
+
+    def success(*); end
+
+    def failure(*); end
+
+    def instrument(*)
+      yield if block_given?
+    end
+  end
+end

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -1,3 +1,5 @@
+require 'vmdb/loggers'
+
 module Vmdb
   class LogProxy < Struct.new(:klass, :separator)
     class NullLogger < Logger

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -2,31 +2,6 @@ require 'vmdb/loggers'
 
 module Vmdb
   class LogProxy < Struct.new(:klass, :separator)
-    class NullLogger < Logger
-      def initialize(*)
-        super('/dev/null')
-        self.level = Logger::UNKNOWN
-      end
-
-      def filename(*); end
-
-      def log_backtrace(*); end
-
-      def log_hashes(*); end
-
-      def success(*); end
-
-      def failure(*); end
-
-      def instrument(*)
-        yield if block_given?
-      end
-    end
-
-    def self.null_logger
-      @null_logger ||= NullLogger.new
-    end
-
     LEVELS = [:debug, :info, :warn, :error]
 
     delegate *LEVELS.map { |level| :"#{level}?" },
@@ -55,7 +30,7 @@ module Vmdb
     private
 
     def logger
-      Vmdb.logger || $log || LogProxy.null_logger
+      Vmdb.logger || Vmdb.null_logger
     end
   end
 


### PR DESCRIPTION
This returns the logger objects initialization back to being very early,
since there are certain code paths (like rake tasks) that do not load
the environment, but still need the loggers defined.

For example, it fixes the following issue with `rake evm:db:start`

    Starting EVM server daemon...
    rake aborted!
    NoMethodError: undefined method `logger' for Vmdb:Module
    /var/www/miq/vmdb/lib/vmdb/logging.rb:56:in `logger'
    /var/www/miq/vmdb/lib/vmdb/logging.rb:41:in `block (2 levels) in <class:LogProxy>'
    /var/www/miq/vmdb/lib/evm_database_ops.rb:127:in `start'
    /var/www/miq/vmdb/lib/tasks/evm_dba.rake:24:in `start'
    /var/www/miq/vmdb/lib/tasks/evm_dba.rake:89:in `block (3 levels) in <top (required)>'
    /var/www/miq/vmdb/lib/tasks/evm_dba.rake:69:in `block (3 levels) in <top (required)>'
    Tasks: TOP => evm:db:silent_start

@jrafanie Please review.
cc @carbonin @JPrause @matthewd