### PR TITLE
Fix missing show:id navigation for container explorer

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -66,9 +66,10 @@ class ContainerController < ApplicationController
       @refresh_partial = "layouts/performance"
     end
 
-    redirect_to :action     => 'show',
+    node_type = TreeBuilder.get_prefix_for_model(@record.class.base_model)
+    redirect_to :action     => 'explorer',
                 :controller => @record.class.base_model.to_s.underscore,
-                :id         => @record.id unless @display == "performance"
+                :id         => "#{node_type}-#{@record.id}" unless @display == "performance"
   end
 
   def show_timeline


### PR DESCRIPTION
This fixes the issue when navigation to a specific container
from other pages didn't work.

is also relevant for completely fixing  #5993

@miq-bot add_label bug, ui, providers/containers, wip