### PR TITLE
Avoid secure_headers 2.5 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>2.13"
 gem "recursive-open-struct",          "~>0.6.1"
 gem "responders",                     "~>2.0"
-gem "secure_headers"
+gem "secure_headers",                 "~>2.4.4"
 gem "spice-html5-rails"
 gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 


### PR DESCRIPTION
It produces many deprecation warnings ([by design](https://github.com/twitter/secureheaders/releases/tag/2.5.0)).