### PR TITLE
Azure private image provisioning support

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -47,13 +47,6 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
     allowed_ci(:availability_zones, [:cloud_network, :cloud_subnet, :security_group], targets.map(&:id))
   end
 
-  def validate_cloud_subnet(field, values, dlg, fld, value)
-    return nil unless value.blank?
-    return nil if get_value(values[:cloud_network]).to_i.zero?
-    return nil unless get_value(values[field]).blank?
-    "#{required_description(dlg, fld)} is required"
-  end
-
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -6,6 +6,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_nested :Refresher
   require_nested :Vm
   require_nested :Template
+  require_nested :Provision
+  require_nested :ProvisionWorkflow
   require_nested :OrchestrationStack
   require_nested :OrchestrationServiceOptionConverter
   require_nested :SecurityGroup

--- a/app/models/manageiq/providers/azure/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision.rb
@@ -1,4 +1,4 @@
 class ManageIQ::Providers::Azure::CloudManager::Provision < ManageIQ::Providers::CloudManager::Provision
   include_concern 'Cloning'
-  include_concern 'StateMachine'
+  include_concern 'OptionsHelper'
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision.rb
@@ -1,0 +1,4 @@
+class ManageIQ::Providers::Azure::CloudManager::Provision < ManageIQ::Providers::CloudManager::Provision
+  include_concern 'Cloning'
+  include_concern 'StateMachine'
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -1,0 +1,143 @@
+module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
+  def do_clone_task_check(clone_task_ref)
+    source.with_provider_connection do |azure|
+      vms               = Azure::Armrest::VirtualMachineService.new(azure)
+      vm_name           = clone_task_ref[3]
+      vm_resource_group = clone_task_ref[1]
+      instance          = vms.get(vm_name, vm_resource_group)
+      status            = instance.properties.provisioning_state
+
+      return true if status == "Succeeded"
+      return false, status
+    end
+  end
+
+  def find_destination_in_vmdb(vm_uid)
+    ems_ref = vm_uid.join("\\")
+    ManageIQ::Providers::Azure::CloudManager::Vm.find_by(:ems_ref => ems_ref.downcase)
+  end
+
+  def gather_storage_account_properties
+    sas = nil
+    source.with_provider_connection do |azure|
+      sas = Azure::Armrest::StorageAccountService.new(azure)
+    end
+    return if sas.nil?
+
+    begin
+      key             = sas.list_account_keys(storage_account_name, storage_account_resource_group).fetch('key1')
+      storage_account = sas.get(storage_account_name, storage_account_resource_group)
+      blob            = storage_account.blobs("system", key).first
+      blob_properties = storage_account.blob_properties(blob.container, blob.name, key)
+      endpoint        = storage_account.properties.primary_endpoints.blob
+      source_uri      = File.join(endpoint, blob.container, blob.name)
+      target_uri      = File.join(endpoint, "manageiq", dest_name + "_" + SecureRandom.uuid + ".vhd")
+    rescue Azure::Armrest::ResourceNotFoundException => err
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+    end
+
+    return target_uri, source_uri, blob_properties.x_ms_meta_microsoftazurecompute_ostype
+  end
+
+  def root_password
+    MiqPassword.decrypt(options[:root_password]) if options[:root_password]
+  end
+
+  def custom_data
+    Base64.encode64(userdata_payload.encode("UTF-8")).delete("\n")
+  end
+
+  def prepare_for_clone_task
+    nic_id = create_nic
+    target_uri, source_uri, os = gather_storage_account_properties
+
+    cloud_options = {
+      :name       => dest_name,
+      :location   => source.location,
+      :properties => {
+        :hardwareProfile => {
+          :vmSize => instance_type.name
+        },
+        :osProfile => {
+            :adminUserName => options[:root_username],
+            :adminPassword => root_password,
+            :computerName  => dest_name
+        },
+        :storageProfile => {
+          :osDisk => {
+            :createOption => 'FromImage',
+            :caching      => 'ReadWrite',
+            :name         => dest_name + SecureRandom.uuid + '.vhd',
+            :osType       => os,
+            :image        => {:uri => source_uri},
+            :vhd          => {:uri => target_uri},
+          }
+        },
+        :networkProfile => {
+          :networkInterfaces => [{:id => nic_id}],
+        }
+      }
+    }
+    cloud_options[:properties][:osProfile][:customData] = custom_data unless userdata_payload.nil?
+    cloud_options
+  end
+
+  def log_clone_options(clone_options)
+    dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
+    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected =>
+    {:path => workflow_class.encrypted_options_field_regs})
+  end
+
+  def region
+    source.location
+  end
+
+  def resource_group
+    ResourceGroup.find_by(:id => options[:resource_group]).name
+  end
+
+  def storage_account_resource_group
+    source.description.split("\\").first
+  end
+
+  def storage_account_name
+    source.description.split("\\")[1]
+  end
+
+  def create_nic
+    source.with_provider_connection do |azure|
+      nis = Azure::Armrest::Network::NetworkInterfaceService.new(azure)
+      ips = Azure::Armrest::Network::IpAddressService.new(azure)
+
+      ip = ips.create("#{dest_name}-publicIp", resource_group, :location => region)
+      network_options = {
+        :location   => region,
+        :properties => {
+          :ipConfigurations => [
+            :name       => dest_name,
+            :properties => {
+              :subnet => {
+                :id => cloud_subnet.ems_ref
+              },
+              :publicIPAddress => {
+                :id => ip.id
+              },
+            }
+          ],
+        }
+      }
+
+      return nis.create(dest_name, resource_group, network_options).id
+    end
+  end
+
+  def start_clone(clone_options)
+    source.with_provider_connection do |azure|
+      vms = Azure::Armrest::VirtualMachineService.new(azure)
+      vm  = vms.create(dest_name, resource_group, clone_options)
+      subscription_id = vm.id.split('/')[2]
+
+      return subscription_id, vm.resource_group, vm.type.downcase, vm.name
+    end
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
@@ -4,6 +4,6 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::OptionsHelper
   end
 
   def resource_group
