### PR TITLE
angular directives - split start-form-div from auto-focus

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require directives/verifypasswd
 //= require directives/required_depends_on
 //= require directives/selectpickerForSelectTag
+//= require directives/start_form_div
 //= require directives/repository/valid_unc_path
 //= require services/miq_service
 //= require services/timer_option_service

--- a/app/assets/javascripts/directives/autofocus.js
+++ b/app/assets/javascripts/directives/autofocus.js
@@ -4,12 +4,6 @@ ManageIQ.angularApplication.directive('autoFocus', ['$timeout', function($timeou
     link: function (scope, elem, attr, ctrl) {
       scope['form_focus_' + ctrl.$name] = elem[0];
 
-      scope.$watch(scope['afterGet'], function() {
-        $timeout(function () {
-          angular.element('#' + attr.startFormDiv).css('display', 'block');
-        }, 0);
-      });
-
       scope.$watch(function() { return elem.is(':visible') }, function() {
         if(attr.autoFocus == "" || attr.autoFocus == "proactiveFocus") {
           angular.element(scope['form_focus_' + ctrl.$name]).focus();

--- a/app/assets/javascripts/directives/start_form_div.js
+++ b/app/assets/javascripts/directives/start_form_div.js
@@ -1,0 +1,11 @@
+ManageIQ.angularApplication.directive('startFormDiv', ['$timeout', function($timeout) {
+  return {
+    link: function(scope, elem, attr) {
+      scope.$watch(scope['afterGet'], function() {
+        $timeout(function () {
+          angular.element('#' + attr.startFormDiv).show();
+        });
+      });
+    },
+  };
+}]);

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -7,7 +7,8 @@
                  "form-fields-url" => "/#{controller_name}/host_form_fields/",
                  "create-url"      => "/#{controller_name}/create/",
                  "update-url"      => "/#{controller_name}/update/",
-                 "novalidate"      => true}
+                 "novalidate"      => true,
+                 "start-form-div"  => "start_form_div"}
     = render :partial => "layouts/flash_msg"
     - if session[:host_items].nil?
       %div
@@ -23,8 +24,7 @@
                                   "maxlength"      => "#{MAX_NAME_LEN}",
                                   "miqrequired"    => "",
                                   "checkchange"    => "",
-                                  "auto-focus"     => "",
-                                  "start-form-div" => "start_form_div"}
+                                  "auto-focus"     => ""}
               %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
                 = _("Required")
           .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}"}


### PR DESCRIPTION
in Host form editor, when more than one item is selected, the div that has auto-focus is not actually rendered (ruby-side), so the whole div was never un-hidden

this splits the start-form-div functionality into a separate directive, and moves it to the form in that case.

Other uses of start-form-div can stay the same.

https://bugzilla.redhat.com/show_bug.cgi?id=1296258

@AparnaKarve can you review, please?
Cc: @skateman 