### PR TITLE
Add method for returning serialized attributes after dynamic updates

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -104,6 +104,10 @@ class DialogField < ActiveRecord::Base
     self
   end
 
+  def update_and_serialize_values
+    DialogFieldSerializer.serialize(self)
+  end
+
   private
 
   def default_resource_action
@@ -124,5 +128,9 @@ class DialogField < ActiveRecord::Base
 
   def get_default_value
     default_value
+  end
+
+  def values_from_automate
+    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/app/models/dialog_field_check_box.rb
+++ b/app/models/dialog_field_check_box.rb
@@ -33,13 +33,13 @@ class DialogFieldCheckBox < DialogField
     {:checked => checked?}
   end
 
+  def trigger_automate_value_updates
+    values_from_automate
+  end
+
   private
 
   def required_value_error?
     value != "t"
-  end
-
-  def values_from_automate
-    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/app/models/dialog_field_date_control.rb
+++ b/app/models/dialog_field_date_control.rb
@@ -45,13 +45,13 @@ class DialogFieldDateControl < DialogField
     {:date => Date.parse(@value).strftime("%m/%d/%Y")}
   end
 
+  def trigger_automate_value_updates
+    values_from_automate
+  end
+
   private
 
   def default_time
     with_current_user_timezone { Time.zone.now + 1.day }.strftime("%m/%d/%Y")
-  end
-
-  def values_from_automate
-    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -1,7 +1,7 @@
 class DialogFieldDropDownList < DialogFieldSortedItem
   def initialize_with_values(dialog_values)
     if load_values_on_init?
-      raw_values
+      set_raw_values
       @value = value_from_dialog_fields(dialog_values) || default_value
     else
       @raw_values = initial_values
@@ -19,7 +19,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def refresh_json_value(checked_value)
     @raw_values = @default_value = nil
 
-    refreshed_values = values
+    refreshed_values = set_raw_values
 
     if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
       @value = checked_value
@@ -30,6 +30,10 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     {:refreshed_values => refreshed_values, :checked_value => @value}
   end
 
+  def trigger_automate_value_updates
+    set_raw_values
+  end
+
   private
 
   def load_values_on_init?
@@ -37,15 +41,11 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     load_values_on_init
   end
 
-  def raw_values
+  def set_raw_values
     @raw_values ||= dynamic ? values_from_automate : super
     @default_value ||= sort_data(@raw_values).first.first
     self.value ||= @default_value
 
     @raw_values
-  end
-
-  def values_from_automate
-    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -1,7 +1,7 @@
 class DialogFieldDropDownList < DialogFieldSortedItem
   def initialize_with_values(dialog_values)
     if load_values_on_init?
-      set_raw_values
+      raw_values
       @value = value_from_dialog_fields(dialog_values) || default_value
     else
       @raw_values = initial_values
@@ -19,7 +19,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def refresh_json_value(checked_value)
     @raw_values = @default_value = nil
 
-    refreshed_values = set_raw_values
+    refreshed_values = values
 
     if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
       @value = checked_value
@@ -31,7 +31,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   end
 
   def trigger_automate_value_updates
-    set_raw_values
+    raw_values
   end
 
   private
@@ -41,7 +41,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     load_values_on_init
   end
 
-  def set_raw_values
+  def raw_values
     @raw_values ||= dynamic ? values_from_automate : super
     @default_value ||= sort_data(@raw_values).first.first
     self.value ||= @default_value

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -1,7 +1,7 @@
 class DialogFieldRadioButton < DialogFieldSortedItem
   def initialize_with_values(dialog_values)
     if load_values_on_init?
-      raw_values
+      set_raw_values
       @value = value_from_dialog_fields(dialog_values) || default_value
     else
       @raw_values = initial_values
@@ -37,15 +37,11 @@ class DialogFieldRadioButton < DialogFieldSortedItem
     load_values_on_init
   end
 
-  def raw_values
+  def set_raw_values
     if dynamic
       @raw_values = values_from_automate
     else
       @raw_values = super
     end
-  end
-
-  def values_from_automate
-    DynamicDialogFieldValueProcessor.values_from_automate(self)
   end
 end

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -1,7 +1,7 @@
 class DialogFieldRadioButton < DialogFieldSortedItem
   def initialize_with_values(dialog_values)
     if load_values_on_init?
-      set_raw_values
+      raw_values
       @value = value_from_dialog_fields(dialog_values) || default_value
     else
       @raw_values = initial_values
@@ -37,7 +37,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
     load_values_on_init
   end
 
-  def set_raw_values
+  def raw_values
     if dynamic
       @raw_values = values_from_automate
     else

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -18,7 +18,7 @@ class DialogFieldSerializer < Serializer
 
     if dialog_field.dynamic?
       dynamic_values = dialog_field.trigger_automate_value_updates
-      extra_attributes.merge!("values" => dynamic_values)
+      extra_attributes["values"] = dynamic_values
     end
 
     included_attributes(dialog_field.attributes).merge(extra_attributes)

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -1,6 +1,10 @@
 class DialogFieldSerializer < Serializer
   EXCLUDED_ATTRIBUTES = ["created_at", "dialog_group_id", "id", "updated_at"]
 
