### PR TITLE
Add specific errors to uses of raise_error matcher

### DIFF
--- a/gems/pending/spec/util/win32/wim_parser_spec.rb
+++ b/gems/pending/spec/util/win32/wim_parser_spec.rb
@@ -46,7 +46,7 @@ describe WimParser do
 
     it "with a non-WIM file" do
       w = WimParser.new(__FILE__)
-      expect { w.header }.to raise_error
+      expect { w.header }.to raise_error(RuntimeError, /is not a WIM file/)
     end
   end
 

--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -65,7 +65,8 @@ describe "FilterByDialogParameters Automate Method" do
       st = ServiceTemplate.find_by_name('vm_service')
       svc = FactoryGirl.create(:service)
 
-      expect { run_automate_method(st, root_service_template_task, svc) }.to raise_exception
+      expect { run_automate_method(st, root_service_template_task, svc) }
+        .to raise_error(MiqAeException::UnknownMethodRc)
     end
 
     it "with an invalid vm_service" do

--- a/spec/automation/unit/method_validation/remove_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/remove_from_provider_spec.rb
@@ -28,6 +28,6 @@ describe "remove_from_provider Method Validation" do
 
   it "errors for a vm equal to nil" do
     @vm_id = nil
-    expect { ws }.to raise_error
+    expect { ws }.to raise_error(MiqAeException::UnknownMethodRc)
   end
 end

--- a/spec/automation/unit/method_validation/unregister_from_provider_spec.rb
+++ b/spec/automation/unit/method_validation/unregister_from_provider_spec.rb
@@ -26,6 +26,6 @@ describe "unregister_from_provider Method Validation" do
   it "errors for a vm equal to nil" do
     @vm_id = nil
 
-    expect { ws }.to raise_error
+    expect { ws }.to raise_error(MiqAeException::UnknownMethodRc)
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -74,10 +74,10 @@ describe ApplicationController do
 
     it "should raise for less than 2 entries" do
       controller.instance_variable_set(:@breadcrumbs, [{}])
-      expect { controller.send(:previous_breadcrumb_url) }.to raise_error
+      expect { controller.send(:previous_breadcrumb_url) }.to raise_error(NoMethodError)
 
       controller.instance_variable_set(:@breadcrumbs, [])
-      expect { controller.send(:previous_breadcrumb_url) }.to raise_error
+      expect { controller.send(:previous_breadcrumb_url) }.to raise_error(NoMethodError)
     end
   end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -88,15 +88,12 @@ describe ProviderForemanController do
     end
 
     it "should not raise an error for feature that user has access to" do
-      expect do
-        controller.send(:assert_privileges, "configured_system_provision")
-      end.not_to raise_error
+      expect { controller.send(:assert_privileges, "configured_system_provision") }.not_to raise_error
     end
 
     it "should raise an error for feature that user has access to" do
-      expect do
-        controller.send(:assert_privileges, "provider_foreman_add_provider")
-      end.to raise_error
+      expect { controller.send(:assert_privileges, "provider_foreman_add_provider") }
+        .to raise_error(MiqException::RbacPrivilegeException)
     end
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -414,7 +414,8 @@ module MiqAeEngineSpec
 
       it "raise error if the object is already in the hash" do
         hash = {:a => 'A', "VmOrTemplate::vm" => Vm.first.id}
-        expect { MiqAeEngine.set_automation_attributes_from_objects([Vm.first], hash) }.to raise_error
+        expect { MiqAeEngine.set_automation_attributes_from_objects([Vm.first], hash) }
+          .to raise_error(RuntimeError, /vm already exists in hash/)
       end
     end
 

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -109,7 +109,8 @@ module MiqAeObjectSpec
       it "should raise an exception after exceeding max_time" do
         Timecop.freeze(Time.parse('2013-01-01 01:00:00 UTC')) do
           @ws.root['ae_state_started'] = '2013-01-01 00:00:00 UTC'
-          expect { @miq_obj.enforce_state_maxima({'max_time' => '1.hour'}) }.to raise_error
+          expect { @miq_obj.enforce_state_maxima('max_time' => '1.hour') }
+            .to raise_error(RuntimeError, /exceeded maximum/)
         end
       end
     end

--- a/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_machine_new_spec.rb
@@ -23,7 +23,8 @@ describe "MiqAeStateMachine" do
       let(:options) { {'ae_state_retries' => 3} }
 
       it "should raise error" do
-        expect { test_class.enforce_max_retries('max_retries' => 2) }.to raise_error
+        expect { test_class.enforce_max_retries('max_retries' => 2) }
+          .to raise_error(RuntimeError, /number of retries.*exceeded maximum/)
       end
     end
 
@@ -52,7 +53,8 @@ describe "MiqAeStateMachine" do
         Timecop.freeze do
           obj = test_class
           Timecop.travel(5) do
-            expect { obj.enforce_max_time('max_time' => 2) }.to raise_error
+            expect { obj.enforce_max_time('max_time' => 2) }
+              .to raise_error(RuntimeError, /time in state.*exceeded maximum/)
           end
         end
       end

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -98,7 +98,8 @@ describe MiqAeDatastore do
   it "temporary file cleanup for unsuccessful import" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
-    expect { MiqAeDatastore.upload(fd, "dummy.zip") }.to raise_error
+    expect { MiqAeDatastore.upload(fd, "dummy.zip") }
+      .to raise_error(/end of central directory signature not found/)
     expect(File.exist?(import_file)).to be_falsey
   end
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_orchestration_stack_spec.rb
@@ -15,7 +15,8 @@ module MiqAeServiceOrchestrationStackSpec
       end
 
       it "raises an error when adding a stack to an invalid service" do
-        expect { service_stack.add_to_service('wrong type') }.to raise_error
+        expect { service_stack.add_to_service('wrong type') }
+          .to raise_error(ArgumentError, /service must be a MiqAeServiceService/)
       end
     end
 

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -31,6 +31,7 @@ describe MiqLdap do
     if @userid
       wrong_ip = 'bugz.mycompany.com'
 
+      # TODO: A specific error should be expected here, not just any
       expect { ldap_wrong = MiqLdap.new(:host => wrong_ip) }.to raise_error
       ldap_right = MiqLdap.new(:host => @host)
 

--- a/spec/lib/vmdb/configuration_encoder_spec.rb
+++ b/spec/lib/vmdb/configuration_encoder_spec.rb
@@ -191,7 +191,7 @@ describe Vmdb::ConfigurationEncoder do
 
     it "invalid" do
       @hash = {"a" => "b"}
-      expect { subject }.to raise_error
+      expect { subject }.to raise_error(NoMethodError)
     end
   end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -280,7 +280,8 @@ describe Classification do
       it "with some errors" do
         allow(MiqEvent).to receive(:raise_evm_event).and_raise
 
-        expect { Classification.bulk_reassignment(@options) }.to raise_error
+        expect { Classification.bulk_reassignment(@options) }
+          .to raise_error(RuntimeError, /Failures occurred during bulk reassignment/)
 
         @dels.each { |d| expect(any_tagged_with(Host, d.name, d.parent.name)).to_not be_empty }
         @adds.each { |a| expect(all_tagged_with(Host, a.name, a.parent.name)).to     be_empty }

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -5,7 +5,8 @@ describe DialogGroup do
     let(:dialog_group) { FactoryGirl.build(:dialog_group, :label => 'group') }
 
     it "fails without element" do
-      expect { dialog_group.save! }.to raise_error
+      expect { dialog_group.save! }
+        .to raise_error(ActiveRecord::RecordInvalid, /Box group must have at least one Element/)
     end
 
     it "validates with at least one element" do

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -50,7 +50,8 @@ describe Dialog do
   context "validate label uniqueness" do
     it "with same label" do
       expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }.to_not raise_error
-      expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }.to raise_error
+      expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }
+        .to raise_error(ActiveRecord::RecordInvalid, /Label has already been taken/)
     end
 
     it "with different labels" do
@@ -61,13 +62,13 @@ describe Dialog do
 
   context "#create" do
     it "validates_presence_of name" do
