### PR TITLE
Convert #stub -> #allow (newer expect syntax for mocks)

### DIFF
--- a/gems/pending/spec/VMwareWebService/MiqVimClientBase_spec.rb
+++ b/gems/pending/spec/VMwareWebService/MiqVimClientBase_spec.rb
@@ -5,7 +5,7 @@ describe MiqVimClientBase do
   before do
     @logger  = $vim_log
     $vim_log = double.as_null_object
-    described_class.any_instance.stub(:retrieveServiceContent => double.as_null_object)
+    allow_any_instance_of(described_class).to receive_messages(:retrieveServiceContent => double.as_null_object)
   end
 
   after do

--- a/gems/pending/spec/appliance_console/certificate_authority_spec.rb
+++ b/gems/pending/spec/appliance_console/certificate_authority_spec.rb
@@ -51,7 +51,7 @@ describe ApplianceConsole::CertificateAuthority do
 
       expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .and_return(double("config", :activate => true, :configure_postgres => true))
-      PostgresAdmin.stub(:service_name => "postgresql")
+      allow(PostgresAdmin).to receive_messages(:service_name => "postgresql")
       expect(LinuxAdmin::Service).to receive(:new).and_return(double("Service", :restart => true))
       expect(FileUtils).to receive(:chmod).with(0644, anything)
 

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -368,7 +368,7 @@ describe ApplianceConsole::Cli do
 
   context "#disk_from_string" do
     before do
-      LinuxAdmin::Disk.stub(:local => [
+      allow(LinuxAdmin::Disk).to receive_messages(:local => [
         double(:path => "/dev/a", :partitions => %w(currently used)),
         double(:path => "/dev/b", :partitions => %w())
       ])

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -108,7 +108,7 @@ describe ApplianceConsole::DatabaseConfiguration do
 
   context "#validated" do
     it "normal case" do
-      @config.stub(:validate! => "truthy_object")
+      allow(@config).to receive_messages(:validate! => "truthy_object")
       expect(@config.validated).to be_truthy
     end
 
@@ -122,12 +122,12 @@ describe ApplianceConsole::DatabaseConfiguration do
 
   context "#create_region" do
     it "normal case" do
-      @config.stub(:log_and_feedback => :some_object)
+      allow(@config).to receive_messages(:log_and_feedback => :some_object)
       expect(@config.create_region).to be_truthy
     end
 
     it "failure" do
-      @config.stub(:log_and_feedback => nil)
+      allow(@config).to receive_messages(:log_and_feedback => nil)
       expect(@config.create_region).to be_falsey
     end
   end
@@ -312,7 +312,7 @@ describe ApplianceConsole::DatabaseConfiguration do
           "pools"    => "5",
         }
       }
-      described_class.stub(:load_current => @settings)
+      allow(described_class).to receive_messages(:load_current => @settings)
     end
 
     context "#merged_settings" do
@@ -336,28 +336,28 @@ describe ApplianceConsole::DatabaseConfiguration do
 
     context "#activate" do
       it "normal case" do
-        @config.stub(:validated => true)
+        allow(@config).to receive_messages(:validated => true)
         expect(@config).to receive(:create_or_join_region).and_return(true)
 
-        @config.stub(:merged_settings => @settings)
+        allow(@config).to receive_messages(:merged_settings => @settings)
         expect(@config).to receive(:do_save).with(@settings)
         expect(@config.activate).to be_truthy
       end
 
       it "doesn't save invalid settings" do
-        @config.stub(:validated => false)
+        allow(@config).to receive_messages(:validated => false)
         expect(@config).to receive(:do_save).never
         expect(@config.activate).to be_falsey
       end
 
       context "reverts on region failure" do
         before do
-          @config.stub(:validated => true)
-          @config.stub(:create_or_join_region => false)
+          allow(@config).to receive_messages(:validated => true)
+          allow(@config).to receive_messages(:create_or_join_region => false)
 
           new_settings = {"production" => @settings["production"].dup}
           new_settings["production"]["host"] = "new_host"
-          @config.stub(:merged_settings => new_settings)
+          allow(@config).to receive_messages(:merged_settings => new_settings)
           expect(@config).to receive(:do_save).with("production" => hash_including(new_settings["production"].except("password")))
           expect(@config).to receive(:do_save).with("production" => hash_including(@settings["production"].except("password")))
         end

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -23,7 +23,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   context "postgresql service" do
     it "#start_postgres (private)" do
       allow(LinuxAdmin::Service).to receive(:new).and_return(double(:service).as_null_object)
-      PostgresAdmin.stub(:service_name => 'postgresql')
+      allow(PostgresAdmin).to receive_messages(:service_name => 'postgresql')
       expect(@config).to receive(:block_until_postgres_accepts_connections)
       @config.send(:start_postgres)
     end
@@ -53,21 +53,21 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   end
 
   it ".postgresql_template" do
-    PostgresAdmin.stub(:data_directory     => Pathname.new("/var/lib/pgsql/data"))
-    PostgresAdmin.stub(:template_directory => Pathname.new("/opt/manageiq/manageiq-appliance/TEMPLATE"))
+    allow(PostgresAdmin).to receive_messages(:data_directory     => Pathname.new("/var/lib/pgsql/data"))
+    allow(PostgresAdmin).to receive_messages(:template_directory => Pathname.new("/opt/manageiq/manageiq-appliance/TEMPLATE"))
     expect(described_class.postgresql_template.to_s).to end_with("TEMPLATE/var/lib/pgsql/data")
   end
 
   context "#update_fstab (private)" do
     before do
-      PostgresAdmin.stub(:data_directory => "/var/lib/pgsql")
+      allow(PostgresAdmin).to receive_messages(:data_directory => "/var/lib/pgsql")
     end
 
     it "adds database disk entry" do
       fstab = double
-      fstab.stub(:entries => [])
+      allow(fstab).to receive_messages(:entries => [])
       expect(fstab).to receive(:write!)
-      LinuxAdmin::FSTab.stub(:instance => fstab)
+      allow(LinuxAdmin::FSTab).to receive_messages(:instance => fstab)
       @config.instance_variable_set(:@logical_volume, double(:path => "/dev/vg/lv"))
       expect(fstab.entries.count).to eq(0)
 
@@ -78,9 +78,9 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
     it "skips update if mount point is in fstab" do
       fstab = double
-      fstab.stub(:entries => [double(:mount_point => PostgresAdmin.data_directory)])
+      allow(fstab).to receive_messages(:entries => [double(:mount_point => PostgresAdmin.data_directory)])
       expect(fstab).to receive(:write!).never
-      LinuxAdmin::FSTab.stub(:instance => fstab)
+      allow(LinuxAdmin::FSTab).to receive_messages(:instance => fstab)
       expect(fstab.entries.count).to eq(1)
 
       @config.send(:update_fstab)

--- a/gems/pending/spec/appliance_console/prompts_spec.rb
+++ b/gems/pending/spec/appliance_console/prompts_spec.rb
@@ -262,7 +262,7 @@ describe ApplianceConsole::Prompts do
   context "#ask_for_disk" do
     context "with nodisks" do
       before do
-        LinuxAdmin::Disk.stub(:local => [double(:partitions => [:partition])])
+        allow(LinuxAdmin::Disk).to receive_messages(:local => [double(:partitions => [:partition])])
       end
 
       it "should be ok with not partitioning" do
@@ -295,7 +295,7 @@ describe ApplianceConsole::Prompts do
 
     context "with one disk" do
       before do
-        LinuxAdmin::Disk.stub(:local => double(:select => [first_disk]))
+        allow(LinuxAdmin::Disk).to receive_messages(:local => double(:select => [first_disk]))
       end
       let(:first_disk)  { double(:path => "/dev/a", :size => 10.megabyte) }
 
@@ -312,7 +312,7 @@ describe ApplianceConsole::Prompts do
 
     context "with disks" do
       before do
-        LinuxAdmin::Disk.stub(:local => double(:select => [first_disk, second_disk]))
+        allow(LinuxAdmin::Disk).to receive_messages(:local => double(:select => [first_disk, second_disk]))
       end
 
       let(:first_disk)  { double(:path => "/dev/a", :size => 10.megabyte) }

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -7,7 +7,7 @@ describe ApplianceConsole::ServiceGroup do
   let(:common_services)   { %w(evminit memcached miqtop evmserverd) }
 
   before do
-    PostgresAdmin.stub(:service_name => "postgresql")
+    allow(PostgresAdmin).to receive_messages(:service_name => "postgresql")
   end
 
   describe "#postgresql?" do

--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -153,7 +153,7 @@ describe MiqApache::Conf do
 
   context ".create_conf_file" do
     it "with existing file should raise error" do
-      File.stub(:exist? => true)
+      allow(File).to receive_messages(:exist? => true)
       expect { described_class.create_conf_file("xxx", []) }.to raise_error(MiqApache::ConfFileAlreadyExists)
     end
 
@@ -206,13 +206,13 @@ My test
 
 </VirtualHost>
 EOF
-      File.stub(:exist? => false)
+      allow(File).to receive_messages(:exist? => false)
       allow(FileUtils).to receive(:touch)
-      File.stub(:file? => true)
-      File.stub(:read => "")
+      allow(File).to receive_messages(:file? => true)
+      allow(File).to receive_messages(:read => "")
       allow(FileUtils).to receive(:cp)
       expect(File).to receive(:write).with(conf_file, expected_output)
-      MiqApache::Control.stub(:config_ok? => true)
+      allow(MiqApache::Control).to receive_messages(:config_ok? => true)
       expect(described_class.create_conf_file(conf_file, content_in)).to be_truthy
     end
 
@@ -226,10 +226,10 @@ EOF
         },
       ]
 
-      File.stub(:exist? => false)
+      allow(File).to receive_messages(:exist? => false)
       allow(FileUtils).to receive(:touch)
-      File.stub(:file? => true)
-      File.stub(:read => "")
+      allow(File).to receive_messages(:file? => true)
+      allow(File).to receive_messages(:read => "")
       expect { described_class.create_conf_file(conf_file, content_in) }.to raise_error(ArgumentError, ":directive key is required")
     end
   end

--- a/gems/pending/spec/util/system/evm_watchdog_spec.rb
+++ b/gems/pending/spec/util/system/evm_watchdog_spec.rb
@@ -14,54 +14,54 @@ describe EvmWatchdog do
   end
 
   it ".get_ps_pids" do
-    described_class.stub(:ps_for_process => "10041\n26726\n26729\n")
+    allow(described_class).to receive_messages(:ps_for_process => "10041\n26726\n26729\n")
     expect(described_class.get_ps_pids("some_running_process")).to eq([10041, 26726, 26729])
   end
 
   context ".check_evm" do
     it "No Pid File. (EVM normal stopped state)" do
-      described_class.stub(:read_pid_file => nil, :get_ps_pids => nil)
+      allow(described_class).to receive_messages(:read_pid_file => nil, :get_ps_pids => nil)
       described_class.check_evm
     end
 
     it "Empty Pid File." do
-      described_class.stub(:read_pid_file => "", :get_ps_pids => nil)
+      allow(described_class).to receive_messages(:read_pid_file => "", :get_ps_pids => nil)
       expect(described_class).to receive(:log_info).with(a_string_including "empty PID file")
       described_class.check_evm
     end
 
     it "Pid File Includes 'no_db' and db is down." do
-      described_class.stub(:read_pid_file => "no_db", :get_ps_pids => nil, :get_db_state => "")
+      allow(described_class).to receive_messages(:read_pid_file => "no_db", :get_ps_pids => nil, :get_db_state => "")
       described_class.check_evm
     end
 
     it "Pid File Includes 'no_db' and db is up." do
-      described_class.stub(:read_pid_file => "no_db", :get_ps_pids => nil, :get_db_state => "something")
+      allow(described_class).to receive_messages(:read_pid_file => "no_db", :get_ps_pids => nil, :get_db_state => "something")
       expect(described_class).to receive(:log_info).with(a_string_including "database is now available")
       expect(described_class).to receive(:start_evm).once
       described_class.check_evm
     end
 
     it "Pid File Includes unexpected text." do
-      described_class.stub(:read_pid_file => "oranges", :get_ps_pids => nil)
+      allow(described_class).to receive_messages(:read_pid_file => "oranges", :get_ps_pids => nil)
       expect(described_class).to receive(:log_info).with(a_string_including "non-numeric PID file")
       described_class.check_evm
     end
 
     it "Pid running. (EVM normal running state)" do
-      described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 12345, 9876])
+      allow(described_class).to receive_messages(:read_pid_file => "12345", :get_ps_pids => [42, 12345, 9876])
       described_class.check_evm
     end
 
     it "Pid not running, DB down." do
-      described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "")
+      allow(described_class).to receive_messages(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "")
       expect(described_class).to receive(:log_info).with(a_string_including "database is down")
       described_class.check_evm
     end
 
     ['started', 'starting'].each do |state|
       it "Pid not running, DB up, state '#{state}'." do
-        described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => state)
+        allow(described_class).to receive_messages(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => state)
         expect(described_class).to receive(:log_info).with(a_string_including "is no longer running")
         expect(described_class).to receive(:start_evm).once
         described_class.check_evm
@@ -69,7 +69,7 @@ describe EvmWatchdog do
     end
 
     it "Pid not running, DB up, any other state." do
-      described_class.stub(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "killed")
+      allow(described_class).to receive_messages(:read_pid_file => "12345", :get_ps_pids => [42, 9876], :get_db_state => "killed")
       expect(described_class).to receive(:log_info).with(a_string_including "server state should be")
       described_class.check_evm
     end

--- a/gems/pending/spec/util/vmdb-logger_spec.rb
+++ b/gems/pending/spec/util/vmdb-logger_spec.rb
@@ -3,15 +3,15 @@ require 'util/vmdb-logger'
 
 describe VMDBLogger do
   it ".contents with no log returns empty string" do
-    File.stub(:file? => false)
+    allow(File).to receive_messages(:file? => false)
     expect(VMDBLogger.contents("mylog.log")).to eq("")
   end
 
   it ".contents with empty log returns empty string" do
     require 'util/miq-system'
-    MiqSystem.stub(:tail => "")
+    allow(MiqSystem).to receive_messages(:tail => "")
 
-    File.stub(:file? => true)
+    allow(File).to receive_messages(:file? => true)
     expect(VMDBLogger.contents("mylog.log")).to eq("")
   end
 

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -90,7 +90,7 @@ describe ApplicationController do
     it "check button_set_form_vars sets correct applies_to_class when editing a button" do
       # button_set_form_vars expects that the simulation screen will be built,
       #   which, in turn, needs *something* to come back from automate
-      MiqAeClass.stub(:find_distinct_instances_across_domains => [double(:name => "foo")])
+      allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
 
       custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm")
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 def set_up_controller_for_show_method(controller, ems_id)
   controller.instance_variable_set(:@_params, {:display => "download_pdf", :id => ems_id})
   controller.instance_variable_set(:@settings, :views => {:vm_summary_cool => "summary"})
-  controller.stub(:record_no_longer_exists? => false)
+  allow(controller).to receive_messages(:record_no_longer_exists? => false)
   allow(controller).to receive(:drop_breadcrumb)
   allow(controller).to receive(:disable_client_cache)
-  controller.stub(:render_to_string => "")
+  allow(controller).to receive_messages(:render_to_string => "")
   allow(controller).to receive(:send_data)
   allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
 end
@@ -101,7 +101,7 @@ describe EmsCloudController do
         end
 
         it "successful flash message (unchanged)" do
