### PR TITLE
Add the miq_debug.js into the list of precompiled assets in development

### DIFF
--- a/app/views/vm_common/console_spice.html.haml
+++ b/app/views/vm_common/console_spice.html.haml
@@ -7,8 +7,6 @@
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'spiceHTML5/spicearraybuffer', 'spice-html5'
-    - if Rails.env.development?
-      = javascript_include_tag 'miq_debug'
 
   %body{:style => 'margin: 0px; padding-top: 0px !important;'}
     = link_to('Ctrl-Alt-Del', '#', :id => 'sendCtrlAltDelButton', :class => 'btn btn-default', :onclick => 'sendCtrlAltDel()')

--- a/app/views/vm_common/console_vnc.html.haml
+++ b/app/views/vm_common/console_vnc.html.haml
@@ -6,8 +6,6 @@
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'novnc-rails', 'miq_novnc'
-    - if Rails.env.development?
-      = javascript_include_tag 'miq_debug'
 
   %body{:style => 'margin: 0px; padding-top: 0px !important;'}
     = link_to('Ctrl-Alt-Del', '#', :id => 'sendCtrlAltDelButton', :class => 'btn btn-default')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Vmdb::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  # Include miq_debug in the list of assets here because it is only used in development
+  config.assets.precompile << 'miq_debug.js'
+
   # Raise exceptions in transactional callbacks
   config.active_record.raise_in_transactional_callbacks = true
 


### PR DESCRIPTION
@kbrock I'm not entirely sure if I'm doing this correctly. I had some issues in development mode with the `miq_debug.js` after I removed the precompiled assets. 