### PR TITLE
Convert gems/pending specs to RSpec 2.99.2 syntax

### DIFF
--- a/gems/pending/spec/VMwareWebService/MiqVimVm_spec.rb
+++ b/gems/pending/spec/VMwareWebService/MiqVimVm_spec.rb
@@ -5,8 +5,8 @@ describe MiqVimVm do
   context 'snapshot disk size check' do
     before(:each) do
       @inv_obj = double
-      @inv_obj.stub(:sic).and_return(nil)
-      @inv_obj.stub(:localVmPath).and_return('/test-vm/test-vm.vmx')
+      allow(@inv_obj).to receive(:sic).and_return(nil)
+      allow(@inv_obj).to receive(:localVmPath).and_return('/test-vm/test-vm.vmx')
 
       vmh = {
         'summary' => {
@@ -24,23 +24,23 @@ describe MiqVimVm do
 
     context "snapshot_directory_mor" do
       before(:each) do
-        @inv_obj.stub(:path2dsName).and_return(VimString.new('path2dsName'))
-        @inv_obj.stub(:dsName2mo_local).and_return(VimString.new('dsName2mo_local'))
+        allow(@inv_obj).to receive(:path2dsName).and_return(VimString.new('path2dsName'))
+        allow(@inv_obj).to receive(:dsName2mo_local).and_return(VimString.new('dsName2mo_local'))
       end
 
       context "API 4.x" do
         before(:each) do
-          @inv_obj.stub(:apiVersion).and_return(VimString.new('4.1'))
+          allow(@inv_obj).to receive(:apiVersion).and_return(VimString.new('4.1'))
         end
 
         it "snapshot_directory_mor" do
-          @vim_vm.snapshot_directory_mor({}).should == 'dsName2mo_local'
+          expect(@vim_vm.snapshot_directory_mor({})).to eq('dsName2mo_local')
         end
       end
 
       context "API 5.x" do
         before(:each) do
-          @inv_obj.stub(:apiVersion).and_return(VimString.new('5.0'))
+          allow(@inv_obj).to receive(:apiVersion).and_return(VimString.new('5.0'))
           @redoNotWithParent = VimHash.new do |vh|
             vh.key =   'snapshot.redoNotWithParent'
             vh.value = 'false'
@@ -50,16 +50,16 @@ describe MiqVimVm do
 
         it "without redoNotWithParent" do
           config = {'config' => {'extraConfig' => []}}
-          @vim_vm.snapshot_directory_mor(config).should be_nil
+          expect(@vim_vm.snapshot_directory_mor(config)).to be_nil
         end
 
         it "API 5.x - with redoNotWithParent = false" do
-          @vim_vm.snapshot_directory_mor(@config).should be_nil
+          expect(@vim_vm.snapshot_directory_mor(@config)).to be_nil
         end
 
         it "API 5.x - with redoNotWithParent = true" do
           @redoNotWithParent['value'] = true
-          @vim_vm.snapshot_directory_mor(@config).should == 'dsName2mo_local'
+          expect(@vim_vm.snapshot_directory_mor(@config)).to eq('dsName2mo_local')
         end
       end
     end
@@ -75,7 +75,7 @@ describe MiqVimVm do
           }
         }
 
-        @inv_obj.stub(:getMoProp_local).and_return(ds_summary)
+        allow(@inv_obj).to receive(:getMoProp_local).and_return(ds_summary)
       end
 
       it "check_disk_space - 100 percent, small disk" do
@@ -85,17 +85,17 @@ describe MiqVimVm do
 
       it "check_disk_space - 100 percent, large disk" do
         max_disk_space_in_kb = 10000
-        -> { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 100) }.should raise_error(MiqException::MiqVmSnapshotError)
+        expect { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 100) }.to raise_error(MiqException::MiqVmSnapshotError)
       end
 
       it "check_disk_space - 0 percent" do
         max_disk_space_in_kb = 10000
-        -> { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 0) }.should_not raise_error
+        expect { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 0) }.not_to raise_error
       end
 
       it "check_disk_space - 10 percent" do
         max_disk_space_in_kb = 10000
-        -> { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 10) }.should_not raise_error
+        expect { @vim_vm.check_disk_space('create', @ds_mor, max_disk_space_in_kb, 10) }.not_to raise_error
       end
     end
 
@@ -115,22 +115,22 @@ describe MiqVimVm do
 
       it "multi-datastore" do
         result = @vim_vm.disk_space_per_datastore(@devices, nil)
-        result.should have(2).things
-        result['datastore-001'].should == 100
-        result['datastore-002'].should == 200
+        expect(result.size).to eq(2)
+        expect(result['datastore-001']).to eq(100)
+        expect(result['datastore-002']).to eq(200)
       end
 
       it "single-datastore" do
         @disk2.backing['datastore'] = 'datastore-001'
         result = @vim_vm.disk_space_per_datastore(@devices, nil)
-        result.should have(1).thing
-        result['datastore-001'].should == 300
+        expect(result.size).to eq(1)
+        expect(result['datastore-001']).to eq(300)
       end
 
       it "snapshot directory override" do
         result = @vim_vm.disk_space_per_datastore(@devices, 'datastore-snap')
-        result.should have(1).thing
-        result['datastore-snap'].should == 300
+        expect(result.size).to eq(1)
+        expect(result['datastore-snap']).to eq(300)
       end
     end
   end

--- a/gems/pending/spec/appliance_console/certificate_authority_spec.rb
+++ b/gems/pending/spec/appliance_console/certificate_authority_spec.rb
@@ -49,13 +49,13 @@ describe ApplianceConsole::CertificateAuthority do
       ipa_configured(true)
       expect_run(/getcert/, anything, response) # getcert returns: the certificate already exist
 
-      ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
+      expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .and_return(double("config", :activate => true, :configure_postgres => true))
       PostgresAdmin.stub(:service_name => "postgresql")
-      LinuxAdmin::Service.should_receive(:new).and_return(double("Service", :restart => true))
-      FileUtils.should_receive(:chmod).with(0644, anything)
+      expect(LinuxAdmin::Service).to receive(:new).and_return(double("Service", :restart => true))
+      expect(FileUtils).to receive(:chmod).with(0644, anything)
 
-      subject.should_receive(:say)
+      expect(subject).to receive(:say)
       subject.activate
       expect(subject.pgserver).to eq(:complete)
       expect(subject.status_string).to eq("pgserver: complete")
@@ -66,8 +66,8 @@ describe ApplianceConsole::CertificateAuthority do
       ipa_configured(true)
       expect_run(/getcert/, anything, response(3)) # getcert returns: waiting on the CA
 
-      ApplianceConsole::InternalDatabaseConfiguration.should_not_receive(:new)
-      LinuxAdmin::Service.should_not_receive(:new)
+      expect(ApplianceConsole::InternalDatabaseConfiguration).not_to receive(:new)
+      expect(LinuxAdmin::Service).not_to receive(:new)
       subject.activate
       expect(subject.pgserver).to eq(:waiting)
       expect(subject.status_string).to eq("pgserver: waiting")

--- a/gems/pending/spec/appliance_console/certificate_spec.rb
+++ b/gems/pending/spec/appliance_console/certificate_spec.rb
@@ -3,7 +3,7 @@ require "fileutils"
 require "appliance_console/certificate"
 
 describe ApplianceConsole::Certificate do
-  before { Open3.should_not_receive(:capture) }
+  before { expect(Open3).not_to receive(:capture) }
   let(:host)  { "client.network.com" }
   let(:realm) { "NETWORK.COM" }
   let(:service) { "postgres" }
@@ -76,7 +76,7 @@ describe ApplianceConsole::Certificate do
   private
 
   def expect_run(cmd, params, *responses)
-    AwesomeSpawn.should_receive(:run).with(cmd, :params => params)
+    expect(AwesomeSpawn).to receive(:run).with(cmd, :params => params)
       .and_return(*(responses.empty? ? response : responses))
   end
 
@@ -97,11 +97,11 @@ describe ApplianceConsole::Certificate do
   end
 
   def expect_chmod(files)
-    FileUtils.should_receive(:chmod).with(0644, files)
+    expect(FileUtils).to receive(:chmod).with(0644, files)
   end
 
   def expect_chown
-    FileUtils.should_receive(:chown).with("user", "group", key_filename)
+    expect(FileUtils).to receive(:chown).with("user", "group", key_filename)
   end
 
   def response(ret_code = 0)

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -18,16 +18,16 @@ describe ApplianceConsole::Cli do
   it "should not set hostname if none specified" do
     expect_any_instance_of(LinuxAdmin::Hosts).to_not receive(:hostname=)
 
-    subject.stub(:create_key) # just give it something to do
+    allow(subject).to receive(:create_key) # just give it something to do
     subject.parse(%w(--key)).run
   end
 
   it "should set database host to localhost if running locally" do
     subject.parse(%w(--internal -r 1 --dbdisk x))
     expect_v2_key
-    subject.should_receive(:disk_from_string).with('x').and_return('/dev/x')
-    subject.should_receive(:say)
-    ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
+    expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')
+    expect(subject).to receive(:say)
+    expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
       .with(:region      => 1,
             :database    => 'vmdb_production',
             :username    => 'root',
@@ -41,9 +41,9 @@ describe ApplianceConsole::Cli do
   it "should pass username and password when configuring database locally" do
     subject.parse(%w(--internal --username user --password pass -r 1 --dbdisk x))
     expect_v2_key
-    subject.should_receive(:disk_from_string).and_return('x')
-    subject.should_receive(:say)
-    ApplianceConsole::InternalDatabaseConfiguration.should_receive(:new)
+    expect(subject).to receive(:disk_from_string).and_return('x')
+    expect(subject).to receive(:say)
+    expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
       .with(:region      => 1,
             :database    => 'vmdb_production',
             :username    => 'user',
@@ -58,8 +58,8 @@ describe ApplianceConsole::Cli do
   it "should handle remote databases (and setup region)" do
     subject.parse(%w(--hostname host --dbname db --username user --password pass -r 1))
     expect_v2_key
-    subject.should_receive(:say)
-    ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
+    expect(subject).to receive(:say)
+    expect(ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
       .with(:host        => 'host',
             :database    => 'db',
             :region      => 1,
@@ -74,8 +74,8 @@ describe ApplianceConsole::Cli do
   it "should handle remote databases (not setting up region)" do
     subject.parse(%w(--hostname host --dbname db --username user --password pass))
     expect_v2_key
-    subject.should_receive(:say)
-    ApplianceConsole::ExternalDatabaseConfiguration.should_receive(:new)
+    expect(subject).to receive(:say)
+    expect(ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
       .with(:host        => 'host',
             :database    => 'db',
             :username    => 'user',
@@ -88,23 +88,23 @@ describe ApplianceConsole::Cli do
 
   context "#ipa" do
     it "should handle uninstalling ipa" do
-      subject.should_receive(:say)
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+      expect(subject).to receive(:say)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:new)
         .and_return(double(:ipa_client_configured? => true, :deactivate => nil))
       subject.parse(%w(--uninstall-ipa)).run
     end
 
     it "should skip uninstalling ipa if not installed" do
-      subject.should_receive(:say)
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+      expect(subject).to receive(:say)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:new)
         .and_return(double(:ipa_client_configured? => false))
       subject.parse(%w(--uninstall-ipa)).run
     end
 
     it "should install ipa" do
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:ipa_client_configured?).and_return(false)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:new)
         .with('client.domain.com',
               :ipaserver => 'ipa.domain.com',
               :principal => 'admin',
@@ -122,8 +122,8 @@ describe ApplianceConsole::Cli do
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)
       expect_any_instance_of(LinuxAdmin::Service.new("test").class).to receive(:restart).and_return(true)
       expect_any_instance_of(LinuxAdmin::Hosts).to_not receive(:hostname)
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(false)
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:new)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:ipa_client_configured?).and_return(false)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:new)
         .with('client.domain.com',
               :ipaserver => 'ipa.domain.com',
               :principal => 'admin',
@@ -134,7 +134,7 @@ describe ApplianceConsole::Cli do
     end
 
     it "should complain if installing ipa-client when ipa is already installed" do
-      ApplianceConsole::ExternalHttpdAuthentication.should_receive(:ipa_client_configured?).and_return(true)
+      expect(ApplianceConsole::ExternalHttpdAuthentication).to receive(:ipa_client_configured?).and_return(true)
       expect do
         subject.parse(%w(--ipaserver ipa.domain.com --ipaprincipal admin --ipapassword pass)).run
       end.to raise_error(/uninstall/)
@@ -143,11 +143,11 @@ describe ApplianceConsole::Cli do
 
   context "#install_certs" do
     it "should basic install completed (default ca_name, non verbose)" do
-      subject.should_receive(:say).with(/creating/)
+      expect(subject).to receive(:say).with(/creating/)
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
-      subject.should_receive(:say).with(/certificate result/)
-      subject.should_not_receive(:say).with(/rerun/)
-      ApplianceConsole::CertificateAuthority.should_receive(:new)
+      expect(subject).to receive(:say).with(/certificate result/)
+      expect(subject).not_to receive(:say).with(/rerun/)
+      expect(ApplianceConsole::CertificateAuthority).to receive(:new)
         .with(
           :hostname => "client.domain.com",
           :realm    => nil,
@@ -162,11 +162,11 @@ describe ApplianceConsole::Cli do
     end
 
     it "should basic install waiting (manual ca_name, verbose)" do
-      subject.should_receive(:say).with(/creating/)
+      expect(subject).to receive(:say).with(/creating/)
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname).and_return('client.domain.com')
-      subject.should_receive(:say).with(/certificate result/)
-      subject.should_receive(:say).with(/rerun/)
-      ApplianceConsole::CertificateAuthority.should_receive(:new)
+      expect(subject).to receive(:say).with(/certificate result/)
+      expect(subject).to receive(:say).with(/rerun/)
+      expect(ApplianceConsole::CertificateAuthority).to receive(:new)
         .with(
           :hostname => "client.domain.com",
           :realm    => "realm.domain.com",
@@ -183,9 +183,9 @@ describe ApplianceConsole::Cli do
 
   context "#config_tmp_disk" do
     it "configures disk" do
-      subject.should_receive(:disk_from_string).with('x').and_return('/dev/x')
-      subject.should_receive(:say)
-      ApplianceConsole::TempStorageConfiguration.should_receive(:new)
+      expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')
+      expect(subject).to receive(:say)
+      expect(ApplianceConsole::TempStorageConfiguration).to receive(:new)
         .with(:disk      => '/dev/x')
         .and_return(double(:activate => true))
 
@@ -193,9 +193,9 @@ describe ApplianceConsole::Cli do
     end
 
     it "configures disk with auto" do
-      subject.should_receive(:disk_from_string).with('auto').and_return('/dev/x')
-      subject.should_receive(:say)
-      ApplianceConsole::TempStorageConfiguration.should_receive(:new)
+      expect(subject).to receive(:disk_from_string).with('auto').and_return('/dev/x')
+      expect(subject).to receive(:say)
+      expect(ApplianceConsole::TempStorageConfiguration).to receive(:new)
         .with(:disk      => '/dev/x')
         .and_return(double(:activate => true))
 
@@ -203,19 +203,19 @@ describe ApplianceConsole::Cli do
     end
 
     it "suggests disk with unknown disk" do
-      subject.should_receive(:disk_from_string).with('abc').and_return(nil)
-      subject.should_receive(:disk).and_return(double(:path => 'dev-good'))
-      subject.should_receive(:say).with(/abc/)
-      subject.should_receive(:say).with(/dev-good/)
+      expect(subject).to receive(:disk_from_string).with('abc').and_return(nil)
+      expect(subject).to receive(:disk).and_return(double(:path => 'dev-good'))
+      expect(subject).to receive(:say).with(/abc/)
+      expect(subject).to receive(:say).with(/dev-good/)
       expect(ApplianceConsole::TempStorageConfiguration).not_to receive(:new)
 
       subject.parse(%w(--tmpdisk abc)).run
     end
 
     it "complains when no disks available" do
-      subject.should_receive(:disk_from_string).with('abc').and_return(nil)
-      subject.should_receive(:disk).and_return(nil)
-      subject.should_receive(:say).with(/no disk/)
+      expect(subject).to receive(:disk_from_string).with('abc').and_return(nil)
+      expect(subject).to receive(:disk).and_return(nil)
+      expect(subject).to receive(:say).with(/no disk/)
       expect(ApplianceConsole::TempStorageConfiguration).not_to receive(:new)
 
       subject.parse(%w(--tmpdisk abc)).run
@@ -278,7 +278,7 @@ describe ApplianceConsole::Cli do
             it "fetches a key" do
               subject.parse(%w(--internal --region 1 --fetch-key remotesystem.com  --sshpassword pass))
               expect_v2_key(false)
-              subject.should_receive(:say).with(/fetch/)
+              expect(subject).to receive(:say).with(/fetch/)
               expect(key_configuration.action).to eq(:fetch)
               expect(key_configuration.force).to eq(true)
               expect(key_configuration.host).to eq("remotesystem.com")

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -20,14 +20,14 @@ describe ApplianceConsole::DatabaseConfiguration do
   context ".initialize" do
     it "accepts hash attributes" do
       config = described_class.new(:adapter => "test", :port => 5433)
-      config.adapter.should == "test"
-      config.port.should == 5433
+      expect(config.adapter).to eq("test")
+      expect(config.port).to eq(5433)
     end
 
     it "default attributes" do
       config = described_class.new
-      config.adapter.should == "postgresql"
-      config.port.should be_nil
+      expect(config.adapter).to eq("postgresql")
+      expect(config.port).to be_nil
     end
 
     it "interactive => false" do
@@ -41,31 +41,31 @@ describe ApplianceConsole::DatabaseConfiguration do
     end
 
     it "raises ArgumentError on unknown attributes" do
-      -> { described_class.new(:unknown => "test") }.should raise_error(ArgumentError)
+      expect { described_class.new(:unknown => "test") }.to raise_error(ArgumentError)
     end
   end
 
   context "#friendly_inspect" do
     it "normal case" do
       config = described_class.new(:host => "abc", :username => "abc", :database => "abc", :region => 1)
-      config.friendly_inspect.should == "Host:     abc\nUsername: abc\nDatabase: abc\nRegion:   1\n"
+      expect(config.friendly_inspect).to eq("Host:     abc\nUsername: abc\nDatabase: abc\nRegion:   1\n")
     end
 
     it "without region" do
       config = described_class.new(:host => "abc", :username => "abc", :database => "abc")
-      config.friendly_inspect.should == "Host:     abc\nUsername: abc\nDatabase: abc\n"
+      expect(config.friendly_inspect).to eq("Host:     abc\nUsername: abc\nDatabase: abc\n")
     end
   end
 
   context "#password=" do
     it "decrypts encrypted value" do
       @config.password = MiqPassword.encrypt("test")
-      @config.password.should == "test"
+      expect(@config.password).to eq("test")
     end
 
     it "clear text" do
       @config.password = "test"
-      @config.password.should == "test"
+      expect(@config.password).to eq("test")
     end
   end
 
@@ -78,26 +78,26 @@ describe ApplianceConsole::DatabaseConfiguration do
 
     it "encrypts once" do
       hash = {"production" => {"password" => "v1:{KSOqhNiOWJbR0lz7v6PTJg==}"}}
-      described_class.encrypt_password(hash)["production"]["password"].should == "v1:{KSOqhNiOWJbR0lz7v6PTJg==}"
+      expect(described_class.encrypt_password(hash)["production"]["password"]).to eq("v1:{KSOqhNiOWJbR0lz7v6PTJg==}")
     end
 
     it "doesn't modify the receiver" do
       hash = {"production" => {"password" => "test"}}
       described_class.encrypt_password(hash)
-      hash["production"]["password"].should == "test"
+      expect(hash["production"]["password"]).to eq("test")
     end
 
     it "retains other environments" do
       hash = {"production" => {"password" => "test"}, "development" => {"password" => "test2"}}
       settings = described_class.encrypt_password(hash)
-      settings["development"]["password"].should == "test2"
+      expect(settings["development"]["password"]).to eq("test2")
     end
   end
 
   context ".decrypt_password" do
     it "decrypt" do
       hash = {"production" => {"password" => MiqPassword.encrypt("test")}}
-      described_class.decrypt_password(hash)["production"]["password"].should == "test"
+      expect(described_class.decrypt_password(hash)["production"]["password"]).to eq("test")
     end
 
     it "shouldn't introduce password field if not present" do
@@ -109,26 +109,26 @@ describe ApplianceConsole::DatabaseConfiguration do
   context "#validated" do
     it "normal case" do
       @config.stub(:validate! => "truthy_object")
-      @config.validated.should be_true
+      expect(@config.validated).to be_truthy
     end
 
     it "failure" do
       expected_message = "FATAL: database 'bad_db' does not exist"
-      @config.stub(:validate!).and_raise(expected_message)
-      @config.should_receive(:say_error).with(:validated, expected_message)
-      @config.validated.should be_false
+      allow(@config).to receive(:validate!).and_raise(expected_message)
+      expect(@config).to receive(:say_error).with(:validated, expected_message)
+      expect(@config.validated).to be_falsey
     end
   end
 
   context "#create_region" do
     it "normal case" do
       @config.stub(:log_and_feedback => :some_object)
-      @config.create_region.should be_true
+      expect(@config.create_region).to be_truthy
     end
 
     it "failure" do
       @config.stub(:log_and_feedback => nil)
-      @config.create_region.should be_false
+      expect(@config.create_region).to be_falsey
     end
   end
 
@@ -144,10 +144,10 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.username = "defaultuser"
       subject.password = nil
 
-      subject.should_receive(:just_ask).with(/hostname/i, "defaulthost", anything, anything).and_return("newhost")
-      subject.should_receive(:just_ask).with(/the database/i, "defaultdb").and_return("x")
-      subject.should_receive(:just_ask).with(/user/i, "defaultuser").and_return("x")
-      subject.should_receive(:just_ask).with(/password/i, nil).twice.and_return("x")
+      expect(subject).to receive(:just_ask).with(/hostname/i, "defaulthost", anything, anything).and_return("newhost")
+      expect(subject).to receive(:just_ask).with(/the database/i, "defaultdb").and_return("x")
+      expect(subject).to receive(:just_ask).with(/user/i, "defaultuser").and_return("x")
+      expect(subject).to receive(:just_ask).with(/password/i, nil).twice.and_return("x")
 
       subject.ask_for_database_credentials
     end
@@ -155,26 +155,26 @@ describe ApplianceConsole::DatabaseConfiguration do
     it "should default password prompt with stars (choosing default doesnt confirm password)" do
       subject.password = "defaultpass"
 
-      subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("x")
-      subject.should_receive(:just_ask).with(/the database/i, anything).and_return("x")
-      subject.should_receive(:just_ask).with(/user/i,     anything).and_return("x")
-      subject.should_receive(:just_ask).with(/password/i, "********").and_return("********")
+      expect(subject).to receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/the database/i, anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/user/i,     anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/password/i, "********").and_return("********")
 
       subject.ask_for_database_credentials
     end
 
     it "should ask for user/password (with confirm) if not local" do
-      subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("host")
-      subject.should_receive(:just_ask).with(/the database/i, anything).and_return("x")
-      subject.should_receive(:just_ask).with(/user/i,     anything).and_return("x")
-      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
+      expect(subject).to receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("host")
+      expect(subject).to receive(:just_ask).with(/the database/i, anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/user/i,     anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
 
       subject.ask_for_database_credentials
     end
 
     it "should only ask for password (with confirm) if local" do
-      subject.should_receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("localhost")
-      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
+      expect(subject).to receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("localhost")
+      expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
 
       subject.ask_for_database_credentials
     end
@@ -192,20 +192,20 @@ describe ApplianceConsole::DatabaseConfiguration do
     end
 
     it "should ask for password (with confirm) if local" do
-      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
+      expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return("the password")
 
       subject.ask_for_database_credentials
     end
 
     it "should prompt again if passwords do not match" do
-      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass3))
+      expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass3))
 
       subject.ask_for_database_credentials
       expect(subject.password).to eq("pass3")
     end
 
     it "should raise an error if passwords do not match twice" do
