### PR TITLE
Fixes #6117 - disabled toolbar button tooltip should remain if no alternate text given

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -119,7 +119,7 @@ class ApplicationHelper::ToolbarBuilder
     dis_title = build_toolbar_disable_button(button['id'])
     if dis_title
       button["enabled"] = "false"
-      button["title"]   = dis_title
+      button["title"]   = dis_title if dis_title.kind_of? String
     end
     button
   end


### PR DESCRIPTION
Fixes #6117
disabled toolbar button tooltip remains the same if no alternate text
![true_tooltip2](https://cloud.githubusercontent.com/assets/11256940/12230606/632e17bc-b85a-11e5-8fa5-a13d8ad61c89.png)
![true_tooltip1](https://cloud.githubusercontent.com/assets/11256940/12230607/6331176e-b85a-11e5-9473-438b69301220.png)

@himdel @abonas @martinpovolny 