### PR TITLE
Added hour in network hourly utilization tooltip

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -1,6 +1,16 @@
 angular.module('miq.util').factory('chartsMixin', function() {
   'use strict';
 
+  var hourlyTimeTooltip = function(d) {
+    var theMoment = moment(d[0].x);
+    return _.template('<table class="c3-tooltip">' +
+    '  <tbody>' +
+    '    <td class="value"><%- col1 %></td>' +
+    '    <td class="value text-nowrap"><%- col2 %></td>' +
+    '  </tbody>' +
+    '</table>')({col1: theMoment.format('h:mm A'), col2: d[0].value + ' ' + d[0].name});
+  };
+
   var chartConfig = {
     cpuUsageConfig: {
       chartId: 'cpuUsageChart',
@@ -27,7 +37,8 @@ angular.module('miq.util').factory('chartsMixin', function() {
       headTitle  : __('Hourly Network Utilization'),
       timeFrame  : __('Last 24 hours'),
       units      : __('KBps'),
-      dataName   : __('KBps')
+      dataName   : __('KBps'),
+      tooltipFn  : hourlyTimeTooltip
     },
     dailyNetworkUsageConfig: {
       chartId  : 'networkUsageDailyChart',


### PR DESCRIPTION
Before:
![hourly_tooltip2](https://cloud.githubusercontent.com/assets/11256940/12265539/3f4b8306-b946-11e5-9b3a-be08f514429b.png)
After:
![hourly_tooltip](https://cloud.githubusercontent.com/assets/11256940/12265503/1225fd66-b946-11e5-9395-1fd9b1936b4c.png)


@abonas @himdel Please review (it should say KBps instead of used, Im opening a PR for it)