### PR TITLE
unescape special characters in tree test/tooltip & right cell headers.

### DIFF
--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -147,7 +147,7 @@ class ExplorerPresenter
     # Scroll to top of main div
     @out << "$('#main_div').scrollTop(0);"
 
-    @out << "$('h1#explorer_title').html('#{j ERB::Util.h(@options[:right_cell_text])}');" if @options[:right_cell_text]
+    @out << "$('h1#explorer_title').html('#{j ERB::Util.h(URI.unescape(@options[:right_cell_text]))}');" if @options[:right_cell_text]
 
     # Reload toolbars
     @options[:reload_toolbars].each_pair do |div_name, toolbar|

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -142,13 +142,13 @@ class TreeNodeBuilder
   def tooltip(tip)
     unless tip.blank?
       tip = tip.kind_of?(Proc) ? tip.call : _(tip)
-      tip = ERB::Util.html_escape(tip) unless tip.html_safe?
+      tip = ERB::Util.html_escape(URI.unescape(tip)) unless tip.html_safe?
       @node[:tooltip] = tip
     end
   end
 
   def generic_node(text, image, tip = nil)
-    text = ERB::Util.html_escape(text) unless text.html_safe?
+    text = ERB::Util.html_escape(URI.unescape(text)) unless text.html_safe?
     @node = {
       :key   => build_object_id,
       :title => text,

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -21,7 +21,7 @@
             .row
               .col-md-7#explorer
                 %h1#explorer_title
-                  = @right_cell_text
+                  = URI.unescape(@right_cell_text)
                   -# Link to clear the current applied filter, will be moved via JS to the right cell header
                   %span#clear_search{:style => "display:none"}
                     - if route_exists?(:action => 'adv_search_clear')

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -60,7 +60,7 @@ describe TreeNodeBuilder do
     end
 
     it 'DialogField node' do
-      field = FactoryGirl.build(:dialog_field, :name => 'random field name')
+      field = FactoryGirl.build(:dialog_field, :name => 'random field name', :label => 'foo')
       node = TreeNodeBuilder.build(field, nil, {})
       expect(node).not_to be_nil
     end
@@ -100,7 +100,7 @@ describe TreeNodeBuilder do
     end
 
     it 'IsoImage node' do
-      image = FactoryGirl.create(:iso_image)
+      image = FactoryGirl.create(:iso_image, :name => 'foo')
       node = TreeNodeBuilder.build(image, nil, {})
       expect(node).not_to be_nil
     end
@@ -115,6 +115,24 @@ describe TreeNodeBuilder do
       vm = FactoryGirl.build(:vm_amazon)
       node = TreeNodeBuilder.build(vm, nil, {})
       expect(node).not_to be_nil
+    end
+
+    it 'Vm node with /' do
+      vm = FactoryGirl.create(:vm_amazon, :name => 'foo / bar')
+      node = TreeNodeBuilder.build(vm, 'foo', {})
+      expect(node[:title]).to eq('foo / bar')
+    end
+
+    it 'Vm node with %2f' do
+      vm = FactoryGirl.create(:vm_amazon, :name => 'foo %2f bar')
+      node = TreeNodeBuilder.build(vm, nil, {})
+      expect(node[:title]).to eq('foo / bar')
+    end
+
+    it 'EmsFolder tooltip with %2f' do
+      ems_folder = FactoryGirl.create(:ems_folder, :name => 'foo %2f bar')
+      node = TreeNodeBuilder.build(ems_folder, nil, {})
+      expect(node[:tooltip]).to eq('Folder: foo / bar')
     end
 
     it 'MiqAeClass node' do
@@ -233,7 +251,7 @@ describe TreeNodeBuilder do
     end
 
     it 'PxeImageType node' do
-      image_type = FactoryGirl.create(:pxe_image_type)
+      image_type = FactoryGirl.create(:pxe_image_type, :name => 'foo')
       node = TreeNodeBuilder.build(image_type, nil, {})
       expect(node).not_to be_nil
     end
@@ -299,7 +317,7 @@ describe TreeNodeBuilder do
     end
 
     it 'MiqWidgetSet node' do
-      widget_set = FactoryGirl.build(:miq_widget_set)
+      widget_set = FactoryGirl.build(:miq_widget_set, :name => 'foo')
       node = TreeNodeBuilder.build(widget_set, nil, {})
       expect(node).not_to be_nil
     end
@@ -311,13 +329,13 @@ describe TreeNodeBuilder do
     end
 
     it 'VmdbIndex node' do
-      index = FactoryGirl.create(:vmdb_index)
+      index = FactoryGirl.create(:vmdb_index, :name => 'foo')
       node = TreeNodeBuilder.build(index, nil, {})
       expect(node).not_to be_nil
     end
 
     it 'Zone node' do
-      zone = FactoryGirl.build(:zone)
+      zone = FactoryGirl.build(:zone, :name => 'foo')
       node = TreeNodeBuilder.build(zone, nil, {})
       expect(node).not_to be_nil
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1282606

@dclarizio @martinpovolny please review, in order to recreate this issue i had to update add "%2f" in the EmsFolder name record in ems_folders table.

before:
![screenshot from 2016-01-11 17 02 54](https://cloud.githubusercontent.com/assets/3450808/12248184/bcbf37fe-b885-11e5-9c96-9de7811b730c.png)

after:
![screenshot from 2016-01-11 17 06 52](https://cloud.githubusercontent.com/assets/3450808/12248222/f04299e0-b885-11e5-8d65-5d3412e87d0a.png)
