### PR TITLE
Remove shoulda-matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,6 @@ unless ENV['APPLIANCE']
     gem "brakeman",         "~>3.1.0",  :require => false
     gem "capybara",         "~>2.2.0",  :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "shoulda-matchers", "~>3.0.0",  :require => false
     gem "vcr",              "~>2.6",    :require => false
     gem "webmock",          "~>1.12",   :require => false
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -2,14 +2,41 @@ require "rails_helper"
 
 include AutomationSpecHelper
 describe MiqAeClass do
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:namespace_id) }
+  describe "name attribute validation" do
+    subject { described_class.new }
 
-  it { is_expected.to allow_value("cla.ss1").for(:name) }
-  it { is_expected.to allow_value("cla-ss1").for(:name) }
+    example "with no name" do
+      subject.name = nil
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+    end
 
-  it { is_expected.not_to allow_value("cla ss1").for(:name) }
-  it { is_expected.not_to allow_value("cla:ss1").for(:name) }
+    example "with no namespace_id" do
+      subject.namespace_id = nil
+      subject.valid?
+      expect(subject.errors[:namespace_id]).to be_present
+    end
+
+    example "with a valid name" do
+      subject.name = "cla.ss1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_blank
+
+      subject.name = "cla-ss1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_blank
+    end
+
+    example "with an invalid name" do
+      subject.name = "cla ss1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+
+      subject.name = "cla:ss1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+    end
+  end
 
   it "should not create class without namespace" do
     expect { MiqAeClass.new(:name => "TEST").save! }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
@@ -1,14 +1,39 @@
 require "rails_helper"
 
 describe MiqAeNamespace do
-  it { is_expected.to validate_presence_of(:name) }
+  describe "name attribute validation" do
+    subject { described_class.new }
 
-  it { is_expected.to allow_value("name.space1").for(:name) }
-  it { is_expected.to allow_value("name-space1").for(:name) }
-  it { is_expected.to allow_value("name$space1").for(:name) }
+    example "with no name" do
+      subject.name = nil
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+    end
 
-  it { is_expected.not_to allow_value("name space1").for(:name) }
-  it { is_expected.not_to allow_value("name:space1").for(:name) }
+    example "with a valid name" do
+      subject.name = "name.space1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_blank
+
+      subject.name = "name-space1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_blank
+
+      subject.name = "name$space1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_blank
+    end
+
+    example "with an invalid name" do
+      subject.name = "name space1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+
+      subject.name = "name:space1"
+      subject.valid?
+      expect(subject.errors[:name]).to be_present
+    end
+  end
 
   it "should find or create namespaces by fqname" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("System/TEST")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,11 +3,3 @@ require 'spec_helper'
 # TODO:
 # * require *this* file instead of spec_helper in the specs.
 # * Move any Rails specific code and setup from spec_helper.rb to this file.
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
-end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require 'application_helper'
 
 require 'rspec/autorun'
 require 'rspec/rails'
-require 'shoulda-matchers'
 require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
Removing them is preferable as we only use them in two places where we need to verify a regular expression in a validation.

This is a follow up of #6110 after discussing on Gitter. (Followup == :smiling_imp: :fire: :fire: :fire:)