### PR TITLE
Update custom matchers to modern API

### DIFF
--- a/gems/pending/spec/support/custom_matchers/be_decrypted.rb
+++ b/gems/pending/spec/support/custom_matchers/be_decrypted.rb
@@ -6,11 +6,11 @@ RSpec::Matchers.define :be_decrypted do |expected|
     actual == expected
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected: #{actual.inspect} to be decrypted to #{expected}"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected: #{actual.inspect} to not equal #{expected}"
   end
 

--- a/gems/pending/spec/support/custom_matchers/be_encrypted.rb
+++ b/gems/pending/spec/support/custom_matchers/be_encrypted.rb
@@ -8,11 +8,11 @@ RSpec::Matchers.define :be_encrypted do |expected|
     )
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected: #{actual.inspect} to be encrypted#{" and decrypt to #{expected}" if expected}"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected: #{actual.inspect} not to be encrypted#{" and decrypt to #{expected}" if expected}"
   end
 

--- a/gems/pending/spec/support/custom_matchers/be_encrypted_version.rb
+++ b/gems/pending/spec/support/custom_matchers/be_encrypted_version.rb
@@ -8,13 +8,13 @@ RSpec::Matchers.define :be_encrypted_version do |expected|
     MiqPassword.split(actual).first == expected.to_s
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     actual_version = MiqPassword.split(actual).first
     actual_version_text = actual_version ? "encrypted with version #{actual_version}" : "not encrypted"
     "expected: #{actual.inspect} to be encrypted with version #{expected} but is #{actual_version_text}"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected: #{actual.inspect} not to be encrypted with version #{expected}"
   end
 

--- a/gems/pending/spec/support/custom_matchers/have_attributes.rb
+++ b/gems/pending/spec/support/custom_matchers/have_attributes.rb
@@ -23,18 +23,18 @@ RSpec::Matchers.define :have_attributes do |attrs|
         unless matcher.matches?(actual)
           name_key = [:name, :id, :object_id].detect { |k| obj.respond_to?(k) }
           @err_msg ||= "with #{obj.class.name} #{name_key}:#{obj.send(name_key).inspect}\n\n"
-          @err_msg << "testing attribute: \"#{attr}\"\n#{matcher.failure_message_for_should}\n\n"
+          @err_msg << "testing attribute: \"#{attr}\"\n#{matcher.failure_message}\n\n"
         end
       end
     end
     @err_msg.nil?
   end
 
-  failure_message_for_should do |_obj|
+  failure_message do |_obj|
     @err_msg
   end
 
-  failure_message_for_should_not do |_obj|
+  failure_message_when_negated do |_obj|
     @err_msg
   end
 

--- a/spec/support/custom_matchers/exceed_query_limit.rb
+++ b/spec/support/custom_matchers/exceed_query_limit.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :exceed_query_limit do |expected|
     @query_count > expected
   end
 
-  failure_message_for_should_not do |_actual|
+  failure_message_when_negated do |_actual|
     "Expected maximum #{expected} queries, got #{@query_count}"
   end
 end

--- a/spec/support/custom_matchers/have_virtual_column.rb
+++ b/spec/support/custom_matchers/have_virtual_column.rb
@@ -6,11 +6,11 @@ RSpec::Matchers.define :have_virtual_column do |name, type|
     klass.instance_methods.include?(name.to_sym)
   end
 
-  failure_message_for_should do |klass|
+  failure_message do |klass|
     "expected #{klass.name} to have virtual column #{name.inspect} with type #{type.inspect}"
   end
 
-  failure_message_for_should_not do |klass|
+  failure_message_when_negated do |klass|
     "expected #{klass.name} to not have virtual column #{name.inspect} with type #{type.inspect}"
   end
 

--- a/spec/support/custom_matchers/match_relationship_tree.rb
+++ b/spec/support/custom_matchers/match_relationship_tree.rb
@@ -17,11 +17,11 @@ RSpec::Matchers.define :match_relationship_tree do |expected_tree|
     end
   end
 
-  failure_message_for_should do |actual_tree|
+  failure_message do |actual_tree|
     "expected actual tree\n#{pretty_tree(actual_tree)}\nto match expected tree\n#{pretty_tree(expected_tree)}"
   end
 
-  failure_message_for_should_not do |actual_tree|
+  failure_message_when_negated do |actual_tree|
     "expected actual tree\n#{pretty_tree(actual_tree)}\nto not match expected tree\n#{pretty_tree(expected_tree)}"
   end
 


### PR DESCRIPTION
Uses RSpec 3+ methods to remove deprecation warnings from custom matchers.

BeSameTimeAs matcher omitted here as it's been rewritten completely in #6098