### PR TITLE
Fix css scoping - container topology and import policy

### DIFF
--- a/app/assets/stylesheets/container_topology.css
+++ b/app/assets/stylesheets/container_topology.css
@@ -5,20 +5,21 @@ kubernetes-topology-graph {
     width: 98%;
     padding: 10px;
 }
-.legend {
+
+.container_topology .legend {
     font-family: sans-serif;
     font-size: 15px;
     display: inline-block;
     vertical-align: middle;
 }
 
-.legend label {
+.container_topology .legend label {
     font-weight: 400;
     cursor: pointer;
     vertical-align: 10px;
 }
 
-.checkbox-inline {
+.container_topology .checkbox-inline {
     font-size: 16px;
     padding-right: 10px;
 }
@@ -37,7 +38,7 @@ kubernetes-topology-graph {
     border-radius: 5px;
 }
 
-.refresh {
+.container_topology .refresh {
     float: right;
     font-size: 16px;
 }
@@ -57,7 +58,7 @@ kubernetes-topology-graph {
     font-size: 20px;
 }
 
-#selected {
+.container_topology #selected {
     float: right;
     display: block;
     margin-top: 15px;
@@ -101,7 +102,7 @@ kubernetes-topology-icon svg {
   stroke-width: 2px;
 }
 
-g.EntityLegend {
+.container_topology g.EntityLegend {
     transform: translate(21px,21px);
 }
 
@@ -109,12 +110,13 @@ g.EntityLegend {
     fill: #636363;
 }
 
-.kube-topology g.EntityLegend.Containers text{
+.kube-topology g.EntityLegend.Containers text {
     fill: #1186C1;
     font-size: 22px;
 }
 
-.kube-topology g.EntityLegend.Containers.Pod text, .kube-topology g.EntityLegend.Containers.Container text  {
+.kube-topology g.EntityLegend.Containers.Pod text,
+.kube-topology g.EntityLegend.Containers.Container text {
     font-family: FontAwesome;
     font-size: 19px;
 }
@@ -123,4 +125,3 @@ g.EntityLegend {
     font-size: 12px;
     fill: black;
 }
-

--- a/app/assets/stylesheets/import_policy.css
+++ b/app/assets/stylesheets/import_policy.css
@@ -2,24 +2,21 @@
   height: 500px;
   width: 1000px;
 }
-.cell-title {
-
-}
-.cell-effort-driven {
+#import_grid .cell-effort-driven {
   text-align: center;
 }
-.toggle {
+#import_grid .toggle {
   height: 14px;
   width: 18px;
   display: inline-block;
 }
-.toggle.expand {
+#import_grid .toggle.expand {
   background: url(/images/layout/plus.gif) no-repeat center center;
 }
-.toggle.collapse {
+#import_grid .toggle.collapse {
   background: url(/images/layout/minus.gif) no-repeat center center;
 }
-.slick-row {
+#import_grid .slick-row {
   margin-left: 0px;
 }
-.odd {background: #f5f5f5}
+#import_grid .odd {background: #f5f5f5}

--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -1,4 +1,4 @@
-%div{'data-ng-app' => "topologyApp", 'ng-controller' => "containerTopologyController"}
+.container_topology{'data-ng-app' => "topologyApp", 'ng-controller' => "containerTopologyController"}
   .topology_header
     .refresh
       %label.checkbox-inline


### PR DESCRIPTION
..Because `container-topology.css` should not really override `.legend` for the whole ManageIQ... (etc.)

Refs: #6076, #6058 .
Cc: @abonas , @skateman , @kbrock 

In container topology, I added a `.container_topology` toplevel class and scope all non-/topology/ css rules under that. Similar change for import_policy, except those are just for the `#import_grid`.