### PR TITLE
Fix error in list of hosts with default filter

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -574,7 +574,7 @@ module ApplicationController::Filter
     @edit[@expkey][:expression] = []                           # Store exps in an array
     @edit[:new] = {}
     @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
-    s = !id.zero? && MiqSearch.find(id)
+    s = MiqSearch.find(id) unless id.zero?
     if s.nil? || s.search_key == "_hidden_" # search not found || admin changed default search to be hidden
       clear_default_search
     else

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -6,6 +6,15 @@ describe ApplicationController, "::Filter" do
     controller.instance_variable_set(:@sb, {})
   end
 
+  describe "#load_default_search" do
+    it "calls load_default_search when filter is ALL(id=0)" do
+      expect(controller).to receive(:clear_default_search)
+      expect do
+        controller.load_default_search(0) # id = 0
+      end.not_to raise_error
+    end
+  end
+
   context "Verify removal of tokens from expressions" do
     it "removes tokens if present" do
       e = MiqExpression.new({"=" => {:field => "Vm.name", :value => "Test"}, :token => 1})


### PR DESCRIPTION
Infrastructure -> Hosts / Nodes
Choose filter "All" (with button set default)
logout, login back and go back(session[:default_search] must be loaded at init not by clicking, so ```@edit[:selected]``` must be false) to Infrastructure -> Hosts / Nodes, it raises error:
```
undefined method `search_key' for false:FalseClass [host/show_list] 
```
thanks @himdel 