+  def self.serialize(dialog_field)
+    new.serialize(dialog_field)
+  end
+
   def initialize(resource_action_serializer = ResourceActionSerializer.new)
     @resource_action_serializer = resource_action_serializer
   end
@@ -8,6 +12,15 @@ class DialogFieldSerializer < Serializer
   def serialize(dialog_field)
     serialized_resource_action = @resource_action_serializer.serialize(dialog_field.resource_action)
 
-    included_attributes(dialog_field.attributes).merge("resource_action" => serialized_resource_action)
+    extra_attributes = {
+      "resource_action" => serialized_resource_action
+    }
+
+    if dialog_field.dynamic?
+      dynamic_values = dialog_field.trigger_automate_value_updates
+      extra_attributes.merge!("values" => dynamic_values)
+    end
+
+    included_attributes(dialog_field.attributes).merge(extra_attributes)
   end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -49,6 +49,10 @@ class DialogFieldSortedItem < DialogField
     result.blank? ? initial_values : result
   end
 
+  def trigger_automate_value_updates
+    set_raw_values
+  end
+
   private
 
   def sort_data(data_to_sort)

--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -66,9 +66,7 @@ class DialogFieldTextBox < DialogField
     {:text => @value}
   end
 
-  private
-
-  def values_from_automate
-    DynamicDialogFieldValueProcessor.values_from_automate(self)
+  def trigger_automate_value_updates
+    values_from_automate
   end
 end

--- a/spec/models/dialog_field_check_box_spec.rb
+++ b/spec/models/dialog_field_check_box_spec.rb
@@ -193,4 +193,16 @@ describe DialogFieldCheckBox do
       expect(dialog_field.value).to eq("f")
     end
   end
+
+  describe "#trigger_automate_value_updates" do
+    let(:dialog_field) { described_class.new }
+
+    before do
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return("f")
+    end
+
+    it "returns the checked value in a hash" do
+      expect(dialog_field.trigger_automate_value_updates).to eq("f")
+    end
+  end
 end

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -192,4 +192,18 @@ describe DialogFieldDateControl do
       expect(subject.show_past_dates).to be_falsey
     end
   end
+
+  describe "#trigger_automate_value_updates" do
+    let(:dialog_field) { described_class.new }
+
+    before do
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
+        "2015-01-02"
+      )
+    end
+
+    it "returns the values from the value processor" do
+      expect(dialog_field.trigger_automate_value_updates).to eq("2015-01-02")
+    end
+  end
 end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -18,7 +18,7 @@ describe DialogFieldSerializer do
         "display"                 => "display",
         "display_method"          => "display method",
         "display_method_options"  => {"display method options" => true},
-        "dynamic"                 => false,
+        "dynamic"                 => dynamic,
         "required"                => false,
         "required_method"         => "required method",
         "required_method_options" => {"required method options" => true},
@@ -44,10 +44,29 @@ describe DialogFieldSerializer do
       allow(resource_action_serializer).to receive(:serialize).with(resource_action).and_return("serialized resource action")
     end
 
-    it "serializes the dialog_field" do
-      expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
-        "resource_action" => "serialized resource action"
-      ))
+    context "when the dialog_field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        allow(dialog_field).to receive(:trigger_automate_value_updates).and_return("dynamic values")
+      end
+
+      it "serializes the dialog_field with the correct values" do
+        expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
+          "resource_action" => "serialized resource action",
+          "values"          => "dynamic values"
+        ))
+      end
+    end
+
+    context "when the dialog_field is not dynamic" do
+      let(:dynamic) { false }
+
+      it "serializes the dialog_field" do
+        expect(dialog_field_serializer.serialize(dialog_field)).to eq(expected_serialized_values.merge(
+          "resource_action" => "serialized resource action"
+        ))
+      end
     end
   end
 end

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -132,4 +132,17 @@ describe DialogField do
       end
     end
   end
+
+  describe "#update_and_serialize_values" do
+    let(:dialog_field) { described_class.new }
+
+    before do
+      allow(DialogFieldSerializer).to receive(:serialize).with(dialog_field)
+    end
+
+    it "serializes the dialog field" do
+      expect(DialogFieldSerializer).to receive(:serialize).with(dialog_field)
+      dialog_field.update_and_serialize_values
+    end
+  end
 end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -269,4 +269,18 @@ describe DialogFieldTextBox do
       expect(dialog_field.value).to eq("processor")
     end
   end
+
+  describe "#trigger_automate_value_updates" do
+    let(:dialog_field) { described_class.new }
+
+    before do
+      allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
+        "processed values"
+      )
+    end
+
+    it "returns the values from automate" do
+      expect(dialog_field.trigger_automate_value_updates).to eq("processed values")
+    end
+  end
 end


### PR DESCRIPTION
@abellotti This should do the trick for replacing `refresh_json_values`, I think. Let me know if you have any feedback.