-      expect { FactoryGirl.create(:dialog) }.to raise_error
+      expect { FactoryGirl.create(:dialog) }.to raise_error(ActiveRecord::RecordInvalid, /Label can't be blank/)
       expect { FactoryGirl.create(:dialog, :label => 'dialog') }.not_to raise_error
 
-      expect { FactoryGirl.create(:dialog_tab) }.to raise_error
+      expect { FactoryGirl.create(:dialog_tab) }.to raise_error(ActiveRecord::RecordInvalid, /Label can't be blank/)
       expect { FactoryGirl.create(:dialog_tab, :label => 'tab') }.not_to raise_error
 
-      expect { FactoryGirl.create(:dialog_group) }.to raise_error
+      expect { FactoryGirl.create(:dialog_group) }.to raise_error(ActiveRecord::RecordInvalid, /Label can't be blank/)
       expect { FactoryGirl.create(:dialog_group, :label => 'group') }.not_to raise_error
     end
   end
@@ -84,7 +85,8 @@ describe Dialog do
 
     it "destroy with resource_action association" do
       resource_action = FactoryGirl.create(:resource_action, :action => "Provision", :dialog => @dialog)
-      expect { @dialog.destroy }.to raise_error
+      expect { @dialog.destroy }
+        .to raise_error(RuntimeError, /Dialog cannot be deleted.*connected to other components/)
       expect(Dialog.count).to eq(1)
     end
   end

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -5,7 +5,8 @@ describe DialogTab do
     let(:dialog_tab) { FactoryGirl.build(:dialog_tab, :label => 'tab') }
 
     it "fails without box" do
-      expect { dialog_tab.save! }.to raise_error
+      expect { dialog_tab.save! }
+        .to raise_error(ActiveRecord::RecordInvalid, /tab must have at least one Box/)
     end
 
     it "validates with box" do

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -40,15 +40,15 @@ describe EmsCluster::CapacityPlanning do
   context "#capacity_profile_method" do
     it "with invalid values" do
       EmsCluster.capacity_settings.delete_path(:profile, :"1", :vcpu_method)
-      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error(RuntimeError, /Invalid vcpu_method/)
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "")
-      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error(RuntimeError, /Invalid vcpu_method/)
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "invalidresource_average")
-      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error(RuntimeError, /Invalid vcpu_method/)
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "vcpu_invalidalgorithm")
-      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error(RuntimeError, /Invalid vcpu_method/)
       EmsCluster.capacity_settings.store_path(:profile, :"1", :vcpu_method, "mem_average") # resource does not match profile key
-      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error
+      expect { @cluster.capacity_profile_method(1, :vcpu) }.to raise_error(RuntimeError, /Invalid vcpu_method/)
     end
 
     it "with valid values" do

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -56,11 +56,12 @@ describe Job::StateMachine do
 
   it "should raise an error if the transition is not allowed" do
     @obj.state = 'working'
-    expect { @obj.signal(:initializing) }.to raise_error
+    expect { @obj.signal(:initializing) }
+      .to raise_error(RuntimeError, /initializing is not permitted at state working/)
   end
 
   it "should raise an error if the signal is not defined" do
     @obj.state = 'working'
-    expect { @obj.signal(:wrong) }.to raise_error
+    expect { @obj.signal(:wrong) }.to raise_error(RuntimeError, /wrong is not permitted at state working/)
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -10,12 +10,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
   context "#perf_collect_metrics" do
     it "raises an error when no EMS is defined" do
       @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => nil)
-      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error
+      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /No EMS defined/)
     end
 
     it "raises an error with no EMS credentials defined" do
       @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => @ems_amazon)
-      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error
+      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /no credentials defined/)
     end
 
     it "handles when nothing is collected" do

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_spec.rb
@@ -28,19 +28,21 @@ describe ManageIQ::Providers::Amazon::CloudManager::Provision do
       expect { subject.validate_dest_name }.to_not raise_error
     end
 
-    it "with a black name" do
+    it "with a blank name" do
       allow(subject).to receive(:dest_name).and_return("")
-      expect { subject.validate_dest_name }.to raise_error
+      expect { subject.validate_dest_name }
+        .to raise_error(MiqException::MiqProvisionError, /Destination Name cannot be blank/)
     end
 
     it "with a nil name" do
       allow(subject).to receive(:dest_name).and_return(nil)
-      expect { subject.validate_dest_name }.to raise_error
+      expect { subject.validate_dest_name }
+        .to raise_error(MiqException::MiqProvisionError, /Destination Name cannot be blank/)
     end
 
     it "with a duplicate name" do
       allow(subject).to receive(:dest_name).and_return(vm.name)
-      expect { subject.validate_dest_name }.to raise_error
+      expect { subject.validate_dest_name }.to raise_error(MiqException::MiqProvisionError, /already exists/)
     end
   end
 

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -51,11 +51,13 @@ describe MiqEvent do
       end
 
       it "will raise an error for missing target" do