-    ResourceGroup.find_by(:id => options[:resource_group]).name
+    @resource_group ||= ResourceGroup.find_by(:id => options[:resource_group])
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers::Azure::CloudManager::Provision::OptionsHelper
+  def root_password
+    MiqPassword.decrypt(options[:root_password]) if options[:root_password]
+  end
+
+  def resource_group
+    ResourceGroup.find_by(:id => options[:resource_group]).name
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
@@ -1,0 +1,2 @@
+module ManageIQ::Providers::Azure::CloudManager::Provision::StateMachine
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/state_machine.rb
@@ -1,2 +1,0 @@
-module ManageIQ::Providers::Azure::CloudManager::Provision::StateMachine
-end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -1,0 +1,45 @@
+class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Providers::CloudManager::ProvisionWorkflow
+  def allowed_instance_types(_options = {})
+    source = load_ar_obj(get_source_vm)
+    ems    = source.try(:ext_management_system)
+    return {} if ems.nil?
+    flavors = ems.flavors
+    flavors.each_with_object({}) { |f, hash| hash[f.id] = display_name_for_name_description(f) }
+  end
+
+  def allowed_resource_groups(_options = {})
+    source = load_ar_obj(get_source_vm)
+    ems    = source.try(:ext_management_system)
+    return {} if ems.nil?
+    resource_groups = ems.resource_groups
+    resource_groups.each_with_object({}) { |rg, hash| hash[rg.id] = rg.name }
+  end
+
+  def allowed_cloud_subnets(_options = {})
+    src = resources_for_ui
+    if (cn = CloudNetwork.find_by(:id => src[:cloud_network_id]))
+      cn.cloud_subnets.each_with_object({}) do |cs, hash|
+        hash[cs.id] = "#{cs.name} (#{cs.cidr})"
+      end
+    else
+      {}
+    end
+  end
+
+  def validate_cloud_subnet(field, values, dlg, fld, value)
+    return nil unless value.blank?
+    return nil if get_value(values[:cloud_network]).to_i.zero?
+    return nil unless get_value(values[field]).blank?
+    "#{required_description(dlg, fld)} is required"
+  end
+
+  private
+
+  def dialog_name_from_automate(message = 'get_dialog_name')
+    super(message, {'platform' => 'azure'})
+  end
+
+  def self.provider_model
+    ManageIQ::Providers::Azure::CloudManager
+  end
+end

