### PR TITLE
Fix sparkline tooltip

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -109,64 +109,41 @@ angular.module('containerDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.
           dashboardUtilsFactory.updateStatus($scope.objectStatus.routes, data.status.routes);
 
           // Node utilization donut
-          $scope.cpuUsageData = data.ems_utilization.cpu;
-          if (!$scope.cpuUsageData) {
-            $scope.cpuUsageData = { dataAvailable: false }
-          }
-
-          $scope.memoryUsageData = data.ems_utilization.mem;
-          if (!$scope.memoryUsageData) {
-            $scope.memoryUsageData = { dataAvailable: false }
-          }
+          $scope.cpuUsageData = chartsMixin.processUtilizationData(data.ems_utilization.cpu,
+                                                                   "dates",
+                                                                   $scope.cpuUsageConfig.units);
+          $scope.memoryUsageData = chartsMixin.processUtilizationData(data.ems_utilization.mem,
+                                                                      "dates",
+                                                                      $scope.memoryUsageConfig.units);
           $scope.utilizationLoadingDone = true;
 
           // Heatmaps
-          $scope.nodeCpuUsage.data = chartsMixin.processHeatmapData(data.heatmaps.nodeCpuUsage);
-          if (!$scope.nodeCpuUsage.data) {
-            $scope.nodeCpuUsage.dataAvailable = false;
-            $scope.nodeCpuUsage.data = [{id: 0, tooltip: '', value: 0}]; // pf-2.8.0 bug, accesses daa when no data
-          }
+          $scope.nodeCpuUsage = chartsMixin.processHeatmapData($scope.nodeCpuUsage, data.heatmaps.nodeCpuUsage);
           $scope.nodeCpuUsage.loadingDone = true;
 
-          $scope.nodeMemoryUsage.data = chartsMixin.processHeatmapData(data.heatmaps.nodeMemoryUsage);
-          if (!$scope.nodeMemoryUsage.data) {
-            $scope.nodeMemoryUsage.dataAvailable = false;
-            $scope.nodeMemoryUsage.data = [{id: 0, tooltip: '', value: 0}]; // pf-2.8.0 bug, accesses data when no data
-          }
+          $scope.nodeMemoryUsage =
+            chartsMixin.processHeatmapData($scope.nodeMemoryUsage, data.heatmaps.nodeMemoryUsage);
           $scope.nodeMemoryUsage.loadingDone = true;
 
           // Network metrics
           $scope.networkUtilizationHourlyConfig = chartsMixin.chartConfig.hourlyNetworkUsageConfig;
           $scope.networkUtilizationDailyConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
 
-          // Workaround for pf-2.8.0 not accepting dates with hours without parsing them beforehand
           if (data.hourly_network_metrics != undefined) {
-            var hourlyxdata = [];
-
-            data.hourly_network_metrics.xData.forEach(function (date) {
-              hourlyxdata.push(dashboardUtilsFactory.parseDate(date))
-            })
-            $scope.hourlyNetworkUtilization = {
-              'yData': data.hourly_network_metrics.yData,
-              'xData': hourlyxdata
-            }
-          } else {
-            $scope.hourlyNetworkUtilization = {
-              dataAvailable: false,
-              yData: ["used"], // pf-2.8.0 bug, accesses data when no data
-              xData: ["date"] // pf-2.8.0 bug, accesses data when no data
-            }
+           data.hourly_network_metrics.xData = data.hourly_network_metrics.xData.map(function (date) {
+              return dashboardUtilsFactory.parseDate(date)
+            });
           }
 
-          $scope.dailyNetworkUtilization = data.daily_network_metrics;
-          if ($scope.dailyNetworkUtilization == undefined) {
-            $scope.dailyNetworkUtilization = {
-                dataAvailable: false,
-                yData: ["used"], // pf-2.8.0 bug, accesses data when no data
-                xData: ["date"] // pf-2.8.0 bug, accesses data when no data
-              }
+          $scope.hourlyNetworkUtilization =
+            chartsMixin.processUtilizationData(data.hourly_network_metrics,
+                                               "dates",
+                                               $scope.networkUtilizationHourlyConfig.units)
 
-          }
+          $scope.dailyNetworkUtilization =
+            chartsMixin.processUtilizationData(data.daily_network_metrics,
+                                               "dates",
+                                               $scope.networkUtilizationDailyConfig.units);
           $scope.networkUtilizationLoadingDone = true;
         });
       };

--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -50,11 +50,9 @@ angular.module('miq.util').factory('chartsMixin', function() {
     }
   };
 