-          controller.stub(:edit_changed? => false)
+          allow(controller).to receive_messages(:edit_changed? => false)
           expect(mocked_ems_cloud).to receive(:authentication_check).with("amqp", :save => true).and_return([true, ""])
           expect(controller).to receive(:add_flash).with(_("Credential validation was successful"))
           expect(controller).to receive(:render_flash)
@@ -109,7 +109,7 @@ describe EmsCloudController do
         end
 
         it "unsuccessful flash message (changed)" do
-          controller.stub(:edit_changed? => true)
+          allow(controller).to receive_messages(:edit_changed? => true)
           expect(mocked_ems_cloud).to receive(:authentication_check)
             .with("amqp", :save => false).and_return([false, "Invalid"])
           expect(controller).to receive(:add_flash).with(_("Credential validation was not successful: Invalid"), :error)

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -20,7 +20,7 @@ describe MiqAeCustomizationController do
   render_views
   describe "#ab_form" do
     it "displays the layout" do
-      MiqAeClass.stub(:find_distinct_instances_across_domains => [double(:name => "foo")])
+      allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
       @sb = {:active_tree => :ab_tree,
              :trees       => {:ab_tree => {:tree => :ab_tree}},
              :params      => {:instance_name => 'CustomButton_1'}

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -14,7 +14,7 @@ describe ReportController do
 
     before :each do
       @previous_count_of_widgets = MiqWidget.count
-      controller.stub(:load_edit => true)
+      allow(controller).to receive_messages(:load_edit => true)
       allow(controller).to receive(:widget_graph_menus)
       allow(controller).to receive(:replace_right_cell)
       allow(controller).to receive(:render)

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -5,7 +5,7 @@ describe MiqTaskController do
     let(:user) { FactoryGirl.create(:user) }
     subject { controller.send(:tasks_condition, @opts) }
     before do
-      controller.stub(:session => user)
+      allow(controller).to receive_messages(:session => user)
     end
 
     describe "My VM Analysis Tasks" do

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -21,7 +21,7 @@ describe OpsController do
         @svr2.vm_scan_host_affinity = [@host2]
         @svr1.vm_scan_storage_affinity = [@storage1]
         @svr2.vm_scan_storage_affinity = [@storage2]
-        MiqServer.any_instance.stub(:is_a_proxy? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
 
         tree_hash = {
           :trees       => {

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -34,7 +34,7 @@ describe OpsController do
     context "normal case" do
       before do
         server = double
-        server.stub(:zone_id => 1)
+        allow(server).to receive_messages(:zone_id => 1)
         allow(MiqServer).to receive(:my_server).and_return(server)
 
         @sch = FactoryGirl.create(:miq_schedule)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -797,7 +797,7 @@ describe ReportController do
     context "normal case" do
       before do
         server = double
-        server.stub(:zone_id => 1)
+        allow(server).to receive_messages(:zone_id => 1)
         allow(MiqServer).to receive(:my_server).and_return(server)
 
         @sch = FactoryGirl.create(:miq_schedule, :enabled => true, :updated_at => 1.hour.ago.utc)
@@ -830,7 +830,7 @@ describe ReportController do
         controller.instance_variable_set(:@_params, :button => "add", :controller => "report",
                                                     :action => "schedule_edit")
         controller.miq_report_schedule_disable
-        controller.stub(:load_edit => true)
+        allow(controller).to receive_messages(:load_edit => true)
         allow(controller).to receive(:replace_right_cell)
         controller.instance_variable_set(:@edit,
                                          :sched_id => nil, :new => {:name => "test_1", :description => "test_1",

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -135,7 +135,7 @@ describe VmInfraController do
     end
 
     context "clear or retain existing breadcrumb path" do
-      before { controller.stub(:render => nil, :build_toolbar => nil) }
+      before { allow(controller).to receive_messages(:render => nil, :build_toolbar => nil) }
 
       it 'it clears the existing breadcrumb path and assigns the new explorer path when controllers are switched' do
         session[:breadcrumbs] = [{:name => "Instances", :url => "/vm_cloud/explorer"}]

--- a/spec/factories/dialog.rb
+++ b/spec/factories/dialog.rb
@@ -1,6 +1,15 @@
 FactoryGirl.define do
   factory :dialog do
+    # HACK: This is required because we were previously depending on rspec-mocks'
+    # .stub monkeypatch here; the monkeypatch has since been removed and rspec-mocks
+    # should NOT be used within factories anyway.
+    # TODO: Rewrite dialog specs to properly mock this within the spec
     # skip validate_children callback for general dialog testing
-    before(:create) { |d| d.stub(:validate_children) }
+    to_create do |instance|
+      class << instance
+        def validate_children; true; end
+      end
+      instance.save!
+    end
   end
 end

--- a/spec/factories/dialog_group.rb
+++ b/spec/factories/dialog_group.rb
@@ -1,6 +1,15 @@
 FactoryGirl.define do
   factory :dialog_group do
+    # HACK: This is required because we were previously depending on rspec-mocks'
+    # .stub monkeypatch here; the monkeypatch has since been removed and rspec-mocks
+    # should NOT be used within factories anyway.
+    # TODO: Rewrite dialog specs to properly mock this within the spec
     # skip validate_children callback for general dialog testing
-    before(:create) { |d| d.stub(:validate_children) }
+    to_create do |instance|
+      class << instance
+        def validate_children; true; end
+      end
+      instance.save!
+    end
   end
 end

--- a/spec/factories/dialog_tab.rb
+++ b/spec/factories/dialog_tab.rb
@@ -1,6 +1,15 @@
 FactoryGirl.define do
   factory :dialog_tab do
+    # HACK: This is required because we were previously depending on rspec-mocks'
+    # .stub monkeypatch here; the monkeypatch has since been removed and rspec-mocks
+    # should NOT be used within factories anyway.
+    # TODO: Rewrite dialog specs to properly mock this within the spec
     # skip validate_children callback for general dialog testing
-    before(:create) { |d| d.stub(:validate_children) }
+    to_create do |instance|
+      class << instance
+        def validate_children; true; end
+      end
+      instance.save!
+    end
   end
 end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -628,7 +628,7 @@ describe ApplicationHelper do
       before do
         @id = "vm_console"
         allow(user).to receive(:role_allows?).and_return(true)
-        @record.stub(:console_supported? => false)
+        allow(@record).to receive_messages(:console_supported? => false)
       end
 
       it "and record is not console supported" do
@@ -646,7 +646,7 @@ describe ApplicationHelper do
       end
 
       it "and record is console supported and server's remote_console_type is MKS" do
-        @record.stub(:console_supported? => true)
+        allow(@record).to receive_messages(:console_supported? => true)
         @vmdb_config = {:server => {:remote_console_type => "MKS"}}
         expect(subject).to be_falsey
       end
@@ -656,7 +656,7 @@ describe ApplicationHelper do
       before do
         @id = "vm_vnc_console"
         allow(user).to receive(:role_allows?).and_return(true)
-        @record.stub(:console_supported? => false)
+        allow(@record).to receive_messages(:console_supported? => false)
       end
 
       it "and record is not console supported" do
@@ -674,7 +674,7 @@ describe ApplicationHelper do
       end
 
       it "and record is console supported and server's remote_console_type is VNC" do
-        @record.stub(:console_supported? => true)
+        allow(@record).to receive_messages(:console_supported? => true)
         @vmdb_config = {:server => {:remote_console_type => "VNC"}}
         expect(subject).to be_falsey
       end
@@ -684,7 +684,7 @@ describe ApplicationHelper do
       before do
         @id = "vm_vmrc_console"
         allow(user).to receive(:role_allows?).and_return(true)
-        @record.stub(:console_supported? => false)
+        allow(@record).to receive_messages(:console_supported? => false)
       end
 
       it "and record is not console supported" do
@@ -702,7 +702,7 @@ describe ApplicationHelper do
       end
 
       it "and record is console supported and server's remote_console_type is VMRC" do
-        @record.stub(:console_supported? => true)
+        allow(@record).to receive_messages(:console_supported? => true)
         @vmdb_config = {:server => {:remote_console_type => "VMRC"}}
         expect(subject).to be_falsey
       end
@@ -787,7 +787,7 @@ describe ApplicationHelper do
       context "and id = host_protect" do
         before do
           @id = 'host_protect'
-          @record.stub(:smart? => false)
+          allow(@record).to receive_messages(:smart? => false)
         end
 
         it "and record is not smart" do
@@ -795,7 +795,7 @@ describe ApplicationHelper do
         end
 
         it "and record is smart" do
-          @record.stub(:smart? => true)
+          allow(@record).to receive_messages(:smart? => true)
           expect(subject).to be_falsey
         end
       end
@@ -803,7 +803,7 @@ describe ApplicationHelper do
       context "and id = host_refresh" do
         before do
           @id = 'host_refresh'
-          @record.stub(:is_refreshable? => false)
+          allow(@record).to receive_messages(:is_refreshable? => false)
         end
 
         it "and record is not refreshable" do
@@ -811,7 +811,7 @@ describe ApplicationHelper do
         end
 
         it "and record is refreshable" do
-          @record.stub(:is_refreshable? => true)
+          allow(@record).to receive_messages(:is_refreshable? => true)
           expect(subject).to be_falsey
         end
       end
@@ -820,12 +820,12 @@ describe ApplicationHelper do
         before { @id = 'host_scan' }
 
         it "and record is not scannable" do
-          @record.stub(:is_scannable? => false)
+          allow(@record).to receive_messages(:is_scannable? => false)
           expect(subject).to be_truthy
         end
 
         it "and record is scannable" do
-          @record.stub(:is_scannable? => true)
+          allow(@record).to receive_messages(:is_scannable? => true)
           expect(subject).to be_falsey
         end
       end
@@ -834,7 +834,7 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:is_available? => false)
+            allow(@record).to receive_messages(:is_available? => false)
           end
 
           it "and record is not available" do
@@ -842,7 +842,7 @@ describe ApplicationHelper do
           end
 
           it "and record is available" do
-            @record.stub(:is_available? => true)
+            allow(@record).to receive_messages(:is_available? => true)
             expect(subject).to be_falsey
           end
         end
@@ -877,16 +877,16 @@ describe ApplicationHelper do
         context "and id = miq_request_approve" do
           before do
             @id = "miq_request_approve"
-            @record.stub(:resource_type => "something", :approval_state => "xx")
+            allow(@record).to receive_messages(:resource_type => "something", :approval_state => "xx")
           end
 
           it "and resource_type = AutomationRequest" do
-            @record.stub(:resource_type => "AutomationRequest")
+            allow(@record).to receive_messages(:resource_type => "AutomationRequest")
             expect(subject).to be_falsey
           end
 
           it "and approval_state = approved" do
-            @record.stub(:approval_state => "approved")
+            allow(@record).to receive_messages(:approval_state => "approved")
             expect(subject).to be_truthy
           end
 
@@ -903,21 +903,21 @@ describe ApplicationHelper do
         context "and id = miq_request_deny" do
           before do
             @id = "miq_request_deny"
-            @record.stub(:resource_type => "something", :approval_state => "xx")
+            allow(@record).to receive_messages(:resource_type => "something", :approval_state => "xx")
           end
 
           it "and resource_type = AutomationRequest" do
-            @record.stub(:resource_type => "AutomationRequest")
+            allow(@record).to receive_messages(:resource_type => "AutomationRequest")
             expect(subject).to be_falsey
           end
 
           it "and approval_state = approved" do
-            @record.stub(:approval_state => "approved")
+            allow(@record).to receive_messages(:approval_state => "approved")
             expect(subject).to be_truthy
           end
 
           it "and approval_state = denied" do
-            @record.stub(:approval_state => "denied")
+            allow(@record).to receive_messages(:approval_state => "denied")
             expect(subject).to be_truthy
           end
 
@@ -934,27 +934,27 @@ describe ApplicationHelper do
         context "and id = miq_request_delete" do
           before do
             @id = "miq_request_delete"
-            @record.stub(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
+            allow(@record).to receive_messages(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
             allow(User).to receive(:find_by_userid).and_return(user)
           end
 
           it "and resource_type = AutomationRequest" do
-            @record.stub(:resource_type => "AutomationRequest")
+            allow(@record).to receive_messages(:resource_type => "AutomationRequest")
             expect(subject).to be_falsey
           end
 
           it "and requester.name != @record.requester_name" do
-            @record.stub(:requester_name => 'admin')
+            allow(@record).to receive_messages(:requester_name => 'admin')
             expect(subject).to be_falsey
           end
 
           it "and approval_state = approved" do
-            @record.stub(:approval_state => "approved")
+            allow(@record).to receive_messages(:approval_state => "approved")
             expect(subject).to be_falsey
           end
 
           it "and approval_state = denied" do
-            @record.stub(:approval_state => "denied")
+            allow(@record).to receive_messages(:approval_state => "denied")
             expect(subject).to be_falsey
           end
 
@@ -966,27 +966,27 @@ describe ApplicationHelper do
         context "and id = miq_request_edit" do
           before do
             @id = "miq_request_edit"
-            @record.stub(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
+            allow(@record).to receive_messages(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
             allow(User).to receive(:find_by_userid).and_return(user)
           end
 
           it "and resource_type = AutomationRequest" do
-            @record.stub(:resource_type => "AutomationRequest")
+            allow(@record).to receive_messages(:resource_type => "AutomationRequest")
             expect(subject).to be_truthy
           end
 
           it "and requester.name != @record.requester_name" do
-            @record.stub(:requester_name => 'admin')
+            allow(@record).to receive_messages(:requester_name => 'admin')
             expect(subject).to be_truthy
           end
 
           it "and approval_state = approved" do
-            @record.stub(:approval_state => "approved")
+            allow(@record).to receive_messages(:approval_state => "approved")
             expect(subject).to be_truthy
           end
 
           it "and approval_state = denied" do
-            @record.stub(:approval_state => "denied")
+            allow(@record).to receive_messages(:approval_state => "denied")
             expect(subject).to be_truthy
           end
 
@@ -998,37 +998,37 @@ describe ApplicationHelper do
         context "and id = miq_request_copy" do
           before do
             @id = "miq_request_copy"
-            @record.stub(:resource_type  => "MiqProvisionRequest",
+            allow(@record).to receive_messages(:resource_type  => "MiqProvisionRequest",
                          :approval_state => "pending_approval",
                          :requester_name => user.name)
             allow(User).to receive(:find_by_userid).and_return(user)
           end
 
           it "and resource_type = AutomationRequest" do
-            @record.stub(:resource_type => "AutomationRequest")
+            allow(@record).to receive_messages(:resource_type => "AutomationRequest")
             expect(subject).to be_truthy
           end
 
           it "and resource_type != MiqProvisionRequest" do
-            @record.stub(:resource_type => "SomeRequest")
+            allow(@record).to receive_messages(:resource_type => "SomeRequest")
             expect(subject).to be_truthy
           end
 
           it "and requester.name != @record.requester_name & showtype = miq_provisions" do
             @showtype = "miq_provisions"
-            @record.stub(:requester_name => 'admin')
+            allow(@record).to receive_messages(:requester_name => 'admin')
             expect(subject).to be_truthy
           end
 
           it "and approval_state = approved & showtype = miq_provisions" do
             @showtype = "miq_provisions"
-            @record.stub(:approval_state => "approved")
+            allow(@record).to receive_messages(:approval_state => "approved")
             expect(subject).to be_truthy
           end
 
           it "and approval_state = denied & showtype = miq_provisions" do
             @showtype = "miq_provisions"
-            @record.stub(:approval_state => "denied")
+            allow(@record).to receive_messages(:approval_state => "denied")
             expect(subject).to be_truthy
           end
 
@@ -1038,7 +1038,7 @@ describe ApplicationHelper do
           end
 
           it "and resource_type = MiqProvisionRequest & showtype != miq_provisions" do
-            @record.stub(:requester_name => 'admin')
+            allow(@record).to receive_messages(:requester_name => 'admin')
             expect(subject).to be_falsey
           end
         end
@@ -1094,11 +1094,11 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:read_only => false)
+            allow(@record).to receive_messages(:read_only => false)
           end
 
           it "and record read only" do
-            @record.stub(:read_only => true)
+            allow(@record).to receive_messages(:read_only => true)
             expect(subject).to be_truthy
           end
 
@@ -1183,19 +1183,19 @@ describe ApplicationHelper do
       context "and id = vm_collect_running_processes" do
         before do
           @id = "vm_collect_running_processes"
-          @record.stub(:retired => false, :current_state => "new")
+          allow(@record).to receive_messages(:retired => false, :current_state => "new")
           allow(@record).to receive(:is_available?).with(:collect_running_processes).and_return(true)
         end
 
         it "and @record.retired & !@record.is_available?(:collect_running_processes)" do
-          @record.stub(:retired => true)
+          allow(@record).to receive_messages(:retired => true)
           allow(@record).to receive(:is_available?).with(:collect_running_processes).and_return(false)
           expect(subject).to be_truthy
         end
 
         it "and @record.current_state = never & !@record.is_available?(:collect_running_processes)" do
           allow(@record).to receive(:is_available?).with(:collect_running_processes).and_return(false)
-          @record.stub(:current_state => "never")
+          allow(@record).to receive_messages(:current_state => "never")
           expect(subject).to be_truthy
         end
 
@@ -1338,11 +1338,11 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:host => double(:vmm_product => "Server"))
+            allow(@record).to receive_messages(:host => double(:vmm_product => "Server"))
           end
 
           it "and @record.host.vmm_product = workstation" do
-            @record.stub(:host => double(:vmm_product => "Workstation"))
+            allow(@record).to receive_messages(:host => double(:vmm_product => "Workstation"))
             expect(subject).to be_truthy
           end
 
@@ -1351,7 +1351,7 @@ describe ApplicationHelper do
           end
 
           it "and @record.host does exist" do
-            @record.stub(:host => nil)
+            allow(@record).to receive_messages(:host => nil)
             expect(subject).to be_falsey
           end
         end
@@ -1360,11 +1360,11 @@ describe ApplicationHelper do
       context "and id = vm_refresh" do
         before do
           @id = "vm_refresh"
-          @record.stub(:host => double(:vmm_product => "Workstation"), :ext_management_system => true)
+          allow(@record).to receive_messages(:host => double(:vmm_product => "Workstation"), :ext_management_system => true)
         end
 
         it "and !@record.ext_management_system & @record.host.vmm_product.downcase != workstation" do
-          @record.stub(:host => double(:vmm_product => "Server"), :ext_management_system => false)
+          allow(@record).to receive_messages(:host => double(:vmm_product => "Server"), :ext_management_system => false)
           expect(subject).to be_truthy
         end
 
@@ -1382,8 +1382,8 @@ describe ApplicationHelper do
           @id = "vm_scan"
           @record = FactoryGirl.create(:vm_vmware)
           allow(@record).to receive(:has_proxy?).and_return(true)
-          @record.stub(:archived? => false)
-          @record.stub(:orphaned? => false)
+          allow(@record).to receive_messages(:archived? => false)
+          allow(@record).to receive_messages(:orphaned? => false)
         end
 
         it "and !@record.has_proxy?" do
@@ -1396,7 +1396,7 @@ describe ApplicationHelper do
         end
 
         it "and @record.has_proxy? and is archived" do
-          @record.stub(:archived? => true)
+          allow(@record).to receive_messages(:archived? => true)
           expect(subject).to eq(true)
         end
       end
@@ -1452,16 +1452,16 @@ describe ApplicationHelper do
         context "and id = #{id}" do
           before do
             @id = id
-            @record.stub(:host => double(:vmm_product => "Server"))
+            allow(@record).to receive_messages(:host => double(:vmm_product => "Server"))
           end
 
           it "and @record.host.vmm_product = workstation" do
-            @record.stub(:host => double(:vmm_product => "Workstation"))
+            allow(@record).to receive_messages(:host => double(:vmm_product => "Workstation"))
             expect(subject).to be_truthy
           end
 
           it "and !@record.host" do
-            @record.stub(:host => nil)
+            allow(@record).to receive_messages(:host => nil)
             expect(subject).to be_falsey
           end
 
@@ -1474,11 +1474,11 @@ describe ApplicationHelper do
       context "and id = miq_template_refresh" do
         before do
           @id = "miq_template_refresh"
-          @record.stub(:host => double(:vmm_product => "Workstation"), :ext_management_system => true)
+          allow(@record).to receive_messages(:host => double(:vmm_product => "Workstation"), :ext_management_system => true)
         end
 
         it "and !@record.ext_management_system & @record.host.vmm_product != workstation" do
-          @record.stub(:host => double(:vmm_product => "Server"), :ext_management_system => false)
+          allow(@record).to receive_messages(:host => double(:vmm_product => "Server"), :ext_management_system => false)
           expect(subject).to be_truthy
         end
 
@@ -1499,7 +1499,7 @@ describe ApplicationHelper do
         end
 
         it "and @record.has_proxy?" do
-          @record.stub(:has_proxy? => true)
+          allow(@record).to receive_messages(:has_proxy? => true)
           expect(subject).to be_falsey
         end
       end
@@ -1752,17 +1752,17 @@ describe ApplicationHelper do
           @message = "This Role is already active on this Server"
           @id = "role_start"
 
-          @record.stub(:miq_server => double(:started? => true), :active => true, :server_role => @server_role)
+          allow(@record).to receive_messages(:miq_server => double(:started? => true), :active => true, :server_role => @server_role)
         end
 
         it "when miq server not started" do
-          @record.stub(:miq_server => double(:started? => false))
+          allow(@record).to receive_messages(:miq_server => double(:started? => false))
           expect(subject).to eq(@message)
         end
 
         it "when miq server started but not active" do
-          @record.stub(:active => false)
-          @record.stub(:miq_server => double(:started? => false))
+          allow(@record).to receive_messages(:active => false)
+          allow(@record).to receive_messages(:miq_server => double(:started? => false))
           expect(subject).to eq("Only available Roles on active Servers can be started")
         end
 
@@ -1773,22 +1773,22 @@ describe ApplicationHelper do
         before do
           @id = "role_suspend"
           @miq_server = MiqServer.new(:name => "xx miq server", :id => "xx server id")
-          @miq_server.stub(:started? => true)
-          @record.stub(:miq_server => @miq_server, :active => true,
+          allow(@miq_server).to receive_messages(:started? => true)
+          allow(@record).to receive_messages(:miq_server => @miq_server, :active => true,
                           :server_role => @server_role)
           @server_role.max_concurrent = 1
         end
 
         context "when miq server started and active" do
           it "and server_role.max_concurrent == 1" do
-            @record.stub(:miq_server => @miq_server)
+            allow(@record).to receive_messages(:miq_server => @miq_server)
             expect(subject).to eq("Activate the #{@record.server_role.description} Role on another Server to suspend it on #{@record.miq_server.name} [#{@record.miq_server.id}]")
           end
           it_behaves_like 'default true_case'
         end
 
         it "when miq_server not started or not active" do
-          @record.stub(:miq_server => double(:started? => false), :active => false)
+          allow(@record).to receive_messages(:miq_server => double(:started? => false), :active => false)
           expect(subject).to eq("Only active Roles on active Servers can be suspended")
         end
       end
@@ -1797,7 +1797,7 @@ describe ApplicationHelper do
     context "when record class = OntapStorageSystem" do
       before do
         @record = OntapStorageSystem.new
-        @record.stub(:latest_derived_metrics => true)
+        allow(@record).to receive_messages(:latest_derived_metrics => true)
       end
 
       context "and id = ontap_storage_system_statistics" do
@@ -1813,7 +1813,7 @@ describe ApplicationHelper do
       context "and id = ontap_logical_disk_perf" do
         before do
           @id = "ontap_logical_disk_perf"
-          @record.stub(:has_perf_data? => true)
+          allow(@record).to receive_messages(:has_perf_data? => true)
         end
         it_behaves_like 'record without perf data', "No Capacity & Utilization data has been collected for this Logical Disk"
         it_behaves_like 'default case'
@@ -1822,7 +1822,7 @@ describe ApplicationHelper do
       context "and id = ontap_logical_disk_statistics" do
         before do
           @id = "ontap_logical_disk_statistics"
-          @record.stub(:latest_derived_metrics => true)
+          allow(@record).to receive_messages(:latest_derived_metrics => true)
         end
         it_behaves_like 'record without latest derived metrics', "No Statistics collected for this Logical Disk"
         it_behaves_like 'default case'
@@ -1832,7 +1832,7 @@ describe ApplicationHelper do
     context "when record class = CimBaseStorageExtent" do
       before do
         @record = CimBaseStorageExtent.new
-        @record.stub(:latest_derived_metrics => true)
+        allow(@record).to receive_messages(:latest_derived_metrics => true)
       end
 
       context "and id = cim_base_storage_extent_statistics" do
@@ -1845,7 +1845,7 @@ describe ApplicationHelper do
     context "when record class = OntapStorageVolume" do
       before do
         @record = OntapStorageVolume.new
-        @record.stub(:latest_derived_metrics => true)
+        allow(@record).to receive_messages(:latest_derived_metrics => true)
       end
 
       context "and id = ontap_storage_volume_statistics" do
@@ -1858,7 +1858,7 @@ describe ApplicationHelper do
     context "when record class = OntapFileShare" do
       before do
         @record = OntapFileShare.new
-        @record.stub(:latest_derived_metrics => true)
+        allow(@record).to receive_messages(:latest_derived_metrics => true)
       end
       context "and id = ontap_file_share_statistics" do
         before { @id = "ontap_file_share_statistics" }
@@ -1870,7 +1870,7 @@ describe ApplicationHelper do
     context "when record class = SniaLocalFileSystem" do
       before do
         @record = SniaLocalFileSystem.new
-        @record.stub(:latest_derived_metrics => true)
+        allow(@record).to receive_messages(:latest_derived_metrics => true)
       end
       context "and id = snia_local_file_system_statistics" do
         before { @id = "snia_local_file_system_statistics" }
@@ -1882,7 +1882,7 @@ describe ApplicationHelper do
     context "when record class = EmsCluster" do
       before do
         @record = EmsCluster.new
-        @record.stub(:has_perf_data? => true, :has_events? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
       end
 
       context "and id = ems_cluster_perf" do
@@ -1901,7 +1901,7 @@ describe ApplicationHelper do
     context "when record class = ContainerProject" do
       before do
         @record = ContainerProject.new
-        @record.stub(:has_perf_data? => true, :has_events? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
       end
 
       context "and id = container_project_timeline" do
@@ -1914,7 +1914,7 @@ describe ApplicationHelper do
     context "when record class = ContainerGroup" do
       before do
         @record = ContainerGroup.new
-        @record.stub(:has_perf_data? => true, :has_events? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
       end
 
       context "and id = container_group_timeline" do
@@ -1927,7 +1927,7 @@ describe ApplicationHelper do
     context "when record class = ContainerNode" do
       before do
         @record = ContainerNode.new
-        @record.stub(:has_perf_data? => true, :has_events? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
       end
 
       context "and id = container_node_timeline" do
@@ -1940,7 +1940,7 @@ describe ApplicationHelper do
     context "when record class = ContainerReplicator" do
       before do
         @record = ContainerReplicator.new
-        @record.stub(:has_perf_data? => true, :has_events? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
       end
 
       context "and id = container_replicator_timeline" do
@@ -1953,7 +1953,7 @@ describe ApplicationHelper do
     context "when record class = Host" do
       before do
         @record = Host.new
-        @record.stub(:has_perf_data? => true)
+        allow(@record).to receive_messages(:has_perf_data? => true)
       end
 
       context "and id = host_perf" do
@@ -1984,11 +1984,11 @@ describe ApplicationHelper do
       context "and id = host_refresh" do
         before do
           @id = "host_refresh"
-          @record.stub(:is_refreshable_now? => true)
+          allow(@record).to receive_messages(:is_refreshable_now? => true)
         end
         it "when not configured for refresh" do
           message = "Host not configured for refresh"
-          @record.stub(:is_refreshable_now_error_message => message, :is_refreshable_now? => false)
+          allow(@record).to receive_messages(:is_refreshable_now_error_message => message, :is_refreshable_now? => false)
           expect(subject).to eq(message)
         end
 
@@ -1998,12 +1998,12 @@ describe ApplicationHelper do
       context "and id = host_scan" do
         before do
           @id = "host_scan"
-          @record.stub(:is_scannable_now? => true)
+          allow(@record).to receive_messages(:is_scannable_now? => true)
         end
 
         it "when not scannable now" do
           message = "Provide credentials for IPMI"
-          @record.stub(:is_scannable_now? => false, :is_scannable_now_error_message => message)
+          allow(@record).to receive_messages(:is_scannable_now? => false, :is_scannable_now_error_message => message)
           expect(subject).to eq(message)
         end
 
@@ -2023,7 +2023,7 @@ describe ApplicationHelper do
       context "and id = host_shutdown" do
         before do
           @id = "host_shutdown"
-          @record.stub(:is_available_now_error_message => false)
+          allow(@record).to receive_messages(:is_available_now_error_message => false)
         end
         it_behaves_like 'record with error message', 'shutdown'
         it_behaves_like 'default case'
@@ -2032,7 +2032,7 @@ describe ApplicationHelper do
       context "and id = host_restart" do
         before do
           @id = "host_restart"
-          @record.stub(:is_available_now_error_message => false)
+          allow(@record).to receive_messages(:is_available_now_error_message => false)
         end
 
         it_behaves_like 'record with error message', 'reboot'
@@ -2196,8 +2196,8 @@ describe ApplicationHelper do
         end
 
         it "when a provision dialog is available" do
-          @record.stub(:resource_actions => [double(:action => 'Provision', :dialog_id => '10')])
-          Dialog.stub(:find_by_id => 'some thing')
+          allow(@record).to receive_messages(:resource_actions => [double(:action => 'Provision', :dialog_id => '10')])
+          allow(Dialog).to receive_messages(:find_by_id => 'some thing')
           expect(subject).to be_falsey
         end
       end
@@ -2209,7 +2209,7 @@ describe ApplicationHelper do
       context "and id = storage_perf" do
         before do
           @id = "storage_perf"
-          @record.stub(:has_perf_data? => true)
+          allow(@record).to receive_messages(:has_perf_data? => true)
         end
         it_behaves_like 'record without perf data', "No Capacity & Utilization data has been collected for this Datastore"
         it_behaves_like 'default case'
@@ -2221,7 +2221,7 @@ describe ApplicationHelper do
           allow(@record).to receive(:hosts).and_return(%w(h1 h2))
           expect(subject).to eq("Only Datastore without VMs and Hosts can be removed")
 
-          @record.stub(:hosts => [], :vms_and_templates => ['v1'])
+          allow(@record).to receive_messages(:hosts => [], :vms_and_templates => ['v1'])
           expect(subject).to eq("Only Datastore without VMs and Hosts can be removed")
         end
         it_behaves_like 'default case'
@@ -2234,7 +2234,7 @@ describe ApplicationHelper do
       context "and id = vm_perf" do
         before do
           @id = "vm_perf"
-          @record.stub(:has_perf_data? => true)
+          allow(@record).to receive_messages(:has_perf_data? => true)
         end
         it_behaves_like 'record without perf data', "No Capacity & Utilization data has been collected for this VM"
         it_behaves_like 'default case'
@@ -2252,7 +2252,7 @@ describe ApplicationHelper do
       context "and id = vm_console" do
         before do
           @id = "vm_console"
-          @record.stub(:current_state => 'on')
+          allow(@record).to receive_messages(:current_state => 'on')
           setup_firefox_with_linux
         end
 
@@ -2263,7 +2263,7 @@ describe ApplicationHelper do
       context "and id = vm_vnc_console" do
         before do
           @id = "vm_vnc_console"
-          @record.stub(:current_state => 'on', :ipaddresses => '192.168.1.1')
+          allow(@record).to receive_messages(:current_state => 'on', :ipaddresses => '192.168.1.1')
         end
 
         it_behaves_like 'vm not powered on', "The web-based VNC console is not available because the VM is not powered on"
@@ -2273,7 +2273,7 @@ describe ApplicationHelper do
       context "and id = vm_vmrc_console" do
         before do
           @id = "vm_vmrc_console"
-          @record.stub(:current_state => 'on', :validate_remote_console_vmrc_support => true)
+          allow(@record).to receive_messages(:current_state => 'on', :validate_remote_console_vmrc_support => true)
           setup_firefox_with_linux
         end
 
@@ -2362,7 +2362,7 @@ describe ApplicationHelper do
         context "and id = #{button_id}" do
           before { @id = button_id }
           it "when VM is already retired" do
-            @record.stub(:retired => true)
+            allow(@record).to receive_messages(:retired => true)
             expect(subject).to eq("VM is already retired")
           end
           it_behaves_like 'default case'
@@ -2373,12 +2373,12 @@ describe ApplicationHelper do
         before do
           @id = "vm_scan"
           @record = FactoryGirl.create(:vm_vmware, :vendor => "vmware")
-          @record.stub(:archived? => false)
-          @record.stub(:orphaned? => false)
-          @record.stub(:has_active_proxy? => true)
+          allow(@record).to receive_messages(:archived? => false)
+          allow(@record).to receive_messages(:orphaned? => false)
+          allow(@record).to receive_messages(:has_active_proxy? => true)
         end
         it "when no active proxy" do
-          @record.stub(:has_active_proxy? => false)
+          allow(@record).to receive_messages(:has_active_proxy? => false)
           expect(subject).to eq("No active SmartProxies found to analyze this VM")
         end
         it_behaves_like 'default case'
@@ -2388,7 +2388,7 @@ describe ApplicationHelper do
         before do
           @id = "instance_scan"
           @record = FactoryGirl.create(:vm_amazon, :vendor => "amazon")
-          @record.stub(:has_active_proxy? => true)
+          allow(@record).to receive_messages(:has_active_proxy? => true)
         end
         before { allow(@record).to receive(:is_available?).with(:smartstate_analysis).and_return(false) }
         it_behaves_like 'record with error message', 'smartstate_analysis'
@@ -2468,11 +2468,11 @@ describe ApplicationHelper do
             it_behaves_like 'record with error message', 'remove_snapshot'
           end
           context "when without snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(0) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
             it_behaves_like 'record with error message', 'remove_snapshot'
           end
           context "when with snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(2) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
             it_behaves_like 'default case'
           end
         end
@@ -2484,11 +2484,11 @@ describe ApplicationHelper do
             it_behaves_like 'record with error message', 'remove_all_snapshots'
           end
           context "when without snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(0) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
             it_behaves_like 'record with error message', 'remove_all_snapshots'
           end
           context "when with snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(2) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
             it_behaves_like 'default case'
           end
         end
@@ -2500,11 +2500,11 @@ describe ApplicationHelper do
             it_behaves_like 'record with error message', 'revert_to_snapshot'
           end
           context "when without snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(0) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
             it_behaves_like 'record with error message', 'revert_to_snapshot'
           end
           context "when with snapshots" do
-            before { @record.stub_chain(:snapshots, :size).and_return(2) }
+            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
             it_behaves_like 'default case'
           end
         end
@@ -2548,16 +2548,16 @@ describe ApplicationHelper do
         @id = "miq_request_delete"
         login_as user
         @record = MiqProvisionRequest.new
-        @record.stub(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
+        allow(@record).to receive_messages(:resource_type => "something", :approval_state => "xx", :requester_name => user.name)
       end
 
       it "and requester.name != @record.requester_name" do
-        @record.stub(:requester_name => 'admin')
+        allow(@record).to receive_messages(:requester_name => 'admin')
         expect(build_toolbar_disable_button("miq_request_delete")).to be_falsey
       end
 
       it "and approval_state = approved" do
-        @record.stub(:approval_state => "approved")
+        allow(@record).to receive_messages(:approval_state => "approved")
         expect(subject).to be_falsey
       end
 
@@ -2966,13 +2966,13 @@ describe ApplicationHelper do
     end
 
     it "Hides PDF button when PdfGenerator is not available" do
-      PdfGenerator.stub(:available? => false)
+      allow(PdfGenerator).to receive_messages(:available? => false)
       buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button['id'] == "download_choice" }.compact.flatten
       expect(buttons).not_to include(@pdf_button)
     end
 
     it "Displays PDF button when PdfGenerator is available" do
-      PdfGenerator.stub(:available? => true)
+      allow(PdfGenerator).to receive_messages(:available? => true)
       buttons = helper.build_toolbar('gtl_view_tb').collect { |button| button[:items] if button['id'] == "download_choice" }.compact.flatten
       expect(buttons).to include(@pdf_button)
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -68,7 +68,7 @@ describe ApplicationHelper do
             expect(Menu::DefaultMenu.services_menu_section.visible?).to be_truthy
             expect(Menu::DefaultMenu.cloud_inteligence_menu_section.visible?).to be_falsey
 
-            User.stub_chain(:current_user, :role_allows?).and_return(true)
+            allow(User).to receive_message_chain(:current_user, :role_allows?).and_return(true)
             expect(Menu::DefaultMenu.cloud_inteligence_menu_section.visible?).to be_falsey
           end
         ensure
@@ -84,7 +84,7 @@ describe ApplicationHelper do
         end
 
         it "and not entitled" do
-          @user.stub(:role_allows_any? => false)
+          allow(@user).to receive_messages(:role_allows_any? => false)
           expect(helper.role_allows(:feature => "miq_report", :any => true)).to be_falsey
         end
       end
@@ -95,7 +95,7 @@ describe ApplicationHelper do
         end
 
         it "and not entitled" do
-          @user.stub(:role_allows? => false)
+          allow(@user).to receive_messages(:role_allows? => false)
           expect(helper.role_allows(:feature => "miq_report")).to be_falsey
         end
       end
@@ -108,7 +108,7 @@ describe ApplicationHelper do
       end
 
       it "and not entitled" do
-        @user.stub(:role_allows_any? => false)
+        allow(@user).to receive_messages(:role_allows_any? => false)
         expect(Menu::DefaultMenu.services_menu_section.visible?).to be_falsey
       end
     end

--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "DatabaseConfiguration patch" do
   before(:each) do
-    Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
+    allow(Rails).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
 
     @app = Vmdb::Application.new
     @app.config.paths["config/database"] = "does/not/exist" # ignore real database.yml

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -102,7 +102,7 @@ module MiqAeEngineSpec
           before(:each) do
             root = {'ae_result' => 'error'}
             @ws = double('ws')
-            @ws.stub(:root => root)
+            allow(@ws).to receive_messages(:root => root)
             allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 
@@ -117,7 +117,7 @@ module MiqAeEngineSpec
           before(:each) do
             root = {'ae_result' => 'ok'}
             @ws = double('ws')
-            @ws.stub(:root => root)
+            allow(@ws).to receive_messages(:root => root)
             allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 
@@ -142,9 +142,9 @@ module MiqAeEngineSpec
           before(:each) do
             root = {'ae_result' => 'retry'}
             @ws = double('ws')
-            @ws.stub(:root => root)
-            @ws.stub(:persist_state_hash => {})
-            @ws.stub(:current_state_info => {})
+            allow(@ws).to receive_messages(:root => root)
+            allow(@ws).to receive_messages(:persist_state_hash => {})
+            allow(@ws).to receive_messages(:current_state_info => {})
             allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
           end
 

--- a/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_event_spec.rb
@@ -28,7 +28,7 @@ module MiqAeEventSpec
                              :vm_or_template_id => vm.id
                             )
         end
-        before { MiqServer.stub(:my_zone => "zone test") }
+        before { allow(MiqServer).to receive_messages(:my_zone => "zone test") }
 
         context "with user owned VM" do
           let(:vm_owner) { user }

--- a/spec/lib/pdf_generator_spec.rb
+++ b/spec/lib/pdf_generator_spec.rb
@@ -13,7 +13,7 @@ describe PdfGenerator do
 
   def stub_generator_instance
     generator = double("PdfGenerator subclass", :available? => true, :pdf_from_string => "pdf-data")
-    PdfGenerator.stub(:instance => generator)
+    allow(PdfGenerator).to receive_messages(:instance => generator)
     generator
   end
 
@@ -25,7 +25,7 @@ describe PdfGenerator do
 
     it "when not available" do
       generator = stub_generator_instance
-      generator.stub(:available? => false)
+      allow(generator).to receive_messages(:available? => false)
       expect(PdfGenerator).to_not be_available
     end
   end

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -5,7 +5,7 @@ describe VMDB::Config do
   let(:enc_pass) { MiqPassword.encrypt(password) }
 
   it ".load_config_file" do
-    IO.stub(:read => "---\r\nsmtp:\r\n  password: #{enc_pass}\r\n")
+    allow(IO).to receive_messages(:read => "---\r\nsmtp:\r\n  password: #{enc_pass}\r\n")
     allow(File).to receive(:exist?).with("test.yml").and_return(true)
     expect(described_class.load_config_file("test.yml")).to eq({:smtp => {:password => password}})
   end

--- a/spec/lib/vmdb/configuration_encoder_spec.rb
+++ b/spec/lib/vmdb/configuration_encoder_spec.rb
@@ -135,7 +135,7 @@ describe Vmdb::ConfigurationEncoder do
   context ".load" do
     context "in production" do
       before do
-        Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
+        allow(Rails).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
       end
 
       it "will not evaluate ERB" do

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -122,7 +122,7 @@ describe VMDB::Util do
 
   it ".get_evm_log_for_date" do
     log_files = ["log/rhevm.log", "log/evm.log"]
-    Dir.stub(:glob => log_files)
+    allow(Dir).to receive_messages(:glob => log_files)
 
     expect(described_class.get_evm_log_for_date("log/*.log")).to eq("log/evm.log")
   end

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -7,7 +7,7 @@ describe EvmServer do
     let(:server) { described_class.new }
 
     before do
-      MiqServer.stub(:running? => false)
+      allow(MiqServer).to receive_messages(:running? => false)
       allow(PidFile).to receive(:create)
     end
 

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -137,7 +137,7 @@ describe AutomationRequest do
       @ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
       root = {'ae_result' => 'ok'}
       ws = double('ws')
-      ws.stub(:root => root)
+      allow(ws).to receive_messages(:root => root)
       allow_any_instance_of(AutomationRequest).to receive(:call_automate_event_sync).and_return(ws)
 
       @ar.create_request_tasks

--- a/spec/models/container_scan_spec.rb
+++ b/spec/models/container_scan_spec.rb
@@ -49,8 +49,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     before(:each) do
       @server = EvmSpecHelper.local_miq_server
 
-      described_class.any_instance.stub(:kubernetes_client => MockKubeClient.new)
-      described_class.any_instance.stub(:image_inspector_client => MockImageInspectorClient.new(IMAGE_ID))
+      allow_any_instance_of(described_class).to receive_messages(:kubernetes_client => MockKubeClient.new)
+      allow_any_instance_of(described_class).to receive_messages(:image_inspector_client => MockImageInspectorClient.new(IMAGE_ID))
 
       @ems = FactoryGirl.create(
         :ems_kubernetes, :hostname => "test.com", :zone => @server.zone, :port => 8443,
@@ -134,7 +134,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     context 'when the image tag points to a different image' do
       before(:each) do
         MODIFIED_IMAGE_ID = '0d071bb732e1e3eb1e01629600c9b6c23f2b26b863b5321335f564c8f018c452'
-        described_class.any_instance.stub(
+        allow_any_instance_of(described_class).to receive_messages(
           :image_inspector_client => MockImageInspectorClient.new(MODIFIED_IMAGE_ID)
         )
       end

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -35,7 +35,7 @@ describe DatabaseBackup do
   context "region" do
     before(:each) do
       @region = FactoryGirl.create(:miq_region, :region => 3)
-      described_class.stub(:my_region_number => @region.region)
+      allow(described_class).to receive_messages(:my_region_number => @region.region)
     end
 
     it "should set region_name based on my_region_number if database backup has a region" do
@@ -45,7 +45,7 @@ describe DatabaseBackup do
 
     it "should set region_name to region_0 if region is unknown" do
       # my_region_number => 0 if REGION file is missing or empty
-      described_class.stub(:my_region_number => 0)
+      allow(described_class).to receive_messages(:my_region_number => 0)
       backup = FactoryGirl.create(:database_backup)
       expect(backup.region_name).to eq("region_0")
     end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -184,14 +184,14 @@ describe EmsEvent do
 
     context ".purge_date" do
       it "using '3.month' syntax" do
-        described_class.stub(:keep_ems_events => "3.months")
+        allow(described_class).to receive_messages(:keep_ems_events => "3.months")
 
         # Exposes 3.months.seconds.ago.utc != 3.months.ago.utc
         expect(described_class.purge_date).to be_within(2.days).of(3.months.ago.utc)
       end
 
       it "defaults to 6 months" do
-        described_class.stub(:keep_ems_events => nil)
+        allow(described_class).to receive_messages(:keep_ems_events => nil)
         expect(described_class.purge_date).to be_within(1.day).of(6.months.ago.utc)
       end
     end

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -28,7 +28,7 @@ describe EmsRefresh do
     end
 
     it "with Storage" do
-      Storage.any_instance.stub(:ext_management_systems => [@ems])
+      allow_any_instance_of(Storage).to receive_messages(:ext_management_systems => [@ems])
       target = FactoryGirl.create(:storage_vmware)
       queue_refresh_and_assert_queue_item(target, [target])
     end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -127,9 +127,9 @@ describe Host do
 
     context "#start" do
       before do
-        described_class.any_instance.stub(:validate_start   => {})
-        described_class.any_instance.stub(:validate_ipmi    => {:available => true, :message => nil})
-        described_class.any_instance.stub(:run_ipmi_command => "off")
+        allow_any_instance_of(described_class).to receive_messages(:validate_start   => {})
+        allow_any_instance_of(described_class).to receive_messages(:validate_ipmi    => {:available => true, :message => nil})
+        allow_any_instance_of(described_class).to receive_messages(:run_ipmi_command => "off")
         FactoryGirl.create(:miq_event_definition, :name => :request_host_start)
         # admin user is needed to process Events
         FactoryGirl.create(:user_with_group, :userid => "admin", :name => "Administrator")

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -48,11 +48,11 @@ module JobProxyDispatcherEmbeddedScanSpec
         end
 
         # TODO: We should be able to set values so we don't need to stub behavior
-        MiqServer.any_instance.stub(:is_vix_disk? => true)
-        MiqServer.any_instance.stub(:is_a_proxy? => true)
-        MiqServer.any_instance.stub(:has_active_role? => true)
-        ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_status_ok? => true)
-        Host.any_instance.stub(:authentication_status_ok? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
+        allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:authentication_status_ok? => true)
+        allow_any_instance_of(Host).to receive_messages(:authentication_status_ok? => true)
 
         @hosts, @proxies, @storages, @vms, @repo_vms = build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)
       end

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -7,7 +7,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
     before(:each) do
       @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
-      MiqServer.any_instance.stub(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
 
       # Support old style class methods or new instance style
       @jpd = JobProxyDispatcher.respond_to?(:get_eligible_proxies_for_job) ? JobProxyDispatcher : JobProxyDispatcher.new
@@ -50,7 +50,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
 
         context "with no proxies for job, " do
           before(:each) do
-            ManageIQ::Providers::Vmware::InfraManager::Vm.any_instance.stub(:proxies4job => {:proxies => [], :message => "blah"})
+            allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive_messages(:proxies4job => {:proxies => [], :message => "blah"})
           end
 
           it "should return an empty array" do

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -29,11 +29,11 @@ module JobProxyDispatcherSpec
         end
 
         # TODO: We should be able to set values so we don't need to stub behavior
-        MiqServer.any_instance.stub(:is_vix_disk? => true)
-        MiqServer.any_instance.stub(:is_a_proxy? => true)
-        MiqServer.any_instance.stub(:has_active_role? => true)
-        ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:missing_credentials? => false)
-        Host.any_instance.stub(:missing_credentials? => false)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
+        allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => false)
+        allow_any_instance_of(Host).to receive_messages(:missing_credentials? => false)
 
         @hosts, @proxies, @storages, @vms, @repo_vms = build_hosts_proxies_storages_vms(:hosts => NUM_HOSTS, :storages => NUM_STORAGES, :vms => NUM_VMS, :repo_vms => NUM_REPO_VMS)
       end

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -8,7 +8,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
     before(:each) do
       @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
-      MiqServer.any_instance.stub(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
@@ -41,7 +41,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
 
       context "with no vix disk enabled servers, " do
         before(:each) do
-          MiqServer.any_instance.stub(:is_vix_disk? => false)
+          allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => false)
         end
         it "should return no servers" do
           expect(@vm.miq_server_proxies).to be_empty
@@ -53,7 +53,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
           @vms_zone = FactoryGirl.create(:zone, :description => "Zone 1", :name => "zone1")
           @server2.zone = @vms_zone
           @server2.save
-          @vm.stub(:my_zone => @vms_zone.name)
+          allow(@vm).to receive_messages(:my_zone => @vms_zone.name)
         end
         it "should return only server2, in same zone" do
           expect(@vm.miq_server_proxies).to eq([@server2])

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -8,7 +8,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
     before(:each) do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
-      MiqServer.any_instance.stub(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
@@ -19,12 +19,12 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
       context "with no eligible active proxies, " do
         before(:each) do
-          @vm.stub(:storage2active_proxies => [])
+          allow(@vm).to receive_messages(:storage2active_proxies => [])
         end
 
         context "with @server1 in list of all eligible proxies before filtering, " do
           before(:each) do
-            @vm.stub(:storage2proxies => [@server1])
+            allow(@vm).to receive_messages(:storage2proxies => [@server1])
           end
 
           it "should return with message asking for VM's host's creds" do
@@ -34,7 +34,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
         context "with first host in list of all eligible proxies before filtering, " do
           before(:each) do
-            @vm.stub(:storage2proxies => [@hosts.first])
+            allow(@vm).to receive_messages(:storage2proxies => [@hosts.first])
           end
 
           it "should return with message 'No active SmartProxies'" do
@@ -46,8 +46,8 @@ describe "JobProxyDispatcherVmProxies4Job" do
       context "with a single host 'eligible' but not the active Vmware Vm's host" do
         before(:each) do
           @host, @vms_host = @hosts
-          @vm.stub(:storage2active_proxies => [@host])
-          @vm.stub(:storage2proxies => [@host])
+          allow(@vm).to receive_messages(:storage2active_proxies => [@host])
+          allow(@vm).to receive_messages(:storage2proxies => [@host])
           @vm.host = @vms_host
           @vm.raw_power_state = "poweredOn"
           @vm.save
@@ -59,7 +59,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
         context "with a server in the all proxy list" do
           before(:each) do
-            @vm.stub(:storage2proxies => [@server1])
+            allow(@vm).to receive_messages(:storage2proxies => [@server1])
           end
           it "should return with message to start a smart proxy or provide Vm's hosts creds" do
             expect(@vm.proxies4job[:message]).to eq("Start a SmartProxy or provide credentials for this VM's Host to perform SmartState Analysis")
@@ -70,8 +70,8 @@ describe "JobProxyDispatcherVmProxies4Job" do
       context "with a vm scan job, with no eligible proxies, " do
         before(:each) do
           @job = @vm.scan
-          @vm.stub(:storage2proxies => [])
-          @vm.stub(:storage2activeproxies => [])
+          allow(@vm).to receive_messages(:storage2proxies => [])
+          allow(@vm).to receive_messages(:storage2activeproxies => [])
         end
 
         it "should accept an instance of a job and call log proxies with a job" do
@@ -89,7 +89,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
             @vm.type = "ManageIQ::Providers::Amazon::CloudManager::Vm"
             @vm.save
             @vm = VmOrTemplate.find(@vm.id)
-            MiqServer.stub(:my_server => @server1)
+            allow(MiqServer).to receive_messages(:my_server => @server1)
           end
 
           it "should return my_server" do

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -7,7 +7,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
     before(:each) do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
-      MiqServer.any_instance.stub(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
@@ -19,7 +19,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
       context "with vm's repository host as the last host, " do
         before(:each) do
           @repo_host = @hosts.last
-          @vm.stub(:myhost => @repo_host)
+          allow(@vm).to receive_messages(:myhost => @repo_host)
         end
 
         context "with a host-less vm and it's storage having hosts, " do

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -8,7 +8,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
     before(:each) do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
-      MiqServer.any_instance.stub(:is_vix_disk? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "hosts with proxy and vmware vms," do
@@ -20,7 +20,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
       context "the vm having a repository host," do
         before(:each) do
           @repo_host = @hosts.last
-          @vm.stub(:myhost => @repo_host)
+          allow(@vm).to receive_messages(:myhost => @repo_host)
         end
 
         context "removing proxy from a host" do
@@ -32,7 +32,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
             @vm.host = @host
             @vm.vendor = "RedHat"
             @vm.save
-            @vm.stub(:miq_server_proxies => [])
+            allow(@vm).to receive_messages(:miq_server_proxies => [])
           end
 
           it "Vm#storage2proxies will exclude proxy-less hosts" do
@@ -64,7 +64,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
               @server1.deactivate_all_roles
               @server1.role    = 'smartproxy'
-              Host.any_instance.stub(:missing_credentials? => false)
+              allow_any_instance_of(Host).to receive_messages(:missing_credentials? => false)
             end
 
             it "will have no roles active" do
@@ -87,14 +87,14 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
           context "with server proxies active," do
             before(:each) do
-              MiqServer.any_instance.stub(:is_proxy_active? => true)
+              allow_any_instance_of(MiqServer).to receive_messages(:is_proxy_active? => true)
               allow(@vm).to receive(:my_zone).and_return(@server1.zone.name)
             end
 
             context "a vm template and invalid VC authentication" do
               before(:each) do
-                ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:missing_credentials? => true)
-                @vm.stub(:template? => true)
+                allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => true)
+                allow(@vm).to receive_messages(:template? => true)
                 @ems1 = FactoryGirl.create(:ems_vmware, :name => "Ems1")
                 @vm.ext_management_system = @ems1
                 @vm.save
@@ -106,8 +106,8 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
             context "a vm and invalid host authentication" do
               before(:each) do
-                Host.any_instance.stub(:missing_credentials? => true)
-                @vm.stub(:template? => false)
+                allow_any_instance_of(Host).to receive_messages(:missing_credentials? => true)
+                allow(@vm).to receive_messages(:template? => false)
               end
               it "Vm#storage2active_proxies will return an empty list" do
                 expect(@vm.storage2active_proxies).to be_empty

--- a/spec/models/log_file_spec.rb
+++ b/spec/models/log_file_spec.rb
@@ -68,7 +68,7 @@ describe LogFile do
 
       context "with _request_logs queue message raising exception due to stopped server" do
         before do
-          MiqServer.any_instance.stub(:status => "stopped")
+          allow_any_instance_of(MiqServer).to receive_messages(:status => "stopped")
           @message.delivered(*@message.deliver)
         end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
@@ -14,7 +14,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream do
   context "#each_batch" do
     it "raises ProviderUnreachable on non existing queue" do
       expect(@ems_stream).to receive(:sqs).and_raise(AWS::SQS::Errors::NonExistentQueue)
-      @ems_stream.stub(:sns => double(:topics => double(:detect => nil)))
+      allow(@ems_stream).to receive_messages(:sns => double(:topics => double(:detect => nil)))
 
       @ems_stream.start
       expect do

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision/state_machine_spec.rb
@@ -18,9 +18,9 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
         :status      => 'Ok',
         :options     => options)
 
-      @task.stub(:miq_request => double("MiqRequest").as_null_object)
-      @task.stub(:dest_host => @host)
-      @task.stub(:dest_storage => @storage)
+      allow(@task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
+      allow(@task).to receive_messages(:dest_host => @host)
+      allow(@task).to receive_messages(:dest_storage => @storage)
     end
 
     it "#create_destination" do

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     output[:data].map{ |h| h.delete(:stdout) }
     output[:data][0][:stdout] = Base64.encode64(ActiveSupport::Gzip.compress(temp))
 
-    WinRM::WinRMWebService.any_instance.stub(:run_powershell_script => output)
+    allow_any_instance_of(WinRM::WinRMWebService).to receive_messages(:run_powershell_script => output)
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/configuration_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/configuration_spec.rb
@@ -19,7 +19,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::Configuration 
                                    :cloud_network => [@net1.id, @net1.name]
                                  }
                                 )
-      @task.stub(:miq_request => double("MiqRequest").as_null_object)
+      allow(@task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
     end
 
     it "sets nic from dialog" do

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision do
   context "#prepare_for_clone_task" do
     let(:flavor)  { FactoryGirl.create(:flavor_openstack) }
 
-    before { subject.stub(:instance_type => flavor, :validate_dest_name => nil) }
+    before { allow(subject).to receive_messages(:instance_type => flavor, :validate_dest_name => nil) }
 
     context "availability zone" do
       let(:az)      { FactoryGirl.create(:availability_zone_openstack,      :ems_ref => "64890ac2-6c34-11e4-b72d-56847afe9799") }

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -53,7 +53,7 @@ describe ManageIQ::Providers::Openstack::CloudManager do
   end
 
   it "event_monitor_options" do
-    ManageIQ::Providers::Openstack::CloudManager::EventCatcher.stub(:worker_settings => {:amqp_port => 1234})
+    allow(ManageIQ::Providers::Openstack::CloudManager::EventCatcher).to receive_messages(:worker_settings => {:amqp_port => 1234})
     @ems = FactoryGirl.build(:ems_openstack, :hostname => "host", :ipaddress => "::1")
     require 'openstack/openstack_event_monitor'
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner do
     let(:catcher) { described_class.new(:ems_id => ems.id) }
 
     before do
-      ManageIQ::Providers::Redhat::InfraManager.any_instance.stub(:authentication_check => [true, ""])
+      allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive_messages(:authentication_check => [true, ""])
       allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
     end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -22,13 +22,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
                                :status      => 'Ok',
                                :options     => {:src_vm_id => template.id}
                               )
-    @task.stub(
+    allow(@task).to receive_messages(
       :dest_cluster             => ems_cluster,
       :get_provider_destination => rhevm_vm
     )
 
-    rhevm_vm.stub(:nics => [rhevm_nic1, rhevm_nic2])
-    Ovirt::Cluster.stub(:find_by_href => rhevm_cluster)
+    allow(rhevm_vm).to receive_messages(:nics => [rhevm_nic1, rhevm_nic2])
+    allow(Ovirt::Cluster).to receive_messages(:find_by_href => rhevm_cluster)
   end
 
   context "#configure_network_adapters" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -9,8 +9,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       options  = {:src_vm_id => template.id}
 
       @task = FactoryGirl.create(:miq_provision_redhat, :source => template, :destination => vm, :state => 'pending', :status => 'Ok', :options => options)
-      @task.stub(:miq_request => double("MiqRequest").as_null_object)
-      @task.stub(:dest_cluster => FactoryGirl.create(:ems_cluster, :ext_management_system => ems))
+      allow(@task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
+      allow(@task).to receive_messages(:dest_cluster => FactoryGirl.create(:ems_cluster, :ext_management_system => ems))
     end
 
     it "#create_destination" do
@@ -113,7 +113,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
 
     context "#poll_destination_powered_on_in_provider" do
       it "requeues if the VM didn't start" do
-        ManageIQ::Providers::Redhat::InfraManager::Vm.any_instance.stub(:with_provider_object => {:state => "down"})
+        allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Vm).to receive_messages(:with_provider_object => {:state => "down"})
         expect(@task).to receive(:requeue_phase)
 
         @task.poll_destination_powered_on_in_provider
@@ -122,7 +122,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       end
 
       it "moves on if the vm started" do
-        ManageIQ::Providers::Redhat::InfraManager::Vm.any_instance.stub(:with_provider_object => {:state => "up"})
+        allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::Vm).to receive_messages(:with_provider_object => {:state => "up"})
         expect(@task).to receive(:poll_destination_powered_off_in_provider)
 
         @task.poll_destination_powered_on_in_provider

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -33,11 +33,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
   context "#remote_console_acquire_ticket_queue" do
     before(:each) do
       @vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
-      @vm.stub(:my_zone => nil)
+      allow(@vm).to receive_messages(:my_zone => nil)
 
       @server = double("MiqServer")
-      @server.stub(:my_zone => nil)
-      MiqServer.stub(:my_server => @server)
+      allow(@server).to receive_messages(:my_zone => nil)
+      allow(MiqServer).to receive_messages(:my_server => @server)
     end
 
     it "with :mks" do
@@ -157,7 +157,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
     context "with a proxy miq_server" do
       it "with no proxy configured" do
         server = double("MiqServer")
-        server.stub_chain(:get_config, :config => {:server => {:vnc_proxy_address => nil, :vnc_proxy_port => nil}})
+        allow(server).to receive_message_chain(:get_config, :config => {:server => {:vnc_proxy_address => nil, :vnc_proxy_port => nil}})
         expect(@vm).to receive(:with_provider_object)
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)
@@ -171,7 +171,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
       it "with a proxy configured" do
         server = double("MiqServer")
-        server.stub_chain(:get_config, :config => {:server => {:vnc_proxy_address => "1.2.3.4", :vnc_proxy_port => "5800"}}) # NOTE: Ports are actually stored as a String in the configuration
+        allow(server).to receive_message_chain(:get_config, :config => {:server => {:vnc_proxy_address => "1.2.3.4", :vnc_proxy_port => "5800"}}) # NOTE: Ports are actually stored as a String in the configuration
         expect(@vm).to receive(:with_provider_object)
 
         password, host_address, host_port, proxy_address, proxy_port = @vm.remote_console_vnc_acquire_ticket(server)

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -144,7 +144,7 @@ describe MiqAction do
     it "asynchronous" do
       input = {:synchronous => false}
       zone  = 'Test Zone'
-      @vm.stub(:my_zone => zone)
+      allow(@vm).to receive_messages(:my_zone => zone)
 
       Timecop.freeze do
         date   = Time.now.utc - 1.day

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -98,7 +98,7 @@ describe MiqAlert do
     context "with a single alert, evaluated to true" do
       before(:each) do
         @alert = MiqAlert.find_by_description("VM Unregistered")
-        @alert.stub(:eval_expression => true)
+        allow(@alert).to receive_messages(:eval_expression => true)
         @alert.evaluate([@vm.class.base_class.name, @vm.id])
       end
 
@@ -120,7 +120,7 @@ describe MiqAlert do
 
       context "with the alert now evaluated to false" do
         before(:each)  do
-          @alert.stub(:eval_expression => false)
+          allow(@alert).to receive_messages(:eval_expression => false)
           @alert.options.store_path(:notifications, :delay_next_evaluation, 0)
           @alert.evaluate([@vm.class.base_class.name, @vm.id])
         end
@@ -214,7 +214,7 @@ describe MiqAlert do
 
   context "With a VM assigned to a realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @vm         = FactoryGirl.create(:vm_vmware)
       @alert      = FactoryGirl.create(:miq_alert, :enabled => true, :db => "Vm", :responds_to_events => "xxx|vm_perf_complete|zzz")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}", :mode => @vm.class.base_model.name)
@@ -229,7 +229,7 @@ describe MiqAlert do
 
   context "With a VM NOT assigned to a realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @vm     = FactoryGirl.create(:vm_vmware)
     end
 
@@ -240,7 +240,7 @@ describe MiqAlert do
 
   context "With a Host assigned to a realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @host     = FactoryGirl.create(:host)
       @alert    = FactoryGirl.create(:miq_alert, :enabled => true, :db => "Host", :responds_to_events => "xxx|host_perf_complete|zzz")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}", :mode => @host.class.base_model.name)
@@ -255,7 +255,7 @@ describe MiqAlert do
 
   context "With a Host NOT assigned to a realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @host     = FactoryGirl.create(:host)
     end
 
@@ -266,7 +266,7 @@ describe MiqAlert do
 
   context "With a VM assigned to a v4-style realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @vm         = FactoryGirl.create(:vm_vmware)
       @alert      = FactoryGirl.create(:miq_alert, :enabled => true, :db => "Vm", :responds_to_events => "xxx|vm_perf_complete|zzz")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}", :mode => @vm.class.base_model.name)
@@ -284,7 +284,7 @@ describe MiqAlert do
 
   context "With a Host assigned to a v4-style realtime C&U alert" do
     before(:each) do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @host     = FactoryGirl.create(:host)
       @alert    = FactoryGirl.create(:miq_alert, :enabled => true, :db => "Host", :responds_to_events => "xxx|host_perf_complete|zzz")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :description => "Alert Profile for Alert Id: #{@alert.id}", :mode => @host.class.base_model.name)
@@ -302,7 +302,7 @@ describe MiqAlert do
 
   context ".evaluate_hourly_timer" do
     before do
-      MiqAlert.any_instance.stub(:validate => true)
+      allow_any_instance_of(MiqAlert).to receive_messages(:validate => true)
       @miq_server = EvmSpecHelper.local_miq_server
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
       @ems_other  = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))

--- a/spec/models/miq_db_config_spec.rb
+++ b/spec/models/miq_db_config_spec.rb
@@ -68,11 +68,11 @@ production:
   username: root
   password: <%= MiqPassword.decrypt(\"#{enc_pass}\")%>
 EOF
-      IO.stub(:read => yaml)
+      allow(IO).to receive_messages(:read => yaml)
     end
 
     it "production" do
-      Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
+      allow(Rails).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
       expect(ERB).not_to receive(:new)
 
       expected = {"host" => "localhost", "username" => "root", "password" => "<%= MiqPassword.decrypt(\"#{enc_pass}\")%>"}
@@ -98,7 +98,7 @@ EOF
           :password => "password"
         }
       }
-      described_class.stub(:database_configuration => @db_config)
+      allow(described_class).to receive_messages(:database_configuration => @db_config)
     end
     subject { described_class.current }
 
@@ -172,7 +172,7 @@ EOF
           :password => "password"
         }
       }
-      described_class.stub(:database_configuration => @db_config)
+      allow(described_class).to receive_messages(:database_configuration => @db_config)
     end
     subject { described_class.current }
 

--- a/spec/models/miq_expression/get_col_spec.rb
+++ b/spec/models/miq_expression/get_col_spec.rb
@@ -26,7 +26,7 @@ describe MiqExpression do
 
     it "with valid model-in_field" do
       @field = "Vm-cpu_limit"
-      described_class.stub(:col_type => :some_type)
+      allow(described_class).to receive_messages(:col_type => :some_type)
       expect(subject).to eq(:some_type)
     end
 
@@ -37,7 +37,7 @@ describe MiqExpression do
 
     it "with valid model.association-in_field" do
       @field = "Vm.guest_applications-vendor"
-      described_class.stub(:col_type => :some_type)
+      allow(described_class).to receive_messages(:col_type => :some_type)
       expect(subject).to eq(:some_type)
     end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -142,7 +142,7 @@ describe MiqGroup do
     end
 
     it "should issue an error message when user name could not be bound to LDAP" do
-      MiqLdap.new.stub(:bind => false)
+      allow(MiqLdap.new).to receive_messages(:bind => false)
       # darn, wanted a MiqException::MiqEVMLoginError
       expect do
         MiqGroup.get_ldap_groups_by_user('fred', 'bind_dn', 'password')
@@ -150,7 +150,7 @@ describe MiqGroup do
     end
 
     it "should issue an error message when user name does not exist in LDAP directory" do
-      MiqLdap.new.stub(:get_user_object => nil)
+      allow(MiqLdap.new).to receive_messages(:get_user_object => nil)
 
       # darn, wanted a MiqException::MiqEVMLoginError
       expect do

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -22,7 +22,7 @@ describe MiqProvision do
     context "#prepare_provision" do
       before do
         allow(task).to receive(:update_and_notify_parent)
-        task.stub(:instance_type => flavor)
+        allow(task).to receive_messages(:instance_type => flavor)
       end
 
       it "sets default :clone_options" do

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -7,8 +7,8 @@ describe MiqProvisionVirtWorkflow do
     let(:sdn) { 'SysprepDomainName' }
 
     before do
-      workflow.stub(:validate => true)
-      workflow.stub(:get_dialogs => {})
+      allow(workflow).to receive_messages(:validate => true)
+      allow(workflow).to receive_messages(:get_dialogs => {})
       workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => 123, :sysprep_enabled => 'fields',
                                      :sysprep_domain_name => sdn)
     end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -552,7 +552,7 @@ describe MiqQueue do
   # this is a private method, but there are too many permutations to properly test get/put
   context "#default_get_options" do
     before do
