### PR TITLE
[WIP] perf_capture: inverse_of

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -7,10 +7,10 @@ class EmsCluster < ActiveRecord::Base
   acts_as_miq_taggable
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many    :hosts, :dependent => :nullify
-  has_many    :vms_and_templates
+  has_many    :hosts, :inverse_of => :ems_cluster, :dependent => :nullify
+  has_many    :vms_and_templates, :inverse_of => :ems_cluster
   has_many    :miq_templates
-  has_many    :vms
+  has_many    :vms, :inverse_of => :ems_cluster
 
   has_many    :metrics,                :as => :resource  # Destroy will be handled by purger
   has_many    :metric_rollups,         :as => :resource  # Destroy will be handled by purger

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -40,11 +40,11 @@ class Host < ActiveRecord::Base
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
   validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.values
 
-  belongs_to                :ext_management_system, :foreign_key => "ems_id"
-  belongs_to                :ems_cluster
+  belongs_to                :ext_management_system, :foreign_key => "ems_id", :inverse_of => :hosts
+  belongs_to                :ems_cluster, :inverse_of => :hosts
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :hardware, :dependent => :destroy
-  has_many                  :vms_and_templates, :dependent => :nullify
+  has_many                  :vms_and_templates, :dependent => :nullify, :inverse_of => :host
   has_many                  :vms
   has_many                  :miq_templates
   has_and_belongs_to_many   :storages, :join_table => :host_storages

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -54,14 +54,14 @@ class VmOrTemplate < ActiveRecord::Base
 
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :hardware, :dependent => :destroy
-  belongs_to                :host
-  belongs_to                :ems_cluster
+  belongs_to                :host, :inverse_of => :vms_and_templates
+  belongs_to                :ems_cluster, :inverse_of => :vms_and_templates
 
   belongs_to                :storage
   has_many                  :repositories, :through => :storage
   has_and_belongs_to_many   :storages, :join_table => 'storages_vms_and_templates'
 
-  belongs_to                :ext_management_system, :foreign_key => "ems_id"
+  belongs_to                :ext_management_system, :foreign_key => "ems_id", :inverse_of => :vms_and_templates
 
   has_one                   :miq_provision, :dependent => :nullify, :as => :destination
   has_many                  :miq_provisions_from_template, :class_name => "MiqProvision", :as => :source, :dependent => :nullify


### PR DESCRIPTION
Use inverse_of to reduce the number of objects accessed in the database.

||before|after
---|---|---
vms|100|100
MiqQueue|79|79
MiqTask|43|43
time|2749 ms|2455 ms
sql queries|486|55
ms db|117 ms|15ms
memory|37MB|6.5MB

https://bugzilla.redhat.com/show_bug.cgi?id=1221750