### PR TITLE
Add all tenant ancestors to group creation page

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1078,11 +1078,10 @@ module OpsController::OpsRbac
     end
 
     @edit[:projects_tenants] = []
-    all_tenants = Tenant.all_tenants
-    all_projects = Tenant.all_projects
+    all_tenants, all_projects = Tenant.tenant_and_project_names
     @edit[:projects_tenants].push(["", [["<Choose a Project/Tentant>", :selected => "<Choose a Project/Tentant>", :disabled => "<Choose a Project/Tentant>", :style => 'display:none']]])
-    @edit[:projects_tenants].push(["Projects", all_projects.sort_by(&:name).collect { |tenant| [tenant.name, tenant.id] }]) unless all_projects.blank?
-    @edit[:projects_tenants].push(["Tenants", all_tenants.sort_by(&:name).collect { |tenant| [tenant.name, tenant.id] }]) unless all_tenants.blank?
+    @edit[:projects_tenants].push(["Projects", all_projects]) unless all_projects.blank?
+    @edit[:projects_tenants].push(["Tenants", all_tenants]) unless all_tenants.blank?
     @edit[:new][:group_tenant] = @group.tenant_id
 
     @edit[:current] = copy_hash(@edit[:new])


### PR DESCRIPTION
This is to avoid ambiguity in case there are more
tenants with the same name.

https://bugzilla.redhat.com/show_bug.cgi?id=1292165

Before
![group-tenants-before](https://cloud.githubusercontent.com/assets/6648365/12234801/bb735cf6-b86f-11e5-86f9-3a10df163d4c.jpg)

After
![group-tenants-after](https://cloud.githubusercontent.com/assets/6648365/12234804/c111b9be-b86f-11e5-81d7-bc67d1440abb.jpg)
