### PR TITLE
Update BeSameTimeAs matcher for RSpec 3

### DIFF
--- a/gems/pending/spec/support/custom_matchers/have_attributes.rb
+++ b/gems/pending/spec/support/custom_matchers/have_attributes.rb
@@ -14,9 +14,11 @@ RSpec::Matchers.define :have_attributes do |attrs|
             RuntimeError.new("Unknown attribute '#{attr}'")
           end
 
-        comparing_times = actual.respond_to?(:acts_like_time?) && expected.respond_to?(:acts_like_time?)
-        matcher = comparing_times ? BeSameTimeAs : RSpec::Matchers::BuiltIn::Eq
-        matcher = matcher.new(expected)
+        matcher = if actual.respond_to?(:acts_like_time?) && expected.respond_to?(:acts_like_time?)
+                    be_same_time_as(expected)
+                  else
+                    eq(expected)
+                  end
 
         unless matcher.matches?(actual)
           name_key = [:name, :id, :object_id].detect { |k| obj.respond_to?(k) }

--- a/spec/support/custom_matchers/be_same_time_as.rb
+++ b/spec/support/custom_matchers/be_same_time_as.rb
@@ -1,25 +1,20 @@
-class BeSameTimeAs
-  attr_reader :actual, :expected
-
-  def initialize(expected)
-    @expected = expected
+RSpec::Matchers.define :be_same_time_as do |expected|
+  match do |actual|
+    actual.round(precision) == expected.round(precision)
   end
 
-  def matches?(actual)
-    @actual = actual
-    @actual.round(precision) == @expected.round(precision)
+  failure_message do |actual|
+    "\nexpected: #{format_time(expected)},\n     " \
+      "got: #{format_time(actual)}\n\n(compared using be_same_time_as with precision of #{precision})"
   end
 
-  def failure_message_for_should
-    "\nexpected: #{format_time(@expected)},\n     got: #{format_time(@actual)}\n\n(compared using be_same_time_as with precision of #{precision})"
+  failure_message_when_negated do
+    "\nexpected different time from #{format_time(expected)}\n\n" \
+      "(compared using be_same_time_as with precision of #{precision})"
   end
 
-  def failure_message_for_should_not
-    "\nexpected different time from #{format_time(@expected)}\n\n(compared using be_same_time_as with precision of #{precision})"
-  end
-
-  def description
-    "be the same time as #{format_time(@expected)} to #{precision} digits of precision"
+  description do
+    "be the same time as #{format_time(expected)} to #{precision} digits of precision"
   end
 
   def with_precision(p)
@@ -36,8 +31,4 @@ class BeSameTimeAs
   def format_time(t)
     "#<#{t.class} #{t.iso8601(10)}>"
   end
-end
-
-def be_same_time_as(expected)
-  BeSameTimeAs.new(expected)
 end


### PR DESCRIPTION
This used a legacy RSpec matcher protocol. The newer RSpec::Matchers.define evaluates the define block in the context of a singleton class. Some tweaking in the have_attributes matcher, where BeSameTimeAs was being instantiated, was required as a result.

Removes deprecation warning.

It's also a net loss in LOC, :wink: @jrafanie 