-      subject.should_receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass4))
+      expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass4))
 
       expect { subject.ask_for_database_credentials }.to raise_error(ArgumentError, "passwords did not match")
     end
@@ -214,12 +214,12 @@ describe ApplianceConsole::DatabaseConfiguration do
   context "#create_or_join_region" do
     it "creates if region" do
       @config.region = 1
-      @config.should_receive(:create_region)
+      expect(@config).to receive(:create_region)
       @config.create_or_join_region
     end
 
     it "joins without a region" do
-      @config.should_receive(:join_region)
+      expect(@config).to receive(:join_region)
       @config.create_or_join_region
     end
   end
@@ -227,15 +227,15 @@ describe ApplianceConsole::DatabaseConfiguration do
   it "#say_error" do
     error = "NoMethodError: undefined method `[]' for NilClass"
     expected_message = "Create region failed with error - #{error}."
-    @config.should_receive(:say).with(expected_message)
+    expect(@config).to receive(:say).with(expected_message)
     @config.interactive = true
-    @config.should_receive(:press_any_key)
-    -> { @config.say_error(:create_region, error) }.should raise_error MiqSignalError
+    expect(@config).to receive(:press_any_key)
+    expect { @config.say_error(:create_region, error) }.to raise_error MiqSignalError
   end
 
   it "#say_error interactive=> false" do
     config = described_class.new(:interactive => false)
-    config.should_receive(:say).never
+    expect(config).to receive(:say).never
     config.say_error(:create_region, "Error message")
   end
 
@@ -250,22 +250,22 @@ describe ApplianceConsole::DatabaseConfiguration do
 
     it "raises ArgumentError with no block_given" do
       @config.logger = nil
-      -> { @config.log_and_feedback(:some_method) }.should raise_error(ArgumentError)
+      expect { @config.log_and_feedback(:some_method) }.to raise_error(ArgumentError)
     end
 
     it "normal case" do
       expected_logging = double
-      expected_logging.should_receive(:info).twice
+      expect(expected_logging).to receive(:info).twice
       @config.logger = expected_logging
-      @config.should_receive(:say_info).with(:some_method, "starting")
-      @config.should_receive(:say_info).with(:some_method, "complete")
-      @config.log_and_feedback(:some_method) { :result }.should == :result
+      expect(@config).to receive(:say_info).with(:some_method, "starting")
+      expect(@config).to receive(:say_info).with(:some_method, "complete")
+      expect(@config.log_and_feedback(:some_method) { :result }).to eq(:result)
     end
 
     context "raising exception:" do
       before do
         expected_logging = double
-        expected_logging.should_receive(:info).once
+        expect(expected_logging).to receive(:info).once
         @config.logger = expected_logging
         @backtrace = [
           "gems/linux_admin-0.4.0/lib/linux_admin/common.rb:40:in `run!'",
@@ -280,10 +280,10 @@ describe ApplianceConsole::DatabaseConfiguration do
         exception = AwesomeSpawn::CommandResultError.new(message, result)
         exception.set_backtrace(@backtrace)
 
-        @config.should_receive(:say_info).with(:some_method, "starting")
-        @config.should_receive(:say_error).with(:some_method, message)
-        @config.should_receive(:log_error).with(:some_method, "Command failed: #{message}. Error: stderr. Output: stdout. At: #{@backtrace.last}")
-        @config.log_and_feedback(:some_method) { raise exception }.should be_nil
+        expect(@config).to receive(:say_info).with(:some_method, "starting")
+        expect(@config).to receive(:say_error).with(:some_method, message)
+        expect(@config).to receive(:log_error).with(:some_method, "Command failed: #{message}. Error: stderr. Output: stdout. At: #{@backtrace.last}")
+        expect(@config.log_and_feedback(:some_method) { raise exception }).to be_nil
       end
 
       it "ArgumentError" do
@@ -291,11 +291,11 @@ describe ApplianceConsole::DatabaseConfiguration do
         exception = ArgumentError.new(message)
         exception.set_backtrace(@backtrace)
 
-        @config.should_receive(:say_info).with(:some_method, "starting")
+        expect(@config).to receive(:say_info).with(:some_method, "starting")
         debugging = "Error: ArgumentError with message: #{message}"
-        @config.should_receive(:say_error).with(:some_method, debugging)
-        @config.should_receive(:log_error).with(:some_method, "#{debugging}. Failed at: #{@backtrace.first}")
-        @config.log_and_feedback(:some_method) { raise exception }.should be_nil
+        expect(@config).to receive(:say_error).with(:some_method, debugging)
+        expect(@config).to receive(:log_error).with(:some_method, "#{debugging}. Failed at: #{@backtrace.first}")
+        expect(@config.log_and_feedback(:some_method) { raise exception }).to be_nil
       end
     end
   end
@@ -337,17 +337,17 @@ describe ApplianceConsole::DatabaseConfiguration do
     context "#activate" do
       it "normal case" do
         @config.stub(:validated => true)
-        @config.should_receive(:create_or_join_region).and_return(true)
+        expect(@config).to receive(:create_or_join_region).and_return(true)
 
         @config.stub(:merged_settings => @settings)
-        @config.should_receive(:do_save).with(@settings)
-        @config.activate.should be_true
+        expect(@config).to receive(:do_save).with(@settings)
+        expect(@config.activate).to be_truthy
       end
 
       it "doesn't save invalid settings" do
         @config.stub(:validated => false)
-        @config.should_receive(:do_save).never
-        @config.activate.should be_false
+        expect(@config).to receive(:do_save).never
+        expect(@config.activate).to be_falsey
       end
 
       context "reverts on region failure" do
@@ -358,17 +358,17 @@ describe ApplianceConsole::DatabaseConfiguration do
           new_settings = {"production" => @settings["production"].dup}
           new_settings["production"]["host"] = "new_host"
           @config.stub(:merged_settings => new_settings)
-          @config.should_receive(:do_save).with("production" => hash_including(new_settings["production"].except("password")))
-          @config.should_receive(:do_save).with("production" => hash_including(@settings["production"].except("password")))
+          expect(@config).to receive(:do_save).with("production" => hash_including(new_settings["production"].except("password")))
+          expect(@config).to receive(:do_save).with("production" => hash_including(@settings["production"].except("password")))
         end
 
         it "where no exception is raised" do
-          @config.activate.should be_false
+          expect(@config.activate).to be_falsey
         end
 
         it "where an exception is raised" do
-          @config.stub(:create_or_join_region).and_raise
-          @config.activate.should be_false
+          allow(@config).to receive(:create_or_join_region).and_raise
+          expect(@config.activate).to be_falsey
         end
       end
     end

--- a/gems/pending/spec/appliance_console/external_httpd_authentication_spec.rb
+++ b/gems/pending/spec/appliance_console/external_httpd_authentication_spec.rb
@@ -51,7 +51,7 @@ describe ApplianceConsole::ExternalHttpdAuthentication do
         expect(subject).to receive(:just_ask).with(/realm/i, "SERVER.COM").and_return("realm.server.com")
         expect(subject).to receive(:just_ask).with(/principal/i, "admin").and_return("admin")
         expect(subject).to receive(:just_ask).with(/password/i, nil).and_return("password")
-        expect(subject.ask_for_parameters).to be_true
+        expect(subject.ask_for_parameters).to be_truthy
         expect(subject.send(:realm)).to eq("REALM.SERVER.COM")
         # expect(subject.ipaserver).to eq("ipa.server.com")
       end

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -14,9 +14,9 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
   context ".new" do
     it "set defaults automatically" do
-      @config.host.should == "127.0.0.1"
-      @config.username.should == "root"
-      @config.database.should == "vmdb_production"
+      expect(@config.host).to eq("127.0.0.1")
+      expect(@config.username).to eq("root")
+      expect(@config.database).to eq("vmdb_production")
     end
   end
 
@@ -24,13 +24,13 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     it "#start_postgres (private)" do
       allow(LinuxAdmin::Service).to receive(:new).and_return(double(:service).as_null_object)
       PostgresAdmin.stub(:service_name => 'postgresql')
-      @config.should_receive(:block_until_postgres_accepts_connections)
+      expect(@config).to receive(:block_until_postgres_accepts_connections)
       @config.send(:start_postgres)
     end
   end
 
   it "#choose_disk" do
-    @config.should_receive(:ask_for_disk)
+    expect(@config).to receive(:ask_for_disk)
     @config.choose_disk
   end
 
@@ -43,13 +43,13 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
   it "#create_partition_to_fill_disk (private)" do
     disk_double = double(:path => "/dev/vdb")
-    disk_double.should_receive(:create_partition_table)
-    disk_double.should_receive(:partitions).and_return(["fake partition"])
-    LinuxAdmin.should_receive(:run!).with("parted -s /dev/vdb mkpart primary 0% 100%")
-    LinuxAdmin::Disk.should_receive(:local).and_return([disk_double])
+    expect(disk_double).to receive(:create_partition_table)
+    expect(disk_double).to receive(:partitions).and_return(["fake partition"])
+    expect(LinuxAdmin).to receive(:run!).with("parted -s /dev/vdb mkpart primary 0% 100%")
+    expect(LinuxAdmin::Disk).to receive(:local).and_return([disk_double])
 
     @config.instance_variable_set(:@disk, disk_double)
-    @config.send(:create_partition_to_fill_disk).should == "fake partition"
+    expect(@config.send(:create_partition_to_fill_disk)).to eq("fake partition")
   end
 
   it ".postgresql_template" do
@@ -66,25 +66,25 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     it "adds database disk entry" do
       fstab = double
       fstab.stub(:entries => [])
-      fstab.should_receive(:write!)
+      expect(fstab).to receive(:write!)
       LinuxAdmin::FSTab.stub(:instance => fstab)
       @config.instance_variable_set(:@logical_volume, double(:path => "/dev/vg/lv"))
-      fstab.entries.count.should == 0
+      expect(fstab.entries.count).to eq(0)
 
       @config.send(:update_fstab)
-      fstab.entries.count.should == 1
-      fstab.entries.first.device.should == "/dev/vg/lv"
+      expect(fstab.entries.count).to eq(1)
+      expect(fstab.entries.first.device).to eq("/dev/vg/lv")
     end
 
     it "skips update if mount point is in fstab" do
       fstab = double
       fstab.stub(:entries => [double(:mount_point => PostgresAdmin.data_directory)])
-      fstab.should_receive(:write!).never
+      expect(fstab).to receive(:write!).never
       LinuxAdmin::FSTab.stub(:instance => fstab)
-      fstab.entries.count.should == 1
+      expect(fstab.entries.count).to eq(1)
 
       @config.send(:update_fstab)
-      fstab.entries.count.should == 1
+      expect(fstab.entries.count).to eq(1)
     end
   end
 end

--- a/gems/pending/spec/appliance_console/key_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/key_configuration_spec.rb
@@ -11,7 +11,7 @@ describe ApplianceConsole::KeyConfiguration do
         v2_exists(false)
         expect(subject).to receive(:ask_with_menu).with(/key/i, anything, :create, false).and_return(:create)
         expect(subject).not_to receive(:just_ask)
-        expect(subject.ask_questions).to be_true
+        expect(subject.ask_questions).to be_truthy
       end
 
       it "defaults to action" do
@@ -19,7 +19,7 @@ describe ApplianceConsole::KeyConfiguration do
         subject.action = :fetch
         expect(subject).to receive(:ask_with_menu).with(/key/i, anything, :fetch, false).and_return(:create)
         expect(subject).not_to receive(:just_ask)
-        expect(subject.ask_questions).to be_true
+        expect(subject.ask_questions).to be_truthy
       end
     end
 
@@ -32,7 +32,7 @@ describe ApplianceConsole::KeyConfiguration do
         expect(subject).to receive(:just_ask).with(/login/i, "root").and_return("root")
         expect(subject).to receive(:just_ask).with(/password/i, nil).and_return("password")
         expect(subject).to receive(:just_ask).with(/path/i, /v2_key$/).and_return("/remote/path/v2_key")
-        expect(subject.ask_questions).to be_true
+        expect(subject.ask_questions).to be_truthy
       end
     end
 
@@ -41,15 +41,15 @@ describe ApplianceConsole::KeyConfiguration do
         v2_exists
         expect(subject).to receive(:agree).with(/overwrite/i).and_return(false)
         expect(subject).not_to receive(:ask_with_menu)
-        expect(subject.ask_questions).not_to be_true
+        expect(subject.ask_questions).not_to be_truthy
       end
 
       it "succeeds if overwrite" do
         v2_exists
         expect(subject).to receive(:agree).with(/overwrite/i).and_return(true)
         expect(subject).to receive(:ask_with_menu).and_return(:create)
-        expect(subject.ask_questions).to be_true
-        expect(subject.force).to be_true
+        expect(subject.ask_questions).to be_truthy
+        expect(subject.force).to be_truthy
       end
     end
   end
@@ -65,14 +65,14 @@ describe ApplianceConsole::KeyConfiguration do
           v2_exists(false) # before download
           v2_exists(true)  # after downloaded
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
-          expect(subject.activate).to be_true
+          expect(subject.activate).to be_truthy
         end
 
         it "creates key" do
           subject.action = :create
           v2_exists(false)
           expect(MiqPassword).to receive(:generate_symmetric).and_return(154)
-          expect(subject.activate).to be_true
+          expect(subject.activate).to be_truthy
         end
       end
 
@@ -85,7 +85,7 @@ describe ApplianceConsole::KeyConfiguration do
           scp = double('scp')
           expect(scp).to receive(:download!).with(subject.key_path, /v2_key/).and_return(:result)
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password).and_yield(scp).and_return(true)
-          expect(subject.activate).to be_true
+          expect(subject.activate).to be_truthy
         end
 
         it "fails if key exists (no force)" do
