### PR TITLE
[api] Simplify hash matching in specs

### DIFF
--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -272,15 +272,12 @@ module ApiSpecHelper
   end
 
   def expect_result_to_match_hash(result, attr_hash)
-    fetch_value(attr_hash).each do |key, value|
-      expect(result).to have_key(key)
+    attr_hash = fetch_value(attr_hash)
+    attr_hash.each do |key, value|
       value = fetch_value(value)
-      if key == "href" || key.ends_with?("_href") || value.kind_of?(Regexp)
-        expect(result[key]).to match(value)
-      else
-        expect(result[key]).to eq(value)
-      end
+      attr_hash[key] = (key == "href" || key.ends_with?("_href")) ? a_string_matching(value) : value
     end
+    expect(result).to include(attr_hash)
   end
 
   def expect_results_to_match_hash(collection, result_hash)


### PR DESCRIPTION
This was motivated by a couple of things:

1. Delete some code. Since RSpec 3 brings better support for hash
matching, we can just use its `include` and composable matchers instead
of traversing the hash and making multiple expectations on each pair.

2. Better failure messages. Before, missing keys resulted in a message
like "expected true, got false". An unmatched value would show up, but
may not be obvious what it was referring to. Now failures will show a
diff of actual and expected values.

Before:
![screenshot from 2016-01-07 14 17 15](https://cloud.githubusercontent.com/assets/1710874/12184634/41eea77c-b54b-11e5-983a-4abfbcee4038.png)

After:
![screenshot from 2016-01-07 14 18 31](https://cloud.githubusercontent.com/assets/1710874/12184647/57b1899e-b54b-11e5-9206-a4c8f4eee659.png)

(Incidentally, the diff appears to be wrong here, but that could be an issue with RSpec)

@abellotti please review
