### PR TITLE
remove css_splitter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem "jquery-rails",                   "~>4.0.4"
 gem "jquery-rjs",                     "=0.1.1",                       :git => "https://github.com/amatsuda/jquery-rjs.git"
 gem "lodash-rails",                   "~>3.10.0"
 gem "patternfly-sass",                "~>2.8.0"
-gem "css_splitter"
 gem "sass-rails"
 
 # Vendored and required

--- a/app/assets/stylesheets/application_split2.css
+++ b/app/assets/stylesheets/application_split2.css
@@ -1,3 +1,0 @@
-/*
- * = require application
- */

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %head
       %title CloudForms Management Engine: #{@layout.titleize}
       = favicon_link_tag
-      = split_stylesheet_link_tag 'application'
+      = stylesheet_link_tag 'application'
       = javascript_include_tag 'application'
       - if Rails.env.development?
         = javascript_include_tag 'miq_debug'
@@ -23,7 +23,7 @@
       %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
 
       = favicon_link_tag
-      = split_stylesheet_link_tag 'application'
+      = stylesheet_link_tag 'application'
       = render :partial => "stylesheets/template50"
       = javascript_include_tag 'application'
       - if Rails.env.development?

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -5,7 +5,7 @@
     %title
       = h(title_from_layout(@layout))
     = tag :link, :rel => "shortcut icon", :href => image_path("favicon.ico")
-    = split_stylesheet_link_tag 'application'
+    = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/app/views/vm_common/console_spice.html.haml
+++ b/app/views/vm_common/console_spice.html.haml
@@ -5,7 +5,7 @@
     %title
       = _('SPICE Console')
     = favicon_link_tag
-    = split_stylesheet_link_tag 'application'
+    = stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'spiceHTML5/spicearraybuffer', 'spice-html5'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/app/views/vm_common/console_vnc.html.haml
+++ b/app/views/vm_common/console_vnc.html.haml
@@ -4,7 +4,7 @@
     %title
       = _('VNC Console')
     = favicon_link_tag
-    = split_stylesheet_link_tag 'application'
+    = stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'novnc-rails', 'miq_novnc'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,9 +60,6 @@ module Vmdb
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
-    # Fix 4095 CSS rule limit by using the css_splitter gem on the application.css
-    config.assets.precompile += %w(application_split2.css)
-
     # Customize any additional options below...
 
     # HACK: By default, Rails.configuration.eager_load_paths contains all of the directories


### PR DESCRIPTION
Remove `css_splitter` gem - it was only needed for ie 9.0

pulled out of #5896

/cc @skateman @Fryguy @dclarizio 