### PR TITLE
[WIP] Capture start_worker mechanics in a Proc so we can invoke it later.

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -42,14 +42,28 @@ module MiqServer::WorkerManagement::Monitor
     MiqVimBrokerWorker.cleanup_for_pid(w.pid)
   end
 
-  def sync_workers
+  def sync_workers(class_names = self.class.monitor_class_names)
     result = {}
-    self.class.monitor_class_names.each do |class_name|
+    Array(class_names).each do |class_name|
       c = class_name.constantize
       result[c.name] = c.sync_workers
-      result[c.name][:adds].each { |pid| worker_add(pid) unless pid.nil? }
+    end
+
+    result.each do |_class_name, sync_result|
+      process_sync_worker_adds_for_worker_class(sync_result)
     end
     result
+  end
+
+  def process_sync_worker_adds_for_worker_class(sync_result)
+    new_adds = sync_result[:adds].collect do |proc|
+      w = proc.call
+      worker_add(w.pid) unless w.pid.nil?
+      w.pid
+    end.compact
+
+    sync_result[:adds] = new_adds
+    sync_result
   end
 
   def restart_worker(w, reason = nil)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -152,7 +152,7 @@ class MiqWorker < ActiveRecord::Base
       _log.info("Workers are being synchronized: Current #: [#{current}], Desired #: [#{desired}]")
 
       if desired > current && enough_resource_to_start_worker?
-        (desired - current).times { result[:adds] << start_worker.pid }
+        (desired - current).times { result[:adds] << Proc.new { start_worker } }
       elsif desired < current
         w = w.to_a
         (current - desired).times do

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -87,8 +87,7 @@ module MiqWebServerWorkerMixin
             _log.info("Reserved port=#{port}, Current ports in use: #{ports.inspect}")
             ports << port
             ports_hash[:adds] << port
-            w = start_worker(:uri => build_uri(port))
-            result[:adds] << w.pid
+            result[:adds] << Proc.new { start_worker(:uri => build_uri(port)) }
           end
         elsif desired < current
           workers = workers.to_a

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -45,8 +45,7 @@ module PerEmsWorkerMixin
 
         if desired.length > current.length && enough_resource_to_start_worker?
           (desired - current).each do |x|
-            w = start_worker_for_ems(x)
-            result[:adds] << w.pid unless w.nil?
+            result[:adds] << Proc.new { start_worker_for_ems(x) }
           end
         elsif desired.length < current.length
           (current - desired).each do |x|

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -411,4 +411,45 @@ describe "MiqWorker Monitor" do
       end
     end
   end
+
+  context ".sync_workers" do
+    before do
+      @miq_server = EvmSpecHelper.local_miq_server
+      @miq_server.setup_drb_variables
+    end
+
+    def assert_sync_workers(klass, expected_args, pids)
+      allow(klass).to receive(:has_required_role?).and_return(true)
+
+      pids_with_doubles = pids.collect do |ret|
+        double(:pid => ret)
+      end
+
+      allow(klass).to receive(:start_worker) do |args|
+        expect(args).to eq(expected_args)
+      end.and_return(*pids_with_doubles)
+
+      expect(@miq_server.sync_workers(klass.name)[klass.name][:adds])
+        .to eq(pids)
+
+      workers = @miq_server.instance_variable_get(:@workers).keys.sort
+      expect(workers).to eq(pids.sort)
+    end
+
+    it "MiqUiWorker" do
+      assert_sync_workers(MiqUiWorker, {:uri => "http://0.0.0.0:3000"}, [10])
+    end
+
+    it "MiqGenericWorker" do
+      assert_sync_workers(MiqGenericWorker, nil, [10, 11])
+    end
+
+    it "MiqEmsRefreshCoreWorker" do
+      allow(MiqEmsRefreshCoreWorker)
+        .to(receive(:desired_queue_names))
+        .and_return(["ems_1"])
+
+      assert_sync_workers(MiqEmsRefreshCoreWorker, {:queue_name => "ems_1"}, [10])
+    end
+  end
 end


### PR DESCRIPTION
Change MiqServer#sync_workers to accept an array of Procs representing added
workers for each worker class sync_workers call.

We can then invoke these "added workers" Procs later in batches with future
hooks before and afterwards:

* before fork: preload, close db connections
* after fork: reconnect db, etc.

Note, this was extracted from the forking workers PR as it will work as-is with Process.spawn.