### PR TITLE
Appended time to filename for downloadable saved reports.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -290,7 +290,7 @@ class ApplicationController < ActionController::Base
   def send_report_data
     if @sb[:render_rr_id]
       rr = MiqReportResult.find(@sb[:render_rr_id])
-      filename = rr.report.title + "_" + format_timezone(Time.now, Time.zone, "fname")
+      filename = rr.report.title + "_" + format_timezone(Time.zone.now, Time.zone, "export_filename")
       disable_client_cache
       generated_result = rr.get_generated_result(@sb[:render_type])
       rr.destroy

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -251,6 +251,10 @@ class MiqReportResult < ActiveRecord::Base
 
       new_res = build_new_result(options.merge(:userid => userid))
 
+      # temporarily stick last_run_on time into report object
+      # to be used by report_formatter while generating downloadable text report
+      rpt.rpt_options.merge!(:last_run_on => last_run_on) if result_type.to_sym == :txt
+
       new_res.report_results = user.with_my_timezone do
         case result_type.to_sym
         when :csv then rpt.to_csv

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -237,7 +237,9 @@ module ReportFormatter
       end
 
       output << @hr
-      cr = format_timezone(Time.now, tz).to_s # Label footer with current time in selected time zone
+      # Label footer with last run on time of selected report or current time for other downloads
+      last_run_on = mri.rpt_options && mri.rpt_options[:last_run_on] || Time.zone.now
+      cr = format_timezone(last_run_on, tz).to_s
       f = cr.center(@line_len - 2)
       output << fit_to_width("|#{f}|" + CRLF)
       output << @hr


### PR DESCRIPTION
Fixed Date/Time displayed in the footer in text version of downloadable  saved reports to show time of when the saved report was last run instead of displaying time when it was downloaded.

https://bugzilla.redhat.com/show_bug.cgi?id=1196377
https://bugzilla.redhat.com/show_bug.cgi?id=1292579
https://bugzilla.redhat.com/show_bug.cgi?id=1292574

@dclarizio please review

before:
![date_in_footer_before](https://cloud.githubusercontent.com/assets/3450808/12179543/85640f3e-b545-11e5-9ecf-204f4e99d200.png)

![report_download_before](https://cloud.githubusercontent.com/assets/3450808/12179542/8562d754-b545-11e5-85bf-8f8a675b5e0f.png)

after:
![date_in_footer_after](https://cloud.githubusercontent.com/assets/3450808/12179546/8bab0f3c-b545-11e5-9bcf-274c72d1144a.png)

![appended_time_in_filename](https://cloud.githubusercontent.com/assets/3450808/12179547/8bb53ce6-b545-11e5-82a5-1b207281a70e.png)

