### PR TITLE
Changed to ignore case sensitive of snapshot status

### DIFF
--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -74,7 +74,7 @@ class MiqOpenStackInstance
     miq_snapshot = Fog::Image::OpenStack::Image.new(rv.body['image'])
     miq_snapshot.collection = image_service.images
 
-    until miq_snapshot.status == "active"
+    until miq_snapshot.status.upcase == "ACTIVE"
       $log.debug "#{log_prefix}: #{miq_snapshot.status}"
       sleep 1
       miq_snapshot.reload


### PR DESCRIPTION
Current validation of snapshot creation is case sensitive. The smart state analysis job will hang and time out if the case of snapshot's status does not match. Fixed to change into case insensitive in the valiation logic.

This PR is for the issue #6039.