### PR TITLE
Proportional set size (PSS) better tracks shared memory usage.

### DIFF
--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -16,7 +16,7 @@ module MiqServer::StatusManagement
     def log_status
       log_system_status
       svr = my_server(true)
-      _log.info("[#{svr.friendly_name}] Process info: Memory Usage [#{svr.memory_usage}], Memory Size [#{svr.memory_size}], Memory % [#{svr.percent_memory}], CPU Time [#{svr.cpu_time}], CPU % [#{svr.percent_cpu}], Priority [#{svr.os_priority}]") unless svr.nil?
+      _log.info("[#{svr.friendly_name}] Process info: Memory Usage [#{svr.memory_usage}], Memory Size [#{svr.memory_size}], Proportional Set Size: [#{svr.proportional_set_size}], Memory % [#{svr.percent_memory}], CPU Time [#{svr.cpu_time}], CPU % [#{svr.percent_cpu}], Priority [#{svr.os_priority}]") unless svr.nil?
     end
 
     def log_system_status

--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -10,7 +10,7 @@ module MiqServer::StatusManagement
       # Ensure the hash only contains the values we want to store in the table
       pinfo.keep_if { |k, _v| MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
       pinfo[:os_priority] = pinfo.delete(:priority)
-      my_server.update_attributes(pinfo)
+      my_server.update_attributes!(pinfo)
     end
 
     def log_status

--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -8,7 +8,7 @@ module MiqServer::StatusManagement
       require 'miq-process'
       pinfo = MiqProcess.processInfo
       # Ensure the hash only contains the values we want to store in the table
-      pinfo.delete_if { |k, _v| !MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
+      pinfo.keep_if { |k, _v| MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
       pinfo[:os_priority] = pinfo.delete(:priority)
       my_server.update_attributes(pinfo)
     end

--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -8,7 +8,7 @@ module MiqServer::StatusManagement
       require 'miq-process'
       pinfo = MiqProcess.processInfo
       # Ensure the hash only contains the values we want to store in the table
-      pinfo.delete_if { |k, _v| ![:priority, :memory_usage, :percent_memory, :percent_cpu, :memory_size, :cpu_time].include?(k) }
+      pinfo.delete_if { |k, _v| !MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
       pinfo[:os_priority] = pinfo.delete(:priority)
       my_server.update_attributes(pinfo)
     end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -32,6 +32,7 @@ class MiqWorker < ActiveRecord::Base
   STATUSES_STOPPED  = [STATUS_STOPPED, STATUS_KILLED, STATUS_ABORTED]
   STATUSES_CURRENT_OR_STARTING = STATUSES_CURRENT + STATUSES_STARTING
   STATUSES_ALIVE    = STATUSES_CURRENT_OR_STARTING + [STATUS_STOPPING]
+  PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time)
 
   def self.atStartup
     # Delete and Kill all workers that were running previously
@@ -410,7 +411,7 @@ class MiqWorker < ActiveRecord::Base
     end
 
     # Ensure the hash only contains the values we want to store in the table
-    pinfo.delete_if { |k, _v| ![:priority, :memory_usage, :percent_memory, :percent_cpu, :memory_size, :cpu_time].include?(k) }
+    pinfo.delete_if { |k, _v| !self.class::PROCESS_INFO_FIELDS.include?(k) }
     pinfo[:os_priority] = pinfo.delete(:priority)
     update_attributes(pinfo)
   end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -32,7 +32,7 @@ class MiqWorker < ActiveRecord::Base
   STATUSES_STOPPED  = [STATUS_STOPPED, STATUS_KILLED, STATUS_ABORTED]
   STATUSES_CURRENT_OR_STARTING = STATUSES_CURRENT + STATUSES_STARTING
   STATUSES_ALIVE    = STATUSES_CURRENT_OR_STARTING + [STATUS_STOPPING]
-  PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time)
+  PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size)
 
   def self.atStartup
     # Delete and Kill all workers that were running previously
@@ -417,7 +417,7 @@ class MiqWorker < ActiveRecord::Base
   end
 
   def log_status(level = :info)
-    _log.send(level, "[#{friendly_name}] Worker ID [#{id}], PID [#{pid}], GUID [#{guid}], Last Heartbeat [#{last_heartbeat}], Process Info: Memory Usage [#{memory_usage}], Memory Size [#{memory_size}], Memory % [#{percent_memory}], CPU Time [#{cpu_time}], CPU % [#{percent_cpu}], Priority [#{os_priority}]")
+    _log.send(level, "[#{friendly_name}] Worker ID [#{id}], PID [#{pid}], GUID [#{guid}], Last Heartbeat [#{last_heartbeat}], Process Info: Memory Usage [#{memory_usage}], Memory Size [#{memory_size}], Proportional Set Size: [#{proportional_set_size}], Memory % [#{percent_memory}], CPU Time [#{cpu_time}], CPU % [#{percent_cpu}], Priority [#{os_priority}]")
   end
 
   def current_timeout

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -413,7 +413,7 @@ class MiqWorker < ActiveRecord::Base
     # Ensure the hash only contains the values we want to store in the table
     pinfo.keep_if { |k, _v| self.class::PROCESS_INFO_FIELDS.include?(k) }
     pinfo[:os_priority] = pinfo.delete(:priority)
-    update_attributes(pinfo)
+    update_attributes!(pinfo)
   end
 
   def log_status(level = :info)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -411,7 +411,7 @@ class MiqWorker < ActiveRecord::Base
     end
 
     # Ensure the hash only contains the values we want to store in the table
-    pinfo.delete_if { |k, _v| !self.class::PROCESS_INFO_FIELDS.include?(k) }
+    pinfo.keep_if { |k, _v| self.class::PROCESS_INFO_FIELDS.include?(k) }
     pinfo[:os_priority] = pinfo.delete(:priority)
     update_attributes(pinfo)
   end

--- a/db/migrate/20160108214044_add_miq_workers_miq_servers_proportional_set_size.rb
+++ b/db/migrate/20160108214044_add_miq_workers_miq_servers_proportional_set_size.rb
@@ -1,0 +1,6 @@
+class AddMiqWorkersMiqServersProportionalSetSize < ActiveRecord::Migration
+  def change
+    add_column :miq_servers, :proportional_set_size, :decimal, :precision => 20, :scale => 0
+    add_column :miq_workers, :proportional_set_size, :decimal, :precision => 20, :scale => 0
+  end
+end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -45,10 +45,7 @@ gem "rufus-lru",               "~>1.0.3",           :require => false
 gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
-
-if RbConfig::CONFIG["host_os"].include?("darwin") # This is only used on Mac
-  gem 'sys-proctable',  "~> 0.9",      :require => false
-end
+gem 'sys-proctable',           "~> 1.0",            :require => false
 
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")

--- a/gems/pending/util/miq-process.rb
+++ b/gems/pending/util/miq-process.rb
@@ -1,6 +1,7 @@
 # encoding: US-ASCII
 
 require 'sys-uname'
+require 'sys/proctable'
 require 'util/runcmd'
 require 'util/win32/miq-wmi'
 require 'util/miq-system'
@@ -111,6 +112,7 @@ class MiqProcess
       cpu_total /= MiqSystem.num_cpus
       percent_cpu             = (1.0 * result[:cpu_time]) / cpu_total
       result[:percent_cpu]    = round_to(percent_cpu * 100.0, 2)
+      result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.pss
     when :macosx
       h = nil
       begin
@@ -205,7 +207,6 @@ class MiqProcess
         end
       end
     when :macosx
-      require 'sys/proctable'
       Sys::ProcTable.ps.select do |p|
         if p.cmdline && cmd.match(p.cmdline.tr("\000", " ").strip)
           pids << p.pid

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -1,13 +1,39 @@
 require "spec_helper"
 
-describe "StatusManagement" do
-  before(:each) do
-    @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-  end
+describe MiqServer do
+  context "StatusManagement" do
+    before(:each) do
+      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    end
 
-  # for now, just making sure there are no syntax errors
-  it ".log_status" do
-    expect(MiqServer).to receive(:log_system_status).once
-    MiqServer.log_status
+    # for now, just making sure there are no syntax errors
+    it ".log_status" do
+      expect(MiqServer).to receive(:log_system_status).once
+      MiqServer.log_status
+    end
+
+    it ".status_update" do
+      require 'miq-process'
+      allow(MiqProcess).to receive(:processInfo).and_return(
+        :pid                   => 94_660,
+        :memory_usage          => 246_824_960,
+        :memory_size           => 2_792_611_840,
+        :percent_memory        => "1.4",
+        :percent_cpu           => "1.0",
+        :cpu_time              => 660,
+        :priority              => "31",
+        :name                  => "ruby",
+        :proportional_set_size => 198_721_987
+      )
+
+      described_class.status_update
+      @miq_server.reload
+      expect(@miq_server.os_priority).to eq 31
+      expect(@miq_server.memory_usage).to eq 246_824_960
+      expect(@miq_server.percent_memory).to eq 1.4
+      expect(@miq_server.percent_cpu).to eq 1.0
+      expect(@miq_server.memory_size).to eq 2_792_611_840
+      expect(@miq_server.proportional_set_size).to eq 198_721_987
+    end
   end
 end

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -226,5 +226,31 @@ describe MiqWorker do
       @worker.update_attribute(:status, described_class::STATUS_WORKING)
       expect(@worker.is_current?).to be_truthy
     end
+
+    it ".status_update" do
+      @worker.update_attribute(:pid, 123)
+
+      require 'miq-process'
+      allow(MiqProcess).to receive(:processInfo).with(123).and_return(
+        :pid                   => 123,
+        :memory_usage          => 246_824_960,
+        :memory_size           => 2_792_611_840,
+        :percent_memory        => "1.4",
+        :percent_cpu           => "1.0",
+        :cpu_time              => 660,
+        :priority              => "31",
+        :name                  => "ruby",
+        :proportional_set_size => 198_721_987
+      )
+
+      described_class.status_update
+      @worker.reload
+      expect(@worker.os_priority).to eq 31
+      expect(@worker.memory_usage).to eq 246_824_960
+      expect(@worker.percent_memory).to eq 1.4
+      expect(@worker.percent_cpu).to eq 1.0
+      expect(@worker.memory_size).to eq 2_792_611_840
+      expect(@worker.proportional_set_size).to eq 198_721_987
+    end
   end
 end


### PR DESCRIPTION
If you fork processes, there can be a significant amount of memory that is shared with
multiple processes. Resident set size (RSS) treats 1k of shared and 1k of private memory as
consuming the same amount of memory.  Using RSS to describe how much memory each
process is using is not accurately accounting for the shared memory being
distributed between multiple processes.

From: https://github.com/djberg96/sys-proctable/pull/49

```
PSS is the size of private pages added to each shared mapping's size
divided by the number of processes that share it. It is meant to provide a
better representation of the amount of memory actually used by a process.

If a process has 4k of private pages, 4k of shared pages shared with one
other process, and 3k of pages shared with two other processes, the PSS
is:

4k + (4k / 2) + (3k / 3) = 7k
```

In the above example, RSS would report:
```
4k + 4k + 3k = 11k
```