### PR TITLE
Upgrade Capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ unless ENV['APPLIANCE']
 
   group :test do
     gem "brakeman",         "~>3.1.0",  :require => false
-    gem "capybara",         "~>2.2.0",  :require => false
+    gem "capybara",         "~>2.5.0",  :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
     gem "vcr",              "~>2.6",    :require => false
     gem "webmock",          "~>1.12",   :require => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,11 +43,6 @@ RSpec.configure do |config|
 
   # == RSPEC 3 UPGRADE ==
   # TODO: These config options should be reevaluated after RSpec 3 conversion.
-  #
-  # RSpec::Core::ExampleGroup#example is removed in RSpec 3
-  # Can't currently update the code at the call site (capybara),
-  # so we're temporarily adding the method for now
-  config.expose_current_running_example_as :example
 
   config.mock_with :rspec do |mocks|
     # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving


### PR DESCRIPTION
Upgrades Capybara 
* Removes patched-in RSpec::Core::ExampleGroup#example we needed in RSpec running the old version.
* Avoids the annoying deprecation that the older version outputs saying that matchers are implemented with the legacy RSpec API (matchers converted in 2.4.1).