### PR TITLE
Deprecations topology

### DIFF
--- a/gems/pending/spec/util/duplicate_blocker_spec.rb
+++ b/gems/pending/spec/util/duplicate_blocker_spec.rb
@@ -128,7 +128,7 @@ describe DuplicateBlocker do
 
   def assert_safe_calls(meth, n, time, interval, *args)
     n.times do
-      make_a_call(meth, time) { |func| func.call(*args).should eq args }
+      make_a_call(meth, time) { |func| expect(func.call(*args)).to eq args }
       time += interval
     end
   end

--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -213,7 +213,7 @@ describe MiqPassword do
   end
 
   it ".sanitize_string" do
-    MiqPassword.sanitize_string!("some :password: v1:{XAWlcAlViNwB} and another :password: v2:{egr+hObB}").should eq(
+    expect(MiqPassword.sanitize_string!("some :password: v1:{XAWlcAlViNwB} and another :password: v2:{egr+hObB}")).to eq(
       "some :password: ******** and another :password: ********")
   end
 

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -174,7 +174,7 @@ describe ContainerTopologyService do
                                                   :name => "service1")
       allow(container_topology_service).to receive(:entities).and_return([[container_node], [container_service]])
 
-      expect(subject[:items]).should be_eql(
+      expect(subject[:items]).to eq(
         "905c90ba-3e00-11e5-a0d2-18037327aaeb" => {:id           => container_node.ems_ref,
                                                    :name         => container_node.name,
                                                    :status       => "Ready",


### PR DESCRIPTION
remove deprecation warnings in tests

```
`expect { }.should` is deprecated.
Use `expect { }.to` instead.
Called from spec/services/container_topology_service_spec.rb:177:in
`block (3 levels) in <top (required)>'.
```

Also convert `should` to an `expect` to remove another warning

/cc @chrisarcand FYI