### PR TITLE
Fix: UI can now set worker memory threshold

### DIFF
--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -251,7 +251,7 @@ module VMDB
       klass = Object.const_get(klass) unless klass.class == Class
 
       # find the key for the class and set the value
-      keys = klass.config_settings_path + settings.to_miq_a
+      keys = klass.config_settings_path + setting.to_miq_a
       config.store_path(keys, value)
     end
 

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -71,4 +71,15 @@ describe VMDB::Config do
       expect(error[1]).to match(/\AFile contents are malformed/)
     end
   end
+
+  describe "set_worker_setting!" do
+    it "stores path" do
+      config = VMDB::Config.new("vmdb")
+      config.set_worker_setting!(:MiqEmsMetricsCollectorWorker, :memory_threshold, "250.megabytes")
+
+      fq_keys = [:workers, :worker_base, :queue_worker_base, :ems_metrics_collector_worker] + [:memory_threshold]
+      v = config.config.fetch_path(fq_keys).to_i_with_method
+      expect(v).to eq(250.megabytes)
+    end
+  end
 end


### PR DESCRIPTION
Introduced a bug while refactoring worker configuration.
Introduced specs around that area and also around where specs are read

Fix: Can now set worker configuration values in UI

Bug introduced in 49dc2581fed7acfc50c5a7d4c984289de0031906

https://bugzilla.redhat.com/show_bug.cgi?id=1296638#c2

/cc @dclarizio @akrzos @Fryguy 