--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -26,13 +26,6 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
     end
   end
 
-  def validate_cloud_subnet(field, values, dlg, fld, value)
-    return nil unless value.blank?
-    return nil if get_value(values[:cloud_network]).to_i.zero?
-    return nil unless get_value(values[field]).blank?
-    "#{required_description(dlg, fld)} is required"
-  end
-
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -533,7 +533,8 @@ module ManageIQ::Providers
           :type               => ManageIQ::Providers::Azure::CloudManager::Template.name,
           :uid_ems            => uid,
           :ems_ref            => uid,
-          :name               => uid.split(%r{Microsoft.Compute\/}i)[1].split('.').first,
+          :name               => build_image_name(image),
+          :description        => build_image_description(image),
           :location           => @ems.provider_region,
           :vendor             => "azure",
           :raw_power_state    => "never",
@@ -550,6 +551,15 @@ module ManageIQ::Providers
       # Compose an id string combining some existing keys
       def resource_uid(*keys)
         keys.join('\\')
+      end
+
+      def build_image_name(image)
+        "#{image.uri.split(%r{Microsoft.Compute\/}i)[1].split('.').first}"
+      end
+
+      def build_image_description(image)
+        # Description is a concatenation of resource group and storage account
+        "#{image.storage_account.resource_group}\\#{image.storage_account.name}"
       end
 
       # Remap from children to parent

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -80,6 +80,13 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
     allowed_cloud_init_customization_templates(options)
   end
 
+  def validate_cloud_subnet(field, values, dlg, fld, value)
+    return nil unless value.blank?
+    return nil if get_value(values[:cloud_network]).to_i.zero?
+    return nil unless get_value(values[field]).blank?
+    "#{required_description(dlg, fld)} is required"
+  end
+
   private
 
   # Run the relationship methods and perform set intersections on the returned values.

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
   def self.eligible_for_provisioning
     super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
                             ManageIQ::Providers::Openstack::CloudManager::Template
+                            ManageIQ::Providers::Azure::CloudManager::Template
                             ManageIQ::Providers::Google::CloudManager::Template))
   end
 

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -31,7 +31,13 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUPPORTED_EMS_CLASSES = %w(ManageIQ::Providers::Vmware::InfraManager ManageIQ::Providers::Redhat::InfraManager ManageIQ::Providers::Amazon::CloudManager ManageIQ::Providers::Openstack::CloudManager ManageIQ::Providers::Microsoft::InfraManager ManageIQ::Providers::Google::CloudManager ManageIQ::Providers::Azure::CloudManager)
+  SUPPORTED_EMS_CLASSES = %w( ManageIQ::Providers::Vmware::InfraManager
+                              ManageIQ::Providers::Redhat::InfraManager
+                              ManageIQ::Providers::Amazon::CloudManager
+                              ManageIQ::Providers::Openstack::CloudManager
+                              ManageIQ::Providers::Microsoft::InfraManager
+                              ManageIQ::Providers::Google::CloudManager
+                              ManageIQ::Providers::Azure::CloudManager)
 
   def self.base_model
     MiqProvision

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -31,7 +31,7 @@ class MiqProvision < MiqProvisionTask
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
-  SUPPORTED_EMS_CLASSES = %w(ManageIQ::Providers::Vmware::InfraManager ManageIQ::Providers::Redhat::InfraManager ManageIQ::Providers::Amazon::CloudManager ManageIQ::Providers::Openstack::CloudManager ManageIQ::Providers::Microsoft::InfraManager ManageIQ::Providers::Google::CloudManager)
+  SUPPORTED_EMS_CLASSES = %w(ManageIQ::Providers::Vmware::InfraManager ManageIQ::Providers::Redhat::InfraManager ManageIQ::Providers::Amazon::CloudManager ManageIQ::Providers::Openstack::CloudManager ManageIQ::Providers::Microsoft::InfraManager ManageIQ::Providers::Google::CloudManager ManageIQ::Providers::Azure::CloudManager)
 
   def self.base_model
     MiqProvision

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -67,7 +67,7 @@
             :owner_manager_phone, :owner_phone, :owner_phone_mobile,
             :owner_state, :owner_title, :owner_zip, :request_notes,
             :subnet_mask, :memory_limit, :memory_reserve,
