### PR TITLE
Remove all #be with no args from spec

### DIFF
--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -205,12 +205,12 @@ describe "MiqAeStateMachineRetry" do
 
     status, _message, ws = deliver_ae_request_from_queue
     expect(status).not_to eq(MiqQueue::STATUS_ERROR)
-    expect(ws).to be
+    expect(ws).to be_truthy
 
     Timecop.travel(@max_time + 1) do
       status, _message, ws = deliver_ae_request_from_queue
       expect(status).not_to eq(MiqQueue::STATUS_ERROR)
-      expect(ws).to be
+      expect(ws).to be_truthy
     end
 
     Timecop.travel(@max_time * 2 + 2) do

--- a/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_password_spec.rb
@@ -43,7 +43,7 @@ describe MiqAePassword do
 
   describe ".key_root" do
     it "has key_root set" do
-      expect(MiqAePassword.key_root).to be
+      expect(MiqAePassword.key_root).to be_truthy
     end
   end
 end

--- a/spec/lib/report_formater/jqplot_formater_charting_counts_spec.rb
+++ b/spec/lib/report_formater/jqplot_formater_charting_counts_spec.rb
@@ -69,7 +69,7 @@ describe ReportFormatter::JqplotFormatter do
       expect(report.chart[:data][0]).to eq([["linux_esx: 3", 3], ["widloze: 1", 1]])
       expect(report.chart[:options][:seriesDefaults][:renderer]).to eq("jQuery.jqplot.PieRenderer")
       expect(report.chart[:options][:series][0][:label]).to eq("OS Name")
-      expect(report.chart[:options][:highlighter]).to be
+      expect(report.chart[:options][:highlighter]).to be_truthy
     end
   end
 end

--- a/spec/lib/vmdb/permission_stores_spec.rb
+++ b/spec/lib/vmdb/permission_stores_spec.rb
@@ -48,7 +48,7 @@ describe Vmdb::PermissionStores do
         config.backend = 'yaml'
         config.options[:filename] = f.path
         config.load
-        expect(config.create).to be
+        expect(config.create).to be_truthy
       end
     end
   end

--- a/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
+++ b/spec/migrations/20151021174140_assign_tenant_default_group_spec.rb
@@ -20,10 +20,10 @@ describe AssignTenantDefaultGroup do
         migrate
 
         t.reload
-        expect(t.default_miq_group_id).to be
+        expect(t.default_miq_group_id).to be_truthy
         g = group_stub.find(t.default_miq_group_id)
         expect(g.miq_user_role_id).to eq(tenant_role.id)
-        expect(g.sequence).to be
+        expect(g.sequence).to be_truthy
       end
 
       it "skips tenants that already have a group" do
@@ -42,7 +42,7 @@ describe AssignTenantDefaultGroup do
       migrate
 
       t.reload
-      expect(t.default_miq_group_id).to be
+      expect(t.default_miq_group_id).to be_truthy
       expect(group_stub.find(t.default_miq_group_id).miq_user_role_id).to be_nil
     end
   end

--- a/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
+++ b/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
@@ -11,7 +11,7 @@ describe FixMiqGroupSequences do
 
       migrate
 
-      expect(g1.reload.sequence).to be
+      expect(g1.reload.sequence).to be_truthy
       expect(g2.reload.sequence).to eq(3)
     end
 
@@ -22,7 +22,7 @@ describe FixMiqGroupSequences do
 
       migrate
 
-      expect(g1.reload.guid).to be
+      expect(g1.reload.guid).to be_truthy
       expect(g2.reload.guid).to eq(old_guid)
     end
   end

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -149,7 +149,7 @@ describe Authenticator::Amazon do
     context "with valid details" do
       it "succeeds" do
         result, errors = described_class.validate_connection(:authentication => config)
-        expect(result).to be
+        expect(result).to be_truthy
         expect(errors).to eq({})
       end
     end

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -12,7 +12,7 @@ describe Authenticator::Database do
 
   describe '#lookup_by_identity' do
     it "finds existing users" do
-      expect(subject.lookup_by_identity('alice')).to be
+      expect(subject.lookup_by_identity('alice')).to be_truthy
     end
 
     it "doesn't create new users" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -22,7 +22,7 @@ describe Condition do
 
       it "valid expression" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2</check></find>"
-        expect(Condition.subst(expr, @cluster, nil)).to be
+        expect(Condition.subst(expr, @cluster, nil)).to be_truthy
       end
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do

--- a/spec/models/miq_db_config_spec.rb
+++ b/spec/models/miq_db_config_spec.rb
@@ -35,7 +35,7 @@ describe MiqDbConfig do
 
       expect(rows.length).to be > 0
       rows.each do |row|
-        expect(row.first).to be
+        expect(row.first).to be_truthy
       end
     end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -292,7 +292,7 @@ describe MiqGroup do
       expect(tenant.reload.default_miq_group.miq_user_role).not_to be
       MiqUserRole.seed
       MiqGroup.seed
-      expect(tenant.reload.default_miq_group.miq_user_role).to be
+      expect(tenant.reload.default_miq_group.miq_user_role).to be_truthy
     end
   end
 
@@ -456,7 +456,7 @@ describe MiqGroup do
       g1 = MiqGroup.create(:description => "one")
       g2 = MiqGroup.create(:description => "two")
 
-      expect(g1.sequence).to be
+      expect(g1.sequence).to be_truthy
       expect(g2.sequence).to eq(g1.sequence + 1)
     end
 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -135,7 +135,7 @@ describe MiqProductFeature do
   describe "#feature_details" do
     it "returns data for visible features" do
       EvmSpecHelper.seed_specific_product_features("container_dashboard")
