### PR TITLE
[api] Enable filtering of categories by  name

### DIFF
--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -182,11 +182,12 @@ class ApiController
         else
           klass.all
         end
-      filter_options = filter_param(klass)
-      res = res.where(filter_options)             if filter_options.present? && res.respond_to?(:where)
+      sql_filter, ruby_filters = filter_param(klass)
+      res = res.where(sql_filter)                                     if sql_filter.present? && res.respond_to?(:where)
+      ruby_filters.each { |ruby_filter| res = ruby_filter.call(res) } if ruby_filters.present?
 
-      sort_options = sort_params(klass)           if res.respond_to?(:reorder)
-      res = res.reorder(sort_options)             if sort_options.present?
+      sort_options = sort_params(klass)                               if res.respond_to?(:reorder)
+      res = res.reorder(sort_options)                                 if sort_options.present?
 
       options = {
         :user => @auth_user_obj,

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe "categories API" do
     expect_request_success
   end
 
+  it "can filter the list of categories by name" do
+    category_1 = FactoryGirl.create(:category, :name => "foo")
+    _category_2 = FactoryGirl.create(:category, :name => "bar")
+    api_basic_authorize
+
+    run_get categories_url, :filter => ["name=foo"]
+
+    expect_query_result(:categories, 1, 2)
+    expect_result_resources_to_include_hrefs("resources", [categories_url(category_1.id)])
+    expect_request_success
+  end
+
+  it "will return a bad request error if the filter name is invalid" do
+    FactoryGirl.create(:category)
+    api_basic_authorize
+
+    run_get categories_url, :filter => ["not_an_attribute=foo"]
+
+    expect_bad_request(/attribute not_an_attribute does not exist/)
+  end
+
   it "can read a category" do
     category = FactoryGirl.create(:category)
     api_basic_authorize


### PR DESCRIPTION
Currently API results can't be filtered by virtual attributes. This is
because all filter attributes are contructed into a SQL query regardless
of whether they represent column names. Filtering by virtual attributes
would result in a database error.

This change will check for non-column attributes before making the
query, and attempt to filter by them in ruby after the results are
returned.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1293891