-            :root_password, :sysprep_password, :sysprep_domain_admin,
+            :root_username, :root_password, :sysprep_password, :sysprep_domain_admin,
             :sysprep_domain_password, :sysprep_workgroup_name,
             :sysprep_full_name, :sysprep_organization,
             :sysprep_product_id, :sysprep_computer_name,
@@ -240,6 +240,7 @@
                :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8,
                :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
                :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
+               :resource_group,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory, 
                :vm_maximum_memory, :boot_disk_size].include?(field)

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -131,7 +131,7 @@
             :keys                       => keys,
             :extra_table_attributes     => "width=100%"})
       - if wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
-        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network, :cloud_subnet, :security_groups, :floating_ip_address]
+        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,
@@ -322,7 +322,7 @@
               :prefix                     => "/miq_request/",
               :keys                       => keys})
     - else
-      - keys = [:root_password]
+      - keys = [:root_username, :root_password]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
           :dialog                     => dialog,

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -1,7 +1,7 @@
 #main_div
   - arr = %w(container_images container_image_registries containers container_replicators container_routes)
   - arr.concat(%w(container_projects container_nodes container_services container_groups availability_zones))
-  - arr.concat(%w(cloud_tenants ems_clusters flavors security_groups hosts instances images miq_templates cloud_volumes))
+  - arr.concat(%w(cloud_tenants ems_clusters flavors security_groups resource_group hosts instances images miq_templates cloud_volumes))
   - arr.concat(%w(orchestration_stacks vms storages miq_proxies persistent_volumes))
   - if arr.include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@ems.id}"}

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-cloud_manager-provision.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Azure_CloudManager_Provision < MiqAeServiceManageIQ_Providers_CloudManager_Provision
+  end
+end

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -143,14 +143,6 @@
           :display: :hide
           :default: false
           :data_type: :boolean
-        :placement_availability_zone:
-          :values_from:
-            :method: :allowed_availability_zones
-          :description: Availability Zone
-          :required: false
-          :display: :hide
-          :data_type: :integer
-          :required_description: Availability Zone Name
         :resource_group:
           :values_from:
             :method: :allowed_resource_groups
@@ -179,15 +171,6 @@
           :values_from:
             :method: :allowed_security_groups
           :description: Security Groups
-          :required: false
-          :display: :hide
-          :data_type: :integer
-        :floating_ip_address:
-          :values_from:
-            :method: :allowed_floating_ip_addresses
-          :description: Reserved IP Address
-          :auto_select_single: false
-          :default: nil
           :required: false
           :display: :hide
           :data_type: :integer
@@ -299,22 +282,6 @@
           :required: true
           :display: :edit
           :data_type: :integer