-      expect(MiqProductFeature.feature_details("container_dashboard")).to be
+      expect(MiqProductFeature.feature_details("container_dashboard")).to be_truthy
     end
 
     it "eats hidden features" do
@@ -152,7 +152,7 @@ describe MiqProductFeature do
 
     it "detects hidden features" do
       EvmSpecHelper.seed_specific_product_features("widget_refresh")
-      expect(MiqProductFeature.feature_hidden("widget_refresh")).to be
+      expect(MiqProductFeature.feature_hidden("widget_refresh")).to be_truthy
     end
   end
 end

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1062,17 +1062,17 @@ describe Rbac do
 
   # determine what to run
   it ".apply_rbac_to_class?" do
-    expect(Rbac.apply_rbac_to_class?(Vm)).to be
+    expect(Rbac.apply_rbac_to_class?(Vm)).to be_truthy
     expect(Rbac.apply_rbac_to_class?(Rbac)).not_to be
   end
 
   it ".apply_rbac_to_associated_class?" do
-    expect(Rbac.apply_rbac_to_associated_class?(HostMetric)).to be
+    expect(Rbac.apply_rbac_to_associated_class?(HostMetric)).to be_truthy
     expect(Rbac.apply_rbac_to_associated_class?(Vm)).not_to be
   end
 
   it ".apply_user_group_rbac_to_class?" do
-    expect(Rbac.apply_user_group_rbac_to_class?(User)).to be
+    expect(Rbac.apply_user_group_rbac_to_class?(User)).to be_truthy
     expect(Rbac.apply_user_group_rbac_to_class?(Vm)).not_to be
   end
 

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -83,7 +83,7 @@ describe ServiceReconfigureTask do
           :miq_group_id     => user.current_group_id,
           :tenant_id        => user.current_tenant.id,
         }
-        expect(user.current_tenant).to be
+        expect(user.current_tenant).to be_truthy
         expect(MiqQueue).to receive(:put).with(
           :class_name  => 'MiqAeEngine',
           :method_name => 'deliver',

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -21,14 +21,14 @@ describe Tenant do
 
   describe "#default_tenant" do
     it "has a default tenant" do
-      expect(default_tenant).to be
+      expect(default_tenant).to be_truthy
     end
   end
 
   describe "#root_tenant" do
     it "has a root tenant" do
       Tenant.seed
-      expect(Tenant.root_tenant).to be
+      expect(Tenant.root_tenant).to be_truthy
     end
 
     it "can update the root_tenant" do

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -196,12 +196,12 @@ describe TimeProfile do
   describe ".profile_for_user_tz" do
     it "finds global profiles" do
       FactoryGirl.create(:time_profile_with_rollup, :tz => "good", :profile_type => "global")
-      expect(TimeProfile.profile_for_user_tz(1, "good")).to be
+      expect(TimeProfile.profile_for_user_tz(1, "good")).to be_truthy
     end
 
     it "finds user profiles" do
       FactoryGirl.create(:time_profile_with_rollup, :tz => "good", :profile_type => "user", :profile_key => 1)
-      expect(TimeProfile.profile_for_user_tz(1, "good")).to be
+      expect(TimeProfile.profile_for_user_tz(1, "good")).to be_truthy
     end
 
     it "skips invalid records" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -588,7 +588,7 @@ describe User do
 
     it "sets the tenant" do
       User.with_user(user1) do
-        expect(User.current_tenant).to be
+        expect(User.current_tenant).to be_truthy
         expect(User.current_tenant).to eq(user1.current_tenant)
       end
     end

--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -36,7 +36,7 @@ describe VmdbDatabaseConnection do
 
     connections = VmdbDatabaseConnection.all
     no_locks = connections.detect { |conn| conn.vmdb_database_locks.empty? }
-    expect(no_locks).to be
+    expect(no_locks).to be_truthy
     expect(no_locks.wait_resource).to be_nil
 
     continue.release
@@ -81,7 +81,7 @@ describe VmdbDatabaseConnection do
     end
 
     blocked_by = connections.detect { |conn| conn.spid == blocked_conn.blocked_by }
-    expect(blocked_by).to be
+    expect(blocked_by).to be_truthy
     expect(blocked_conn.spid).not_to eq(blocked_by.spid)
 
     continue_latch.release

--- a/spec/models/vmdb_database_setting_spec.rb
+++ b/spec/models/vmdb_database_setting_spec.rb
@@ -70,7 +70,7 @@ describe VmdbDatabaseSetting do
   ].each do |field|
     it "has a #{field}" do
       setting = VmdbDatabaseSetting.all.first
-      expect(setting.send(field)).to be
+      expect(setting.send(field)).to be_truthy
     end
   end
 end

--- a/spec/presenters/menu/menu_manager_spec.rb
+++ b/spec/presenters/menu/menu_manager_spec.rb
@@ -12,7 +12,7 @@ describe Menu::Manager do
   context "initialize" do
     it "loads default menu items" do
       section = Menu::Manager.section(:vi)
-      expect(section).to be
+      expect(section).to be_truthy
       expect(section.items[0].id).to eq('dashboard')
     end
 
@@ -33,8 +33,8 @@ describe Menu::Manager do
         Menu::Manager.menu do |a_section|
           section = a_section if a_section.name == 'Red Hat'
         end
-        expect(section).to be
-        expect(section.items.first).to be
+        expect(section).to be_truthy
+        expect(section.items.first).to be_truthy
       ensure
         temp_file.unlink
         temp_file2.unlink


### PR DESCRIPTION
Removes all cases of .be (with no args) following conversation in Gitter. Because its confusing!