-        expect { MiqEvent.raise_evm_event([:MiqServer, 30000], "some_event") }.to raise_error
+        expect { MiqEvent.raise_evm_event([:MiqServer, 30_000], "some_event") }
+          .to raise_error(RuntimeError, /Unable to find object for target/)
       end
 
       it "will raise an error for nil target" do
-        expect { MiqEvent.raise_evm_event(nil, "some_event") }.to raise_error
+        expect { MiqEvent.raise_evm_event(nil, "some_event") }
+          .to raise_error(RuntimeError, /Unable to find object for target/)
       end
 
       it "will raise the event to automate given target directly" do

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -249,7 +249,7 @@ describe MiqGroup do
       FactoryGirl.create(:user, :miq_groups => [group])
 
       expect {
-        expect { group.destroy }.to raise_error
+        expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
       }.to_not change { MiqGroup.count }
     end
 
@@ -258,12 +258,13 @@ describe MiqGroup do
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
 
       expect {
-        expect { group.destroy }.to raise_error
+        expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
       }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by a tenant#default_miq_group" do
-      expect { FactoryGirl.create(:tenant).default_miq_group.reload.destroy }.to raise_error
+      expect { FactoryGirl.create(:tenant).default_miq_group.reload.destroy }
+        .to raise_error(RuntimeError, /A tenant default group can not be deleted/)
     end
   end
 
@@ -405,9 +406,8 @@ describe MiqGroup do
     it "fails for default groups" do
       tenant = FactoryGirl.create(:tenant)
       g = FactoryGirl.create(:tenant).default_miq_group
-      expect do
-        g.update_attributes!(:tenant => tenant)
-      end.to raise_error
+      expect { g.update_attributes!(:tenant => tenant) }
+        .to raise_error(ActiveRecord::RecordInvalid, /Tenant cant change the tenant of a default group/)
     end
   end
 

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -35,10 +35,12 @@ describe MiqReport do
       rpt = FactoryGirl.create(:miq_report)
 
       # Can't create a graph without a sortby column
-      expect { rpt.to_chart(@report_theme, @show_title, @options) }.to raise_exception
+      expect { rpt.to_chart(@report_theme, @show_title, @options) }
+        .to raise_error(RuntimeError, /Can't create a graph without a sortby column/)
 
       # Graph type not specified
-      expect { rpt.to_chart(@report_theme, @show_title, @options) }.to raise_exception
+      expect { rpt.to_chart(@report_theme, @show_title, @options) }
+        .to raise_error(RuntimeError, /Can't create a graph without a sortby column/)
     end
 
     it "returns an empty chart for a report with empty results" do

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -58,7 +58,7 @@ describe MiqSearch do
     # TODO: return matched_vms
     it "works with models" do
       all_vms
-      expect { vm_location_search.filtered(Vm).first }.to raise_error
+      expect { vm_location_search.filtered(Vm).first }.to raise_error(NoMethodError)
     end
 
     it "works with scopes" do

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -37,7 +37,7 @@ describe MiqWidgetSet do
     end
 
     it "the belong to group is being deleted" do
-      expect { group.destroy }.to raise_error
+      expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
       expect(MiqWidgetSet.count).to eq(2)
     end
 

--- a/spec/models/mixins/new_with_type_sti_mixin_spec.rb
+++ b/spec/models/mixins/new_with_type_sti_mixin_spec.rb
@@ -25,19 +25,30 @@ describe NewWithTypeStiMixin do
 
     context "with invalid type" do
       it "that doesn't exist" do
-        expect { Host.new(:type  => "Xxx") }.to raise_error
-        expect { Host.new("type" => "Xxx") }.to raise_error
+        expect { Host.new(:type  => "Xxx") }.to raise_error(NameError)
+        expect { Host.new("type" => "Xxx") }.to raise_error(NameError)
       end
 
       it "that isn't a subclass" do
-        expect { Host.new(:type  => "ManageIQ::Providers::Vmware::InfraManager::Vm") }.to raise_error
-        expect { Host.new("type" => "ManageIQ::Providers::Vmware::InfraManager::Vm") }.to raise_error
+        expect { Host.new(:type  => "ManageIQ::Providers::Vmware::InfraManager::Vm") }
+          .to raise_error(RuntimeError, /Vm is not a subclass of Host/)
+        expect { Host.new("type" => "ManageIQ::Providers::Vmware::InfraManager::Vm") }
+          .to raise_error(RuntimeError, /Vm is not a subclass of Host/)
 
-        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new(:type  => "Host") }.to raise_error
-        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new("type" => "Host") }.to raise_error
+        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new(:type  => "Host") }
+          .to raise_error(RuntimeError, /Host is not a subclass of ManageIQ::Providers::.*/)
+        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new("type" => "Host") }
+          .to raise_error(RuntimeError, /Host is not a subclass of ManageIQ::Providers::.*/)
 