-        :guest_access_key_pair:
-          :values_from:
-            :method: :allowed_guest_access_key_pairs
-          :description: Guest Access Key Pair
-          :required: false
-          :display: :hide
-          :data_type: :integer
-        :monitoring:
-          :values:
-            basic: Basic
-            advanced: Advanced
-          :description: CloudWatch
-          :required: true
-          :default: basic
-          :display: :hide
-          :data_type: :string
       :display: :show
     :customize:
       :description: Customize

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -1,0 +1,397 @@
+--- 
+:name: miq_provision_azure_dialogs_template
+:description: Sample Azure Instance Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content: 
+  :buttons: 
+  - :submit
+  - :cancel
+  :dialogs: 
+    :requester: 
+      :description: Request
+      :fields: 
+        :owner_phone: 
+          :description: Phone
+          :required: false
+          :display: :show
+          :data_type: :string
+        :owner_country: 
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile: 
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title: 
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name: 
+          :description: First Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager: 
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address: 
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company: 
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name: 
+          :description: Last Name
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail: 
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city: 
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department: 
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap: 
+          :pressed: 
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone: 
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state: 
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office: 
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip: 
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email: 
+          :description: E-Mail
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order: 
+    :purpose: 
+      :description: Purpose
+      :fields: 
+        :vm_tags: 
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options: 
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order: 
+    :environment: 
+      :description: Environment
+      :fields:
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :hide
+          :default: false
+          :data_type: :boolean
+        :placement_availability_zone:
+          :values_from:
+            :method: :allowed_availability_zones
+          :description: Availability Zone
+          :required: false
+          :display: :hide
+          :data_type: :integer
+          :required_description: Availability Zone Name
+        :resource_group:
+          :values_from:
+            :method: :allowed_resource_groups
+          :description: Resource Groups
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :cloud_network:
+          :values_from:
+            :method: :allowed_cloud_networks
+          :description: Virtual Private Cloud
+          :auto_select_single: false
+          :default: nil
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :cloud_subnet:
+          :values_from:
+            :method: :allowed_cloud_subnets
+          :description: Cloud Subnet
+          :required: true
+          :required_method: :validate_cloud_subnet
+          :display: :edit
+          :data_type: :integer
+        :security_groups:
+          :values_from:
+            :method: :allowed_security_groups
+          :description: Security Groups
+          :required: false
+          :display: :hide
+          :data_type: :integer
+        :floating_ip_address:
+          :values_from:
+            :method: :allowed_floating_ip_addresses
+          :description: Reserved IP Address
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :hide
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: Instance Description
+          :required: false
+          :display: :hide
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: Instance Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes: 
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :hide
+        :vm_name: 
+          :description: Instance Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes: 
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length: 
+          :max_length:
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :hardware:
+      :description: Properties
+      :fields:
+        :instance_type:
+          :values_from:
+            :method: :allowed_instance_types
+          :description: Instance Type
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :guest_access_key_pair:
+          :values_from:
+            :method: :allowed_guest_access_key_pairs
+          :description: Guest Access Key Pair
+          :required: false
+          :display: :hide
+          :data_type: :integer
+        :monitoring:
+          :values:
+            basic: Basic
+            advanced: Advanced
+          :description: CloudWatch
+          :required: true
+          :default: basic
+          :display: :hide
+          :data_type: :string
+      :display: :show
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :root_username:
+          :description: Username
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :root_password:
+          :description: Password
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+  :dialog_order: 
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :customize
+  - :schedule

--- a/spec/factories/flavor.rb
+++ b/spec/factories/flavor.rb
@@ -7,5 +7,4 @@ FactoryGirl.define do
   factory :flavor_google,    :parent => :flavor, :class => "ManageIQ::Providers::Google::CloudManager::Flavor"
   factory :flavor_openstack, :parent => :flavor, :class => "ManageIQ::Providers::Openstack::CloudManager::Flavor"
   factory :flavor_azure,     :parent => :flavor, :class => "ManageIQ::Providers::Azure::CloudManager::Flavor"
-
 end

--- a/spec/factories/flavor.rb
+++ b/spec/factories/flavor.rb
@@ -6,4 +6,6 @@ FactoryGirl.define do
   factory :flavor_amazon,    :parent => :flavor, :class => "ManageIQ::Providers::Amazon::CloudManager::Flavor"
   factory :flavor_google,    :parent => :flavor, :class => "ManageIQ::Providers::Google::CloudManager::Flavor"
   factory :flavor_openstack, :parent => :flavor, :class => "ManageIQ::Providers::Openstack::CloudManager::Flavor"
