### PR TITLE
Verify presence of required fields for chargeback rates

### DIFF
--- a/app/controllers/api_controller/rates.rb
+++ b/app/controllers/api_controller/rates.rb
@@ -8,7 +8,9 @@ class ApiController
     end
 
     def create_resource_rates(_type, _id, data = {})
-      ChargebackRateDetail.create(data)
+      rate_detail = ChargebackRateDetail.create(data)
+      raise BadRequestError, "#{rate_detail.errors.full_messages.join(', ')}" unless rate_detail.valid?
+      rate_detail
     end
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -2,7 +2,8 @@ class ChargebackRateDetail < ActiveRecord::Base
   belongs_to :chargeback_rate
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
 
-  validates_numericality_of :rate
+  validates :rate, :numericality => true
+  validates :group, :source, :presence => true
 
   def cost(value)
     return 0.0 unless self.enabled?

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail do
     rate    0
+    group   "unknown"
+    source  "unknown"
   end
 
   factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -76,11 +76,27 @@ RSpec.describe "chargebacks API" do
     it "can create a new chargeback rate detail" do
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
 
-      expect { run_post rates_url, :rate => "0", :enabled => true }.to change(ChargebackRateDetail, :count).by(1)
-      actual = @result["results"].first
-      expect(actual["rate"]).to eq("0")
-      expect(actual["enabled"]).to be_truthy
+      expect do
+        run_post rates_url,
+                 :rate    => "0",
+                 :group   => "fixed",
+                 :source  => "used",
+                 :enabled => true
+      end.to change(ChargebackRateDetail, :count).by(1)
+      expect_result_to_match_hash(@result["results"].first, "rate" => "0", "enabled" => true)
       expect_request_success
+    end
+
+    it "returns bad request for incomplete chargeback rate detail" do
+      api_basic_authorize action_identifier(:rates, :create, :collection_actions)
+
+      expect do
+        run_post rates_url,
+                 :rate    => "0",
+                 :enabled => true
+      end.not_to change(ChargebackRateDetail, :count)
+      expect_bad_request(/group can't be blank/i)
+      expect_bad_request(/source can't be blank/i)
     end
 
     it "can edit a chargeback rate detail through POST" do


### PR DESCRIPTION
in case the group parameter is not present when creating a ChargebackRate via
the API an exception is raised when displaying the rates in the UI.
This PR adds validations to `ChargebackRateDetail` to enforce presence of 
group and source fields. It also checks the if a rate is valid when created via the API .
If not, it raises a `BadRequestError`

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1284454

see previous conversation in #6062 (sorry, messed up rebasing and could no re-open the PR)
@gtanzillo please review and also see my comment https://github.com/ManageIQ/manageiq/pull/6062#issuecomment-169482301

@miq-bot add_label bug, chargeback