### PR TITLE
Need to restore certain keys back into session hash

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -659,16 +659,12 @@ class DashboardController < ApplicationController
   end
 
   def session_reset
-    # Clear session hash just to be sure nothing is left (but copy over some fields)
-    winh    = session[:winH]
-    winw    = session[:winW]
-    referer = session['referer']
+    # save some fields to recover back into session hash after session is cleared
+    keys_to_restore = [:winH, :winW, :referer, :browser, :user_TZO]
+    data_to_restore = keys_to_restore.each_with_object({}) { |k, v| v[k] = session[k] }
 
     session.clear
-
-    session[:winH]     = winh
-    session[:winW]     = winw
-    session['referer'] = referer
+    session.merge!(data_to_restore)
 
     # Clear instance vars that end up in the session
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -297,6 +297,31 @@ describe DashboardController do
     end
   end
 
+  context "#session_reset" do
+    it "verify certain keys are restored after session is cleared" do
+      winH               = '600'
+      winW               = '800'
+      referer            = 'foo'
+      user_TZO           = '5'
+      browser_info       = {:name => 'firefox', :version => '32'}
+      session[:browser]  = browser_info
+      session['referer'] = referer
+      session[:user_TZO] = user_TZO
+      session[:winH]     = winH
+      session[:winW]     = winW
+      session[:foo]      = 'foo_bar'
+
+      controller.send(:session_reset)
+
+      expect(session['referer']).to eq(referer)
+      expect(session[:browser]).to eq(browser_info)
+      expect(session[:winH]).to eq(winH)
+      expect(session[:winW]).to eq(winW)
+      expect(session[:user_TZO]).to eq(user_TZO)
+      expect(session[:foo]).to eq(nil)
+    end
+  end
+
   def skip_data_checks(url = '/')
     allow_any_instance_of(UserValidationService).to receive(:server_ready?).and_return(true)
     allow(controller).to receive(:start_url_for_user).and_return(url)


### PR DESCRIPTION
session.clear call clears out user's browser information that's being saved in session when user logs in, need to save & restore certain keys in session hash for later use.

https://bugzilla.redhat.com/show_bug.cgi?id=1297074
https://bugzilla.redhat.com/show_bug.cgi?id=1297432
https://bugzilla.redhat.com/show_bug.cgi?id=1297434

@dclarizio please review.