### PR TITLE
Better handling of duplicate GCE flavors

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
@@ -40,7 +40,9 @@ module ManageIQ::Providers
       end
 
       def get_flavors
-        flavors = @connection.flavors.all
+        # connection.flavors returns a duplicate flavor for every zone
+        # so build a unique list of flavors using the flavor id
+        flavors = @connection.flavors.to_a.uniq(&:id)
         process_collection(flavors, :flavors) { |flavor| parse_flavor(flavor) }
       end
 
@@ -71,7 +73,7 @@ module ManageIQ::Providers
           uid, new_result = yield(item)
           next if uid.nil?
 
-          @data[key] |= [new_result]
+          @data[key] << new_result
           @data_index.store_path(key, uid, new_result)
         end
       end

--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -122,12 +122,12 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :cpu_shares_level      => nil
     )
 
-    expect(v.ext_management_system).to eql(@ems)
-    expect(v.availability_zone).to eql(@zone)
-    #TODO parse instance flavor v.flavor.should eql(@flavor)
-    #TODO parse instance OS v.operating_system.product_name.should eql("Red Hat Enterprise Linux")
-    expect(v.custom_attributes.size).to eql(0)
-    expect(v.snapshots.size).to         eql(0)
+    expect(v.ext_management_system).to         eql(@ems)
+    expect(v.availability_zone).to             eql(@zone)
+    expect(v.flavor).to                        eql(@flavor)
+    expect(v.operating_system.product_name).to eql("linux_redhat")
+    expect(v.custom_attributes.size).to        eql(0)
+    expect(v.snapshots.size).to                eql(0)
 
     assert_specific_vm_powered_on_hardware(v)
   end
@@ -144,7 +144,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :virtualization_type => nil
     )
 
-    expect(v.hardware.disks.size).to         eql(1) # TODO: Change to a flavor that has disks
+    expect(v.hardware.disks.size).to         eql(1)
     expect(v.hardware.guest_devices.size).to eql(0)
     expect(v.hardware.nics.size).to          eql(0)
 


### PR DESCRIPTION
GCE returns a duplicate flavor for every zone, so 228 flavors end up being returned for just 18 flavor types.  This was causing problems when linking instances to flavors when using the @data_index.

cc @blomquisg @lwander