@@ -94,7 +94,7 @@ describe ApplianceConsole::KeyConfiguration do
           v2_exists(true)
           expect(FileUtils).not_to receive(:rm)
           expect(Net::SCP).not_to receive(:start)
-          expect(subject.activate).to be_false
+          expect(subject.activate).to be_falsey
         end
       end
     end

--- a/gems/pending/spec/appliance_console/logging_spec.rb
+++ b/gems/pending/spec/appliance_console/logging_spec.rb
@@ -19,7 +19,7 @@ describe ApplianceConsole::Logging do
 
   it "should not have default logger when setting" do
     subject.logger = double(:info => true)
-    expect(subject.logger.info).to be_true
+    expect(subject.logger.info).to be_truthy
   end
 
   it "should use default_logger if not set" do
@@ -33,17 +33,17 @@ describe ApplianceConsole::Logging do
 
   context "log_and_feedback" do
     it "should log_and_feedback when successful" do
-      subject.should_receive(:say).with("Method starting")
-      subject.should_receive(:say).with("Method complete")
+      expect(subject).to receive(:say).with("Method starting")
+      expect(subject).to receive(:say).with("Method complete")
       expect(subject.log_and_feedback("method") do
         55
       end).to eq(55)
     end
 
     it "should log_and_feedback when failing" do
-      subject.should_receive(:say).with("Test starting")
-      subject.should_receive(:say).with(/Test.*error.*Issue/)
-      subject.should_receive(:press_any_key)
+      expect(subject).to receive(:say).with("Test starting")
+      expect(subject).to receive(:say).with(/Test.*error.*Issue/)
+      expect(subject).to receive(:press_any_key)
 
       expect { subject.log_and_feedback("test") { raise "Issue" } }.to raise_error(MiqSignalError)
     end
@@ -76,12 +76,12 @@ describe ApplianceConsole::Logging do
         exception = AwesomeSpawn::CommandResultError.new(message, result)
         exception.set_backtrace(@backtrace)
 
-        subject.logger.should_receive(:info)
-        subject.logger.should_receive(:error)
+        expect(subject.logger).to receive(:info)
+        expect(subject.logger).to receive(:error)
           .with("MIQ(#some_method)  Command failed: #{message}. Error: stderr. Output: stdout. At: #{@backtrace.last}")
-        subject.should_receive(:say).with("Some method starting")
-        subject.should_receive(:say).with(/Some method.*error.*some error/)
-        subject.should_receive(:press_any_key)
+        expect(subject).to receive(:say).with("Some method starting")
+        expect(subject).to receive(:say).with(/Some method.*error.*some error/)
+        expect(subject).to receive(:press_any_key)
 
         expect { subject.log_and_feedback(:some_method) { raise exception } }.to raise_error(MiqSignalError)
       end
@@ -92,13 +92,13 @@ describe ApplianceConsole::Logging do
         exception.set_backtrace(@backtrace)
         debugging = "Error: ArgumentError with message: #{message}"
 
-        subject.logger.should_receive(:info)
-        subject.logger.should_receive(:error)
+        expect(subject.logger).to receive(:info)
+        expect(subject.logger).to receive(:error)
           .with("MIQ(#some_method)  #{debugging}. Failed at: #{@backtrace.first}")
 
