### PR TITLE
Fix faulty MIQExtract exception + spec

### DIFF
--- a/gems/pending/metadata/VmConfig/VmConfig.rb
+++ b/gems/pending/metadata/VmConfig/VmConfig.rb
@@ -24,11 +24,14 @@ class VmConfig
       if filename.index("\n")
         f = filename
       else
-        # raise "Cannot open config file: [#{filename}]" if not File.file?(filename)
         set_vmconfig_path(filename)
 
-        configType = File.extname(filename).delete(".").downcase
-        require "metadata/VmConfig/#{configType}Config"
+        begin
+          configType = File.extname(filename).delete(".").downcase
+          require "metadata/VmConfig/#{configType}Config"
+        rescue LoadError => e
+          raise e, "Filetype unrecognized for file #{filename}"
+        end
         extend Kernel.const_get(configType.capitalize + "Config")
         f = convert(filename)
       end

--- a/gems/pending/spec/metadata/MIQExtract/MIQExtract_spec.rb
+++ b/gems/pending/spec/metadata/MIQExtract/MIQExtract_spec.rb
@@ -6,7 +6,7 @@ describe MIQExtract do
     @test_password = "v1:{acd1234567890ACEGIKzwusq/+==}"
 
     @original_log = $log
-    $log = double
+    $log = double(:info => nil, :debug => nil, :warn => nil, :error => nil)
   end
 
   after do
@@ -51,7 +51,8 @@ describe MIQExtract do
 
       expect($log).to receive(:info).with(/ems/)
       expect($log).not_to receive(:info).with(/#{@test_password}/)
-      expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
+      expect { MIQExtract.new("/bad/file/path", ost) }
+        .to raise_exception(LoadError, /Filetype unrecognized for file \/bad\/file\/path/)
     end
 
     it "when no password is found in the input data" do
@@ -89,7 +90,8 @@ describe MIQExtract do
 
       expect($log).to receive(:info).with(/ems/)
       expect($log).not_to receive(:info).with(/#{@test_password}/)
-      expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
+      expect { MIQExtract.new("/bad/file/path", ost) }
+        .to raise_exception(LoadError, /Filetype unrecognized for file \/bad\/file\/path/)
     end
 
     it "when one password is found in the input data and masked in the log file" do
@@ -128,7 +130,8 @@ describe MIQExtract do
 
       expect($log).to receive(:info).with(/ems/)
       expect($log).not_to receive(:info).with(/#{@test_password}/)
-      expect { MIQExtract.new("/bad/file/path", ost) }.to raise_exception
+      expect { MIQExtract.new("/bad/file/path", ost) }
+        .to raise_exception(LoadError, /Filetype unrecognized for file \/bad\/file\/path/)
     end
   end
 end


### PR DESCRIPTION
The spec here has been a false positive for quite a long time; I discovered it while adding fully qualified errors to raise_error matchers (to avoid this sort of thing from happening!). It is expecting the LoadError in the class from trying to load the file type config when indeed it's actually throwing an RSpec Mocks exception from the double receiving an unexpected message.

The LoadError 'properly' given is somewhat odd as if configType is nil (invalid), the message will be "could not load 'metadata/VmConfig/Config'"

This fixes the spec and refines the error thrown to be more helpful.