### PR TITLE
Replace ui_lookup_for_ems_cluster_types() with gettext

### DIFF
--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -114,7 +114,7 @@ module MiqAeCustomizationController::CustomButtons
               when "Host"
                 _("Host / Node")
               when "EmsCluster"
-                ui_lookup(:ems_cluster_types => "cluster")
+                _("Cluster / Deployment Role")
               else
                 @nodetype[1]
               end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1198,15 +1198,14 @@ module ApplicationHelper
   end
 
   def title_for_cluster(plural = false)
-    key = case EmsCluster.node_types
-          when :non_openstack
-            "cluster_infra"
-          when :openstack
-            "cluster_openstack"
-          else
-            "cluster"
-          end
-    ui_lookup(:ems_cluster_types => plural ? key.pluralize : key)
+    case EmsCluster.node_types
+    when :non_openstack
+      plural ? _("Clusters") : _("Cluster")
+    when :openstack
+      plural ? _("Deployment Roles") : _("Deployment Role")
+    else
+      plural ? _("Clusters / Deployment Roles") : _("Cluster / Deployment Role")
+    end
   end
 
   def title_for_host_record(record)
@@ -1214,9 +1213,7 @@ module ApplicationHelper
   end
 
   def title_for_cluster_record(record)
-    record.openstack_cluster? ?
-      ui_lookup(:ems_cluster_types => 'cluster_openstack') :
-      ui_lookup(:ems_cluster_types => 'cluster_infra')
+    record.openstack_cluster? ? _("Deployment Role") : _("Cluster")
   end
 
   def start_page_allowed?(start_page)

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -10,13 +10,12 @@ class TreeBuilderUtilization < TreeBuilderRegion
     return total if count_only
     return [] if total == 0
 
-    click_to_open = _('Click to open')
     [
       {
         :id    => "folder_c_xx-#{to_cid(object.id)}",
-        :text  => ui_lookup(:ems_cluster_types => "cluster"),
+        :text  => _("Cluster / Deployment Role"),
         :image => "folder",
-        :tip   => "#{ui_lookup(:ems_cluster_types => "cluster")} (#{click_to_open})"
+        :tip   => _("Cluster / Deployment Role (Click to open)")
       }
     ]
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -708,14 +708,6 @@ en:
       virtualcenter:   VMware vCenter
       vmwareserver:    VMware Server
 
-    ems_cluster_types:
-      cluster:            Cluster / Deployment Role
-      clusters:           Clusters / Deployment Roles
-      cluster_infra:      Cluster
-      cluster_infras:     Clusters
-      cluster_openstack:  Deployment Role
-      cluster_openstacks: Deployment Roles
-
     host_os_type:
       linux_generic:   Linux
       windows_generic: Windows

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -78,8 +78,6 @@ module Vmdb
         ui_lookup_for_model(options[:model]).singularize
       elsif options[:models]
         ui_lookup_for_model(options[:models]).pluralize
-      elsif options[:ems_cluster_types]
-        ui_lookup_for_ems_cluster_types(options[:ems_cluster_types])
       elsif options[:ui_title]
         ui_lookup_for_title(options[:ui_title])
       else
@@ -94,10 +92,6 @@ module Vmdb
 
     def ui_lookup_for_model(text)
       Dictionary.gettext(text, :type => :model, :notfound => :titleize)
-    end
-
-    def ui_lookup_for_ems_cluster_types(text)
-      Dictionary.gettext(text, :type => :ems_cluster_types, :notfound => :titleize)
     end
 
     def ui_lookup_for_title(text)


### PR DESCRIPTION
This is part of effort of minimizing ui_lookup to a bare
minimum and replacing it with gettext for easier internationalization.