-  var processHeatmapData = function(data) {
+  var processHeatmapData = function(heatmapsStruct, data) {
     if (data) {
-      data = _.sortBy(data, 'value');
-
-      return data.map(function(d) {
+      heatmapsStruct.data = _.sortBy(data, 'value').map(function(d) {
         var percent = d.value * 100;
         var used = Math.floor(d.value * d.info.total);
         var available = d.info.total - used;
@@ -67,6 +65,20 @@ angular.module('miq.util').factory('chartsMixin', function() {
           "value": d.value
         };
       }).reverse()
+    } else  {
+      heatmapsStruct.dataAvailable = false
+    }
+
+    return heatmapsStruct
+  };
+
+  var processUtilizationData = function(data, xDataLabel, yDataLabel) {
+    if (data) {
+      data.xData.unshift(xDataLabel)
+      data.yData.unshift(yDataLabel)
+      return data;
+    } else {
+      return { dataAvailable: false }
     }
   };
 
@@ -74,6 +86,7 @@ angular.module('miq.util').factory('chartsMixin', function() {
     dashboardHeatmapChartHeight:    281,
     nodeHeatMapUsageLegendLabels:   ['< 70%', '70-80%' ,'80-90%', '> 90%'],
     chartConfig: chartConfig,
-    processHeatmapData: processHeatmapData
+    processHeatmapData: processHeatmapData,
+    processUtilizationData: processUtilizationData
   };
 });

--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -1,6 +1,16 @@
 angular.module('miq.util').factory('chartsMixin', function() {
   'use strict';
 
+  var hourlyTimeTooltip = function(d) {
+    var theMoment = moment(d[0].x);
+    return _.template('<table class="c3-tooltip">' +
+    '  <tbody>' +
+    '    <td class="value"><%- col1 %></td>' +
+    '    <td class="value text-nowrap"><%- col2 %></td>' +
+    '  </tbody>' +
+    '</table>')({col1: theMoment.format('h:mm A'), col2: d[0].value + ' ' + d[0].name});
+  };
+
   var chartConfig = {
     cpuUsageConfig: {
       chartId: 'cpuUsageChart',
@@ -27,7 +37,8 @@ angular.module('miq.util').factory('chartsMixin', function() {
       headTitle  : __('Hourly Network Utilization'),
       timeFrame  : __('Last 24 hours'),
       units      : __('KBps'),
-      dataName   : __('KBps')
+      dataName   : __('KBps'),
+      tooltipFn  : hourlyTimeTooltip
     },
     dailyNetworkUsageConfig: {
       chartId  : 'networkUsageDailyChart',

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -176,14 +176,14 @@ class ContainerDashboardService
         :cpu => {
           :used  => used_cpu.values.last.round,
           :total => total_cpu.values.last.round,
-          :xData => ["date"] + used_cpu.keys,
-          :yData => ["used"] + used_cpu.values.map(&:round)
+          :xData => used_cpu.keys,
+          :yData => used_cpu.values.map(&:round)
         },
         :mem => {
           :used  => (used_mem.values.last / 1024.0).round,
           :total => (total_mem.values.last / 1024.0).round,
-          :xData => ["date"] + used_mem.keys,
-          :yData => ["used"] + used_mem.values.map { |m| (m / 1024.0).round }
+          :xData => used_mem.keys,
+          :yData => used_mem.values.map { |m| (m / 1024.0).round }
         }
       }
     else
@@ -209,8 +209,8 @@ class ContainerDashboardService
 
     if hourly_metrics.any?
       {
-        :xData => ["date"] + hourly_network_trend.keys,
-        :yData => ["used"] + hourly_network_trend.values.map(&:round)
+        :xData => hourly_network_trend.keys,
+        :yData => hourly_network_trend.values.map(&:round)
       }
     end
   end
@@ -224,8 +224,8 @@ class ContainerDashboardService
 
     if daily_provider_metrics.any?
       {
-        :xData => ["date"] + daily_network_metrics.keys,
-        :yData => ["used"] + daily_network_metrics.values.map(&:round)
+        :xData => daily_network_metrics.keys,
+        :yData => daily_network_metrics.values.map(&:round)
       }
     end
   end

--- a/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
@@ -75,15 +75,15 @@ describe('containerDashboardController gets no data and', function() {
     });
 
     it('in heatmaps and donut', function() {
-      expect($scope.nodeMemoryUsage.data).toBeDefined();
-      expect($scope.nodeCpuUsage.data).toBeDefined();
-      expect($scope.cpuUsageData).toBeDefined();
-      expect($scope.memoryUsageData).toBeDefined();
+      expect($scope.nodeMemoryUsage.dataAvailable).toBeDefined();
+      expect($scope.nodeCpuUsage.dataAvailable).toBeDefined();
+      expect($scope.cpuUsageData.dataAvailable).toBeDefined();
+      expect($scope.memoryUsageData.dataAvailable).toBeDefined();
     });
 
     it('in network metrics', function() {
-      expect($scope.dailyNetworkUtilization).toBeDefined();
-      expect($scope.hourlyNetworkUtilization).toBeDefined();
+      expect($scope.dailyNetworkUtilization.dataAvailable).toBeDefined();
+      expect($scope.hourlyNetworkUtilization.dataAvailable).toBeDefined();
     });
   });
 });

--- a/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
@@ -49,7 +49,7 @@
     "providers": [
       {
         "count": 2,
-        "providerType": "openShift"
+        "providerType": "openshift"
       },
       {
         "count": 1,

--- a/spec/javascripts/fixtures/json/container_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_response.json
@@ -81,11 +81,9 @@
         "total": 8,
         "used": 3,
         "xData": [
-          "dates",
           "2015-11-26"
         ],
         "yData": [
-          "used",
           3
         ]
       },
@@ -93,34 +91,28 @@
         "total": 21,
         "used": 12,
         "xData": [
-          "dates",
           "2015-11-26"
         ],
         "yData": [
-          "used",
           12
         ]
       }
     },
     "daily_network_metrics" : {
       "xData": [
-        "date",
         "2015-12-07",
         "2015-12-08"
       ],
       "yData": [
-        "used",
         2420,
         2431
       ]
     },
     "hourly_network_metrics" : {
       "xData": [
-        "dates",
         "2015-12-21T11:00:00.000Z"
       ],
       "yData": [
-        "used",
         1599
       ]
     }

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -75,14 +75,14 @@ describe ContainerDashboardService do
         :cpu => {
           :used  => 2,
           :total => 2,
-          :xData => ["date", current_date.strftime("%Y-%m-%d")],
-          :yData => ["used", 2]
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [2]
         },
         :mem => {
           :used  => 1,
           :total => 2,
-          :xData => ["date", current_date.strftime("%Y-%m-%d")],
-          :yData => ["used", 1]
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [1]
         }
       )
 
@@ -90,14 +90,14 @@ describe ContainerDashboardService do
         :cpu => {
           :used  => 3,
           :total => 3,
-          :xData => ["date", current_date.strftime("%Y-%m-%d")],
-          :yData => ["used", 3]
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [3]
         },
         :mem => {
           :used  => 2,
           :total => 3,
-          :xData => ["date", current_date.strftime("%Y-%m-%d")],
-          :yData => ["used", 2]
+          :xData => [current_date.strftime("%Y-%m-%d")],
+          :yData => [2]
         }
       )
     end
@@ -156,13 +156,13 @@ describe ContainerDashboardService do
       daily_network_trends_single_provider = described_class.new(ems_openshift.id, controller).daily_network_metrics
 
       expect(daily_network_trends_single_provider).to eq(
-        :xData => ["date", current_date.strftime("%Y-%m-%d")],
-        :yData => ["used", 1000]
+        :xData => [current_date.strftime("%Y-%m-%d")],
+        :yData => [1000]
       )
 
       expect(daily_network_trends).to eq(
-        :xData => ["date", current_date.strftime("%Y-%m-%d")],
-        :yData => ["used", 2500]
+        :xData => [current_date.strftime("%Y-%m-%d")],
+        :yData => [2500]
       )
     end
 
@@ -200,13 +200,13 @@ describe ContainerDashboardService do
       hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).hourly_network_metrics
 
       expect(hourly_network_trends_single_provider).to eq(
-        :xData => ["date", current_date.beginning_of_hour.utc],
-        :yData => ["used", 1000]
+        :xData => [current_date.beginning_of_hour.utc],
+        :yData => [1000]
       )
 
       expect(hourly_network_trends).to eq(
-        :xData => ["date", current_date.beginning_of_hour.utc],
-        :yData => ["used", 2500]
+        :xData => [current_date.beginning_of_hour.utc],
+        :yData => [2500]
       )
     end
 


### PR DESCRIPTION
Depends on #6145
In this patch I took out the sparkline labels from containerDashboardService and instead added them on the frontend side. A lot of the code looked the same so refactored it from the dashboard controller to methods in chartMixin.

Before:
![used_to_kbps2](https://cloud.githubusercontent.com/assets/11256940/12269352/ae9831ba-b959-11e5-902e-f951463f0e63.png)
After
![used_to_kbps](https://cloud.githubusercontent.com/assets/11256940/12269351/ae8f6044-b959-11e5-84cf-0aa7efb6aea8.png)

Please review @himdel @abonas 
