### PR TITLE
checks for last created BottleneckEvent failed for Hosts

### DIFF
--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -6,7 +6,8 @@ class BottleneckEvent < ActiveRecord::Base
   serialize :context_data
 
   def self.last_created_on(obj)
-    event = where("resource_type = ? AND resource_id = ?", obj.class.name, obj.id).order("created_on DESC").first
+    event = where("resource_type = ? AND resource_id = ?", obj.class.base_class.name, obj.id)
+            .order("created_on DESC").first
     event ? event.created_on : nil
   end
 

--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -13,7 +13,6 @@ class BottleneckEvent < ActiveRecord::Base
 
   def self.generate_future_events(obj)
     log_message_uniq_prefix = "Generating future bottleneck events for: [#{obj.class} - #{obj.name}]..."
-    _log.info(log_message_uniq_prefix)
     last = last_created_on(obj)
     if last && last >= 24.hours.ago.utc
       _log.info("#{log_message_uniq_prefix} Skipped, last creation [#{last}] was less than 24 hours ago")

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -77,36 +77,34 @@ describe BottleneckEvent do
     end
   end
 
-  describe ".last_created_on" do
-    context "returns the last created_on date" do
-      def expect_last_created_on_to_eq_resource_last_created_on(resource)
-        bottleneck_event = BottleneckEvent.create!(:resource => resource)
-        expect(described_class.last_created_on(resource)).to be_same_time_as(bottleneck_event.created_on)
-      end
+  describe "#last_created_on" do
+    subject { described_class.last_created_on(resource) }
+    let(:resource) { FactoryGirl.create(resource_name) }
+    let!(:bottleneck_event) { BottleneckEvent.create!(:resource => resource) }
 
-      specify "for a host_redhat resource" do
-        resource = FactoryGirl.create(:host_redhat)
-        expect_last_created_on_to_eq_resource_last_created_on(resource)
-      end
+    context "for a host_redhat resource" do
+      let(:resource_name) { :host_redhat }
+      it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
+    end
 
-      specify "for a host_vmware resource" do
-        resource = FactoryGirl.create(:host_vmware)
-        expect_last_created_on_to_eq_resource_last_created_on(resource)
-      end
-      specify "for a miq_enterprise resource" do
-        resource = FactoryGirl.create(:miq_enterprise)
-        expect_last_created_on_to_eq_resource_last_created_on(resource)
-      end
+    context "for a host_vmware resource" do
+      let(:resource_name) { :host_vmware }
+      it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
+    end
 
-      specify "for a ems_redhat resource" do
-        resource = FactoryGirl.create(:ems_redhat)
-        expect_last_created_on_to_eq_resource_last_created_on(resource)
-      end
+    context "for a miq_enterprise resource" do
+      let(:resource_name) { :miq_enterprise }
+      it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
+    end
 
-      specify "for a ems_cluster_openstack resource" do
-        resource = FactoryGirl.create(:ems_cluster_openstack)
-        expect_last_created_on_to_eq_resource_last_created_on(resource)
-      end
+    context "for a ems_redhat resource" do
+      let(:resource_name) { :ems_redhat }
+      it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
+    end
+
+    context "for a ems_cluster_openstack resource" do
+      let(:resource_name) { :ems_cluster_openstack }
+      it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
     end
   end
 end

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -81,7 +81,7 @@ describe BottleneckEvent do
     context "returns the last created_on date" do
       def expect_last_created_on_to_eq_resource_last_created_on(resource)
         bottleneck_event = BottleneckEvent.create!(:resource => resource)
-        expect(described_class.last_created_on(resource)).to eq(bottleneck_event.reload.created_on)
+        expect(described_class.last_created_on(resource)).to be_same_time_as(bottleneck_event.created_on)
       end
 
       specify "for a host_redhat resource" do

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -76,4 +76,18 @@ describe BottleneckEvent do
       expect(query).to match(/resource_type = 'EmsCluster'.*resource_type = 'Host'/)
     end
   end
+
+  describe ".last_created_on" do
+    it "returns the last created_on date for a host" do
+      host_redhat = FactoryGirl.create(:host_redhat)
+      bottleneck_event = BottleneckEvent.create!(:resource => host_redhat)
+      expect(described_class.last_created_on(host_redhat)).to eq(bottleneck_event.reload.created_on)
+    end
+
+    it "returns the last created_on date for a miq_region" do
+      miq_region = FactoryGirl.create(:miq_region)
+      bottleneck_event = BottleneckEvent.create!(:resource => miq_region)
+      expect(described_class.last_created_on(miq_region)).to eq(bottleneck_event.reload.created_on)
+    end
+  end
 end

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -78,16 +78,35 @@ describe BottleneckEvent do
   end
 
   describe ".last_created_on" do
-    it "returns the last created_on date for a host" do
-      host_redhat = FactoryGirl.create(:host_redhat)
-      bottleneck_event = BottleneckEvent.create!(:resource => host_redhat)
-      expect(described_class.last_created_on(host_redhat)).to eq(bottleneck_event.reload.created_on)
-    end
+    context "returns the last created_on date" do
+      def expect_last_created_on_to_eq_resource_last_created_on(resource)
+        bottleneck_event = BottleneckEvent.create!(:resource => resource)
+        expect(described_class.last_created_on(resource)).to eq(bottleneck_event.reload.created_on)
+      end
 
-    it "returns the last created_on date for a miq_region" do
-      miq_region = FactoryGirl.create(:miq_region)
-      bottleneck_event = BottleneckEvent.create!(:resource => miq_region)
-      expect(described_class.last_created_on(miq_region)).to eq(bottleneck_event.reload.created_on)
+      specify "for a host_redhat resource" do
+        resource = FactoryGirl.create(:host_redhat)
+        expect_last_created_on_to_eq_resource_last_created_on(resource)
+      end
+
+      specify "for a host_vmware resource" do
+        resource = FactoryGirl.create(:host_vmware)
+        expect_last_created_on_to_eq_resource_last_created_on(resource)
+      end
+      specify "for a miq_enterprise resource" do
+        resource = FactoryGirl.create(:miq_enterprise)
+        expect_last_created_on_to_eq_resource_last_created_on(resource)
+      end
+
+      specify "for a ems_redhat resource" do
+        resource = FactoryGirl.create(:ems_redhat)
+        expect_last_created_on_to_eq_resource_last_created_on(resource)
+      end
+
+      specify "for a ems_cluster_openstack resource" do
+        resource = FactoryGirl.create(:ems_cluster_openstack)
+        expect_last_created_on_to_eq_resource_last_created_on(resource)
+      end
     end
   end
 end


### PR DESCRIPTION
`Host` uses STI and `BottleneckEvent` uses a polymorphic relation to
a resource, which can be a `Host`.
When creating a `BottleneckEvent` its resource_type is the base_class
of the STI class. Like this

```ruby
host = ManageIQ::Providers::Redhat::InfraManager::Host.create!(name: 'test')
event = BottleneckEvent.create!(:resource => host)
event.resource_type # => 'Host'
```

This caused the check for the last created `BottleneckEvent` to fail,
because `BottleneckEvent.last_created_on(obj)` queried on `class_name`.

It happened only for Hosts and could lead to way too many events created.
Normally we would only create one, if the last one was created less
than 24hrs ago.

Also, creating a BottleneckEvent may silently fail.
This could lead to a false log message about how many events have
been created. 

https://bugzilla.redhat.com/show_bug.cgi?id=1296113

- [ ] rebased