-        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new(:type  => "ManageIQ::Providers::Redhat::InfraManager::Host") }.to raise_error
-        expect { ManageIQ::Providers::Vmware::InfraManager::Host.new("type" => "ManageIQ::Providers::Redhat::InfraManager::Host") }.to raise_error
+        expect do
+          ManageIQ::Providers::Vmware::InfraManager::Host
+            .new(:type => "ManageIQ::Providers::Redhat::InfraManager::Host")
+        end.to raise_error(RuntimeError, /ManageIQ.*Redhat.*is not a subclass of ManageIQ.*Vmware.*/)
+
+        expect do
+          ManageIQ::Providers::Vmware::InfraManager::Host
+            .new("type" => "ManageIQ::Providers::Redhat::InfraManager::Host")
+        end.to raise_error(RuntimeError, /ManageIQ.*Redhat.*is not a subclass of ManageIQ.*Vmware.*/)
       end
     end
   end

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -58,7 +58,7 @@ describe Picture do
 
   context "#basename" do
     it "fails when record is new" do
-      expect { subject.filename }.to raise_error
+      expect { subject.filename }.to raise_error(RuntimeError, /must have a numeric id/)
     end
 
     context "works when record is saved" do

--- a/spec/models/rr_pending_change_spec.rb
+++ b/spec/models/rr_pending_change_spec.rb
@@ -10,7 +10,7 @@ describe RrPendingChange do
   end
 
   it ".last_id" do
-    expect { described_class.last_id }.to raise_error
+    expect { described_class.last_id }.to raise_error(ActiveRecord::StatementInvalid)
   end
 
   context ".for_region_number" do
@@ -28,7 +28,7 @@ describe RrPendingChange do
 
     it ".last_id" do
       described_class.for_region_number(1000) do
-        expect { described_class.last_id }.to raise_error
+        expect { described_class.last_id }.to raise_error(ActiveRecord::StatementInvalid)
       end
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -137,7 +137,7 @@ describe Service do
     end
 
     it "should not allow service to connect to itself" do
-      expect { @service << @service }.to raise_error
+      expect { @service << @service }.to raise_error(MiqException::MiqServiceCircularReferenceError)
     end
 
     it "should set the group index when adding a resource" do

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -8,9 +8,8 @@ describe ServiceTemplateCatalog do
   describe "#name" do
     it "is unique per tenant" do
       FactoryGirl.create(:service_template_catalog, :name => "common", :tenant => root_tenant)
-      expect do
-        FactoryGirl.create(:service_template_catalog, :name => "common", :tenant => root_tenant)
-      end.to raise_error
+      expect { FactoryGirl.create(:service_template_catalog, :name => "common", :tenant => root_tenant) }
+        .to raise_error(ActiveRecord::RecordInvalid, /Name has already been taken/)
     end
 
     it "can be the same across tenants" do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -115,7 +115,7 @@ describe ServiceTemplate do
     end
 
     it "should not allow service templates to be connected to itself" do
-      expect { add_and_save_service(@svc_a, @svc_a) }.to raise_error
+      expect { add_and_save_service(@svc_a, @svc_a) }.to raise_error(MiqException::MiqServiceCircularReferenceError)
     end
 
     it "should not allow service templates to be connected in a circular reference" do
@@ -125,9 +125,9 @@ describe ServiceTemplate do
       expect { add_and_save_service(@svc_c, @svc_d) }.not_to raise_error
       expect { add_and_save_service(@svc_a, @svc_e) }.not_to raise_error
 
