### PR TITLE
Remove more RSpec 2 shims

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,19 +40,6 @@ RSpec.configure do |config|
   # `post` methods in spec/controllers, without specifying type
   config.infer_spec_type_from_file_location!
 
-  # == RSPEC 3 UPGRADE ==
-  # TODO: These config options should be reevaluated after RSpec 3 conversion.
-
-  config.mock_with :rspec do |mocks|
-    # Monkey-patch Marshal.dump to enable dumping of mocked or stubbed objects. By
-    # default this will not work since RSpec mocks works by adding singleton methods
-    # that cannot be serialized. This patch removes these singleton methods before
-    # serialization. Potentially but unlikely to be removed post upgrade.
-    mocks.patch_marshal_to_support_partial_doubles = true
-  end
-
-  # =====================
-
   # config.before(:all) do
   #   EvmSpecHelper.log_ruby_object_usage
   # end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,12 +44,6 @@ RSpec.configure do |config|
   # TODO: These config options should be reevaluated after RSpec 3 conversion.
 
   config.mock_with :rspec do |mocks|
-    # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
-    # instance as the first block argument to allow the implementation block to use
-    # the state of the receiver. This opts-in to the behavior now and can be removed
-    # once the upgrade is complete.
-    mocks.yield_receiver_to_any_instance_implementation_blocks = true
-
     # Monkey-patch Marshal.dump to enable dumping of mocked or stubbed objects. By
     # default this will not work since RSpec mocks works by adding singleton methods
     # that cannot be serialized. This patch removes these singleton methods before


### PR DESCRIPTION
Removes unnecessary RSpec configurations that were needed for transition to RSpec 2.99

* Removes opt-in to any_instance RSpec 3 behavior
* Removes monkeypatch to mock Marshal library