### PR TITLE
Fix condition in tenancy scoping

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1913,7 +1913,8 @@ class VmOrTemplate < ActiveRecord::Base
     vm_tenant_ids       = Vm.accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(Vm))
     return if template_tenant_ids.empty? && vm_tenant_ids.empty?
 
-    ["(template = true AND tenant_id IN (?)) OR (template = false AND tenant_id IN (?))", template_tenant_ids, vm_tenant_ids]
+    ["(vms.template = true AND vms.tenant_id IN (?)) OR (vms.template = false AND vms.tenant_id IN (?))",
+     template_tenant_ids, vm_tenant_ids]
   end
 
   private


### PR DESCRIPTION
I have non admin user and when I click on:
Infrastructure -> Virtual Machines
I am getting error 
```
[----] F, [2016-01-07T16:07:10.435522 #238:3fcebd05e1fc] FATAL -- : Error caught: [PG::AmbiguousColumn] ERROR:  column reference "tenant_id" is ambiguous
LINE 1: ...mplate','TemplateXen')) AND ((template = true AND tenant_id ...
```

@gtanzillo @jrafanie is this fix ok ? or is there better way ?

I think that we cannnot use partial relation here because method merge_where_clauses (
https://github.com/ManageIQ/manageiq/blob/master/app/models/rbac.rb#L281 ) is expecting array of sql condintion is we have in self.tenant_id_clause(https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1916). 

original PR: https://github.com/ManageIQ/manageiq/pull/5898