### PR TITLE
Use DRb#uri instead of assuming the "current server" is the right one.

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -34,7 +34,7 @@ module MiqServer::WorkerManagement
     DRb.install_acl(acl)
 
     drb = DRb.start_service("druby://127.0.0.1:0", self)
-    update_attributes(:drb_uri => DRb.uri)
+    update_attributes(:drb_uri => drb.uri)
   end
 
   def worker_add(worker_pid)


### PR DESCRIPTION
At first glance DRb.uri looks like a typo even though it works by getting
the URI of the current DRb server which may or may not be the correct one.

Extracted from #3593(forking workers) at @kbrock's request (thanks!)