-      Zone.stub(:determine_queue_zone => "defaultzone")
+      allow(Zone).to receive_messages(:determine_queue_zone => "defaultzone")
     end
 
     it "should default the queue name" do

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -41,7 +41,7 @@ describe MiqRegion do
   context ".seed" do
     before do
       @region_number = 99
-      MiqRegion.stub(:my_region_number => @region_number)
+      allow(MiqRegion).to receive_messages(:my_region_number => @region_number)
       MiqRegion.seed
     end
 
@@ -60,7 +60,7 @@ describe MiqRegion do
 
     it "raises Exception if db region_id doesn't match my_region_number" do
       @db = FactoryGirl.create(:miq_database)
-      MiqRegion.stub(:my_region_number => @region_number + 1)
+      allow(MiqRegion).to receive_messages(:my_region_number => @region_number + 1)
       expect { MiqRegion.seed }.to raise_error(Exception)
     end
   end

--- a/spec/models/miq_replication_worker/runner_spec.rb
+++ b/spec/models/miq_replication_worker/runner_spec.rb
@@ -26,12 +26,12 @@ describe MiqReplicationWorker::Runner do
 
   context "testing child process heartbeat" do
     it "should be alive if heartbeat within threshold" do
-      @worker.stub(:child_process_last_heartbeat => 1.second.ago.utc)
+      allow(@worker).to receive_messages(:child_process_last_heartbeat => 1.second.ago.utc)
       expect(@worker.child_process_recently_active?).to be_truthy
     end
 
     it "should not be alive if heartbeat beyond threshold" do
