### PR TITLE
perf_capture_timer preload resources to reduce queries

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -43,8 +43,7 @@ module Metric::Capture
   # Capture entry points
   #
 
-  def self.perf_capture_health_check(zone = nil)
-    zone ||= MiqServer.my_server.zone(true)
+  def self.perf_capture_health_check(zone)
     q_items = MiqQueue.select("created_on, args").where(:state => "ready", :role => "ems_metrics_collector", :method_name => "perf_capture", :zone => zone.name).order("created_on ASC")
 
     items_by_interval = q_items.group_by { |i| i.args.first }
@@ -138,6 +137,7 @@ module Metric::Capture
   def self.perf_capture_timer(zone = nil)
     _log.info "Queueing performance capture..."
 
+    zone ||= MiqServer.my_server.zone(true)
     perf_capture_health_check(zone)
     targets = Metric::Targets.capture_targets(zone)
 

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -19,7 +19,7 @@ module Metric::Targets
     targets += zone.storages.select { |s| Storage::SUPPORTED_STORAGE_TYPES.include?(s.store_type) } unless options[:exclude_storages]
 
     targets = targets.select(&:perf_capture_enabled?)
-    targets = targets.collect { |t| t.kind_of?(EmsCluster) ? t.hosts : t }.flatten
+    targets = targets.flat_map { |t| t.kind_of?(EmsCluster) ? t.hosts : t }
 
     targets += capture_vm_targets(targets, Host, options)
 
@@ -61,7 +61,7 @@ module Metric::Targets
     zone.ems_containers.each do |ems|
       targets += ems.container_nodes
       targets += ems.container_groups
-      targets += ems.container_groups.collect(&:containers).flatten
+      targets += ems.container_groups.flat_map(&:containers)
     end
 
     targets
@@ -77,7 +77,7 @@ module Metric::Targets
         t.respond_to?(:vms)
       end
       MiqPreloader.preload(enabled_parents, :vms)
-      vms = targets.collect { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }.flatten.compact
+      vms = targets.flat_map { |t| enabled_parents.include?(t) ? t.vms.select { |v| v.state == 'on' } : [] }
     end
     vms
   end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -8,7 +8,7 @@ module Metric::Targets
     MiqRegion.my_region.perf_capture_always = options
   end
 
-  def self.capture_infra_targets(zone, options = {})
+  def self.capture_infra_targets(zone, options)
     # Preload all of the objects we are going to be inspecting.
     # TODO: Include hosts under clusters
     includes = {:ext_management_systems => {:hosts => {:tags => {}}, :ems_clusters => :tags}}
@@ -67,7 +67,7 @@ module Metric::Targets
     targets
   end
 
-  def self.capture_vm_targets(targets, parent_class, options = {})
+  def self.capture_vm_targets(targets, parent_class, options)
     vms = []
     unless options[:exclude_vms]
       enabled_parents = targets.select do |t|

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -11,7 +11,7 @@ module Metric::Targets
   def self.capture_infra_targets(zone, options)
     # Preload all of the objects we are going to be inspecting.
     # TODO: Include hosts under clusters
-    includes = {:ext_management_systems => {:hosts => {:tags => {}}, :ems_clusters => :tags}}
+    includes = {:ext_management_systems => {:hosts => {:tags => {}}, :ems_clusters => [:tags, :hosts]}}
     includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
     MiqPreloader.preload(zone, includes)
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -161,10 +161,9 @@ class Zone < ActiveRecord::Base
   end
 
   def vms_without_availability_zone
-    MiqPreloader.preload(self, :ext_management_systems => :vms)
-    ext_management_systems.flat_map do |e|
-      e.kind_of?(EmsCloud) ? e.vms.select { |vm| vm.availability_zone.nil? } : []
-    end
+    clouds = ext_management_systems.select { |e| e.kind_of?(EmsCloud) }
+    MiqPreloader.preload(clouds, :vms => :availability_zone)
+    clouds.flat_map { |e| e.vms.select { |vm| vm.availability_zone.nil? } }
   end
 
   def vms_and_templates


### PR DESCRIPTION
We have many queries for perf_capture_timer. This aims to reduce them.

Still have one more pass after this

- We were looking up `Zone` multiple times.
- We were loading all the vms without an availability zone even when not necessary.
- Made a number of smaller changes, like using `flat_map` and `with_object`, which will have a negligible effect.
- Split up the primary method so we could focus on the slower portion of code.

||before|after
---|---|---
vms|10k|10k|
miq_queue|7950|7950|
miq_task|1543|7950|
time|6750ms|4729 ms
sql count|879|679
sql time|323ms|191ms
memory|190mb|110mb

**DISCLAIMER:** this does not include `capture_queue` (which is the biggest method) (it was timing out on my box)

https://bugzilla.redhat.com/show_bug.cgi?id=1221750