-        subject.should_receive(:say).with("Some method starting")
-        subject.should_receive(:say).with(/Some method.*error.*#{debugging}/)
-        subject.should_receive(:press_any_key)
+        expect(subject).to receive(:say).with("Some method starting")
+        expect(subject).to receive(:say).with(/Some method.*error.*#{debugging}/)
+        expect(subject).to receive(:press_any_key)
         expect { subject.log_and_feedback(:some_method) { raise exception } }.to raise_error(MiqSignalError)
       end
     end

--- a/gems/pending/spec/appliance_console/principal_spec.rb
+++ b/gems/pending/spec/appliance_console/principal_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "appliance_console/principal"
 
 describe ApplianceConsole::Principal do
-  before { Open3.should_not_receive(:capture3) }
+  before { expect(Open3).not_to receive(:capture3) }
   let(:hostname) { "machine.network.com" }
   let(:realm)    { "NETWORK.COM" }
   let(:service)  { "postgres" }
@@ -39,7 +39,7 @@ describe ApplianceConsole::Principal do
   private
 
   def expect_run(cmd, params, *responses)
-    AwesomeSpawn.should_receive(:run).with(cmd, :params => params)
+    expect(AwesomeSpawn).to receive(:run).with(cmd, :params => params)
       .and_return(*(responses.empty? ? response : responses))
   end
 

--- a/gems/pending/spec/appliance_console/prompts_spec.rb
+++ b/gems/pending/spec/appliance_console/prompts_spec.rb
@@ -91,13 +91,13 @@ describe ApplianceConsole::Prompts do
   end
 
   it "should ask for any key" do
-    subject.should_receive(:say)
-    STDIN.should_receive(:getc)
+    expect(subject).to receive(:say)
+    expect(STDIN).to receive(:getc)
     subject.press_any_key
   end
 
   it "should print for a clear screen" do
-    subject.should_receive(:print)
+    expect(subject).to receive(:print)
     subject.clear_screen
   end
 
@@ -106,19 +106,19 @@ describe ApplianceConsole::Prompts do
       prompt = "Are you sure? (Y/N): "
       error = %(Please enter "yes" or "no".\n)
       say %w(um yes)
-      expect(subject.are_you_sure?).to be_true
+      expect(subject.are_you_sure?).to be_truthy
       expect_heard [prompt + error, prompt]
     end
 
     it "should ask are you sure with clarifier" do
       say ["no"]
-      expect(subject.are_you_sure?("x y")).to be_false
+      expect(subject.are_you_sure?("x y")).to be_falsey
       expect_heard "Are you sure you want to x y? (Y/N): ", false
     end
 
     it "should ask are you sure with complete clarifier" do
       say ["no"]
-      expect(subject.are_you_sure?(" you dont want to x y")).to be_false
+      expect(subject.are_you_sure?(" you dont want to x y")).to be_falsey
       expect_heard "Are you sure you dont want to x y? (Y/N): ", false
     end
   end
@@ -421,37 +421,37 @@ describe ApplianceConsole::Prompts do
     it "should respond to yes (and enforce y/n)" do
       error = "Please provide yes or no."
       say %w(x z yes)
-      expect(subject.ask_yn?("prompt")).to be_true
+      expect(subject.ask_yn?("prompt")).to be_truthy
       expect_heard ["prompt? (Y/N): ", error, prompt + error, prompt]
     end
 
     it "should respond to no" do
       say %w(n)
-      expect(subject.ask_yn?("prompt")).not_to be_true
+      expect(subject.ask_yn?("prompt")).not_to be_truthy
       expect_heard "prompt? (Y/N): "
     end
 
     it "should support the default true" do
       say ""
-      expect(subject.ask_yn?("prompt", "Y")).to be_true
+      expect(subject.ask_yn?("prompt", "Y")).to be_truthy
       expect_heard "prompt? (Y/N): |Y| "
     end
 
     it "should support the default false" do
       say ""
-      expect(subject.ask_yn?("prompt", "N")).not_to be_true
+      expect(subject.ask_yn?("prompt", "N")).not_to be_truthy
       expect_heard "prompt? (Y/N): |N| "
     end
 
     it "should support overriding the default true" do
       say %w(no)
-      expect(subject.ask_yn?("prompt", "Y")).not_to be_true
+      expect(subject.ask_yn?("prompt", "Y")).not_to be_truthy
       expect_heard "prompt? (Y/N): |Y| "
     end
 
     it "should support overriding the default false" do
       say %w(yes)
-      expect(subject.ask_yn?("prompt", "N")).to be_true
+      expect(subject.ask_yn?("prompt", "N")).to be_truthy
       expect_heard "prompt? (Y/N): |N| "
     end
   end
@@ -498,7 +498,7 @@ describe ApplianceConsole::Prompts do
   end
 
   def expect_cls
-    subject.should_receive(:print)
+    expect(subject).to receive(:print)
   end
 
   def expect_heard(strs, check_eof = true)

--- a/gems/pending/spec/db/MiqBdb/miq_bdb_page_spec.rb
+++ b/gems/pending/spec/db/MiqBdb/miq_bdb_page_spec.rb
@@ -10,7 +10,7 @@ describe MiqBerkeleyDB::MiqBdbPage do
   end
 
   it "#dump" do
-    @page.dump.should == <<-DUMP
+    expect(@page.dump).to eq <<-DUMP
 Page 1
   type:            btree internal
   prev:            0

--- a/gems/pending/spec/db/MiqBdb/miq_bdb_spec.rb
+++ b/gems/pending/spec/db/MiqBdb/miq_bdb_spec.rb
@@ -5,7 +5,7 @@ require "#{__dir__}/test_files"
 
 describe MiqBerkeleyDB::MiqBdb do
   it "#new" do
-    -> { described_class.new(MiqBdb::TestFiles::RPM_PROVIDE_VERSION).close }.should_not raise_error
+    expect { described_class.new(MiqBdb::TestFiles::RPM_PROVIDE_VERSION).close }.not_to raise_error
   end
 
   it "#pages" do
@@ -19,7 +19,7 @@ describe MiqBerkeleyDB::MiqBdb do
       end
     end
 
-    nkeys.should == 657
+    expect(nkeys).to eq(657)
 
     bdb.close
   end
@@ -27,10 +27,10 @@ describe MiqBerkeleyDB::MiqBdb do
   context "Hash Database" do
     it "validates" do
       bdb = described_class.new(MiqBdb::TestFiles::RPM_PACKAGES)
-      bdb.db.should be_kind_of(MiqBerkeleyDB::MiqBdbHashDatabase)
+      expect(bdb.db).to be_kind_of(MiqBerkeleyDB::MiqBdbHashDatabase)
 
       # Assert that the number of keys in header is what was extracted
-      bdb.db.nkeys.should == bdb.size
+      expect(bdb.db.nkeys).to eq(bdb.size)
 
       bdb.close
     end

--- a/gems/pending/spec/db/MiqBdb/miq_bdb_util_spec.rb
+++ b/gems/pending/spec/db/MiqBdb/miq_bdb_util_spec.rb
@@ -7,6 +7,6 @@ describe MiqBerkeleyDB::MiqBdbUtil do
   it "#getkeys" do
     bdbUtil = described_class.new
     keys = bdbUtil.getkeys(MiqBdb::TestFiles::RPM_NAME)
-    keys.size.should == 690
+    expect(keys.size).to eq(690)
   end
 end

--- a/gems/pending/spec/discovery/PortScan_spec.rb
+++ b/gems/pending/spec/discovery/PortScan_spec.rb
@@ -12,48 +12,48 @@ describe PortScanner do
 
   context ".portOpen" do
     it "with an open port" do
-      TCPSocket.should_receive(:open).and_return(StringIO.new)
-      described_class.portOpen(@ost, 903).should be_true
+      expect(TCPSocket).to receive(:open).and_return(StringIO.new)
+      expect(described_class.portOpen(@ost, 903)).to be_truthy
     end
 
     it "with a closed port" do
-      TCPSocket.should_receive(:open).and_raise(Timeout::Error)
-      described_class.portOpen(@ost, 904).should be_false
+      expect(TCPSocket).to receive(:open).and_raise(Timeout::Error)
+      expect(described_class.portOpen(@ost, 904)).to be_falsey
     end
 
     it "with a changed timeout value" do
       @ost.timeout = 0.001
-      TCPSocket.stub(:open) { sleep 1 }
+      allow(TCPSocket).to receive(:open) { sleep 1 }
       ts = Benchmark.realtime do
-        described_class.portOpen(@ost, 123).should be_false
+        expect(described_class.portOpen(@ost, 123)).to be_falsey
       end
-      ts.should < 0.5
+      expect(ts).to be < 0.5
     end
   end
 
   context ".scanPortArray" do
     before(:each) do
-      described_class.stub(:portOpen).with(@ost, 902).and_return(true)
-      described_class.stub(:portOpen).with(@ost, 903).and_return(true)
-      described_class.stub(:portOpen).with(@ost, 904).and_return(false)
-      described_class.stub(:portOpen).with(@ost, 905).and_return(false)
+      allow(described_class).to receive(:portOpen).with(@ost, 902).and_return(true)
+      allow(described_class).to receive(:portOpen).with(@ost, 903).and_return(true)
+      allow(described_class).to receive(:portOpen).with(@ost, 904).and_return(false)
+      allow(described_class).to receive(:portOpen).with(@ost, 905).and_return(false)
     end
 
-    it("with all open ports")  { described_class.scanPortArray(@ost, [902, 903]).should == [902, 903] }
-    it("with some open ports") { described_class.scanPortArray(@ost, [903, 904]).should == [903] }
-    it("with no open ports")   { described_class.scanPortArray(@ost, [904, 905]).should == [] }
+    it("with all open ports")  { expect(described_class.scanPortArray(@ost, [902, 903])).to eq([902, 903]) }
+    it("with some open ports") { expect(described_class.scanPortArray(@ost, [903, 904])).to eq([903]) }
+    it("with no open ports")   { expect(described_class.scanPortArray(@ost, [904, 905])).to eq([]) }
   end
 
   context ".scanPortRange" do
     before(:each) do
-      described_class.stub(:portOpen).with(@ost, 902).and_return(true)
-      described_class.stub(:portOpen).with(@ost, 903).and_return(true)
-      described_class.stub(:portOpen).with(@ost, 904).and_return(false)
-      described_class.stub(:portOpen).with(@ost, 905).and_return(false)
+      allow(described_class).to receive(:portOpen).with(@ost, 902).and_return(true)
+      allow(described_class).to receive(:portOpen).with(@ost, 903).and_return(true)
+      allow(described_class).to receive(:portOpen).with(@ost, 904).and_return(false)
+      allow(described_class).to receive(:portOpen).with(@ost, 905).and_return(false)
     end
 
-    it("with all open ports")  { described_class.scanPortRange(@ost, 902, 903).should == [902, 903] }
-    it("with some open ports") { described_class.scanPortRange(@ost, 903, 904).should == [903] }
-    it("with no open ports")   { described_class.scanPortRange(@ost, 904, 905).should == [] }
+    it("with all open ports")  { expect(described_class.scanPortRange(@ost, 902, 903)).to eq([902, 903]) }
+    it("with some open ports") { expect(described_class.scanPortRange(@ost, 903, 904)).to eq([903]) }
+    it("with no open ports")   { expect(described_class.scanPortRange(@ost, 904, 905)).to eq([]) }
   end
 end

--- a/gems/pending/spec/disk/miq_disk_spec.rb
+++ b/gems/pending/spec/disk/miq_disk_spec.rb
@@ -13,12 +13,12 @@ describe MiqDisk do
       disk_info.fileName = ""
 
       disk = Object.new
-      MiqDisk.should_receive(:new).with(RawDisk, disk_info, 0).and_return(disk)
+      expect(MiqDisk).to receive(:new).with(RawDisk, disk_info, 0).and_return(disk)
 
-      QcowDiskProbe.should_receive(:probe).with(disk_info).and_return(nil)
-      RawDiskProbe.should_receive(:probe).with(disk_info).and_return("RawDisk")
+      expect(QcowDiskProbe).to receive(:probe).with(disk_info).and_return(nil)
+      expect(RawDiskProbe).to receive(:probe).with(disk_info).and_return("RawDisk")
 
-      MiqDisk.getDisk(disk_info, %w(QcowDiskProbe RawDiskProbe)).should == disk
+      expect(MiqDisk.getDisk(disk_info, %w(QcowDiskProbe RawDiskProbe))).to eq(disk)
     end
   end
 
@@ -30,7 +30,7 @@ describe MiqDisk do
 
         disk_info = OpenStruct.new(:fileName => image_path('dos2.img'))
         disk      = MiqDisk.getDisk(disk_info, "RawDiskProbe")
-        disk.getPartitions.size.should == 5
+        expect(disk.getPartitions.size).to eq(5)
       end
     end
 
@@ -41,7 +41,7 @@ describe MiqDisk do
 
         disk_info = OpenStruct.new(:fileName => image_path('basic.img'))
         disk      = MiqDisk.getDisk(disk_info, "RawDiskProbe")
-        disk.getPartitions.should be_empty
+        expect(disk.getPartitions).to be_empty
       end
     end
   end

--- a/gems/pending/spec/disk/modules/raw_disk_spec.rb
+++ b/gems/pending/spec/disk/modules/raw_disk_spec.rb
@@ -12,7 +12,7 @@ describe RawDisk do
 
       disk_info = OpenStruct.new(:fileName => image_path('basic.img'))
       disk      = MiqDisk.getDisk(disk_info, "RawDiskProbe")
-      disk.read(10).should == "\0\0\0\0\0\0\0\0\0\0"
+      expect(disk.read(10)).to eq("\0\0\0\0\0\0\0\0\0\0")
     end
   end
 
@@ -25,7 +25,7 @@ describe RawDisk do
                                  :mountMode => 'rw')
       disk      = MiqDisk.getDisk(disk_info, "RawDiskProbe")
       data      = Array.new(10) { 0 }
-      disk.write(data, 10).should == 30
+      expect(disk.write(data, 10)).to eq(30)
     end
   end
 end

--- a/gems/pending/spec/metadata/MIQExtract/MIQExtract_spec.rb
+++ b/gems/pending/spec/metadata/MIQExtract/MIQExtract_spec.rb
@@ -49,8 +49,8 @@ describe MIQExtract do
       ost = OpenStruct.new
       ost.scanData = test_data_with_pw
 
-      $log.should_receive(:info).with(/ems/)
-      $log.should_not_receive(:info).with(/#{@test_password}/)
+      expect($log).to receive(:info).with(/ems/)
+      expect($log).not_to receive(:info).with(/#{@test_password}/)
       expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
     end
 
@@ -87,8 +87,8 @@ describe MIQExtract do
       ost = OpenStruct.new
       ost.scanData = test_data_no_pw
 
-      $log.should_receive(:info).with(/ems/)
-      $log.should_not_receive(:info).with(/#{@test_password}/)
+      expect($log).to receive(:info).with(/ems/)
+      expect($log).not_to receive(:info).with(/#{@test_password}/)
       expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
     end
 
@@ -126,8 +126,8 @@ describe MIQExtract do
       ost = OpenStruct.new
       ost.scanData = test_data_connect_type_pw
 
-      $log.should_receive(:info).with(/ems/)
-      $log.should_not_receive(:info).with(/#{@test_password}/)
+      expect($log).to receive(:info).with(/ems/)
+      expect($log).not_to receive(:info).with(/#{@test_password}/)
       expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
     end
   end

--- a/gems/pending/spec/metadata/VmConfig/VmConfig_spec.rb
+++ b/gems/pending/spec/metadata/VmConfig/VmConfig_spec.rb
@@ -6,7 +6,7 @@ describe VmConfig do
     it "with a HyperV configuration file encoding in UTF-16" do
       filename = File.join(File.dirname(__FILE__), 'data/hyperv_utf_16.xml')
       config = VmConfig.new(filename)
-      config.vendor.should == "microsoft"
+      expect(config.vendor).to eq("microsoft")
     end
   end
 end

--- a/gems/pending/spec/metadata/linux/LinuxUtils_spec.rb
+++ b/gems/pending/spec/metadata/linux/LinuxUtils_spec.rb
@@ -56,17 +56,17 @@ EOS
     let(:subject) { MiqLinux::Utils.parse_openstack_status(text) }
 
     it "should return Array" do
-      should be_a Array
+      is_expected.to be_a Array
     end
 
     # we omit Keystone users section
     it "should have 9 OpenStack services" do
-      subject.count.should be_equal 9
+      expect(subject.count).to be_equal 9
     end
 
     %w(Nova Glance Keystone Swift neutron Ceilometer Heat Support).map do |service|
       it "should have contain correct OpenStack #{service} service" do
-        subject.count { |service_hash| service_hash['name'].include?(service) }.should be_equal 1
+        expect(subject.count { |service_hash| service_hash['name'].include?(service) }).to be_equal 1
       end
     end
 
@@ -76,15 +76,15 @@ EOS
       end
 
       it "should have 6 services total" do
-        subject.count.should be_equal 6
+        expect(subject.count).to be_equal 6
       end
 
       it "should have 4 active services" do
-        subject.count { |service| service['active'] }.should be_equal 4
+        expect(subject.count { |service| service['active'] }).to be_equal 4
       end
 
       it "should have 2 inactive services" do
-        subject.count { |service| !service['active'] }.should be_equal 2
+        expect(subject.count { |service| !service['active'] }).to be_equal 2
       end
     end
   end

--- a/gems/pending/spec/openstack/amqp/openstack_rabbit_event_monitor_spec.rb
+++ b/gems/pending/spec/openstack/amqp/openstack_rabbit_event_monitor_spec.rb
@@ -17,7 +17,7 @@ describe OpenstackRabbitEventMonitor do
     @options = @receiver_options.merge(:topics => @topics, :client_ip => "10.11.12.13")
 
     @rabbit_connection = double
-    OpenstackRabbitEventMonitor.stub(:connect).and_return(@rabbit_connection)
+    allow(OpenstackRabbitEventMonitor).to receive(:connect).and_return(@rabbit_connection)
   end
 
   after do
@@ -26,15 +26,15 @@ describe OpenstackRabbitEventMonitor do
 
   context "testing a connection" do
     it "returns true on a successful test" do
-      @rabbit_connection.should_receive(:start)
-      @rabbit_connection.should_receive(:close)
+      expect(@rabbit_connection).to receive(:start)
+      expect(@rabbit_connection).to receive(:close)
 
-      OpenstackRabbitEventMonitor.test_connection(@options).should be_true
+      expect(OpenstackRabbitEventMonitor.test_connection(@options)).to be_truthy
     end
 
     it "returns false on an unsuccessful test" do
-      @rabbit_connection.should_receive(:start).and_raise("Cannot connect to rabbit amqp")
-      OpenstackRabbitEventMonitor.test_connection(@options).should be_false
+      expect(@rabbit_connection).to receive(:start).and_raise("Cannot connect to rabbit amqp")
+      expect(OpenstackRabbitEventMonitor.test_connection(@options)).to be_falsey
     end
   end
 
@@ -48,14 +48,14 @@ describe OpenstackRabbitEventMonitor do
 
   it "#remove_legacy_queues (private)" do
     @rabbit_channel = double
-    @rabbit_connection.stub(:create_channel).and_return(@rabbit_channel)
-    @rabbit_channel.stub(:close).and_return(nil)
+    allow(@rabbit_connection).to receive(:create_channel).and_return(@rabbit_channel)
+    allow(@rabbit_channel).to receive(:close).and_return(nil)
 
-    @rabbit_connection.should_receive(:queue_exists?).at_least(2).times.with(/^miq-/).and_return(true)
-    @rabbit_channel.should_receive(:queue_delete).at_least(2).times.with(/^miq-/).and_return(nil)
+    expect(@rabbit_connection).to receive(:queue_exists?).at_least(2).times.with(/^miq-/).and_return(true)
+    expect(@rabbit_channel).to receive(:queue_delete).at_least(2).times.with(/^miq-/).and_return(nil)
 
-    @rabbit_connection.should_receive(:queue_exists?).once.with("notifications.*").and_return(true)
-    @rabbit_channel.should_receive(:queue_delete).once.with("notifications.*").and_return(nil)
+    expect(@rabbit_connection).to receive(:queue_exists?).once.with("notifications.*").and_return(true)
+    expect(@rabbit_channel).to receive(:queue_delete).once.with("notifications.*").and_return(nil)
 
     @event_monitor = OpenstackRabbitEventMonitor.new(@options)
 

--- a/gems/pending/spec/openstack/openstack_event_monitor_spec.rb
+++ b/gems/pending/spec/openstack/openstack_event_monitor_spec.rb
@@ -14,27 +14,27 @@ describe OpenstackEventMonitor do
 
   it "selects null event monitor when nothing is available" do
     opts = @options.merge(@bad_host)
-    OpenstackRabbitEventMonitor.stub(:test_connection).with(opts).and_return(false)
+    allow(OpenstackRabbitEventMonitor).to receive(:test_connection).with(opts).and_return(false)
 
-    OpenstackEventMonitor.new(opts).class.should eq OpenstackNullEventMonitor
+    expect(OpenstackEventMonitor.new(opts).class).to eq OpenstackNullEventMonitor
   end
 
   it "caches multiple event monitors for different keys" do
     rabbit_options = @options.merge(@rabbit_host)
-    OpenstackRabbitEventMonitor.stub(:test_connection).with(rabbit_options).and_return(true)
+    allow(OpenstackRabbitEventMonitor).to receive(:test_connection).with(rabbit_options).and_return(true)
     rabbit_instance = OpenstackEventMonitor.new(rabbit_options)
-    rabbit_instance.class.should eq OpenstackRabbitEventMonitor
+    expect(rabbit_instance.class).to eq OpenstackRabbitEventMonitor
 
     # additionally, we should be able to access the event_monitor instance
     # directly from the parent event_monitor
     instance = OpenstackEventMonitor.new(rabbit_options)
-    instance.should eq rabbit_instance
+    expect(instance).to eq rabbit_instance
   end
 
   it "orders the event monitor plugins correctly" do
     plugins = OpenstackEventMonitor.subclasses
 
-    plugins.first.should eq OpenstackRabbitEventMonitor
-    plugins.last.should eq OpenstackNullEventMonitor
+    expect(plugins.first).to eq OpenstackRabbitEventMonitor
+    expect(plugins.last).to eq OpenstackNullEventMonitor
   end
 end

--- a/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
+++ b/gems/pending/spec/openstack/openstack_handle/handle_spec.rb
@@ -18,14 +18,14 @@ describe OpenstackHandle::Handle do
       @openstack_project = double('project')
 
       @handle = OpenstackHandle::Handle.new("dummy", "dummy", "dummy")
-      @handle.stub(:service_for_each_accessible_tenant).and_yield(@openstack_svc, @openstack_project)
+      allow(@handle).to receive(:service_for_each_accessible_tenant).and_yield(@openstack_svc, @openstack_project)
     end
 
     it "ignores 404 errors from services" do
       expect(@openstack_svc).to receive(:security_groups).and_raise(Fog::Network::OpenStack::NotFound)
 
       data = @handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
-      data.should be_empty
+      expect(data).to be_empty
     end
 
     it "ignores 404 errors from services returning arrays" do
@@ -35,7 +35,7 @@ describe OpenstackHandle::Handle do
       expect(@openstack_svc).to receive(:security_groups).and_return(security_groups)
 
       data = @handle.accessor_for_accessible_tenants("Network", :security_groups, :id)
-      data.should be_empty
+      expect(data).to be_empty
     end
   end
 
@@ -45,11 +45,11 @@ describe OpenstackHandle::Handle do
       handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address")
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
-      OpenstackHandle::Handle.should_receive(:raw_connect).once do |_, _, address|
-        address.should == auth_url
+      expect(OpenstackHandle::Handle).to receive(:raw_connect).once do |_, _, address|
+        expect(address).to eq(auth_url)
         fog
       end
-      handle.connect(:tenant_name => "admin").should == fog
+      expect(handle.connect(:tenant_name => "admin")).to eq(fog)
     end
 
     it "handles ssl connections just fine, too" do
@@ -61,19 +61,19 @@ describe OpenstackHandle::Handle do
       # setup the socket error for the initial ssl failure
       socket_error = double('socket_error')
       allow(socket_error).to receive(:message).and_return("unknown protocol (OpenSSL::SSL::SSLError)")
-      socket_error.should_receive(:class).and_return(Object)
-      socket_error.should_receive(:backtrace)
+      expect(socket_error).to receive(:class).and_return(Object)
+      expect(socket_error).to receive(:backtrace)
 
-      OpenstackHandle::Handle.should_receive(:raw_connect) do |_, _, address|
-        address.should == auth_url_ssl
+      expect(OpenstackHandle::Handle).to receive(:raw_connect) do |_, _, address|
+        expect(address).to eq(auth_url_ssl)
         raise Excon::Errors::SocketError.new(socket_error)
       end
-      OpenstackHandle::Handle.should_receive(:raw_connect) do |_, _, address|
-        address.should == auth_url_nossl
+      expect(OpenstackHandle::Handle).to receive(:raw_connect) do |_, _, address|
+        expect(address).to eq(auth_url_nossl)
         fog
       end
 
-      handle.connect(:tenant_name => "admin").should == fog
+      expect(handle.connect(:tenant_name => "admin")).to eq(fog)
     end
   end
 end

--- a/gems/pending/spec/util/duplicate_blocker_spec.rb
+++ b/gems/pending/spec/util/duplicate_blocker_spec.rb
@@ -80,7 +80,7 @@ describe DuplicateBlocker do
     t = @base_time + THRESHOLD * SHORT_TIME + SLOT_WIDTH
     assert_error_call :instance, t, 'arg'
 
-    @dedup_handler.logger.should_receive(:warn).twice
+    expect(@dedup_handler.logger).to receive(:warn).twice
     (DUPS_PER_LOG * 2).times do
       t += SHORT_TIME
       assert_error_call :instance, t, 'arg'
@@ -108,9 +108,9 @@ describe DuplicateBlocker do
     assert_safe_calls :class, 1, @base_time + SHORT_TIME, SHORT_TIME, 'arg3'
     assert_safe_calls :instance, 1, @base_time + TIME_WINDOW / 2 + SHORT_TIME * 2, SHORT_TIME, 'arg1', 'arg2'
     Timecop.freeze(@base_time + TIME_WINDOW + SHORT_TIME * 3) do
-      @dedup_handler.histories.size.should eq 2
+      expect(@dedup_handler.histories.size).to eq 2
       @dedup_handler.purge_histories
-      @dedup_handler.histories.size.should eq 1
+      expect(@dedup_handler.histories.size).to eq 1
     end
   end
 
@@ -140,6 +140,6 @@ describe DuplicateBlocker do
   end
 
   def assert_nil_call(meth, time, *args)
-    make_a_call(meth, time) { |func| func.call(*args).should be nil }
+    make_a_call(meth, time) { |func| expect(func.call(*args)).to be nil }
   end
 end

--- a/gems/pending/spec/util/extensions/miq-benchmark_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-benchmark_spec.rb
@@ -17,10 +17,10 @@ describe Benchmark do
       end
       "test"
     end
-    result.should == "test"
-    timings[:test1].should be_within(0.5).of(1500)
-    timings[:test2].should be_within(0.5).of(1000)
-    timings[:test3].should be_within(0.5).of(500)
+    expect(result).to eq("test")
+    expect(timings[:test1]).to be_within(0.5).of(1500)
+    expect(timings[:test2]).to be_within(0.5).of(1000)
+    expect(timings[:test3]).to be_within(0.5).of(500)
   end
 
   it '.realtime_store with an Exception' do
@@ -31,7 +31,7 @@ describe Benchmark do
         raise Exception
       end
     rescue Exception
-      timings[:test1].should be_within(0.5).of(500)
+      expect(timings[:test1]).to be_within(0.5).of(500)
     end
   end
 
@@ -46,17 +46,17 @@ describe Benchmark do
       end
       "test"
     end
-    result.should == "test"
-    timings[:test1].should be_within(0.5).of(1500)
-    timings[:test2].should be_within(0.5).of(1000)
-    timings[:test3].should be_within(0.5).of(500)
+    expect(result).to eq("test")
+    expect(timings[:test1]).to be_within(0.5).of(1500)
+    expect(timings[:test2]).to be_within(0.5).of(1000)
+    expect(timings[:test3]).to be_within(0.5).of(500)
   end
 
   it '.in_realtime_block?' do
-    Benchmark.in_realtime_block?.should be_false
+    expect(Benchmark.in_realtime_block?).to be_falsey
     Benchmark.realtime_block(:test1) do
-      Benchmark.in_realtime_block?.should be_true
+      expect(Benchmark.in_realtime_block?).to be_truthy
     end
-    Benchmark.in_realtime_block?.should be_false
+    expect(Benchmark.in_realtime_block?).to be_falsey
   end
 end

--- a/gems/pending/spec/util/extensions/miq-deep_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-deep_spec.rb
@@ -19,7 +19,7 @@ describe 'miq-deep' do
 
     h = CASE_HASH.deep_clone
     h = h.deep_delete(:token)
-    h.should == normal_delete
+    expect(h).to eq(normal_delete)
   end
 
   it 'Array#deep_delete' do
@@ -28,14 +28,14 @@ describe 'miq-deep' do
 
     h = CASE_ARRAY.deep_clone
     h = h.deep_delete(:token)
-    h.should == normal_delete
+    expect(h).to eq(normal_delete)
   end
 
   # TODO: More test cases for deleting other keys, and deleting multiple keys
 
   def should_deep_clone(o1, o2)
-    o1.should == o2
-    o1.should_not equal(o2)
+    expect(o1).to eq(o2)
+    expect(o1).not_to equal(o2)
 
     # TODO: Add test cases that show that all sub-elements are cloned properly
   end

--- a/gems/pending/spec/util/extensions/miq-erb_for_yaml_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-erb_for_yaml_spec.rb
@@ -5,27 +5,27 @@ describe MiqERBForYAML do
   context "yaml load after ERB#result" do
     it "leading YAML characters" do
       erb = MiqERBForYAML.new("--- \nname: <%= \"!#Joe\" %>")
-      YAML.load(erb.result).should == {'name' => '!#Joe'}
+      expect(YAML.load(erb.result)).to eq({'name' => '!#Joe'})
     end
 
     it "leading %" do
       erb = MiqERBForYAML.new("--- \nname: <%= \"\%Joe\" %>")
-      YAML.load(erb.result).should == {'name' => "%Joe"}
+      expect(YAML.load(erb.result)).to eq({'name' => "%Joe"})
     end
 
     it "backslash within" do
       erb = MiqERBForYAML.new("--- \nname: <%= 'Joe\\234' %>")
-      YAML.load(erb.result).should == {'name' => 'Joe\234'}
+      expect(YAML.load(erb.result)).to eq({'name' => 'Joe\234'})
     end
 
     it "single quote within" do
       erb = MiqERBForYAML.new("--- \nname: <%= \"Joe\'234\" %>")
-      YAML.load(erb.result).should == {'name' => "Joe\'234"}
+      expect(YAML.load(erb.result)).to eq({'name' => "Joe\'234"})
     end
 
     it "double quote within" do
       erb = MiqERBForYAML.new("--- \nname: <%= 'Joe\"234' %>")
-      YAML.load(erb.result).should == {'name' => "Joe\"234"}
+      expect(YAML.load(erb.result)).to eq({'name' => "Joe\"234"})
     end
   end
 end

--- a/gems/pending/spec/util/extensions/miq-hash_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-hash_spec.rb
@@ -15,8 +15,8 @@ describe Hash do
     h[s] = "test"
     s2 = h.keys.first
 
-    s2.should == s
-    s2.sub_str.should == s.sub_str
+    expect(s2).to eq(s)
+    expect(s2.sub_str).to eq(s.sub_str)
   end
 
   it "#sort!" do
@@ -25,8 +25,8 @@ describe Hash do
 
     h.sort!
 
-    h.keys.should == [:a, :b, :x, :y]
-    h.object_id.should == h_id
+    expect(h.keys).to eq([:a, :b, :x, :y])
+    expect(h.object_id).to eq(h_id)
   end
 
   it "#sort_by!" do
@@ -35,7 +35,7 @@ describe Hash do
 
     h.sort_by! { |k, _v| k }
 
-    h.keys.should == [:a, :b, :x, :y]
-    h.object_id.should == h_id
+    expect(h.keys).to eq([:a, :b, :x, :y])
+    expect(h.object_id).to eq(h_id)
   end
 end

--- a/gems/pending/spec/util/extensions/miq-kernel_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-kernel_spec.rb
@@ -15,16 +15,16 @@ describe Kernel do
     end
 
     it 'will add the path if it is not already there' do
-      $LOAD_PATH.should == @expected
+      expect($LOAD_PATH).to eq(@expected)
     end
 
     it 'will ignore the path if it is already there' do
       add_to_load_path @new_path
-      $LOAD_PATH.should == @expected
+      expect($LOAD_PATH).to eq(@expected)
     end
   end
 
   it ".require_relative" do
-    Kernel.respond_to?(:require_relative).should be_true
+    expect(Kernel.respond_to?(:require_relative)).to be_truthy
   end
 end

--- a/gems/pending/spec/util/extensions/miq-module_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-module_spec.rb
@@ -10,11 +10,11 @@ describe Module do
     before(:each) do
       @settings = 60
 
-      -> { TestClass.cache_with_timeout(:default) { rand } }.should_not raise_error
-      -> { TestClass.cache_with_timeout(:override, 60) { rand } }.should_not raise_error
-      -> { TestClass.cache_with_timeout(:override_proc, -> { @settings }) { rand } }.should_not raise_error
+      expect { TestClass.cache_with_timeout(:default) { rand } }.not_to raise_error
+      expect { TestClass.cache_with_timeout(:override, 60) { rand } }.not_to raise_error
+      expect { TestClass.cache_with_timeout(:override_proc, -> { @settings }) { rand } }.not_to raise_error
 
-      -> { TestModule.cache_with_timeout(:default) { rand } }.should_not raise_error
+      expect { TestModule.cache_with_timeout(:default) { rand } }.not_to raise_error
     end
 
     after(:each) do
@@ -22,62 +22,62 @@ describe Module do
     end
 
     it 'will create the class method on that class/module only' do
-      TestClass.should  respond_to(:default)
-      TestClass.new.should_not respond_to(:default)
-      Object.should_not respond_to(:default)
-      Class.should_not  respond_to(:default)
-      Module.should_not respond_to(:default)
+      expect(TestClass).to  respond_to(:default)
+      expect(TestClass.new).not_to respond_to(:default)
+      expect(Object).not_to respond_to(:default)
+      expect(Class).not_to  respond_to(:default)
+      expect(Module).not_to respond_to(:default)
 
-      TestModule.should respond_to(:default)
-      Object.should_not respond_to(:default)
-      Class.should_not  respond_to(:default)
-      Module.should_not respond_to(:default)
+      expect(TestModule).to respond_to(:default)
+      expect(Object).not_to respond_to(:default)
+      expect(Class).not_to  respond_to(:default)
+      expect(Module).not_to respond_to(:default)
     end
 
     it 'will return the cached value' do
       value = TestClass.default(true)
-      TestClass.default.should == value
+      expect(TestClass.default).to eq(value)
 
       value = TestModule.default(true)
-      TestModule.default.should == value
+      expect(TestModule.default).to eq(value)
     end
 
     it 'will not return the cached value when passed force_reload = true' do
       value = TestClass.default(true)
-      TestClass.default(true).should_not == value
+      expect(TestClass.default(true)).not_to eq(value)
 
       value = TestModule.default(true)
-      TestModule.default(true).should_not == value
+      expect(TestModule.default(true)).not_to eq(value)
     end
 
     it 'will return the cached value if the default timeout has not passed' do
       value = TestClass.default(true)
-      Timecop.travel(60) { TestClass.default.should == value }
+      Timecop.travel(60) { expect(TestClass.default).to eq(value) }
     end
 
     it 'will not return the cached value if the default timeout has passed' do
       value = TestClass.default(true)
-      Timecop.travel(600) { TestClass.default.should_not == value }
+      Timecop.travel(600) { expect(TestClass.default).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout has not passed' do
       value = TestClass.override(true)
-      Timecop.travel(30) { TestClass.override.should == value }
+      Timecop.travel(30) { expect(TestClass.override).to eq(value) }
     end
 
     it 'will not return the cached value if the overridden timeout has passed' do
       value = TestClass.override(true)
-      Timecop.travel(120) { TestClass.override.should_not == value }
+      Timecop.travel(120) { expect(TestClass.override).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout (via a proc) has not passed' do
       value = TestClass.override_proc(true)
-      Timecop.travel(30) { TestClass.override_proc.should == value }
+      Timecop.travel(30) { expect(TestClass.override_proc).to eq(value) }
     end
 
     it 'will not return the cached value if the overridden timeout (via a proc) has passed' do
       value = TestClass.override_proc(true)
-      Timecop.travel(120) { TestClass.override_proc.should_not == value }
+      Timecop.travel(120) { expect(TestClass.override_proc).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout (via a proc) was changed but has not passed' do
@@ -85,7 +85,7 @@ describe Module do
       # prove that the new value is working
       @settings = 300 # 5 minutes
       value = TestClass.override_proc(true)
-      Timecop.travel(120) { TestClass.override_proc.should == value }
+      Timecop.travel(120) { expect(TestClass.override_proc).to eq(value) }
       @settings = 60 # reset back to 1 minute
     end
 
@@ -94,7 +94,7 @@ describe Module do
       # prove that the new value is working
       @settings = 300 # 5 minutes
       value = TestClass.override_proc(true)
-      Timecop.travel(600) { TestClass.override_proc.should_not == value }
+      Timecop.travel(600) { expect(TestClass.override_proc).not_to eq(value) }
       @settings = 60 # reset back to 1 minute
     end
 
@@ -109,27 +109,27 @@ describe Module do
       TestClass.override_proc_clear_cache
       TestModule.default_clear_cache
 
-      TestClass.default_cached?.should be_false
-      TestClass.override_cached?.should be_false
-      TestClass.override_proc_cached?.should be_false
-      TestModule.default_cached?.should be_false
+      expect(TestClass.default_cached?).to be_falsey
+      expect(TestClass.override_cached?).to be_falsey
+      expect(TestClass.override_proc_cached?).to be_falsey
+      expect(TestModule.default_cached?).to be_falsey
     end
 
     it 'generated .*_cached?' do
-      TestClass.default_cached?.should be_false
-      TestClass.override_cached?.should be_false
-      TestClass.override_proc_cached?.should be_false
-      TestModule.default_cached?.should be_false
+      expect(TestClass.default_cached?).to be_falsey
+      expect(TestClass.override_cached?).to be_falsey
+      expect(TestClass.override_proc_cached?).to be_falsey
+      expect(TestModule.default_cached?).to be_falsey
 
       TestClass.default
       TestClass.override
       TestClass.override_proc
       TestModule.default
 
-      TestClass.default_cached?.should be_true
-      TestClass.override_cached?.should be_true
-      TestClass.override_proc_cached?.should be_true
-      TestModule.default_cached?.should be_true
+      expect(TestClass.default_cached?).to be_truthy
+      expect(TestClass.override_cached?).to be_truthy
+      expect(TestClass.override_proc_cached?).to be_truthy
+      expect(TestModule.default_cached?).to be_truthy
     end
 
     it 'will cache with thread safety' do
@@ -145,7 +145,7 @@ describe Module do
       end
 
       10000.times do
-        TestClass.thread_safety.should == 2
+        expect(TestClass.thread_safety).to eq(2)
       end
     end
   end

--- a/gems/pending/spec/util/extensions/miq-numeric_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-numeric_spec.rb
@@ -3,18 +3,18 @@ require 'util/extensions/miq-numeric'
 
 describe Numeric do
   it "#apply_min_max" do
-    8.apply_min_max(nil, nil).should == 8
-    8.apply_min_max(3, nil).should == 8
-    8.apply_min_max(13, nil).should == 13
-    8.apply_min_max(nil, 6).should == 6
-    8.apply_min_max(13, 16).should == 13
-    20.apply_min_max(13, 16).should == 16
+    expect(8.apply_min_max(nil, nil)).to eq(8)
+    expect(8.apply_min_max(3, nil)).to eq(8)
+    expect(8.apply_min_max(13, nil)).to eq(13)
+    expect(8.apply_min_max(nil, 6)).to eq(6)
+    expect(8.apply_min_max(13, 16)).to eq(13)
+    expect(20.apply_min_max(13, 16)).to eq(16)
 
-    8.0.apply_min_max(nil, nil).should == 8.0
-    8.0.apply_min_max(3.0, nil).should == 8.0
-    8.0.apply_min_max(13.0, nil).should == 13.0
-    8.0.apply_min_max(nil, 6.0).should == 6.0
-    8.0.apply_min_max(13.0, 16.0).should == 13.0
-    20.0.apply_min_max(13.0, 16.0).should == 16.0
+    expect(8.0.apply_min_max(nil, nil)).to eq(8.0)
+    expect(8.0.apply_min_max(3.0, nil)).to eq(8.0)
+    expect(8.0.apply_min_max(13.0, nil)).to eq(13.0)
+    expect(8.0.apply_min_max(nil, 6.0)).to eq(6.0)
+    expect(8.0.apply_min_max(13.0, 16.0)).to eq(13.0)
+    expect(20.0.apply_min_max(13.0, 16.0)).to eq(16.0)
   end
 end

--- a/gems/pending/spec/util/extensions/miq-object_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-object_spec.rb
@@ -4,58 +4,58 @@ require 'util/extensions/miq-object'
 describe Object do
   context "#deep_send" do
     it "with string" do
-      10.deep_send("to_s").should == "10"
-      10.deep_send("to_s.length").should == 2
-      10.deep_send("to_s.length.to_s").should == "2"
-      [].deep_send("first.length").should be_nil
+      expect(10.deep_send("to_s")).to eq("10")
+      expect(10.deep_send("to_s.length")).to eq(2)
+      expect(10.deep_send("to_s.length.to_s")).to eq("2")
+      expect([].deep_send("first.length")).to be_nil
     end
 
     it "with array of strings" do
-      10.deep_send(["to_s"]).should == "10"
-      10.deep_send(["to_s", "length"]).should == 2
-      10.deep_send(["to_s", "length", "to_s"]).should == "2"
-      10.deep_send(["to_s", "length.to_s"]).should == "2"
-      10.deep_send(["to_s.length", "to_s.length"]).should == 1
-      [].deep_send(["first", "length"]).should be_nil
+      expect(10.deep_send(["to_s"])).to eq("10")
+      expect(10.deep_send(["to_s", "length"])).to eq(2)
+      expect(10.deep_send(["to_s", "length", "to_s"])).to eq("2")
+      expect(10.deep_send(["to_s", "length.to_s"])).to eq("2")
+      expect(10.deep_send(["to_s.length", "to_s.length"])).to eq(1)
+      expect([].deep_send(["first", "length"])).to be_nil
     end
 
     it "with direct strings" do
-      10.deep_send("to_s").should == "10"
-      10.deep_send("to_s", "length").should == 2
-      10.deep_send("to_s", "length", "to_s").should == "2"
-      10.deep_send("to_s", "length.to_s").should == "2"
-      10.deep_send("to_s.length", "to_s.length").should == 1
-      [].deep_send("first", "length").should be_nil
+      expect(10.deep_send("to_s")).to eq("10")
+      expect(10.deep_send("to_s", "length")).to eq(2)
+      expect(10.deep_send("to_s", "length", "to_s")).to eq("2")
+      expect(10.deep_send("to_s", "length.to_s")).to eq("2")
+      expect(10.deep_send("to_s.length", "to_s.length")).to eq(1)
+      expect([].deep_send("first", "length")).to be_nil
     end
 
     it "with array of symbols" do
-      10.deep_send([:to_s]).should == "10"
-      10.deep_send([:to_s, :length]).should == 2
-      10.deep_send([:to_s, :length, "to_s"]).should == "2"
-      [].deep_send([:first, :length]).should be_nil
+      expect(10.deep_send([:to_s])).to eq("10")
+      expect(10.deep_send([:to_s, :length])).to eq(2)
+      expect(10.deep_send([:to_s, :length, "to_s"])).to eq("2")
+      expect([].deep_send([:first, :length])).to be_nil
     end
 
     it "with direct symbols" do
-      10.deep_send(:to_s).should == "10"
-      10.deep_send(:to_s, :length).should == 2
-      10.deep_send(:to_s, :length, "to_s").should == "2"
-      [].deep_send(:first, :length).should be_nil
+      expect(10.deep_send(:to_s)).to eq("10")
+      expect(10.deep_send(:to_s, :length)).to eq(2)
+      expect(10.deep_send(:to_s, :length, "to_s")).to eq("2")
+      expect([].deep_send(:first, :length)).to be_nil
     end
 
     it "with invalid" do
-      -> { 10.deep_send }.should raise_error(ArgumentError)
-      -> { 10.deep_send(nil) }.should raise_error(ArgumentError)
-      -> { 10.deep_send("") }.should raise_error(ArgumentError)
+      expect { 10.deep_send }.to raise_error(ArgumentError)
+      expect { 10.deep_send(nil) }.to raise_error(ArgumentError)
+      expect { 10.deep_send("") }.to raise_error(ArgumentError)
     end
 
     it "does not damage args" do
       args = ["to_s", "length", "to_s"]
       10.deep_send(args)
-      args.should == ["to_s", "length", "to_s"]
+      expect(args).to eq(["to_s", "length", "to_s"])
 
       args = ["to_s", "length", "to_s"]
       10.deep_send(*args)
-      args.should == ["to_s", "length", "to_s"]
+      expect(args).to eq(["to_s", "length", "to_s"])
     end
   end
 end

--- a/gems/pending/spec/util/extensions/miq-range_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-range_spec.rb
@@ -34,7 +34,7 @@ describe Range do
       it "with #{msg}" do
         ary = []
         rng.step_value(value) { |x| ary << x }
-        ary.should == expected
+        expect(ary).to eq(expected)
       end
     end
   end
@@ -42,7 +42,7 @@ describe Range do
   context '#step_value without block' do
     STEP_VALUE_CASES.each_slice(4) do |msg, rng, value, expected|
       it "with #{msg}" do
-        rng.step_value(value).should == expected
+        expect(rng.step_value(value)).to eq(expected)
       end
     end
   end

--- a/gems/pending/spec/util/extensions/miq-symbol_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-symbol_spec.rb
@@ -3,10 +3,10 @@ require 'util/extensions/miq-symbol'
 
 describe Symbol do
   it "#to_i" do
-    :"1".to_i.should == 1
-    :"-1".to_i.should == -1
-    :test.to_i.should == 0
-    :test1.to_i.should == 0
-    :"1test".to_i.should == 1
+    expect(:"1".to_i).to eq(1)
+    expect(:"-1".to_i).to eq(-1)
+    expect(:test.to_i).to eq(0)
+    expect(:test1.to_i).to eq(0)
+    expect(:"1test".to_i).to eq(1)
   end
 end

--- a/gems/pending/spec/util/extensions/miq-to_i_with_method_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-to_i_with_method_spec.rb
@@ -4,44 +4,44 @@ require 'active_support/core_ext/numeric'
 
 describe "to_i_with_method" do
   it 'String#to_i_with_method' do
-    "20".to_i_with_method.should == 20
-    "20.percent".to_i_with_method.should == 20
-    "20.bytes".to_i_with_method.should == 20.bytes
-    "20.megabytes".to_i_with_method.should == 20971520
-    "20.5.megabytes".to_i_with_method.should == 20.5.megabytes
-    "123abc".to_i_with_method.should == 123
-    "2.51234.megabytes".to_i_with_method.should == 2634379
-    "2,000.megabytes".to_i_with_method.should == 2097152000
+    expect("20".to_i_with_method).to eq(20)
+    expect("20.percent".to_i_with_method).to eq(20)
+    expect("20.bytes".to_i_with_method).to eq(20.bytes)
+    expect("20.megabytes".to_i_with_method).to eq(20971520)
+    expect("20.5.megabytes".to_i_with_method).to eq(20.5.megabytes)
+    expect("123abc".to_i_with_method).to eq(123)
+    expect("2.51234.megabytes".to_i_with_method).to eq(2634379)
+    expect("2,000.megabytes".to_i_with_method).to eq(2097152000)
   end
 
   it 'String#to_f_with_method' do
-    "20".to_f_with_method.should == 20.0
-    "20.percent".to_f_with_method.should == 20.0
-    "20.1.percent".to_f_with_method.should == 20.1
-    "20.bytes".to_f_with_method.should == 20.0.bytes.to_f
-    "2.51234.megabytes".to_f_with_method.should == 2634379.42784
-    "20.5.megabytes".to_f_with_method.should == 20.5.megabytes.to_f
-    "123abc".to_f_with_method.should == 123.0
-    "2,000.megabytes".to_f_with_method.should == 2097152000.0
+    expect("20".to_f_with_method).to eq(20.0)
+    expect("20.percent".to_f_with_method).to eq(20.0)
+    expect("20.1.percent".to_f_with_method).to eq(20.1)
+    expect("20.bytes".to_f_with_method).to eq(20.0.bytes.to_f)
+    expect("2.51234.megabytes".to_f_with_method).to eq(2634379.42784)
+    expect("20.5.megabytes".to_f_with_method).to eq(20.5.megabytes.to_f)
+    expect("123abc".to_f_with_method).to eq(123.0)
+    expect("2,000.megabytes".to_f_with_method).to eq(2097152000.0)
   end
 
   it 'String#number_with_method?' do
-    "20".number_with_method?.should              be_false
-    "20.percent".number_with_method?.should      be_true
-    "20.1.percent".number_with_method?.should    be_true
-    "123abc".number_with_method?.should          be_false
-    "2,000.megabytes".number_with_method?.should be_true
+    expect("20".number_with_method?).to              be_falsey
+    expect("20.percent".number_with_method?).to      be_truthy
+    expect("20.1.percent".number_with_method?).to    be_truthy
+    expect("123abc".number_with_method?).to          be_falsey
+    expect("2,000.megabytes".number_with_method?).to be_truthy
   end
 
-  it('Integer#to_i_with_method')   { 20.to_i_with_method.should == 20 }
-  it('Integer#to_f_with_method')   { 20.to_f_with_method.should == 20.0 }
-  it('Integer#number_with_method') { 20.number_with_method?.should be_false }
+  it('Integer#to_i_with_method')   { expect(20.to_i_with_method).to eq(20) }
+  it('Integer#to_f_with_method')   { expect(20.to_f_with_method).to eq(20.0) }
+  it('Integer#number_with_method') { expect(20.number_with_method?).to be_falsey }
 
-  it('Float#to_i_with_method')   { 20.0.to_i_with_method.should == 20 }
-  it('Float#to_f_with_method')   { 20.0.to_f_with_method.should == 20.0 }
-  it('Float#number_with_method') { 20.0.number_with_method?.should be_false }
+  it('Float#to_i_with_method')   { expect(20.0.to_i_with_method).to eq(20) }
+  it('Float#to_f_with_method')   { expect(20.0.to_f_with_method).to eq(20.0) }
+  it('Float#number_with_method') { expect(20.0.number_with_method?).to be_falsey }
 
-  it('NilClass#to_i_with_method')   { nil.to_i_with_method.should == 0 }
-  it('NilClass#to_f_with_method')   { nil.to_f_with_method.should == 0 }
-  it('NilClass#number_with_method') { nil.number_with_method?.should be_false }
+  it('NilClass#to_i_with_method')   { expect(nil.to_i_with_method).to eq(0) }
+  it('NilClass#to_f_with_method')   { expect(nil.to_f_with_method).to eq(0) }
+  it('NilClass#number_with_method') { expect(nil.number_with_method?).to be_falsey }
 end

--- a/gems/pending/spec/util/extensions/miq-yaml_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-yaml_spec.rb
@@ -14,8 +14,8 @@ describe YAML do
 :b: 2
 __iv__@val: 3
 eoyml
-    hash[:a].should == 1
-    hash[:b].should == 2
-    hash.val.should == 3
+    expect(hash[:a]).to eq(1)
+    expect(hash[:b]).to eq(2)
+    expect(hash.val).to eq(3)
   end
 end

--- a/gems/pending/spec/util/miq-encode_spec.rb
+++ b/gems/pending/spec/util/miq-encode_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 require 'util/miq-encode'
 
 describe MIQEncode do
-  it('.encode') { pending }
-  it('.decode') { pending }
-  it('.base64Encode') { pending }
-  it('.base64Decode') { pending }
+  it('.encode') { skip }
+  it('.decode') { skip }
+  it('.base64Encode') { skip }
+  it('.base64Decode') { skip }
 
   it '.base24Decode' do
     byteArray = [0xbb, 0xe0, 0x11, 0xa1, 0x1b, 0x29, 0x3e, 0xa4, 0xd5, 0xc3, 0x97, 0x04, 0x1c, 0x7b, 0x02, 0x00]
-    MIQEncode.base24Decode(byteArray).should == "PX4FW-XP3BB-7Q99T-VVTPQ-XV8VF"
+    expect(MIQEncode.base24Decode(byteArray)).to eq("PX4FW-XP3BB-7Q99T-VVTPQ-XV8VF")
   end
 end

--- a/gems/pending/spec/util/miq-hash_struct_spec.rb
+++ b/gems/pending/spec/util/miq-hash_struct_spec.rb
@@ -4,92 +4,92 @@ require 'util/miq-hash_struct'
 describe MiqHashStruct do
   it ".new" do
     m = MiqHashStruct.new
-    m._key_type.should == Symbol
+    expect(m._key_type).to eq(Symbol)
 
-    m.test1.should be_nil
-    m.test2.should be_nil
+    expect(m.test1).to be_nil
+    expect(m.test2).to be_nil
 
     m.test2 = "ok2"
-    m.test1.should be_nil
-    m.test2.should == "ok2"
+    expect(m.test1).to be_nil
+    expect(m.test2).to eq("ok2")
 
     [Symbol, String, Symbol].each do |typ|
       m._key_type = typ
-      m.test1.should be_nil
-      m.test2.should == "ok2"
+      expect(m.test1).to be_nil
+      expect(m.test2).to eq("ok2")
     end
   end
 
   it ".new with Hash with String keys" do
     m = MiqHashStruct.new("test1" => "ok")
-    m._key_type.should == String
+    expect(m._key_type).to eq(String)
 
-    m.test1.should == "ok"
-    m.test2.should be_nil
+    expect(m.test1).to eq("ok")
+    expect(m.test2).to be_nil
 
     m.test2 = "ok2"
-    m.test1.should == "ok"
-    m.test2.should == "ok2"
+    expect(m.test1).to eq("ok")
+    expect(m.test2).to eq("ok2")
 
     [String, Symbol, String].each do |typ|
       m._key_type = typ
-      m.test1.should == "ok"
-      m.test2.should == "ok2"
-      m.test3.should be_nil
+      expect(m.test1).to eq("ok")
+      expect(m.test2).to eq("ok2")
+      expect(m.test3).to be_nil
     end
   end
 
   it ".new with Hash with Symbol keys" do
     m = MiqHashStruct.new(:test1 => "ok")
-    m._key_type.should == Symbol
+    expect(m._key_type).to eq(Symbol)
 
-    m.test1.should == "ok"
-    m.test2.should be_nil
+    expect(m.test1).to eq("ok")
+    expect(m.test2).to be_nil
 
     m.test2 = "ok2"
-    m.test1.should == "ok"
-    m.test2.should == "ok2"
+    expect(m.test1).to eq("ok")
+    expect(m.test2).to eq("ok2")
 
     [Symbol, String, Symbol].each do |typ|
       m._key_type = typ
-      m.test1.should == "ok"
-      m.test2.should == "ok2"
-      m.test3.should be_nil
+      expect(m.test1).to eq("ok")
+      expect(m.test2).to eq("ok2")
+      expect(m.test3).to be_nil
     end
   end
 
   it ".new with invalid argument (non-Hash)" do
-    -> { MiqHashStruct.new(["test1"]) }.should raise_error(ArgumentError)
+    expect { MiqHashStruct.new(["test1"]) }.to raise_error(ArgumentError)
   end
 
   it ".new with invalid argument (non-String/Symbol keys)" do
-    -> { MiqHashStruct.new(["test1"] => "ok") }.should raise_error(ArgumentError)
+    expect { MiqHashStruct.new(["test1"] => "ok") }.to raise_error(ArgumentError)
   end
 
   it '#send with String keys' do
     m = MiqHashStruct.new("test1" => "ok")
-    m.send('test1').should == "ok"
-    m.send(:test1).should == "ok"
-    m.send('test2').should be_nil
-    m.send(:test2).should  be_nil
+    expect(m.send('test1')).to eq("ok")
+    expect(m.send(:test1)).to eq("ok")
+    expect(m.send('test2')).to be_nil
+    expect(m.send(:test2)).to  be_nil
   end
 
   it '#send with Symbol keys' do
     m = MiqHashStruct.new(:test1 => "ok")
-    m.send('test1').should == "ok"
-    m.send(:test1).should == "ok"
-    m.send('test2').should be_nil
-    m.send(:test2).should  be_nil
+    expect(m.send('test1')).to eq("ok")
+    expect(m.send(:test1)).to eq("ok")
+    expect(m.send('test2')).to be_nil
+    expect(m.send(:test2)).to  be_nil
   end
 
   it '#id when Hash has a key of :id' do
     m = MiqHashStruct.new(:id => "test_id")
-    m.id.should == "test_id"
+    expect(m.id).to eq("test_id")
   end
 
   it '#id when Hash does not have a key of :id' do
     m = MiqHashStruct.new(:no_id => "test_id")
-    m.id.should be_nil
+    expect(m.id).to be_nil
   end
 
   context "#==" do
@@ -97,16 +97,16 @@ describe MiqHashStruct do
 
     it "with a matching miq-hash_struct" do
       matching = MiqHashStruct.new(:number => 1, :string => "test")
-      test_struct.should == matching
+      expect(test_struct).to eq(matching)
     end
 
     it "with a non-matching miq-hash_struct" do
       non_matching = MiqHashStruct.new(:number => 2, :string => "test")
-      test_struct.should_not == non_matching
+      expect(test_struct).not_to eq(non_matching)
     end
 
     it "with a different object class" do
-      test_struct.should_not == "string"
+      expect(test_struct).not_to eq("string")
     end
   end
 

--- a/gems/pending/spec/util/miq-ipmi_spec.rb
+++ b/gems/pending/spec/util/miq-ipmi_spec.rb
@@ -5,7 +5,7 @@ describe MiqIPMI do
   subject { described_class.new }
 
   it "#chassis_status" do
-    described_class.stub(:is_2_0_available?).and_return(true)
+    allow(described_class).to receive(:is_2_0_available?).and_return(true)
     response = <<-EOF
 System Power         : off
 Power Overload       : false
@@ -55,21 +55,21 @@ EOF
   end
 
   context "version 1.5" do
-    before { described_class.stub(:is_2_0_available?).and_return(false) }
+    before { allow(described_class).to receive(:is_2_0_available?).and_return(false) }
     before { allow_any_instance_of(MiqIPMI).to receive(:chassis_status).and_return({}) }
 
     it "#interface_mode" do
-      subject.interface_mode.should == "lan"
+      expect(subject.interface_mode).to eq("lan")
     end
 
     it "#run_command" do
-      MiqUtil.should_receive(:runcmd).with { |cmd| cmd.should include("-I lan") }
+      expect(MiqUtil).to receive(:runcmd).with { |cmd| expect(cmd).to include("-I lan") }
       subject.run_command("chassis power status")
     end
   end
 
   context "version 2.0" do
-    before { described_class.stub(:is_2_0_available?).and_return(true) }
+    before { allow(described_class).to receive(:is_2_0_available?).and_return(true) }
     before { allow_any_instance_of(MiqIPMI).to receive(:chassis_status).and_return({}) }
 
     context "Power Ops" do
@@ -157,11 +157,11 @@ EOR
     end
 
     it "#interface_mode" do
-      subject.interface_mode.should == "lanplus"
+      expect(subject.interface_mode).to eq("lanplus")
     end
 
     it "#run_command" do
-      MiqUtil.should_receive(:runcmd).with { |cmd| cmd.should include("-I lanplus") }
+      expect(MiqUtil).to receive(:runcmd).with { |cmd| expect(cmd).to include("-I lanplus") }
       subject.run_command("chassis power status")
     end
   end

--- a/gems/pending/spec/util/miq-password_spec.rb
+++ b/gems/pending/spec/util/miq-password_spec.rb
@@ -89,9 +89,9 @@ describe MiqPassword do
       it("#decrypt v1 erb") { expect(MiqPassword.new.decrypt(erberize(enc_v1))).to be_decrypted(pass) }
       it("#decrypt erb")    { expect(MiqPassword.new.decrypt(erberize(enc_v0))).to be_decrypted(pass) }
 
-      it(".encrypt(.decrypt)") { MiqPassword.decrypt(MiqPassword.encrypt(pass)).should         be_decrypted(pass) }
-      it(".encStr/.decrypt")   { MiqPassword.decrypt(MiqPassword.new(pass).encStr).should      be_decrypted(pass) }
-      it("#encrypt(#decrypt)") { MiqPassword.new.decrypt(MiqPassword.new.encrypt(pass)).should be_decrypted(pass) }
+      it(".encrypt(.decrypt)") { expect(MiqPassword.decrypt(MiqPassword.encrypt(pass))).to         be_decrypted(pass) }
+      it(".encStr/.decrypt")   { expect(MiqPassword.decrypt(MiqPassword.new(pass).encStr)).to      be_decrypted(pass) }
+      it("#encrypt(#decrypt)") { expect(MiqPassword.new.decrypt(MiqPassword.new.encrypt(pass))).to be_decrypted(pass) }
 
       it("#try_encrypt (non-encrypted)") { expect(MiqPassword.try_encrypt(pass)).to   be_encrypted(pass) }
       it("#try_encrypt erb")             { expect(MiqPassword.try_encrypt(erberize(enc_v0))).to eq(erberize(enc_v0)) }
@@ -128,14 +128,14 @@ describe MiqPassword do
       "abcdefghijklmnopqrstuvwxyz123456", # 32 character password will not end in a "=" after Base64 encoding
     ].each do |pass|
       it "with #{pass.inspect}" do
-        MiqPassword.encrypted?(pass).should                      be_false
-        MiqPassword.encrypted?(MiqPassword.encrypt(pass)).should be_true
+        expect(MiqPassword.encrypted?(pass)).to                      be_falsey
+        expect(MiqPassword.encrypted?(MiqPassword.encrypt(pass))).to be_truthy
       end
     end
 
     it "should handle blanks" do
-      expect(MiqPassword.encrypted?(nil)).to be_false
-      expect(MiqPassword.encrypted?("")).to  be_false
+      expect(MiqPassword.encrypted?(nil)).to be_falsey
+      expect(MiqPassword.encrypted?("")).to  be_falsey
     end
   end
 

--- a/gems/pending/spec/util/miq-syntax-checker_spec.rb
+++ b/gems/pending/spec/util/miq-syntax-checker_spec.rb
@@ -6,21 +6,21 @@ describe MiqSyntaxChecker do
   context "#check" do
     it "valid" do
       result = described_class.check "this.is.valid.syntax"
-      result.should be_valid
+      expect(result).to be_valid
 
       result = described_class.check "i = 1"
-      result.should be_valid
+      expect(result).to be_valid
     end
 
     it "invalid" do
       result = described_class.check "this.is -> not -> valid $ruby:syntax"
-      result.should_not be_valid
+      expect(result).not_to be_valid
     end
   end
 
   it "#error_line, #error_text" do
     result = described_class.check "line(1).is.okay\nline(2) is not :("
-    result.error_line.should == 2
-    result.error_text.should =~ /syntax error/
+    expect(result.error_line).to eq(2)
+    expect(result.error_text).to match(/syntax error/)
   end
 end

--- a/gems/pending/spec/util/miq-system_spec.rb
+++ b/gems/pending/spec/util/miq-system_spec.rb
@@ -13,13 +13,13 @@ describe MiqSystem do
 
     it "file exists" do
       file = "/dev/null"
-      File.stub(:exist?).with(file).and_return(true)
+      allow(File).to receive(:exist?).with(file).and_return(true)
       expect(described_class.normalize_df_file_argument(file)).to eq(file)
     end
 
     it "file missing" do
       file = "/dev/null"
-      File.stub(:exist?).with(file).and_return(false)
+      allow(File).to receive(:exist?).with(file).and_return(false)
       expect { described_class.normalize_df_file_argument(file) }.to raise_error(RuntimeError, "file /dev/null does not exist")
     end
   end
@@ -138,8 +138,8 @@ EOF
       ]
 
       stub_const("Sys::Platform::IMPL", :linux)
-      AwesomeSpawn.should_receive(:launch).with("df -T -P -l", {}).and_return([linux_df_output_bytes, "", 0])
-      AwesomeSpawn.should_receive(:launch).with("df -T -P -i -l", {}).and_return([linux_df_output_inodes, "", 0])
+      expect(AwesomeSpawn).to receive(:launch).with("df -T -P -l", {}).and_return([linux_df_output_bytes, "", 0])
+      expect(AwesomeSpawn).to receive(:launch).with("df -T -P -i -l", {}).and_return([linux_df_output_inodes, "", 0])
 
       expect(described_class.disk_usage).to eq(expected)
     end
@@ -205,7 +205,7 @@ EOF
       ]
 
       stub_const("Sys::Platform::IMPL", :macosx)
-      AwesomeSpawn.should_receive(:launch).and_return([mac_df_output, "", 0])
+      expect(AwesomeSpawn).to receive(:launch).and_return([mac_df_output, "", 0])
 
       expect(described_class.disk_usage).to eq(expected)
     end

--- a/gems/pending/spec/util/miq-unicode_spec.rb
+++ b/gems/pending/spec/util/miq-unicode_spec.rb
@@ -13,26 +13,26 @@ describe 'miq-unicode' do
 
     it '.UnicodeToUtf8' do
       converted_utf8 = @unicode_str.UnicodeToUtf8
-      converted_utf8.object_id.should_not == @unicode_str.object_id
-      converted_utf8.should == @utf8_str
+      expect(converted_utf8.object_id).not_to eq(@unicode_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
     end
 
     it '.UnicodeToUtf8!' do
       converted_utf8 = @unicode_str.UnicodeToUtf8!
-      converted_utf8.object_id.should == @unicode_str.object_id
-      converted_utf8.should == @utf8_str
+      expect(converted_utf8.object_id).to eq(@unicode_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
     end
 
     it '.Utf8ToUnicode' do
       converted_unicode = @utf8_str.Utf8ToUnicode
-      converted_unicode.object_id.should_not == @utf8_str.object_id
-      converted_unicode.should == @unicode_str
+      expect(converted_unicode.object_id).not_to eq(@utf8_str.object_id)
+      expect(converted_unicode).to eq(@unicode_str)
     end
 
     it '.Utf8ToUnicode!' do
       converted_unicode = @utf8_str.Utf8ToUnicode!
-      converted_unicode.object_id.should == @utf8_str.object_id
-      converted_unicode.should == @unicode_str
+      expect(converted_unicode.object_id).to eq(@utf8_str.object_id)
+      expect(converted_unicode).to eq(@unicode_str)
     end
   end
 
@@ -47,26 +47,26 @@ describe 'miq-unicode' do
 
     it '.AsciiToUtf8' do
       converted_utf8 = @ascii_str.AsciiToUtf8
-      converted_utf8.object_id.should_not == @ascii_str.object_id
-      converted_utf8.should == @utf8_str
+      expect(converted_utf8.object_id).not_to eq(@ascii_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
     end
 
     it '.AsciiToUtf8!' do
       converted_utf8 = @ascii_str.AsciiToUtf8!
-      converted_utf8.object_id.should == @ascii_str.object_id
-      converted_utf8.should == @utf8_str
+      expect(converted_utf8.object_id).to eq(@ascii_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
     end
 
     it '.Utf8ToAscii' do
       converted_ascii = @utf8_str.Utf8ToAscii
-      converted_ascii.object_id.should_not == @utf8_str.object_id
-      converted_ascii.should == @ascii_str
+      expect(converted_ascii.object_id).not_to eq(@utf8_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
     end
 
     it '.Utf8ToAscii!' do
       converted_ascii = @utf8_str.Utf8ToAscii!
-      converted_ascii.object_id.should == @utf8_str.object_id
-      converted_ascii.should == @ascii_str
+      expect(converted_ascii.object_id).to eq(@utf8_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
     end
   end
 
@@ -81,14 +81,14 @@ describe 'miq-unicode' do
 
     it '.Ucs2ToAscii' do
       converted_ascii = @ucs2_str.Ucs2ToAscii
-      converted_ascii.object_id.should_not == @ucs2_str.object_id
-      converted_ascii.should == @ascii_str
+      expect(converted_ascii.object_id).not_to eq(@ucs2_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
     end
 
     it '.Ucs2ToAscii!' do
       converted_ascii = @ucs2_str.Ucs2ToAscii!
-      converted_ascii.object_id.should == @ucs2_str.object_id
-      converted_ascii.should == @ascii_str
+      expect(converted_ascii.object_id).to eq(@ucs2_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
     end
   end
 end

--- a/gems/pending/spec/util/miq-uuid_spec.rb
+++ b/gems/pending/spec/util/miq-uuid_spec.rb
@@ -18,18 +18,18 @@ describe MiqUUID do
   ]
 
   MIQ_UUID_CASES.each_slice(3) do |title, value, expected|
-    it(".clean_guid with #{title}") { MiqUUID.clean_guid(value).should == expected }
+    it(".clean_guid with #{title}") { expect(MiqUUID.clean_guid(value)).to eq(expected) }
   end
 
   it ".new_guid" do
     guid = MiqUUID.new_guid
-    guid.should be_kind_of String
-    guid.should match MiqUUID::REGEX_FORMAT
+    expect(guid).to be_kind_of String
+    expect(guid).to match MiqUUID::REGEX_FORMAT
   end
 
   it ".parse_raw" do
     guid = MiqUUID.parse_raw("\001#Eg\211\253\315\357\253\315\357\001#Eg\211")
-    guid.should be_kind_of UUIDTools::UUID
-    guid.to_s.should == '01234567-89ab-cdef-abcd-ef0123456789'
+    expect(guid).to be_kind_of UUIDTools::UUID
+    expect(guid.to_s).to eq('01234567-89ab-cdef-abcd-ef0123456789')
   end
 end

--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -3,11 +3,11 @@ require 'util/miq_apache'
 
 describe MiqApache::Conf do
   it "should raise ConfFileNotSpecified for a missing conf file" do
-    lambda { MiqApache::Conf.new }.should raise_error(MiqApache::ConfFileNotSpecified)
+    expect { MiqApache::Conf.new }.to raise_error(MiqApache::ConfFileNotSpecified)
   end
 
   it "should raise ConfFileNotSpecified for a bogus conf file" do
-    lambda { MiqApache::Conf.new("foo") }.should raise_error(MiqApache::ConfFileNotFound)
+    expect { MiqApache::Conf.new("foo") }.to raise_error(MiqApache::ConfFileNotFound)
   end
 
   context "building balancer config" do
@@ -61,28 +61,28 @@ describe MiqApache::Conf do
     end
 
     it "should have fname attribute" do
-      @conf.fname.should_not be_nil
+      expect(@conf.fname).not_to be_nil
     end
 
     it "instance should return existing conf instance" do
-      MiqApache::Conf.should_receive(:new).never
+      expect(MiqApache::Conf).to receive(:new).never
       MiqApache::Conf.instance(File.expand_path(File.join(File.dirname(__FILE__), "data", "apache_test1.conf")))
     end
 
     it "should have valid conf object" do
-      @conf.should_not be_nil
+      expect(@conf).not_to be_nil
     end
 
     it "should have #{TOTAL_LINES} lines" do
-      @conf.line_count.should == TOTAL_LINES
+      expect(@conf.line_count).to eq(TOTAL_LINES)
     end
 
     it "should have #{CONTENT_LINES} lines of real content due to comments" do
-      @conf.content_lines.size.should == CONTENT_LINES
+      expect(@conf.content_lines.size).to eq(CONTENT_LINES)
     end
 
     it "should have #{BLOCK_DIRECTIVES} block directives" do
-      @conf.block_directives.size.should == BLOCK_DIRECTIVES
+      expect(@conf.block_directives.size).to eq(BLOCK_DIRECTIVES)
     end
   end
 
@@ -94,57 +94,57 @@ describe MiqApache::Conf do
 
     it "add_ports should add the first port line" do
       @conf.add_ports(3000)
-      @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
+      expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"])
     end
 
     it "add_ports should add the first two port lines" do
       @conf.add_ports([3000, 3001])
-      @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"]
+      expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"])
     end
 
     it "add_ports should add a single port line to existing lines" do
       @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"]
       @conf.add_ports(3002)
-      @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3002\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"]
+      expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3002\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"])
     end
 
     it "remove_ports should do nothing with no BalancerMember lines" do
       before = @conf.raw_lines.dup
       @conf.remove_ports(3000)
-      @conf.raw_lines.should == before
+      expect(@conf.raw_lines).to eq(before)
     end
 
     it "remove_ports should remove the only port line" do
       before = @conf.raw_lines.dup
       @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
       @conf.remove_ports(3000)
-      @conf.raw_lines.should == before
+      expect(@conf.raw_lines).to eq(before)
     end
 
     it "remove_ports should remove the only two port lines" do
       before = @conf.raw_lines.dup
       @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"]
       @conf.remove_ports([3000, 3001])
-      @conf.raw_lines.should == before
+      expect(@conf.raw_lines).to eq(before)
     end
 
     it "remove_ports should remove one port line, leaving one" do
       @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "BalancerMember http://0.0.0.0:3001\n", "</Proxy>\n"]
       @conf.remove_ports(3001)
-      @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
+      expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"])
     end
 
     it "#save" do
-      MiqApache::Control.stub(:config_ok?).and_return(true)
+      allow(MiqApache::Control).to receive(:config_ok?).and_return(true)
       backup = "#{@conf_file}_old"
       FileUtils.cp(@conf_file, backup)
       begin
         @conf.add_ports(3000)
-        @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
+        expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"])
         @conf.save
 
         @conf.reload
-        @conf.raw_lines.should == ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
+        expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"])
       ensure
         FileUtils.mv(backup, @conf_file)
       end
@@ -207,13 +207,13 @@ My test
 </VirtualHost>
 EOF
       File.stub(:exist? => false)
-      FileUtils.stub(:touch)
+      allow(FileUtils).to receive(:touch)
       File.stub(:file? => true)
       File.stub(:read => "")
-      FileUtils.stub(:cp)
-      File.should_receive(:write).with(conf_file, expected_output)
+      allow(FileUtils).to receive(:cp)
+      expect(File).to receive(:write).with(conf_file, expected_output)
       MiqApache::Control.stub(:config_ok? => true)
-      expect(described_class.create_conf_file(conf_file, content_in)).to be_true
+      expect(described_class.create_conf_file(conf_file, content_in)).to be_truthy
     end
 
     it "with proper args should generate a config file" do
@@ -227,7 +227,7 @@ EOF
       ]
 
       File.stub(:exist? => false)
-      FileUtils.stub(:touch)
+      allow(FileUtils).to receive(:touch)
       File.stub(:file? => true)
       File.stub(:read => "")
       expect { described_class.create_conf_file(conf_file, content_in) }.to raise_error(ArgumentError, ":directive key is required")

--- a/gems/pending/spec/util/miq_apache/control_spec.rb
+++ b/gems/pending/spec/util/miq_apache/control_spec.rb
@@ -2,151 +2,151 @@ require "spec_helper"
 
 describe MiqApache::Control do
   it "should run_apache_cmd with start when calling start" do
-    MiqApache::Control.should_receive(:run_apache_cmd).with('start')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('start')
     MiqApache::Control.start
   end
 
   it "should run_apache_cmd with graceful-stop and start when calling restart with graceful true" do
-    MiqApache::Control.should_receive(:run_apache_cmd).with('graceful-stop')
-    MiqApache::Control.should_receive(:run_apache_cmd).with('start')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('graceful-stop')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('start')
     MiqApache::Control.restart(true)
   end
 
   it "should run_apache_cmd with restart when calling restart with graceful false" do
-    MiqApache::Control.should_receive(:run_apache_cmd).with('restart')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('restart')
     MiqApache::Control.restart(false)
   end
 
   it "should run_apache_cmd with graceful-stop when calling stop with graceful true" do
-    MiqApache::Control.should_receive(:run_apache_cmd).with('graceful-stop')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('graceful-stop')
     MiqApache::Control.stop(true)
   end
 
   it "should run_apache_cmd with stop when calling stop with graceful false" do
-    MiqApache::Control.should_receive(:run_apache_cmd).with('stop')
+    expect(MiqApache::Control).to receive(:run_apache_cmd).with('stop')
     MiqApache::Control.stop(false)
   end
 
   it "should run_apache_cmd with /usr/bin/systemctl status httpd status when calling httpd_status" do
-    MiqUtil.should_receive(:runcmd).with('/usr/bin/systemctl status httpd').and_return("Active: active")
+    expect(MiqUtil).to receive(:runcmd).with('/usr/bin/systemctl status httpd').and_return("Active: active")
     MiqApache::Control.httpd_status
   end
 
   it "should return false with result when calling httpd_status raising 'httpd is stopped' RuntimeError" do
     result = "Active: inactive"
-    MiqUtil.stub(:runcmd).and_raise(RuntimeError.new(result))
-    MiqApache::Control.httpd_status.should == [false, result]
+    allow(MiqUtil).to receive(:runcmd).and_raise(RuntimeError.new(result))
+    expect(MiqApache::Control.httpd_status).to eq([false, result])
   end
 
   it "should return false with result when calling httpd_status raising 'Active: inactive' RuntimeError" do
     result = "Active: inactive"
-    MiqUtil.stub(:runcmd).and_raise(RuntimeError.new(result))
-    MiqApache::Control.httpd_status.should == [false, result]
+    allow(MiqUtil).to receive(:runcmd).and_raise(RuntimeError.new(result))
+    expect(MiqApache::Control.httpd_status).to eq([false, result])
   end
 
   it "should return true with result when calling httpd_status raising 'Active: inactive' RuntimeError" do
     result = "Active: active"
-    MiqUtil.stub(:runcmd).and_return(result)
-    MiqApache::Control.httpd_status.should == [true, result]
+    allow(MiqUtil).to receive(:runcmd).and_return(result)
+    expect(MiqApache::Control.httpd_status).to eq([true, result])
   end
 
   it "should raise an error when calling httpd_status raising unknown result RuntimeError" do
     result = "unknown result"
-    MiqUtil.stub(:runcmd).and_raise(RuntimeError.new(result))
-    -> { MiqApache::Control.httpd_status }.should raise_error(RuntimeError)
+    allow(MiqUtil).to receive(:runcmd).and_raise(RuntimeError.new(result))
+    expect { MiqApache::Control.httpd_status }.to raise_error(RuntimeError)
   end
 
   it "should runcmd with killall -9 httpd when running kill_all and cleanup file descriptors" do
-    MiqUtil.should_receive(:runcmd).with("killall -9 httpd")
-    MiqUtil.should_receive(:runcmd).with { |arg| arg =~ /^for i in/ }
+    expect(MiqUtil).to receive(:runcmd).with("killall -9 httpd")
+    expect(MiqUtil).to receive(:runcmd).with { |arg| arg =~ /^for i in/ }
     MiqApache::Control.kill_all
   end
 
   it "should raise an error if killall failed with unknown result" do
     result = "unknown result"
-    MiqUtil.stub(:runcmd).and_raise(RuntimeError.new(result))
-    -> { MiqApache::Control.kill_all }.should raise_error(RuntimeError)
+    allow(MiqUtil).to receive(:runcmd).and_raise(RuntimeError.new(result))
+    expect { MiqApache::Control.kill_all }.to raise_error(RuntimeError)
   end
 
   it "should not raise an error if the kill returned no process found" do
     result = "httpd: no process found"
-    MiqUtil.stub(:runcmd).and_raise(RuntimeError.new(result))
-    -> { MiqApache::Control.kill_all }.should_not raise_error
+    allow(MiqUtil).to receive(:runcmd).and_raise(RuntimeError.new(result))
+    expect { MiqApache::Control.kill_all }.not_to raise_error
   end
 
   # FIXME: need to implement the code and change the test
   it "should not do anything when calling status with full true" do
-    MiqApache::Control.should_receive(:run_apache_cmd).never
-    MiqApache::Control.status(true).should be_nil
+    expect(MiqApache::Control).to receive(:run_apache_cmd).never
+    expect(MiqApache::Control.status(true)).to be_nil
   end
 
   # FIXME: need to implement the code and change the test
   it "should not do anything when calling status with full false" do
-    MiqApache::Control.should_receive(:run_apache_cmd).never
-    MiqApache::Control.status(false).should be_nil
+    expect(MiqApache::Control).to receive(:run_apache_cmd).never
+    expect(MiqApache::Control.status(false)).to be_nil
   end
 
   it "should return true with when calling config_ok? and result was 'Syntax OK'" do
     result = "Syntax OK"
-    MiqUtil.stub(:runcmd).and_return(result)
-    MiqApache::Control.should be_config_ok
+    allow(MiqUtil).to receive(:runcmd).and_return(result)
+    expect(MiqApache::Control).to be_config_ok
   end
 
   it "should return false with when calling config_ok? and an error was raised" do
-    MiqUtil.stub(:runcmd).and_raise("some error message")
-    MiqApache::Control.should_not be_config_ok
+    allow(MiqUtil).to receive(:runcmd).and_raise("some error message")
+    expect(MiqApache::Control).not_to be_config_ok
   end
 
   it "should return false with when calling config_ok? and result was NOT 'Syntax OK'" do
     result = "Blah!"
-    MiqUtil.stub(:runcmd).and_return(result)
-    MiqApache::Control.should_not be_config_ok
+    allow(MiqUtil).to receive(:runcmd).and_return(result)
+    expect(MiqApache::Control).not_to be_config_ok
   end
 
   it "should runcmd with rpm -qa... when calling version" do
-    MiqUtil.should_receive(:runcmd).with { |arg| arg == "rpm -qa --queryformat '%{VERSION}' httpd" }
+    expect(MiqUtil).to receive(:runcmd).with { |arg| arg == "rpm -qa --queryformat '%{VERSION}' httpd" }
     MiqApache::Control.version
   end
 
   it "should make the apache control log's directory if missing when calling run_apache_cmd" do
-    File.stub(:exist?).and_return(false)
-    Dir.should_receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG))
-    MiqUtil.stub(:runcmd)
+    allow(File).to receive(:exist?).and_return(false)
+    expect(Dir).to receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG))
+    allow(MiqUtil).to receive(:runcmd)
     MiqApache::Control.run_apache_cmd("start")
   end
 
   it "should not make the apache control log's directory if it exists when calling run_apache_cmd" do
-    File.stub(:exist?).and_return(true)
-    Dir.should_receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG)).never
-    MiqUtil.stub(:runcmd)
+    allow(File).to receive(:exist?).and_return(true)
+    expect(Dir).to receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG)).never
+    allow(MiqUtil).to receive(:runcmd)
     MiqApache::Control.run_apache_cmd("start")
   end
 
   it "should build cmdline when calling run_apache_cmd with start" do
     cmd = "start"
-    File.stub(:exist?).and_return(true)
+    allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
-    $log.stub(:debug?).and_return(false)
-    MiqUtil.should_receive(:runcmd).with("apachectl #{cmd}")
+    allow($log).to receive(:debug?).and_return(false)
+    expect(MiqUtil).to receive(:runcmd).with("apachectl #{cmd}")
     MiqApache::Control.run_apache_cmd("start")
   end
 
   it "should build cmdline when calling run_apache_cmd with start in debug mode if $log is debug" do
     cmd = "start"
-    File.stub(:exist?).and_return(true)
+    allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
-    $log.stub(:debug?).and_return(true)
-    MiqUtil.should_receive(:runcmd).with("apachectl #{cmd}")
+    allow($log).to receive(:debug?).and_return(true)
+    expect(MiqUtil).to receive(:runcmd).with("apachectl #{cmd}")
     MiqApache::Control.run_apache_cmd("start")
   end
 
   it "should log a warning when calling run_apache_cmd with start that raises an error" do
     cmd = "start"
-    File.stub(:exist?).and_return(true)
+    allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
-    $log.stub(:debug?).and_return(false)
-    MiqUtil.stub(:runcmd).and_raise("warn")
-    $log.should_receive(:warn)
+    allow($log).to receive(:debug?).and_return(false)
+    allow(MiqUtil).to receive(:runcmd).and_raise("warn")
+    expect($log).to receive(:warn)
     MiqApache::Control.run_apache_cmd("start")
   end
 end

--- a/gems/pending/spec/util/miq_logger_processor_spec.rb
+++ b/gems/pending/spec/util/miq_logger_processor_spec.rb
@@ -71,62 +71,62 @@ describe MiqLoggerProcessor do
     before(:each) { @lines = @lp.to_a }
 
     it "will read the correct number of lines" do
-      @lines.length.should == EXPECTED_RAW_LINES.length
+      expect(@lines.length).to eq(EXPECTED_RAW_LINES.length)
     end
 
     it "will read the correct number of lines when called twice" do
       @lines = @lp.to_a
-      @lines.length.should == EXPECTED_RAW_LINES.length
+      expect(@lines.length).to eq(EXPECTED_RAW_LINES.length)
     end
 
     it "will read regular lines correctly" do
-      @lines[0].should == EXPECTED_RAW_LINES[0]
+      expect(@lines[0]).to eq(EXPECTED_RAW_LINES[0])
     end
 
     it "will read lines with shortened pid/tid correctly" do
-      @lines[1].should == EXPECTED_RAW_LINES[1]
+      expect(@lines[1]).to eq(EXPECTED_RAW_LINES[1])
     end
 
     it "will read multi-line lines correctly" do
-      @lines[2].should == EXPECTED_RAW_LINES[2]
+      expect(@lines[2]).to eq(EXPECTED_RAW_LINES[2])
     end
 
     it "will read Q-task_id lines correctly" do
-      @lines[3].should == EXPECTED_RAW_LINES[3]
+      expect(@lines[3]).to eq(EXPECTED_RAW_LINES[3])
     end
 
     it "will read Q-task_id lines that do not have GUIDs correctly" do
-      @lines[4].should == EXPECTED_RAW_LINES[4]
+      expect(@lines[4]).to eq(EXPECTED_RAW_LINES[4])
     end
 
     it "will read lines with a numeric starting message correctly" do
-      @lines[5].should == EXPECTED_RAW_LINES[5]
+      expect(@lines[5]).to eq(EXPECTED_RAW_LINES[5])
     end
   end
 
   shared_examples_for "all line processors" do
     it "will read regular lines correctly" do
-      @lines[0].should == EXPECTED_LINE_PARTS[0]
+      expect(@lines[0]).to eq(EXPECTED_LINE_PARTS[0])
     end
 
     it "will read lines with shortened pid/tid correctly" do
-      @lines[1].should == EXPECTED_LINE_PARTS[1]
+      expect(@lines[1]).to eq(EXPECTED_LINE_PARTS[1])
     end
 
     it "will read multi-line lines correctly" do
-      @lines[2].should == EXPECTED_LINE_PARTS[2]
+      expect(@lines[2]).to eq(EXPECTED_LINE_PARTS[2])
     end
 
     it "will read Q-task_id lines correctly" do
-      @lines[3].should == EXPECTED_LINE_PARTS[3]
+      expect(@lines[3]).to eq(EXPECTED_LINE_PARTS[3])
     end
 
     it "will read Q-task_id lines that do not have GUIDs correctly" do
-      @lines[4].should == EXPECTED_LINE_PARTS[4]
+      expect(@lines[4]).to eq(EXPECTED_LINE_PARTS[4])
     end
 
     it "will read lines with a numeric starting message correctly" do
-      @lines[5].should == EXPECTED_LINE_PARTS[5]
+      expect(@lines[5]).to eq(EXPECTED_LINE_PARTS[5])
     end
   end
 

--- a/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/gems/pending/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -3,7 +3,7 @@ require "util/mount/miq_generic_mount_session"
 
 describe MiqGenericMountSession do
   it "#connect returns a string pointing to the mount point" do
-    described_class.stub(:raw_disconnect)
+    allow(described_class).to receive(:raw_disconnect)
     s = described_class.new(:uri => '/tmp/abc')
     s.logger = Logger.new("/dev/null")
 

--- a/gems/pending/spec/util/system/evm_watchdog_spec.rb
+++ b/gems/pending/spec/util/system/evm_watchdog_spec.rb
@@ -5,17 +5,17 @@ require 'util/system/evm_watchdog'
 
 describe EvmWatchdog do
   before(:each) do
-    EvmWatchdog.stub(:`).and_raise("Shell access via backtick is unavailable in unit tests.")
+    allow(EvmWatchdog).to receive(:`).and_raise("Shell access via backtick is unavailable in unit tests.")
   end
 
   it ".read_pid_file" do
     pid_contents = StringIO.new("10041")
-    described_class.read_pid_file(pid_contents).should == "10041"
+    expect(described_class.read_pid_file(pid_contents)).to eq("10041")
   end
 
   it ".get_ps_pids" do
     described_class.stub(:ps_for_process => "10041\n26726\n26729\n")
-    described_class.get_ps_pids("some_running_process").should == [10041, 26726, 26729]
+    expect(described_class.get_ps_pids("some_running_process")).to eq([10041, 26726, 26729])
   end
 
   context ".check_evm" do
@@ -26,7 +26,7 @@ describe EvmWatchdog do
 
     it "Empty Pid File." do
       described_class.stub(:read_pid_file => "", :get_ps_pids => nil)
-      described_class.should_receive(:log_info).with { |msg| msg.include?("empty PID file") }
+      expect(described_class).to receive(:log_info).with { |msg| msg.include?("empty PID file") }
       described_class.check_evm
     end
 
@@ -37,14 +37,14 @@ describe EvmWatchdog do
 
     it "Pid File Includes 'no_db' and db is up." do
       described_class.stub(:read_pid_file => "no_db", :get_ps_pids => nil, :get_db_state => "something")
-      described_class.should_receive(:log_info).with { |msg| msg.include?("database is now available") }
-      described_class.should_receive(:start_evm).once
+      expect(described_class).to receive(:log_info).with { |msg| msg.include?("database is now available") }
+      expect(described_class).to receive(:start_evm).once
       described_class.check_evm
     end
 
     it "Pid File Includes unexpected text." do
       described_class.stub(:read_pid_file => "oranges", :get_ps_pids => nil)
-      described_class.should_receive(:log_info).with { |msg| msg.include?("non-numeric PID file") }
+      expect(described_class).to receive(:log_info).with { |msg| msg.include?("non-numeric PID file") }
       described_class.check_evm
     end
 
@@ -55,22 +55,22 @@ describe EvmWatchdog do
 
     it "Pid not running, DB down." do
       described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "")
-      described_class.should_receive(:log_info).with { |msg| msg.include?("database is down") }
+      expect(described_class).to receive(:log_info).with { |msg| msg.include?("database is down") }
       described_class.check_evm
     end
 
     ['started', 'starting'].each do |state|
       it "Pid not running, DB up, state '#{state}'." do
         described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => state)
-        described_class.should_receive(:log_info).with { |msg| msg.include?("is no longer running") }
-        described_class.should_receive(:start_evm).once
+        expect(described_class).to receive(:log_info).with { |msg| msg.include?("is no longer running") }
+        expect(described_class).to receive(:start_evm).once
         described_class.check_evm
       end
     end
 
     it "Pid not running, DB up, any other state." do
       described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "killed")
-      described_class.should_receive(:log_info).with { |msg| msg.include?("server state should be") }
+      expect(described_class).to receive(:log_info).with { |msg| msg.include?("server state should be") }
       described_class.check_evm
     end
   end

--- a/gems/pending/spec/util/vmdb-logger_spec.rb
+++ b/gems/pending/spec/util/vmdb-logger_spec.rb
@@ -4,7 +4,7 @@ require 'util/vmdb-logger'
 describe VMDBLogger do
   it ".contents with no log returns empty string" do
     File.stub(:file? => false)
-    VMDBLogger.contents("mylog.log").should == ""
+    expect(VMDBLogger.contents("mylog.log")).to eq("")
   end
 
   it ".contents with empty log returns empty string" do
@@ -12,7 +12,7 @@ describe VMDBLogger do
     MiqSystem.stub(:tail => "")
 
     File.stub(:file? => true)
-    VMDBLogger.contents("mylog.log").should == ""
+    expect(VMDBLogger.contents("mylog.log")).to eq("")
   end
 
   context "with evm log snippet with invalid utf8 byte sequence data" do
@@ -26,12 +26,12 @@ describe VMDBLogger do
       end
 
       it "should have content with the invalid utf8 lines" do
-        @data.should_not be_nil
-        @data.kind_of?(String).should be_true
+        expect(@data).not_to be_nil
+        expect(@data.kind_of?(String)).to be_truthy
       end
 
       it "should unpack raw data as UTF-8 characters and raise ArgumentError" do
-        lambda { @data.unpack("U*") }.should raise_error(ArgumentError)
+        expect { @data.unpack("U*") }.to raise_error(ArgumentError)
       end
     end
 
@@ -42,12 +42,12 @@ describe VMDBLogger do
       end
 
       it "should have content but without the invalid utf8 lines" do
-        @contents.should_not be_nil
-        @contents.kind_of?(String).should be_true
+        expect(@contents).not_to be_nil
+        expect(@contents.kind_of?(String)).to be_truthy
       end
 
       it "should unpack logger.consents as UTF-8 characters and raise nothing" do
-        lambda { @contents.unpack("U*") }.should_not raise_error
+        expect { @contents.unpack("U*") }.not_to raise_error
       end
     end
 
@@ -58,12 +58,12 @@ describe VMDBLogger do
       end
 
       it "should have content but without the invalid utf8 lines" do
-        @contents.should_not be_nil
-        @contents.kind_of?(String).should be_true
+        expect(@contents).not_to be_nil
+        expect(@contents.kind_of?(String)).to be_truthy
       end
 
       it "should unpack logger.consents as UTF-8 characters and raise nothing" do
-        lambda { @contents.unpack("U*") }.should_not raise_error
+        expect { @contents.unpack("U*") }.not_to raise_error
       end
     end
 
@@ -74,26 +74,26 @@ describe VMDBLogger do
       end
 
       it "should have content but without the invalid utf8 lines" do
-        @contents.should_not be_nil
-        @contents.kind_of?(String).should be_true
+        expect(@contents).not_to be_nil
+        expect(@contents.kind_of?(String)).to be_truthy
       end
 
       it "should unpack logger.consents as UTF-8 characters and raise nothing" do
-        lambda { @contents.unpack("U*") }.should_not raise_error
+        expect { @contents.unpack("U*") }.not_to raise_error
       end
     end
 
     context "encoding" do
       it "with ascii file" do
         log = File.expand_path(File.join(File.dirname(__FILE__), "data/miq_ascii.log"))
-        VMDBLogger.new(log).contents.encoding.name.should == "UTF-8"
-        VMDBLogger.new(log).contents(100, nil).encoding.name.should == "UTF-8"
+        expect(VMDBLogger.new(log).contents.encoding.name).to eq("UTF-8")
+        expect(VMDBLogger.new(log).contents(100, nil).encoding.name).to eq("UTF-8")
       end
 
       it "with utf-8 file" do
         log = File.expand_path(File.join(File.dirname(__FILE__), "data/miq_utf8.log"))
-        VMDBLogger.new(log).contents.encoding.name.should == "UTF-8"
-        VMDBLogger.new(log).contents(100, nil).encoding.name.should == "UTF-8"
+        expect(VMDBLogger.new(log).contents.encoding.name).to eq("UTF-8")
+        expect(VMDBLogger.new(log).contents(100, nil).encoding.name).to eq("UTF-8")
       end
     end
   end

--- a/gems/pending/spec/util/win32/miq-powershell_spec.rb
+++ b/gems/pending/spec/util/win32/miq-powershell_spec.rb
@@ -15,15 +15,15 @@ describe MiqPowerShell do
     hash = ps_array.first
 
     # Time value contains timezone offset (localtime)
-    hash[:ps_time][:DT].should == Time.parse("2012-12-10T14:44:07.0033672-06:00")
-    hash[:ps_time][:DT].utc?.should == false
+    expect(hash[:ps_time][:DT]).to eq(Time.parse("2012-12-10T14:44:07.0033672-06:00"))
+    expect(hash[:ps_time][:DT].utc?).to eq(false)
 
     # Time value contains timezone offset (UTC)
-    hash[:ps_time_utc].should == Time.parse("2012-12-10T20:44:07.0033672Z")
-    hash[:ps_time_utc].utc?.should == true
+    expect(hash[:ps_time_utc]).to eq(Time.parse("2012-12-10T20:44:07.0033672Z"))
+    expect(hash[:ps_time_utc].utc?).to eq(true)
 
     # Time value does not contain timezone (Treat as UTC)
-    hash[:xen_desktop_time].should == Time.parse("2012-12-10T20:43:29.649091Z")
-    hash[:xen_desktop_time].utc?.should == true
+    expect(hash[:xen_desktop_time]).to eq(Time.parse("2012-12-10T20:43:29.649091Z"))
+    expect(hash[:xen_desktop_time].utc?).to eq(true)
   end
 end

--- a/gems/pending/spec/util/win32/wim_parser_spec.rb
+++ b/gems/pending/spec/util/win32/wim_parser_spec.rb
@@ -13,7 +13,7 @@ describe WimParser do
 
   context "#header" do
     it "with a WIM file" do
-      @wim_parser.header.should == {
+      expect(@wim_parser.header).to eq({
         "image_tag"                   => "MSWIM\0\0\0",
         "size"                        => 208,
         "version"                     => 68864,
@@ -41,17 +41,17 @@ describe WimParser do
         "integrity_offset"            => 0,
         "integrity_original_size"     => 0,
         "unused"                      => ("\0" * 60),
-      }
+      })
     end
 
     it "with a non-WIM file" do
       w = WimParser.new(__FILE__)
-      lambda { w.header }.should raise_error
+      expect { w.header }.to raise_error
     end
   end
 
   it "#xml_data" do
-    @wim_parser.xml_data.should == {
+    expect(@wim_parser.xml_data).to eq({
       "total_bytes" => 2404,
       "images"      => [
         {
@@ -77,6 +77,6 @@ describe WimParser do
           "last_modification_time" => Time.parse("2012-09-01 04:08:59 UTC"),
         },
       ]
-    }
+    })
   end
 end

--- a/gems/pending/spec/util/xml/miq_rexml_spec.rb
+++ b/gems/pending/spec/util/xml/miq_rexml_spec.rb
@@ -9,7 +9,7 @@ describe MIQRexml do
     copyright_char = "\xC2\xAE"
     attr_string = "string #{copyright_char}"
     xml.root.add_element("element_1", 'attr1' => attr_string)
-    xml.root.elements[1].attributes['attr1'].should == attr_string
+    expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
 
   it "load document encoding" do
@@ -17,7 +17,7 @@ describe MIQRexml do
     attr_string = "string #{copyright_char}"
     doc_text = "<test><element_1 attr1='#{attr_string}'/></test>"
     xml = MiqXml.load(doc_text)
-    xml.root.elements[1].attributes['attr1'].should == attr_string
+    expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
 
   it "load document with UTF-8 BOM" do
@@ -26,6 +26,6 @@ describe MIQRexml do
     doc_text = "#{utf8_bom}<test><element_1 attr1='#{attr_string}'/></test>"
 
     xml = MiqXml.load(doc_text)
-    xml.root.elements[1].attributes['attr1'].should == attr_string
+    expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
 end

--- a/gems/pending/spec/vmware/esx_thumb_print_spec.rb
+++ b/gems/pending/spec/vmware/esx_thumb_print_spec.rb
@@ -15,33 +15,33 @@ describe ESXThumbPrint do
   end
 
   it ".new" do
-    @tp.user.should == USER
-    @tp.host.should == HOST
-    @tp.password.should == PASSWORD
-    @tp.should be_kind_of(ESXThumbPrint)
-    @tp.should_not be_kind_of(VcenterThumbPrint)
-    @tp.should be_kind_of(ThumbPrint)
+    expect(@tp.user).to eq(USER)
+    expect(@tp.host).to eq(HOST)
+    expect(@tp.password).to eq(PASSWORD)
+    expect(@tp).to be_kind_of(ESXThumbPrint)
+    expect(@tp).not_to be_kind_of(VcenterThumbPrint)
+    expect(@tp).to be_kind_of(ThumbPrint)
   end
 
   it ".new_http_request" do
     req = @tp.http_request
-    req.should be_kind_of(Net::HTTP::Get)
-    @tp.http.verify_mode.should == OpenSSL::SSL::VERIFY_NONE
+    expect(req).to be_kind_of(Net::HTTP::Get)
+    expect(@tp.http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
   end
 
   it ".new_uri" do
     uri = @tp.uri
-    uri.should be_kind_of(URI::HTTPS)
-    uri.host.should be_kind_of(String)
-    uri.host.should == HOST
-    uri.port.should be_kind_of(Integer)
-    uri.port.should == 443
+    expect(uri).to be_kind_of(URI::HTTPS)
+    expect(uri.host).to be_kind_of(String)
+    expect(uri.host).to eq(HOST)
+    expect(uri.port).to be_kind_of(Integer)
+    expect(uri.port).to eq(443)
   end
 
   it ".generates_a_sha1" do
     @tp.cert = CERT
     sha1 = @tp.to_sha1
-    sha1.should be_kind_of(String)
-    sha1.should == SHA1
+    expect(sha1).to be_kind_of(String)
+    expect(sha1).to eq(SHA1)
   end
 end

--- a/gems/pending/spec/vmware/vcenter_thumb_print_spec.rb
+++ b/gems/pending/spec/vmware/vcenter_thumb_print_spec.rb
@@ -10,24 +10,24 @@ describe VcenterThumbPrint do
   end
 
   it ".new" do
-    @tp.host.should == VCHOST
-    @tp.should be_kind_of(VcenterThumbPrint)
-    @tp.should_not be_kind_of(ESXThumbPrint)
-    @tp.should be_kind_of(ThumbPrint)
+    expect(@tp.host).to eq(VCHOST)
+    expect(@tp).to be_kind_of(VcenterThumbPrint)
+    expect(@tp).not_to be_kind_of(ESXThumbPrint)
+    expect(@tp).to be_kind_of(ThumbPrint)
   end
 
   it ".new_http_object" do
     http = @tp.http
-    http.should be_kind_of(Net::HTTP)
-    @tp.http.verify_mode.should == OpenSSL::SSL::VERIFY_NONE
+    expect(http).to be_kind_of(Net::HTTP)
+    expect(@tp.http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
   end
 
   it ".new_uri" do
     uri = @tp.uri
-    uri.should be_kind_of(URI::HTTPS)
-    uri.host.should be_kind_of(String)
-    uri.host.should == VCHOST
-    uri.port.should be_kind_of(Integer)
-    uri.port.should == 443
+    expect(uri).to be_kind_of(URI::HTTPS)
+    expect(uri.host).to be_kind_of(String)
+    expect(uri.host).to eq(VCHOST)
+    expect(uri.port).to be_kind_of(Integer)
+    expect(uri.port).to eq(443)
   end
 end


### PR DESCRIPTION
Converts gems/pending spec to newer `expect` syntax in preparation for RSpec 3

Punting on Rubocop violations for this conversion.