### PR TITLE
Remove rspec/autorun require

### DIFF
--- a/gems/pending/spec/spec_helper.rb
+++ b/gems/pending/spec/spec_helper.rb
@@ -5,8 +5,6 @@ if ENV["TRAVIS"]
   Coveralls.wear_merged! { add_filter("/spec/") }
 end
 
-require 'rspec/autorun'
-
 # Push the gems/pending directory onto the load path
 GEMS_PENDING_ROOT ||= File.expand_path(File.join(__dir__, ".."))
 $LOAD_PATH << GEMS_PENDING_ROOT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'application_helper'
 
-require 'rspec/autorun'
 require 'rspec/rails'
 require 'vcr'
 


### PR DESCRIPTION
Requiring this is deprecated and unnecessary in RSpec 3 :tada: