### PR TITLE
Fix Rails console SQL output from being hidden

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,6 +111,13 @@ module Vmdb
     end
 
     console do
+      # Re-enable SQL logging in the console.  This log level setting gets set
+      #   to INFO, by default, for the loggers in Vmdb::Initializer.init.  So,
+      #   we set the value back to DEBUG for now.
+      # TODO: This can be removed once we can have separate config settings for
+      #   dev/test/prod in the config revamp.
+      ActiveRecord::Base.logger.level = Logger::DEBUG
+
       Rails::ConsoleMethods.class_eval do
         include Vmdb::ConsoleMethods
       end


### PR DESCRIPTION
The default log level for the Rails logger is INFO, which causes
the SQL output to be disabled.  So, for now, hardcode it to DEBUG,
until we can get separate config settings for dev/test/prod.

This happened because we now properly set configuration settings
at the right time.

@jrafanie or @matthewd Please review.
cc @romanblanco 