### PR TITLE
Fix for disabling the web_services worker

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -91,6 +91,7 @@ module MiqWebServerWorkerMixin
             result[:adds] << w.pid
           end
         elsif desired < current
+          workers = workers.to_a
           (current - desired).times do
             w = workers.pop
             port = w.port


### PR DESCRIPTION
Disabling the web_services role fails to terminate the worker due to 'pop' no longer being defined for associations.  Same fix as 1bdcf2e6.

This was causing the worker monitor to error out, not terminating the VimBrokerWorker and causing errors on the resulting inventory refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1286811

/cc @blomquisg 