### PR TITLE
Upgrade to shoulda-matchers 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ unless ENV['APPLIANCE']
     gem "brakeman",         "~>3.1.0",  :require => false
     gem "capybara",         "~>2.2.0",  :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "shoulda-matchers", "~>1.0.0",  :require => false
+    gem "shoulda-matchers", "~>3.0.0",  :require => false
     gem "vcr",              "~>2.6",    :require => false
     gem "webmock",          "~>1.12",   :require => false
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,7 +54,6 @@ Vmdb::Application.configure do
 end
 
 require "minitest"
-require "shoulda-matchers"
 require "factory_girl"
 require "timecop"
 require "vcr"

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 include AutomationSpecHelper
 describe MiqAeClass do

--- a/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe MiqAeNamespace do
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,3 +3,11 @@ require 'spec_helper'
 # TODO:
 # * require *this* file instead of spec_helper in the specs.
 # * Move any Rails specific code and setup from spec_helper.rb to this file.
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'application_helper'
 
 require 'rspec/autorun'
 require 'rspec/rails'
+require 'shoulda-matchers'
 require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ RSpec.configure do |config|
 
   config.include VMDBConfigurationHelper
 
+  config.define_derived_metadata(:file_path => /spec\/lib\/miq_automation_engine\/models/) do |metadata|
+    metadata[:type] ||= :model
+  end
+
   config.include AuthHelper,     :type => :view
   config.include ViewSpecHelper, :type => :view
   config.include UiConstants,    :type => :view

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,17 @@ RSpec.configure do |config|
   #   EvmSpecHelper.log_ruby_object_usage
   # end
 
-  # Preconfigure and auto-tag specs in the automation subdirectory a la rspec-rails
+  config.include VMDBConfigurationHelper
+
+  config.include AuthHelper,     :type => :view
+  config.include ViewSpecHelper, :type => :view
+  config.include UiConstants,    :type => :view
+
+  config.include ControllerSpecHelper, :type => :controller
+  config.include UiConstants,          :type => :controller
+  config.include AuthHelper,           :type => :controller
+
+  config.include AutomationSpecHelper,   :type => :automation
   config.include AutomationExampleGroup, :type => :automation
   config.define_derived_metadata(:file_path => /spec\/automation/) do |metadata|
     metadata[:type] ||= :automation
@@ -83,26 +93,19 @@ RSpec.configure do |config|
   config.include MigrationSpecHelper, :migrations => :up
   config.include MigrationSpecHelper, :migrations => :down
 
-  config.include ApiSpecHelper, :type => :request, :rest_api => true
+  config.include ApiSpecHelper,     :type => :request, :rest_api => true
+  config.include AuthRequestHelper, :type => :request
   config.define_derived_metadata(:file_path => /spec\/requests\/api/) do |metadata|
     metadata[:type] ||= :request
   end
 
-  config.include ControllerSpecHelper, :type => :controller
-  config.include ViewSpecHelper, :type => :view
-  config.include UiConstants, :type => :controller
-  config.include AuthHelper,  :type => :controller
-  config.include AuthHelper,  :type => :view
   config.include AuthHelper,  :type => :helper
-  config.include AuthRequestHelper, :type => :request
-  config.include UiConstants, :type => :view
-  config.include VMDBConfigurationHelper
 
-  config.include AutomationSpecHelper, :type => :automation
   config.include PresenterSpecHelper, :type => :presenter
   config.define_derived_metadata(:file_path => /spec\/presenters/) do |metadata|
     metadata[:type] ||= :presenter
   end
+
   config.include RakeTaskExampleGroup, :type => :rake_task
 
   config.before(:each) do


### PR DESCRIPTION
Upgrades our shoulda-matchers to version 3.

This keeps us on a modern API and also removes the annoying deprecations we are receiving from an old version of shoulda-matchers implementing matchers in a legacy RSpec API.