-      expect { add_and_save_service(@svc_c, @svc_a) }.to raise_error
-      expect { add_and_save_service(@svc_d, @svc_a) }.to raise_error
-      expect { add_and_save_service(@svc_c, @svc_b) }.to raise_error
+      expect { add_and_save_service(@svc_c, @svc_a) }.to raise_error(MiqException::MiqServiceCircularReferenceError)
+      expect { add_and_save_service(@svc_d, @svc_a) }.to raise_error(MiqException::MiqServiceCircularReferenceError)
+      expect { add_and_save_service(@svc_c, @svc_b) }.to raise_error(MiqException::MiqServiceCircularReferenceError)
 
       # Print tree-view of services
       # puts "\n#{svc_a.name}"
@@ -141,11 +141,11 @@ describe ServiceTemplate do
       expect { add_and_save_service(@svc_d, @svc_e) }.not_to raise_error
       expect { add_and_save_service(@svc_e, @svc_a) }.not_to raise_error
 
-      expect { add_and_save_service(@svc_c, @svc_d) }.to raise_error
+      expect { add_and_save_service(@svc_c, @svc_d) }.to raise_error(MiqException::MiqServiceCircularReferenceError)
     end
 
     it "should not allow service template to connect to self" do
-      expect { @svc_a << @svc_a }.to raise_error
+      expect { @svc_a << @svc_a }.to raise_error(MiqException::MiqServiceCircularReferenceError)
     end
 
     it "should allow service template to connect to a service with the same id" do
@@ -158,8 +158,8 @@ describe ServiceTemplate do
       add_and_save_service(@svc_a, @svc_b)
       add_and_save_service(@svc_b, @svc_c)
 
-      expect { @svc_b.destroy }.to raise_error
-      expect { @svc_c.destroy }.to raise_error
+      expect { @svc_b.destroy }.to raise_error(MiqException::MiqServiceError, /Cannot delete.*child of another service/)
+      expect { @svc_c.destroy }.to raise_error(MiqException::MiqServiceError, /Cannot delete.*child of another service/)
 
       expect { @svc_a.destroy }.not_to raise_error
       expect { @svc_b.destroy }.not_to raise_error

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -155,9 +155,8 @@ describe Tenant do
 
     it "is unique per parent tenant" do
       FactoryGirl.create(:tenant, :name => "common", :parent => root_tenant)
-      expect do
-        FactoryGirl.create(:tenant, :name => "common", :parent => root_tenant)
-      end.to raise_error
+      expect { FactoryGirl.create(:tenant, :name => "common", :parent => root_tenant) }
+        .to raise_error(ActiveRecord::RecordInvalid, /Name should be unique per parent/)
     end
 
     it "can be the same for different parents" do
@@ -358,9 +357,7 @@ describe Tenant do
       described_class.destroy_all
       root_tenant # create a root tenant
 
-      expect do
-        described_class.create!
-      end.to raise_error
+      expect { described_class.create! }.to raise_error(ActiveRecord::RecordInvalid, /Parent required/)
     end
   end
 
@@ -369,13 +366,15 @@ describe Tenant do
       tenant1 = FactoryGirl.create(:tenant)
       tenant2 = FactoryGirl.create(:tenant)
       g = FactoryGirl.create(:miq_group, :tenant => tenant1)
-      expect { tenant2.update_attributes!(:default_miq_group => g) }.to raise_error
+      expect { tenant2.update_attributes!(:default_miq_group => g) }
+        .to raise_error(ActiveRecord::RecordInvalid, /default group must be a default group for this tenant/)
     end
 
     # we may want to change this in the future
     it "prevents changing default_miq_group" do
       g = FactoryGirl.create(:miq_group, :tenant => tenant)
-      expect { tenant.update_attributes!(:default_miq_group => g) }.to raise_error
+      expect { tenant.update_attributes!(:default_miq_group => g) }
+        .to raise_error(ActiveRecord::RecordInvalid, /default group must be a default group for this tenant/)
     end
   end
 
@@ -383,7 +382,7 @@ describe Tenant do
     it "wouldn't delete tenant with groups associated" do
       tenant = FactoryGirl.create(:tenant)
       FactoryGirl.create(:miq_group, :tenant => tenant)
-      expect { tenant.destroy! }.to raise_error
+      expect { tenant.destroy! }.to raise_error(RuntimeError, /A tenant with groups.*cannot be deleted/)
     end
   end
 


### PR DESCRIPTION
Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call.

Along with #6091, these are all cases of this issue.