### PR TITLE
Bz1244842 - Render Configuration button in the toolbar when a Foreman provider node is selected

### DIFF
--- a/product/toolbars/configuration_profile_foreman_center_tb.yaml
+++ b/product/toolbars/configuration_profile_foreman_center_tb.yaml
@@ -12,19 +12,19 @@
     :text: Configuration
     :enabled: 'true'
     :items:
-    - :button: provider_foreman_refresh
+    - :button: provider_foreman_refresh_provider
       :image: refresh
       :text: "Refresh Relationships and Power states"
       :title: "Refresh relationships for all items related to this Provider"
       :url: refresh
       :confirm: "Refresh relationships for all items related to this Provider?"
     - :separator:
-    - :button: provider_foreman_edit
+    - :button: provider_foreman_edit_provider
       :image: edit
       :text: Edit this Provider
       :title: Edit this Provider
       :url: edit
-    - :button: provider_foreman_delete
+    - :button: provider_foreman_delete_provider
       :image: remove
       :text: Remove this Provider from the VMDB
       :title: Remove this Provider from the VMDB

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -304,6 +304,28 @@ describe ProviderForemanController do
     expect(response.status).to eq(200)
   end
 
+  context "tree_select on provider foreman node" do
+    before do
+      login_as user_with_feature %w(provider_foreman_refresh_provider provider_foreman_edit_provider provider_foreman_delete_provider)
+
+      allow(controller).to receive(:check_privileges)
+      allow(controller).to receive(:process_show_list)
+      allow(controller).to receive(:add_unassigned_configuration_profile_record)
+      allow(controller).to receive(:replace_explorer_trees)
+      allow(controller).to receive(:build_listnav_search_list)
+      allow(controller).to receive(:replace_search_box)
+      allow(controller).to receive(:x_active_tree).and_return(:foreman_providers_tree)
+    end
+
+    it "does not hide Configuration button in the toolbar" do
+      controller.send(:build_foreman_tree, :providers, :foreman_providers_tree)
+      key = ems_key_for_provider(@provider)
+      post :tree_select, :id => key
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include('<div class=\"hidden btn-group dropdown\"><button data-explorer=\"true\" title=\"Configuration\"')
+    end
+  end
+
   context "fetches the list setting:Grid/Tile/List from settings" do
     before do
       allow(controller).to receive(:items_per_page).and_return(20)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1244842

Before -
<img width="1440" alt="screen shot 2016-01-12 at 9 33 20 am_broken" src="https://cloud.githubusercontent.com/assets/1538216/12271497/4afeb69a-b910-11e5-8e23-2e993d052793.png">

After -
<img width="1435" alt="screen shot 2016-01-12 at 9 24 21 am_fixed" src="https://cloud.githubusercontent.com/assets/1538216/12271514/5a3aa38a-b910-11e5-83a3-25bb65ebad6e.png">