+  factory :flavor_azure,     :parent => :flavor, :class => "ManageIQ::Providers::Azure::CloudManager::Flavor"
+
 end

--- a/spec/factories/miq_provision_azure.rb
+++ b/spec/factories/miq_provision_azure.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_provision_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Provision" do
+  end
+end

--- a/spec/factories/template_azure.rb
+++ b/spec/factories/template_azure.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :template_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Template", :parent => :template_cloud do
+    location { |x| "#{x.name}/#{x.name}.img.manifest.xml" }
+    vendor   "azure"
+  end
+end

--- a/spec/factories/vm_azure.rb
+++ b/spec/factories/vm_azure.rb
@@ -2,6 +2,9 @@ FactoryGirl.define do
   factory :vm_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Vm", :parent => :vm_cloud do
     location "westus"
     vendor   "azure"
+    uid_ems  "01234567890\\test_resource_group\\microsoft.resources\\vm_1"
+    ems_ref  "01234567890\\test_resource_group\\microsoft.resources\\vm_1"
     raw_power_state "VM running"
+    name "vm_1"
   end
 end

--- a/spec/factories/vm_openstack.rb
+++ b/spec/factories/vm_openstack.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :vm_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::Vm", :parent => :vm_cloud do
     vendor          "openstack"
     raw_power_state "ACTIVE"
+    ems_ref         "openstack-vm"
   end
 
   factory :vm_perf_openstack, :parent => :vm_openstack do

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -4,6 +4,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
   let(:provider) { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template) { FactoryGirl.create(:template_azure, :ext_management_system => provider) }
   let(:flavor)   { FactoryGirl.create(:flavor_azure) }
+  let(:vm)       { FactoryGirl.create(:vm_azure, :ext_management_system => provider) }
 
   context "#create vm" do
     subscription_id = "01234567890"
@@ -26,7 +27,8 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
         :name            => name
       }
       it "VM in same sub-class" do
-        vm = FactoryGirl.create(:vm_azure, :ext_management_system => provider)
+        vm_uid_hash[:subscription_id] = subscription_id
+        vm
         expect(subject.find_destination_in_vmdb(vm_uid_hash)).to eq(vm)
       end
 
@@ -37,7 +39,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
 
       it "VM in different sub-class" do
         vm = FactoryGirl.create(:vm_openstack, :ext_management_system => provider)
-        expect(subject.find_destination_in_vmdb(:ems_ref=> vm.ems_ref)).to be_nil
+        expect(subject.find_destination_in_vmdb(:ems_ref => vm.ems_ref)).to be_nil
       end
     end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Azure::CloudManager::Provision do
