### PR TITLE
Precompile assets

### DIFF
--- a/app/views/vm_common/console_spice.html.haml
+++ b/app/views/vm_common/console_spice.html.haml
@@ -5,13 +5,7 @@
     %title
       = _('SPICE Console')
     = split_stylesheet_link_tag 'application'
-    = javascript_include_tag 'application', 'spiceHTML5/enums', 'spiceHTML5/atKeynames', 'spiceHTML5/utils',
-    'spiceHTML5/png', 'spiceHTML5/lz', 'spiceHTML5/quic', 'spiceHTML5/bitmap',
-    'spiceHTML5/spicedataview', 'spiceHTML5/spicetype', 'spiceHTML5/spicemsg', 'spiceHTML5/wire',
-    'spiceHTML5/spiceconn', 'spiceHTML5/display', 'spiceHTML5/main', 'spiceHTML5/inputs',
-    'spiceHTML5/cursor', 'spiceHTML5/thirdparty/jsbn', 'spiceHTML5/thirdparty/rsa',
-    'spiceHTML5/thirdparty/prng4', 'spiceHTML5/thirdparty/rng', 'spiceHTML5/thirdparty/sha1',
-    'spiceHTML5/ticket', 'spiceHTML5/spicearraybuffer', 'spice-html5'
+    = javascript_include_tag 'application', 'spiceHTML5/spicearraybuffer', 'spice-html5'
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,10 @@
+Rails.application.config.assets.precompile += %w(
+  miq_browser_detect.js
+  jquery-1.8/jquery.js jquery_overrides.js
+  miq_policy/import.js
+  novnc-rails.js miq_novnc.js
+  spice-html5.js
+
+  xml_display.css
+  container_topology.css service_dialogs.css import_policy.css vmrc.css
+)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,7 +3,7 @@ Rails.application.config.assets.precompile += %w(
   jquery-1.8/jquery.js jquery_overrides.js
   miq_policy/import.js
   novnc-rails.js miq_novnc.js
-  spice-html5.js
+  spice-html5.js spiceHTML5/spicearraybuffer.js
 
   xml_display.css
   container_topology.css service_dialogs.css import_policy.css vmrc.css

--- a/lib/vmdb/productization.rb
+++ b/lib/vmdb/productization.rb
@@ -16,29 +16,8 @@ module Vmdb
       Rails.application.config.assets.paths.unshift(*paths)
     end
 
-    # Override Rails' default precompilation of assets, which excludes all .js
-    #   and .css files except application.js and application.css, to also
-    #   process productization.js and productization.css if available.  In
-    #   addition, include printing of resolved assets.
-    #
-    #   The original value is located at:
-    #     https://github.com/rails/rails/blob/v3.2.15/railties/lib/rails/application/configuration.rb#L48-L49
     def prepare_asset_precompilation
-      Rails.application.config.assets.precompile = [
-        proc do |path|
-          file =
-            !File.extname(path).in?(['.js', '.css', '']) ||
-            path =~ /(?:\/|\\|\A)(application|productization)\.(css|js)$/
-
-          if ENV["DEBUG_PRECOMPILE"]
-            resolved = Pathname.new(Rails.application.assets.resolve(path))
-            resolved = resolved.relative_path_from(Rails.root) if resolved.to_s.start_with?(Rails.root.to_s)
-            puts " #{file ? "+" : "-"} #{resolved}"
-          end
-
-          file
-        end
-      ]
+      Rails.application.config.assets.precompile += %w(productization.css productization.js)
     end
 
     # Replace the default Sprockets::DirectiveProcessor with our overriden one


### PR DESCRIPTION
**Before:**

- stylesheet and javascript files were referenced from haml, but not precompiled into our appliance.
- This causes asset metadata errors (500) and missing asset errors (404).
- Newer versions of sprockets gem are more pedantic and raise exceptions for these errors.
- This is needed for #5896 (and rails5 upgrade)

**After:**

Added any assets referenced by `javascript_include_tag` and `stylesheet_link_tag` to our precompiled assets list

/cc @dclarizio @skateman @himdel @Fryguy @matthewd 
/cc @epwinchell FYI