-      @worker.stub(:child_process_last_heartbeat => 6.minutes.ago.utc)
+      allow(@worker).to receive_messages(:child_process_last_heartbeat => 6.minutes.ago.utc)
       expect(@worker.child_process_recently_active?).to be_falsey
     end
   end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -137,7 +137,7 @@ describe MiqReport do
 
       group = FactoryGirl.create(:miq_group)
       user  = FactoryGirl.create(:user, :miq_groups => [group])
-      User.stub(:server_timezone => "UTC")
+      allow(User).to receive_messages(:server_timezone => "UTC")
       group.update_attributes(:filters => {"managed" => [["/managed/environment/prod"]], "belongsto" => []})
 
       report = MiqReport.new(:db => "Vm")
@@ -166,7 +166,7 @@ describe MiqReport do
       vm1.tag_with(tag, :ns => "*")
       vm2.tag_with(tag, :ns => "*")
 
-      User.stub(:server_timezone => "UTC")
+      allow(User).to receive_messages(:server_timezone => "UTC")
       report = MiqReport.new(:db => "Vm", :sortby => %w(storage.name name), :order => "Ascending", :include => {"storage" => {"columns" => ["name"]}})
       options = {
         :only   => ["name", "storage.name"],
@@ -235,7 +235,7 @@ describe MiqReport do
       vm2.tag_with(tag, :ns => "*")
       vm3.tag_with(tag, :ns => "*")
 
-      User.stub(:server_timezone => "UTC")
+      allow(User).to receive_messages(:server_timezone => "UTC")
 
       report = MiqReport.new(:db => "Vm")
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -252,8 +252,8 @@ describe MiqRequest do
     end
 
     it "#deny" do
-      MiqApproval.any_instance.stub(:authorized? => true)
-      MiqServer.stub(:my_zone => "default")
+      allow_any_instance_of(MiqApproval).to receive_messages(:authorized? => true)
+      allow(MiqServer).to receive_messages(:my_zone => "default")
 
       provision_request = FactoryGirl.create(:miq_provision_request, :requester => fred, :src_vm_id => template.id)
 

--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -5,7 +5,7 @@ describe MiqRequestTask do
     context "#signal" do
       it "will deal with exceptions" do
         task = FactoryGirl.create(:miq_request_task)
-        task.stub(:miq_request => double("MiqRequest").as_null_object)
+        allow(task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
         exception = String.xxx rescue $!
         allow(task).to receive(:some_state).and_raise(exception)
 

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -507,7 +507,7 @@ describe MiqScheduleWorker::Runner do
 
             context "#do_work appliance_specific" do
               it "on an appliance" do
-                MiqEnvironment::Command.stub(:is_appliance? => true)
+                allow(MiqEnvironment::Command).to receive_messages(:is_appliance? => true)
                 expect_any_instance_of(MiqServer).to receive(:has_assigned_role?).with("rhn_mirror").and_return(true)
 
                 Timecop.freeze(@start_time) do
@@ -519,7 +519,7 @@ describe MiqScheduleWorker::Runner do
               end
 
               it "not an appliance" do
-                MiqEnvironment::Command.stub(:is_appliance? => false)
+                allow(MiqEnvironment::Command).to receive_messages(:is_appliance? => false)
 
                 Timecop.freeze(@start_time) do
                   @schedule_worker.schedules_for_all_roles

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -96,7 +96,7 @@ describe "Server Environment Management" do
   context "#check_disk_usage" do
     before do
       _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
-      @miq_server.stub(:disk_usage_threshold => 70)
+      allow(@miq_server).to receive_messages(:disk_usage_threshold => 70)
     end
 
     it "normal usage" do

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -91,26 +91,26 @@ describe MiqServer do
 
     context "#pg_data_log_patterns" do
       it "nil pg_data_dir" do
-        @miq_server.stub(:pg_data_dir => nil)
+        allow(@miq_server).to receive_messages(:pg_data_dir => nil)
         expect(@miq_server.pg_log_patterns).to eql []
       end
 
       it "pg_data_dir set" do
-        @miq_server.stub(:pg_data_dir => '/var/lib/pgsql/data')
+        allow(@miq_server).to receive_messages(:pg_data_dir => '/var/lib/pgsql/data')
         expected = %w(/var/lib/pgsql/data/*.conf /var/lib/pgsql/data/pg_log/*)
         expect(@miq_server.pg_log_patterns.collect(&:to_s)).to match_array expected
       end
     end
 
     it "#current_log_patterns" do
-      @miq_server.stub(:current_log_pattern_configuration => %w(/var/log/syslog*))
-      @miq_server.stub(:pg_log_patterns => %w(/var/lib/pgsql/data/*.conf))
+      allow(@miq_server).to receive_messages(:current_log_pattern_configuration => %w(/var/log/syslog*))
+      allow(@miq_server).to receive_messages(:pg_log_patterns => %w(/var/lib/pgsql/data/*.conf))
       expect(@miq_server.current_log_patterns).to match_array %w(/var/log/syslog* /var/lib/pgsql/data/*.conf)
     end
 
     it "#current_log_patterns with pg_logs duplicated in current_log_pattern_configuration" do
-      @miq_server.stub(:current_log_pattern_configuration => %w(/var/log/syslog* /var/lib/pgsql/data/*.conf))
-      @miq_server.stub(:pg_log_patterns => %w(/var/lib/pgsql/data/*.conf))
+      allow(@miq_server).to receive_messages(:current_log_pattern_configuration => %w(/var/log/syslog* /var/lib/pgsql/data/*.conf))
+      allow(@miq_server).to receive_messages(:pg_log_patterns => %w(/var/lib/pgsql/data/*.conf))
       expect(@miq_server.current_log_patterns).to match_array %w(/var/log/syslog* /var/lib/pgsql/data/*.conf)
     end
 

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -34,17 +34,17 @@ describe "Server Role Management" do
 
     context "#apache_needed?" do
       it "false with neither webservices or user_interface active" do
-        @miq_server.stub(:active_role_names => ["reporting"])
+        allow(@miq_server).to receive_messages(:active_role_names => ["reporting"])
         expect(@miq_server.apache_needed?).to be_falsey
       end
 
       it "true with web_services active" do
-        @miq_server.stub(:active_role_names => ["web_services"])
+        allow(@miq_server).to receive_messages(:active_role_names => ["web_services"])
         expect(@miq_server.apache_needed?).to be_truthy
       end
 
       it "true with both web_services and user_interface active" do
-        @miq_server.stub(:active_role_names => ["web_services", "user_interface"])
+        allow(@miq_server).to receive_messages(:active_role_names => ["web_services", "user_interface"])
         expect(@miq_server.apache_needed?).to be_truthy
       end
     end

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -171,7 +171,7 @@ describe MiqServer do
   it "#check_updates" do
     expect(yum).to receive(:updates_available?).twice.and_return(true)
     expect(yum).to receive(:version_available).with("cfme-appliance").once.and_return({"cfme-appliance" => "3.1"})
-    MiqDatabase.stub(:postgres_package_name => "postgresql-server")
+    allow(MiqDatabase).to receive_messages(:postgres_package_name => "postgresql-server")
 
     @server.check_updates
 
@@ -180,7 +180,7 @@ describe MiqServer do
 
   context "#apply_updates" do
     before do
-      MiqDatabase.stub(:postgres_package_name => "postgresql-server")
+      allow(MiqDatabase).to receive_messages(:postgres_package_name => "postgresql-server")
     end
 
     it "will apply cfme updates only with local database" do
@@ -209,7 +209,7 @@ describe MiqServer do
     it "does not have updates to apply" do
       expect(yum).to receive(:updates_available?).twice.and_return(false)
       expect(yum).to receive(:version_available).once.and_return({})
-      MiqDatabase.stub(:postgres_package_name => "postgresql-server")
+      allow(MiqDatabase).to receive_messages(:postgres_package_name => "postgresql-server")
 
       @server.apply_updates
     end

--- a/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
@@ -14,20 +14,20 @@ describe MiqServer do
         EOS
                                    )
 
-      @server.stub(:worker_monitor_settings => @monitor_settings)
-      @server.stub(:child_worker_settings => {:generic_worker => {}})
+      allow(@server).to receive_messages(:worker_monitor_settings => @monitor_settings)
+      allow(@server).to receive_messages(:child_worker_settings => {:generic_worker => {}})
       @memory_usage = {:MemFree => 0.megabytes, :SwapTotal => 10.gigabytes, :SwapFree => 3.gigabytes}
     end
 
     context "used_swap_percent_lt_value" do
       context "#enough_resource_to_start_worker?" do
         it "70% swap used" do
-          MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
+          allow(MiqSystem).to receive_messages(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
           expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_falsey
         end
 
         it "30% swap used" do
-          MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
+          allow(MiqSystem).to receive_messages(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
           expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_truthy
         end
 
@@ -39,21 +39,21 @@ describe MiqServer do
                 :value: 20
             EOS
                            )
-          @server.stub(:child_worker_settings => child)
+          allow(@server).to receive_messages(:child_worker_settings => child)
 
-          MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
+          allow(MiqSystem).to receive_messages(:memory => @memory_usage.merge(:SwapFree => 7.gigabytes))
           expect(@server.enough_resource_to_start_worker?(MiqGenericWorker)).to be_falsey
         end
       end
 
       context "#kill_workers_due_to_resources_exhausted?" do
         it "90% swap used" do
-          MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 1.gigabytes))
+          allow(MiqSystem).to receive_messages(:memory => @memory_usage.merge(:SwapFree => 1.gigabytes))
           expect(@server.kill_workers_due_to_resources_exhausted?).to be_truthy
         end
 
         it "70% swap used" do
-          MiqSystem.stub(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
+          allow(MiqSystem).to receive_messages(:memory => @memory_usage.merge(:SwapFree => 3.gigabytes))
           expect(@server.kill_workers_due_to_resources_exhausted?).to be_falsey
         end
       end

--- a/spec/models/miq_vim_broker_worker_spec.rb
+++ b/spec/models/miq_vim_broker_worker_spec.rb
@@ -5,7 +5,7 @@ describe MiqVimBrokerWorker do
     guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
     other_ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
-    ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_status_ok? => true)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:authentication_status_ok? => true)
   end
 
   it ".emses_to_monitor" do

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -25,25 +25,25 @@ describe AuthenticationMixin do
 
       it "no authentication" do
         t = TestClass.new
-        t.stub(:authentication_best_fit => nil)
+        allow(t).to receive_messages(:authentication_best_fit => nil)
         expect(t.send(method)).to eq(expected)
       end
 
       it "no #{required_field}" do
         t = TestClass.new
-        t.stub(:authentication_best_fit => double(required_field => nil))
+        allow(t).to receive_messages(:authentication_best_fit => double(required_field => nil))
         expect(t.send(method)).to eq(expected)
       end
 
       it "blank #{required_field}" do
         t = TestClass.new
-        t.stub(:authentication_best_fit => double(required_field => ""))
+        allow(t).to receive_messages(:authentication_best_fit => double(required_field => ""))
         expect(t.send(method)).to eq(expected)
       end
 
       it "normal case" do
         t = TestClass.new
-        t.stub(:authentication_best_fit => double(required_field => "test"))
+        allow(t).to receive_messages(:authentication_best_fit => double(required_field => "test"))
 
         expected = case method
                    when :has_credentials?

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -6,7 +6,7 @@ describe MiqWebServerWorkerMixin do
       include MiqWebServerWorkerMixin
     end
 
-    test_class.stub(:binding_address => "::1")
+    allow(test_class).to receive_messages(:binding_address => "::1")
     expect(test_class.build_uri(123)).to eq "http://[::1]:123"
   end
 end

--- a/spec/models/mixins/provider_object_mixin_spec.rb
+++ b/spec/models/mixins/provider_object_mixin_spec.rb
@@ -15,7 +15,7 @@ describe ProviderObjectMixin do
     @ems        = double("ems")
     @connection = double("connection")
     expect(@ems).to receive(:with_provider_connection).and_yield(@connection)
-    TestClass.any_instance.stub(:ext_management_system => @ems)
+    allow_any_instance_of(TestClass).to receive_messages(:ext_management_system => @ems)
   end
 
   it "#with_provider_connection" do
@@ -26,7 +26,7 @@ describe ProviderObjectMixin do
   context "when provider_object is written" do
     before do
       @provider_object = double("provider_object")
-      TestClass.any_instance.stub(:provider_object => @provider_object)
+      allow_any_instance_of(TestClass).to receive_messages(:provider_object => @provider_object)
     end
 
     it "#provider_object" do

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -74,7 +74,7 @@ describe OrchestrationTemplate do
 
   describe "#eligible_managers" do
     before do
-      OrchestrationTemplate.stub(:eligible_manager_types => [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Openstack::CloudManager])
+      allow(OrchestrationTemplate).to receive_messages(:eligible_manager_types => [ManageIQ::Providers::Amazon::CloudManager, ManageIQ::Providers::Openstack::CloudManager])
       @template = FactoryGirl.create(:orchestration_template)
       @aws = FactoryGirl.create(:ems_amazon)
       @openstack = FactoryGirl.create(:ems_openstack)
@@ -89,7 +89,7 @@ describe OrchestrationTemplate do
     before do
       @template = FactoryGirl.create(:orchestration_template)
       @manager = FactoryGirl.create(:ems_amazon)
-      @manager.stub(:orchestration_template_validate => "Validation Message")
+      allow(@manager).to receive_messages(:orchestration_template_validate => "Validation Message")
     end
 
     it "uses caller provided manager to do validation" do
@@ -97,12 +97,12 @@ describe OrchestrationTemplate do
     end
 
     it "uses all eligible managers to do validation" do
-      @template.stub(:eligible_managers => [@manager])
+      allow(@template).to receive_messages(:eligible_managers => [@manager])
       expect(@template.validate_content).to eq("Validation Message")
     end
 
     it "gets an error message if no eligible managers" do
-      @template.stub(:eligible_managers => ["Invalid Object"])
+      allow(@template).to receive_messages(:eligible_managers => ["Invalid Object"])
       expect(@template.validate_content).to match(/No (.*) is capable to validate the template/)
     end
   end
@@ -174,7 +174,7 @@ describe OrchestrationTemplate do
 
     context "when format validation fails" do
       it "raises an error showing the failure reason" do
-        template.stub(:validate_format => "format is invalid")
+        allow(template).to receive_messages(:validate_format => "format is invalid")
         expect { template.save_with_format_validation! }
           .to raise_error(MiqException::MiqParsingError, "format is invalid")
       end
@@ -182,7 +182,7 @@ describe OrchestrationTemplate do
 
     context "when format validation passes" do
       it "saves the template" do
-        template.stub(:validate_format => nil)
+        allow(template).to receive_messages(:validate_format => nil)
         expect(template.save_with_format_validation!).to be_truthy
       end
     end
@@ -190,7 +190,7 @@ describe OrchestrationTemplate do
     context "when the template is draft" do
       it "always saves the template" do
         template.draft = true
-        template.stub(:validate_format => "format is invalid")
+        allow(template).to receive_messages(:validate_format => "format is invalid")
         expect(template.save_with_format_validation!).to be_truthy
       end
     end

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -134,7 +134,7 @@ PXEMENU
   context "#synchronize" do
     before(:each) do
       @pxe_server = FactoryGirl.create(:pxe_server)
-      @pxe_server.stub(:read_file => @contents_ipxe)
+      allow(@pxe_server).to receive_messages(:read_file => @contents_ipxe)
     end
 
     it "on typed menu" do

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Rbac do
-  before { User.stub(:server_timezone => "UTC") }
+  before { allow(User).to receive_messages(:server_timezone => "UTC") }
   let(:default_tenant) { Tenant.seed }
 
   let(:owner_tenant) { FactoryGirl.create(:tenant) }
@@ -390,7 +390,7 @@ describe Rbac do
         end
 
         it "search on VMs and Templates should return no objects if self-service user" do
-          User.any_instance.stub(:self_service? => true)
+          allow_any_instance_of(User).to receive_messages(:self_service? => true)
           User.with_user(user) do
             results = Rbac.search(:class => "VmOrTemplate", :results_format => :objects)
             objects = results.first
@@ -570,7 +570,7 @@ describe Rbac do
 
       context ".search" do
         it "self-service group" do
-          MiqGroup.any_instance.stub(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
 
           results = Rbac.search(:class => "Service", :results_format => :objects, :miq_group => user.current_group).first
           expect(results.to_a).to match_array([@service4, @service5])
@@ -578,7 +578,7 @@ describe Rbac do
 
         context "with self-service user" do
           before(:each) do
-            User.any_instance.stub(:self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -590,8 +590,8 @@ describe Rbac do
         end
 
         it "limited self-service group" do
-          MiqGroup.any_instance.stub(:self_service? => true)
-          MiqGroup.any_instance.stub(:limited_self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
 
           results = Rbac.search(:class => "Service", :results_format => :objects, :miq_group => user.current_group).first
           expect(results.to_a).to match_array([@service4, @service5])
@@ -599,8 +599,8 @@ describe Rbac do
 
         context "with limited self-service user" do
           before(:each) do
-            User.any_instance.stub(:self_service? => true)
-            User.any_instance.stub(:limited_self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:limited_self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -652,7 +652,7 @@ describe Rbac do
 
       context ".search" do
         it "self-service group" do
-          MiqGroup.any_instance.stub(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
 
           results = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group => user.current_group).first
           expect(results.length).to eq(2)
@@ -660,7 +660,7 @@ describe Rbac do
 
         context "with self-service user" do
           before(:each) do
-            User.any_instance.stub(:self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:self_service? => true)
           end
 
           it "works when targets are empty" do
@@ -679,8 +679,8 @@ describe Rbac do
         end
 
         it "limited self-service group" do
-          MiqGroup.any_instance.stub(:self_service? => true)
-          MiqGroup.any_instance.stub(:limited_self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
+          allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
 
           results = Rbac.search(:class => "Vm", :results_format => :objects, :miq_group => user.current_group).first
           expect(results.length).to eq(2)
@@ -688,8 +688,8 @@ describe Rbac do
 
         context "with limited self-service user" do
           before(:each) do
-            User.any_instance.stub(:self_service? => true)
-            User.any_instance.stub(:limited_self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:self_service? => true)
+            allow_any_instance_of(User).to receive_messages(:limited_self_service? => true)
           end
 
           it "works when targets are empty" do

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -91,7 +91,7 @@ describe "RegistrationSystem" do
     end
 
     it "should rescue NotImplementedError" do
-      LinuxAdmin::Rhn.any_instance.stub(:registered? => true)
+      allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => true)
       expect(RegistrationSystem.verify_credentials(@creds)).to be_falsey
     end
 

--- a/spec/models/rss_feed/rss_feed_spec.rb
+++ b/spec/models/rss_feed/rss_feed_spec.rb
@@ -91,7 +91,7 @@ EOXML
         feed_link: "/alert/rss?feed=newest_hosts"
         EOF
 
-      File.stub(:mtime => Time.now.utc)
+      allow(File).to receive_messages(:mtime => Time.now.utc)
       allow(File).to receive(:read).and_return(NEW_YML_FILE)
 
       described_class.sync_from_yml_file(@name)

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -2,40 +2,40 @@ require "spec_helper"
 
 describe Storage do
   it "#scan_watchdog_interval" do
-    Storage.stub(:vmdb_storage_config => {})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {})
     expect(Storage.scan_watchdog_interval).to eq(Storage::DEFAULT_WATCHDOG_INTERVAL)
 
-    Storage.stub(:vmdb_storage_config => {'watchdog_interval' => '5.minutes'})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {'watchdog_interval' => '5.minutes'})
     expect(Storage.scan_watchdog_interval).to eq(5.minutes)
   end
 
   it "#max_parallel_storage_scans_per_host" do
-    Storage.stub(:vmdb_storage_config => {})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {})
     expect(Storage.max_parallel_storage_scans_per_host).to eq(Storage::DEFAULT_MAX_PARALLEL_SCANS_PER_HOST)
 
-    Storage.stub(:vmdb_storage_config => {'max_parallel_scans_per_host' => 3})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {'max_parallel_scans_per_host' => 3})
     expect(Storage.max_parallel_storage_scans_per_host).to eq(3)
   end
 
   it "#max_qitems_per_scan_request" do
-    Storage.stub(:vmdb_storage_config => {})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {})
     expect(Storage.max_qitems_per_scan_request).to eq(Storage::DEFAULT_MAX_QITEMS_PER_SCAN_REQUEST)
 
-    Storage.stub(:vmdb_storage_config => {'max_qitems_per_scan_request' => 3})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {'max_qitems_per_scan_request' => 3})
     expect(Storage.max_qitems_per_scan_request).to eq(3)
   end
 
   it "#scan_collection_timeout" do
-    Storage.stub(:vmdb_storage_config => {})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {})
     expect(Storage.scan_collection_timeout).to be_nil
 
-    Storage.stub(:vmdb_storage_config => {:collection => {:timeout => 3}})
+    allow(Storage).to receive_messages(:vmdb_storage_config => {:collection => {:timeout => 3}})
     expect(Storage.scan_collection_timeout).to eq(3)
   end
 
   it "#scan_watchdog_deliver_on" do
     scan_watchdog_interval = 7.minutes
-    Storage.stub(:scan_watchdog_interval => scan_watchdog_interval)
+    allow(Storage).to receive_messages(:scan_watchdog_interval => scan_watchdog_interval)
     start = Time.parse("Sun March 10 01:00:00 UTC 2010")
     Timecop.travel(start) do
       expect(Storage.scan_watchdog_deliver_on - (start + scan_watchdog_interval)).to be_within(0.001).of(0.0)
@@ -113,7 +113,7 @@ describe Storage do
 
     it "#scan_queue_item" do
       scan_collection_timeout = 456
-      Storage.stub(:scan_collection_timeout => scan_collection_timeout)
+      allow(Storage).to receive_messages(:scan_collection_timeout => scan_collection_timeout)
 
       miq_task = FactoryGirl.create(:miq_task)
       qitem = @storage1.scan_queue_item(miq_task.id)
@@ -152,7 +152,7 @@ describe Storage do
     it "#scan_queue_watchdog" do
       miq_task = FactoryGirl.create(:miq_task)
       deliver_on = Time.now.utc + 1.hour
-      Storage.stub(:scan_watchdog_deliver_on => deliver_on)
+      allow(Storage).to receive_messages(:scan_watchdog_deliver_on => deliver_on)
       watchdog = Storage.scan_queue_watchdog(miq_task.id)
       expect(watchdog.class_name).to eq('Storage')
       expect(watchdog.method_name).to eq('scan_watchdog')
@@ -222,7 +222,7 @@ describe Storage do
 
       context "with performance capture disabled" do
         before(:each) do
-          Storage.any_instance.stub(:perf_capture_enabled? => false)
+          allow_any_instance_of(Storage).to receive_messages(:perf_capture_enabled? => false)
         end
 
         it "#scan_eligible_storages" do
@@ -243,7 +243,7 @@ describe Storage do
 
       context "with performance capture enabled" do
         before(:each) do
-          Storage.any_instance.stub(:perf_capture_enabled? => true)
+          allow_any_instance_of(Storage).to receive_messages(:perf_capture_enabled? => true)
           allow(MiqEvent).to receive(:raise_evm_job_event)
         end
 
@@ -255,7 +255,7 @@ describe Storage do
         end
 
         it "#scan_queue" do
-          Storage.stub(:max_parallel_storage_scans => 1)
+          allow(Storage).to receive_messages(:max_parallel_storage_scans => 1)
           bogus_id = @storage1.id - 1
           miq_task = FactoryGirl.create(:miq_task)
           miq_task.context_data = {:targets => [], :complete => [], :pending  => {}}
@@ -265,7 +265,7 @@ describe Storage do
           miq_task.save!
 
           qitem1  = FactoryGirl.create(:miq_queue)
-          Storage.any_instance.stub(:scan_queue_item => qitem1)
+          allow_any_instance_of(Storage).to receive_messages(:scan_queue_item => qitem1)
           Storage.scan_queue(miq_task)
           miq_task.reload
           expect(miq_task.context_data[:targets]).to eq([@storage1.id, @storage2.id, @storage3.id])
@@ -277,7 +277,7 @@ describe Storage do
           miq_task.context_data[:pending].delete(@storage1.id)
           miq_task.save!
           qitem2  = FactoryGirl.create(:miq_queue)
-          Storage.any_instance.stub(:scan_queue_item => qitem2)
+          allow_any_instance_of(Storage).to receive_messages(:scan_queue_item => qitem2)
           Storage.scan_queue(miq_task)
           miq_task.reload
           expect(miq_task.context_data[:targets]).to eq([@storage1.id, @storage2.id, @storage3.id])
@@ -298,7 +298,7 @@ describe Storage do
 
         it "#scan_watchdog" do
           max_qitems_per_scan_request = 1
-          Storage.stub(:max_qitems_per_scan_request => max_qitems_per_scan_request)
+          allow(Storage).to receive_messages(:max_qitems_per_scan_request => max_qitems_per_scan_request)
           miq_task = FactoryGirl.create(:miq_task)
           miq_task.context_data = {:targets => [], :complete => [], :pending  => {}}
           miq_task.context_data[:targets]  = [@storage1.id, @storage2.id, @storage3.id]

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -58,7 +58,7 @@ describe TenantQuota do
 
       it "cannot have less quota than the amount that has already been used" do
         nq = described_class.new(:tenant => grandchild_tenant2, :name => "cpu_allocated", :value => 1)
-        nq.stub(:used => 2)
+        allow(nq).to receive_messages(:used => 2)
         expect(nq).not_to be_valid
       end
     end
@@ -78,7 +78,7 @@ describe TenantQuota do
       it "cannot have more quota than the parent has available to allocate when parent has used up its available" do
         described_class.create!(:tenant => child_tenant, :name => "cpu_allocated", :value => 5)
 
-        described_class.any_instance.stub(:used => 5)
+        allow_any_instance_of(described_class).to receive_messages(:used => 5)
         expect(described_class.new(:tenant => grandchild_tenant1, :name => "cpu_allocated", :value => 1)).not_to be_valid
       end
 
@@ -92,7 +92,7 @@ describe TenantQuota do
         described_class.create!(:tenant => child_tenant, :name => "cpu_allocated", :value => 5)
         described_class.create!(:tenant => grandchild_tenant1, :name => "cpu_allocated", :value => 3)
 
-        described_class.any_instance.stub(:used => 2)
+        allow_any_instance_of(described_class).to receive_messages(:used => 2)
         expect(described_class.new(:tenant => grandchild_tenant2, :name => "cpu_allocated", :value => 1)).not_to be_valid
       end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -748,7 +748,7 @@ describe Tenant do
         :templates_allocated => {:value => 4}
       )
 
-      TenantQuota.any_instance.stub(:used => 2)
+      allow_any_instance_of(TenantQuota).to receive_messages(:used => 2)
     end
 
     it "calculates quotas allocated to child tenants" do

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -23,7 +23,7 @@ describe Authenticator::Ldap do
       @fqusername  = "#{@username}@#{@user_suffix}"
 
       init_ldap_setup
-      @ldap.stub(:fqusername => @fqusername)
+      allow(@ldap).to receive_messages(:fqusername => @fqusername)
     end
 
     it "initial status" do
@@ -60,7 +60,7 @@ describe Authenticator::Ldap do
     end
 
     it "ldap bind fails" do
-      @login_ldap.stub(:bind => false)
+      allow(@login_ldap).to receive_messages(:bind => false)
 
       expect(AuditEvent).to receive(:failure)
       expect(-> { subject }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
@@ -69,7 +69,7 @@ describe Authenticator::Ldap do
     context "ldap binds" do
       it "get groups from ldap" do
         user = double("some user")
-        @auth.stub(:authorize_queue => user)
+        allow(@auth).to receive_messages(:authorize_queue => user)
         expect(subject).to eq(user)
       end
 
@@ -109,11 +109,11 @@ describe Authenticator::Ldap do
 
   def init_ldap_setup
     @login_ldap = double('login_ldap')
-    @login_ldap.stub(:bind => true)
+    allow(@login_ldap).to receive_messages(:bind => true)
     allow(MiqLdap).to receive(:new).and_return(@login_ldap)
 
     @ldap = double('ldap')
-    @auth.stub(:ldap => @ldap)
+    allow(@auth).to receive_messages(:ldap => @ldap)
   end
 
   def setup_vmdb_config
@@ -122,14 +122,14 @@ describe Authenticator::Ldap do
 
   def setup_to_create_user(group)
     setup_vmdb_config
-    @ldap.stub(:get_user_object => "A Net::LDAP::Entry object")
-    @ldap.stub(:normalize => "some unique string")
-    @ldap.stub(:get_attr => "xx@xx.com")
-    @auth.stub(:groups_for => [group.description])
+    allow(@ldap).to receive_messages(:get_user_object => "A Net::LDAP::Entry object")
+    allow(@ldap).to receive_messages(:normalize => "some unique string")
+    allow(@ldap).to receive_messages(:get_attr => "xx@xx.com")
+    allow(@auth).to receive_messages(:groups_for => [group.description])
   end
 
   def setup_to_get_fqdn
-    @ldap.stub(:fqusername => "some FQDN")
-    @ldap.stub(:normalize => "some normalized name")
+    allow(@ldap).to receive_messages(:fqusername => "some FQDN")
+    allow(@ldap).to receive_messages(:normalize => "some normalized name")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,15 +209,15 @@ describe User do
           }
         stub_server_configuration(@auth_config)
         @miq_ldap = double('miq_ldap')
-        @miq_ldap.stub(:bind => false)
+        allow(@miq_ldap).to receive_messages(:bind => false)
       end
 
       it "will fail task if user object not found in ldap" do
-        @miq_ldap.stub(:get_user_object => nil)
+        allow(@miq_ldap).to receive_messages(:get_user_object => nil)
 
         expect(AuditEvent).to receive(:failure).once
         authenticate = Authenticator::Ldap.new(@auth_config[:authentication])
-        authenticate.stub(:ldap => @miq_ldap)
+        allow(authenticate).to receive_messages(:ldap => @miq_ldap)
 
         expect(authenticate.authorize(@task.id, @fq_user)).to be_nil
 
@@ -228,13 +228,13 @@ describe User do
       end
 
       it "will fail task if user group doesn't match an EVM role" do
-        @miq_ldap.stub(:get_user_object => "user object")
-        @miq_ldap.stub(:get_attr => nil)
-        @miq_ldap.stub(:normalize => "a-username")
+        allow(@miq_ldap).to receive_messages(:get_user_object => "user object")
+        allow(@miq_ldap).to receive_messages(:get_attr => nil)
+        allow(@miq_ldap).to receive_messages(:normalize => "a-username")
 
         authenticate = Authenticator::Ldap.new(@auth_config[:authentication])
-        authenticate.stub(:ldap => @miq_ldap)
-        authenticate.stub(:groups_for => [])
+        allow(authenticate).to receive_messages(:ldap => @miq_ldap)
+        allow(authenticate).to receive_messages(:groups_for => [])
 
         expect(AuditEvent).to receive(:failure).once
         expect(authenticate.authorize(@task.id, @fq_user)).to be_nil

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -212,7 +212,7 @@ describe VmOrTemplate do
                                  :storages => [@storage1, @storage2])
         @zone = FactoryGirl.create(:zone, :name => 'zone')
 
-        MiqServer.any_instance.stub(:is_vix_disk? => true)
+        allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
         @svr1 = EvmSpecHelper.local_miq_server(:name => 'svr1')
         @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @svr1.zone)
         @svr3 = FactoryGirl.create(:miq_server, :name => 'svr3', :zone => @svr1.zone)
@@ -432,8 +432,8 @@ describe VmOrTemplate do
   context "#is_available? for Smartstate Analysis" do
     it "returns true for VMware VM" do
       vm =  FactoryGirl.create(:vm_vmware)
-      vm.stub(:archived? => false)
-      vm.stub(:orphaned? => false)
+      allow(vm).to receive_messages(:archived? => false)
+      allow(vm).to receive_messages(:orphaned? => false)
       expect(vm.is_available?(:smartstate_analysis)).to eq(true)
     end
 

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -6,9 +6,9 @@ describe VmScan do
       @server = EvmSpecHelper.local_miq_server
 
       # TODO: We should be able to set values so we don't need to stub behavior
-      MiqServer.any_instance.stub(:is_a_proxy? => true, :has_active_role? => true, :is_vix_disk? => true)
-      ManageIQ::Providers::Vmware::InfraManager.any_instance.stub(:authentication_status_ok? => true)
-      Vm.stub(:scan_via_ems? => true)
+      allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true, :has_active_role? => true, :is_vix_disk? => true)
+      allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:authentication_status_ok? => true)
+      allow(Vm).to receive_messages(:scan_via_ems? => true)
 
       @user      = FactoryGirl.create(:user_with_group, :userid => "tester")
       @ems       = FactoryGirl.create(:ems_vmware,       :name => "Test EMS", :zone => @server.zone, :tenant => FactoryGirl.create(:tenant))
@@ -24,7 +24,7 @@ describe VmScan do
                                      )
       @ems_auth  = FactoryGirl.create(:authentication, :resource => @ems)
 
-      MiqEventDefinition.stub(:find_by_name => true)
+      allow(MiqEventDefinition).to receive_messages(:find_by_name => true)
       @job = @vm.scan
       MiqQueue.delete_all # clear the queue items that are not related to Vm scan testing
     end
@@ -123,7 +123,7 @@ describe VmScan do
           end
 
           it "should call callback when message is delivered" do
-            VmScan.any_instance.stub(:signal => true)
+            allow_any_instance_of(VmScan).to receive_messages(:signal => true)
             expect_any_instance_of(VmScan).to receive(:check_policy_complete)
             q = MiqQueue.where(:class_name => "MiqAeEngine", :method_name => "deliver").first
             q.delivered(*q.deliver)
@@ -179,7 +179,7 @@ describe VmScan do
       end
 
       it "should have vmScanProfiles from scan_profiles option" do
-        profiles = [ScanItemSet.any_instance.stub(:name => 'default')]
+        profiles = [{:name => 'default'}]
         @job.options[:scan_profiles] = profiles
         args = @job.create_scan_args(@vm)
         expect(args["vmScanProfiles"]).to eq profiles

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -172,7 +172,7 @@ describe Vm do
     it "policy passes" do
       expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:raw_start)
 
-      MiqAeEngine.stub(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+      allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
       @vm.start
       status, message, result = MiqQueue.first.deliver
       MiqQueue.first.delivered(status, message, result)
@@ -183,7 +183,7 @@ describe Vm do
 
       event = {:attributes => {"full_data" => {:policy => {:prevented => true}}}}
       allow_any_instance_of(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:get_obj_from_path).with("/").and_return(:event_stream => event)
-      MiqAeEngine.stub(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+      allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
       @vm.start
       status, message, _result = MiqQueue.first.deliver
       MiqQueue.first.delivered(status, message, MiqAeEngine::MiqAeWorkspaceRuntime.new)

--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -96,7 +96,7 @@ describe VmdbDatabaseConnection do
 
   it 'wait_time_ms defaults to 0 on nil query_start' do
     conn = VmdbDatabaseConnection.first
-    conn.stub(:query_start => nil)
+    allow(conn).to receive_messages(:query_start => nil)
     expect(conn.wait_time_ms).to eq 0
   end
 

--- a/spec/models/volume_spec.rb
+++ b/spec/models/volume_spec.rb
@@ -55,7 +55,7 @@ describe Volume do
     it "disk_id when controller like 'scsi0:0:0'" do
       parent = disk = double
       allow(disk).to receive(:find_by_controller_type_and_location).with('scsi', '0:1').and_return('001')
-      parent.stub(:hardware => double(:disks => disk))
+      allow(parent).to receive_messages(:hardware => double(:disks => disk))
       expect(described_class.find_disk_by_controller(parent, 'scsi0:1:1')).to eq('001')
     end
   end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -91,7 +91,7 @@ describe Zone do
     subject           { described_class }
 
     before do
-      ServerRole.stub(:region_scoped_roles => [ServerRole.new(:name => "inregion")])
+      allow(ServerRole).to receive_messages(:region_scoped_roles => [ServerRole.new(:name => "inregion")])
       allow(MiqServer).to receive(:my_zone) { "myzone" }
     end
 

--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -1,14 +1,14 @@
 
 shared_examples_for 'record without latest derived metrics' do |message|
   it "#{message}" do
-    @record.stub(:latest_derived_metrics => false)
+    allow(@record).to receive_messages(:latest_derived_metrics => false)
     expect(subject).to eq(message)
   end
 end
 
 shared_examples_for 'record without perf data' do |message|
   it "#{message}" do
-    @record.stub(:has_perf_data? => false)
+    allow(@record).to receive_messages(:has_perf_data? => false)
     expect(subject).to eq(message)
   end
 end
@@ -38,7 +38,7 @@ end
 
 shared_examples_for 'vm not powered on' do |message|
   it "#{message}" do
-    @record.stub(:current_state => 'off')
+    allow(@record).to receive_messages(:current_state => 'off')
     expect(subject).to eq(message)
   end
 end

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -48,7 +48,7 @@ describe FixAuth::AuthModel do
     end
 
     it "should limit available_columns when not all columns are available" do
-      subject.stub(:column_names => %w(password id))
+      allow(subject).to receive_messages(:column_names => %w(password id))
       expect(subject.available_columns).to eq(%w(password))
     end
 


### PR DESCRIPTION
This converts all of our uses of .stub (and related methods) to RSpec 3+ expect syntax, preceeding us disabling `should` syntax for both rspec-expectations and rspec-mocks.