+  let(:provider) { FactoryGirl.create(:ems_azure_with_authentication) }
+  let(:template) { FactoryGirl.create(:template_azure, :ext_management_system => provider) }
+  let(:flavor)   { FactoryGirl.create(:flavor_azure) }
+
+  context "#create vm" do
+    subscription_id = "01234567890"
+    resource_group  = "test_resource_group"
+    type            = "microsoft.resources"
+    name            = "vm_1"
+    nic_id          = "nic_id_1"
+
+    before(:each) do
+      subject.source = template
+      allow(subject).to receive(:gather_storage_account_properties).and_return(%w("target_uri", "source_uri", "windows"))
+      allow(subject).to receive(:create_nic).and_return(nic_id)
+    end
+
+    context "#find_destination_in_vmdb" do
+      it "VM in same sub-class" do
+        vm = FactoryGirl.create(:vm_azure, :ext_management_system => provider)
+        expect(subject.find_destination_in_vmdb([subscription_id, resource_group, type, name])).to eq(vm)
+      end
+
+      it "VM in same sub-class with invalid parameters" do
+        expect(subject.find_destination_in_vmdb(["invalid_subscription_id", resource_group, type, name])).to be_nil
+      end
+
+      it "VM in different sub-class" do
+        vm = FactoryGirl.create(:vm_openstack, :ext_management_system => provider)
+        vm.ems_ref = "openstack_vm"
+        expect(subject.find_destination_in_vmdb([vm.ems_ref])).to be_nil
+      end
+    end
+
+    context "#validate_dest_name" do
+      let(:vm) { FactoryGirl.create(:vm_azure, :ext_management_system => provider) }
+
+      it "with valid name" do
+        allow(subject).to receive(:dest_name).and_return("new_vm_1")
+        expect { subject.validate_dest_name }.to_not raise_error
+      end
+
+      it "with a blank name" do
+        allow(subject).to receive(:dest_name).and_return("")
+        expect { subject.validate_dest_name }.to raise_error
+      end
+
+      it "with a nil name" do
+        allow(subject).to receive(:dest_name).and_return(nil)
+        expect { subject.validate_dest_name }.to raise_error
+      end
+
+      it "with a duplicate name" do
+        allow(subject).to receive(:dest_name).and_return(vm.name)
+        expect { subject.validate_dest_name }.to raise_error
+      end
+    end
+
+    context "#prepare_for_clone_task" do
+      before do
+        allow(subject).to receive(:instance_type).and_return(flavor)
+      end
+
+      context "nic settings" do
+        it "with nic" do
+          subject.options[:vm_target_name] = name
+          expect(subject.prepare_for_clone_task[:properties][:networkProfile][:networkInterfaces][0][:id]).to eq(nic_id)
+        end
+      end
+    end
+
+    it "#workflow" do
+      user    = FactoryGirl.create(:user)
+      options = {:src_vm_id => [template.id, template.name]}
+      vm_prov = FactoryGirl.create(:miq_provision_azure,
+                                   :userid       => user.userid,
+                                   :source       => template,
+                                   :request_type => 'template',
+                                   :state        => 'pending',
+                                   :status       => 'Ok',
+                                   :options      => options)
+
+      workflow_class = ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow
+      allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
+
+      expect(vm_prov.workflow.class).to eq workflow_class
+      expect(vm_prov.workflow_class).to eq workflow_class
+    end
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -1,0 +1,170 @@
+require "spec_helper"
+
+describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
+  include WorkflowSpecHelper
+
+  let(:admin)    { FactoryGirl.create(:user_with_group) }
+  let(:ems)      { FactoryGirl.create(:ems_azure) }
+  let(:template) { FactoryGirl.create(:template_azure, :name => "template", :ext_management_system => ems) }
+  let(:workflow) do
+    stub_dialog
+    allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
+    allow_any_instance_of(ManageIQ::Providers::CloudManager::ProvisionWorkflow).to receive(:update_field_visibility)
+
+    wf = described_class.new({:src_vm_id => template.id}, admin.userid)
+    wf.instance_variable_set("@ems_xml_nodes", {})
+    wf
+  end
+
+  it "pass platform attributes to automate" do
+    stub_dialog
+    assert_automate_dialog_lookup(admin, 'cloud', 'azure')
+    described_class.new({}, admin.userid)
+  end
+
+  context "without applied tags" do
+    context "Instance Type (Flavor)" do
+      it "#get_targets_for_ems" do
+        flavor = FactoryGirl.create(:flavor, :name => "Standard_A0", :supports_32_bit => false,
+                                    :supports_64_bit => true)
+        ems.flavors << flavor
+        expect(workflow.allowed_instance_types.length).to eq(1)
+      end
+    end
+  end
+
+  context "with applied tags" do
+    before do
+      FactoryGirl.create(:classification_cost_center_with_tags)
+      admin.current_group.set_managed_filters([['/managed/cc/001']])
+      admin.current_group.set_belongsto_filters([])
+      admin.current_group.save
+      ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A0", :supports_32_bit => false,
+                                        :supports_64_bit => true)
+      ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,
+                                        :supports_64_bit => true)
+      tagged_flavor = ems.flavors.first
+      Classification.classify(tagged_flavor, 'cc', '001')
+    end
+
+    context "instance types (Flavor)" do
+      it "#get_targets_for_ems" do
+        expect(ems.flavors.size).to eq(2)
+        expect(ems.flavors.first.tags.size).to eq(1)
+        expect(ems.flavors.last.tags.size).to eq(0)
+        expect(workflow.allowed_instance_types.length).to eq(2)
+      end
+    end
+  end
+
+  context "when a template object is returned from the provider" do
+    context "with empty relationships" do
+      it "#allowed_instance_types" do
+        expect(workflow.allowed_instance_types).to eq({})
+      end
+
+      it "#allowed_resource_groups" do
+        expect(workflow.allowed_resource_groups).to eq({})
+      end
+    end
+
+    context "with valid relationships" do
+      before do
+        ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A0", :supports_32_bit => false,
+                                          :supports_64_bit => true)
+        ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,
+                                          :supports_64_bit => true)
+        ems.resource_groups << FactoryGirl.create(:resource_group)
+        ems.resource_groups << FactoryGirl.create(:resource_group)
+      end
+
+      it "#allowed_instance_types" do
+        expect(workflow.allowed_instance_types.length).to eq(2)
+      end
+
+      it "allowed_resource_groups" do
+        expect(workflow.allowed_resource_groups.length).to eq(2)
+      end
+    end
+  end
+
+  context "with VPC relationships" do
+    before do
+      @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems)
+      @cs1 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1)
+      @cs2 = FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1)
+    end
+
+    context "#allowed_cloud_subnets" do
+      it "without a cloud_network" do
+        expect(workflow.allowed_cloud_subnets.length).to be_zero
+      end
+
+      it "with a cloud_network" do
+        workflow.values[:cloud_network] = [@cn1.id, @cn1.name]
+        expect(workflow.allowed_cloud_subnets.length).to eq(2)
+      end
+    end
+  end
+
+  context "#display_name_for_name_description" do
+    let(:flavor) { FactoryGirl.create(:flavor_azure, :name => "test_flavor") }
+
+    it "with name only" do
+      expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor")
+    end
+
+    it "with name and description" do
+      flavor.description = "Small"
+      expect(workflow.display_name_for_name_description(flavor)).to eq("test_flavor: Small")
+    end
+  end
+
+  describe "#make_request" do
+    let(:alt_user) { FactoryGirl.create(:user_with_group) }
+    it "creates and update a request" do
+      stub_dialog(:get_pre_dialogs)
+      stub_dialog(:get_dialogs)
+
+      # if running_pre_dialog is set, it will run 'continue_request'
+      workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_created",
+        :target_class => "Vm",
+        :userid       => admin.userid,
+        :message      => "VM Provisioning requested by <#{admin.userid}> for Vm:#{template.id}"
+      )
+
+      # creates a request
+      stub_get_next_vm_name
+
+      # the dialogs populate this
+      values.merge!(:src_vm_id => template.id, :vm_tags => [])
+
+      request = workflow.make_request(nil, values)
+
+      expect(request).to be_valid
+      expect(request).to be_a_kind_of(MiqProvisionRequest)
+      expect(request.request_type).to eq("template")
+      expect(request.description).to eq("Provision from [#{template.name}] to [New VM]")
+      expect(request.requester).to eq(admin)
+      expect(request.userid).to eq(admin.userid)
+      expect(request.requester_name).to eq(admin.name)
+
+      # updates a request
+
+      stub_get_next_vm_name
+
+      workflow = described_class.new(values, alt_user)
+
+      expect(AuditEvent).to receive(:success).with(
+        :event        => "vm_provision_request_updated",
+        :target_class => "Vm",
+        :userid       => alt_user.userid,
+        :message      => "VM Provisioning request updated by <#{alt_user.userid}> for Vm:#{template.id}"
+      )
+      workflow.make_request(request, values)
+    end
+  end
+end


### PR DESCRIPTION
This PR is for Azure private imagine provisioning support.
It does not include support for security groups, floating IPs and key/value pairs because the Azure EMS Refresh does not support these pieces yet. However, support for security groups is in progress.