### PR TITLE
Multi endpoint support

### DIFF
--- a/app/controllers/api_controller/providers.rb
+++ b/app/controllers/api_controller/providers.rb
@@ -5,6 +5,7 @@ class ApiController
     CREDENTIALS_ATTR  = "credentials"
     AUTH_TYPE_ATTR    = "auth_type"
     DEFAULT_AUTH_TYPE = "default"
+    ENDPOINT_ATTRS    = %w(hostname ipaddress port)
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
     def create_resource_providers(type, _id, data = {})
@@ -133,7 +134,7 @@ class ApiController
 
     def fetch_provider_data(provider_klass, data, options = {})
       provider_data = data.except(*RESTRICTED_ATTRS)
-      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys
+      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS
       raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?
 
       specify_zone(provider_data, data, options)

--- a/app/controllers/api_controller/providers.rb
+++ b/app/controllers/api_controller/providers.rb
@@ -154,7 +154,7 @@ class ApiController
 
       zone_id = parse_id(data[ZONE_ATTR], :zone)
       raise BadRequestError, "Missing zone href or id" if zone_id.nil?
-      resource_search(zone_id, :zone, Zone)   # Only support Rbac allowed zone
+      resource_search(zone_id, :zone, Zone) # Only support Rbac allowed zone
     end
   end
 end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,0 +1,3 @@
+class Endpoint < ActiveRecord::Base
+  belongs_to :resource, :polymorphic => true
+end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,3 +1,25 @@
 class Endpoint < ActiveRecord::Base
   belongs_to :resource, :polymorphic => true
+
+  default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
+
+  def verify_ssl=(val)
+    val = resolve_verify_ssl_value(val)
+    super
+  end
+
+  def verify_ssl?
+    verify_ssl != OpenSSL::SSL::VERIFY_NONE
+  end
+
+  private
+
+  def resolve_verify_ssl_value(val)
+    case val
+    when true  then OpenSSL::SSL::VERIFY_PEER
+    when false then OpenSSL::SSL::VERIFY_NONE
+    else            val
+    end
+  end
 end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -64,8 +64,7 @@ class ExtManagementSystem < ActiveRecord::Base
     return unless hostname_required?
     return unless hostname.present? # Presence is checked elsewhere
 
-    query = ExtManagementSystem.where.not(:id => id).includes(:hostname)
-    existing_hostnames = query.collect { |e| e.hostname.downcase }
+    existing_hostnames = Endpoint.where.not(:resource_id => id).pluck(:hostname).compact.map(&:downcase)
 
     errors.add(:hostname, "has already been taken") if existing_hostnames.include?(hostname.downcase)
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -28,6 +28,8 @@ class ExtManagementSystem < ActiveRecord::Base
   belongs_to :provider
   belongs_to :tenant
 
+  has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
+
   has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify, :inverse_of => :ext_management_system
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
   has_many :miq_templates,     :foreign_key => :ems_id, :inverse_of => :ext_management_system
@@ -93,6 +95,18 @@ class ExtManagementSystem < ActiveRecord::Base
   include AuthenticationMixin
   include Metric::CiMixin
   include AsyncDeleteMixin
+
+  delegate :ipaddress,
+           :ipaddress=,
+           :hostname,
+           :hostname=,
+           :port,
+           :port=,
+           :to => :default_endpoint
+
+  virtual_column :ipaddress,               :type => :string,  :uses => :endpoints
+  virtual_column :hostname,                :type => :string,  :uses => :endpoints
+  virtual_column :port,                    :type => :integer, :uses => :endpoints
 
   virtual_column :emstype,                 :type => :string
   virtual_column :emstype_description,     :type => :string
@@ -222,6 +236,11 @@ class ExtManagementSystem < ActiveRecord::Base
   # UI method for determining which icon to show for a particular EMS
   def image_name
     emstype.downcase
+  end
+
+  def default_endpoint
+    default = endpoints.detect { |e| e.role == "default" }
+    default || endpoints.build(:role => "default")
   end
 
   def authentication_check_role

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -110,7 +110,7 @@ class ExtManagementSystem < ActiveRecord::Base
            :port=,
            :to => :default_endpoint
 
-  alias_method :address, :hostname   # TODO: Remove all callers of address
+  alias_method :address, :hostname # TODO: Remove all callers of address
 
   virtual_column :ipaddress,               :type => :string,  :uses => :endpoints
   virtual_column :hostname,                :type => :string,  :uses => :endpoints
@@ -125,7 +125,7 @@ class ExtManagementSystem < ActiveRecord::Base
   virtual_column :total_hosts,             :type => :integer
   virtual_column :total_storages,          :type => :integer
   virtual_column :total_clusters,          :type => :integer
-  virtual_column :zone_name,               :type => :string,  :uses => :zone
+  virtual_column :zone_name,               :type => :string, :uses => :zone
   virtual_column :total_vms_on,            :type => :integer
   virtual_column :total_vms_off,           :type => :integer
   virtual_column :total_vms_unknown,       :type => :integer

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -154,6 +154,10 @@ class ExtManagementSystem < ActiveRecord::Base
     joins(:endpoints).where(:endpoints => {:hostname => hostname})
   end
 
+  def self.with_port(port)
+    joins(:endpoints).where(:endpoints => {:port => port})
+  end
+
   def self.create_discovered_ems(ost)
     ip = ost.ipaddr
     unless with_ipaddress(ip).exist?

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -63,7 +63,6 @@ class ExtManagementSystem < ActiveRecord::Base
     return unless hostname.present? # Presence is checked elsewhere
 
     query = ExtManagementSystem.where.not(:id => id).includes(:hostname)
-    query = query.where(:tenant_id => tenant_id) if tenant_id
     existing_hostnames = query.collect { |e| e.hostname.downcase }
 
     errors.add(:hostname, "has already been taken") if existing_hostnames.include?(hostname.downcase)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -30,12 +30,14 @@ class ExtManagementSystem < ActiveRecord::Base
 
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
-  has_many :hosts,  :foreign_key => "ems_id", :dependent => :nullify, :inverse_of => :ext_management_system
-  has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify, :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
+  has_many :hosts, :foreign_key => "ems_id", :dependent => :nullify, :inverse_of => :ext_management_system
+  has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify,
+           :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
   has_many :miq_templates,     :foreign_key => :ems_id, :inverse_of => :ext_management_system
   has_many :vms,               :foreign_key => :ems_id, :inverse_of => :ext_management_system
 
-  has_many :ems_events,     -> { order "timestamp" }, :class_name => "EmsEvent",    :foreign_key => "ems_id", :inverse_of => :ext_management_system
+  has_many :ems_events,     -> { order "timestamp" }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
+                                                      :inverse_of => :ext_management_system
   has_many :policy_events,  -> { order "timestamp" }, :class_name => "PolicyEvent", :foreign_key => "ems_id"
 
   has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
@@ -51,7 +53,7 @@ class ExtManagementSystem < ActiveRecord::Base
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
-  has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger
+  has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger
   has_many :miq_events,             :as => :target, :dependent => :destroy
 
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
@@ -178,7 +180,8 @@ class ExtManagementSystem < ActiveRecord::Base
       )
 
       _log.info "#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created"
-      AuditEvent.success(:event => "ems_created", :target_id => ems.id, :target_class => "ExtManagementSystem", :message => "#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created")
+      AuditEvent.success(:event => "ems_created", :target_id => ems.id, :target_class => "ExtManagementSystem",
+                         :message => "#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created")
     end
   end
 
@@ -353,7 +356,7 @@ class ExtManagementSystem < ActiveRecord::Base
   alias_method_chain :clear_association_cache, :storages
 
   alias_method :storages,               :all_storages
-  alias_method :datastores,             :all_storages  # Used by web-services to return datastores as the property name
+  alias_method :datastores,             :all_storages # Used by web-services to return datastores as the property name
 
   alias_method :all_hosts,              :hosts
   alias_method :all_host_ids,           :host_ids

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -146,16 +146,17 @@ class ExtManagementSystem < ActiveRecord::Base
     'amazon' => 'ec2',
   }
 
-  def self.find_by_ipaddress(ipaddress)
-    Endpoint.where(
-      :ipaddress     => ipaddress,
-      :resource_type => base_class.name
-    ).take.try(:resource)
+  def self.with_ipaddress(ipaddress)
+    joins(:endpoints).where(:endpoints => {:ipaddress => ipaddress})
+  end
+
+  def self.with_hostname(hostname)
+    joins(:endpoints).where(:endpoints => {:hostname => hostname})
   end
 
   def self.create_discovered_ems(ost)
     ip = ost.ipaddr
-    if find_by_ipaddress(ip).nil?
+    unless with_ipaddress(ip).exist?
       hostname = Socket.getaddrinfo(ip, nil)[0][2]
 
       ems_klass, ems_name = if ost.hypervisor.include?(:scvmm)

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -7,6 +7,12 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
 
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
+  delegate :url,
+           :url=,
+           :to => :default_endpoint
+
+  virtual_column :url, :type => :string, :uses => :endpoints
+
   before_validation :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -5,6 +5,8 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
           :dependent   => :destroy,
           :autosave    => true
 
+  has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
+
   before_validation :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true

--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     auth_type = options[:auth_type]
     raise "no credentials defined" if self.missing_credentials?(auth_type) && (options[:username].nil? || options[:password].nil?)
 
-    verify_ssl = resolve_verify_ssl_value(options[:verify_ssl]) || self.verify_ssl
+    verify_ssl = options[:verify_ssl] || self.verify_ssl
     base_url   = options[:base_url] || url
     username   = options[:username] || authentication_userid(auth_type)
     password   = options[:password] || authentication_password(auth_type)

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -12,6 +12,12 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
 
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
+  delegate :url,
+           :url=,
+           :to => :default_endpoint
+
+  virtual_column :url, :type => :string, :uses => :endpoints
+
   delegate :api_cached?, :ensure_api_cached, :to => :connect
 
   before_validation :ensure_managers

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -10,7 +10,6 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
           :dependent   => :destroy,
           :autosave    => true
 
-  # TODO: Does this even make sense?
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
   delegate :api_cached?, :ensure_api_cached, :to => :connect

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -32,7 +32,7 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     auth_type = options[:auth_type]
     raise "no credentials defined" if self.missing_credentials?(auth_type)
 
-    verify_ssl = resolve_verify_ssl_value(options[:verify_ssl]) || self.verify_ssl
+    verify_ssl = options[:verify_ssl] || self.verify_ssl
     base_url   = options[:url] || url
     username   = options[:username] || authentication_userid(auth_type)
     password   = options[:password] || authentication_password(auth_type)

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -10,6 +10,9 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
           :dependent   => :destroy,
           :autosave    => true
 
+  # TODO: Does this even make sense?
+  has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
+
   delegate :api_cached?, :ensure_api_cached, :to => :connect
 
   before_validation :ensure_managers

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -103,9 +103,9 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     ret = @ems_ids_for_notify[key] || begin
       zone_id = MiqServer.my_server.zone_id
       ems = ManageIQ::Providers::Vmware::InfraManager
-        .includes(:authentications)
-        .where(:zone_id => zone_id)
-        .detect { |e| e.hostname == address && e.authentication_userid == userid }
+            .includes(:authentications)
+            .where(:zone_id => zone_id)
+            .detect { |e| e.hostname == address && e.authentication_userid == userid }
       ems_id = ems.nil? ? :ignore : ems.id
       _log.warn("#{log_prefix} Ignoring updates for unknown connection, address: [#{address}], userid: [#{userid}]") if ems_id == :ignore
       @ems_ids_for_notify[key] = ems_id

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -103,10 +103,9 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     ret = @ems_ids_for_notify[key] || begin
       zone_id = MiqServer.my_server.zone_id
       ems = ManageIQ::Providers::Vmware::InfraManager
-            .includes(:authentications)
-            .where(:zone_id => zone_id)
-            .where(:hostname => address)
-            .detect { |e| e.authentication_userid == userid }
+        .includes(:authentications)
+        .where(:zone_id => zone_id)
+        .detect { |e| e.hostname == address && e.authentication_userid == userid }
       ems_id = ems.nil? ? :ignore : ems.id
       _log.warn("#{log_prefix} Ignoring updates for unknown connection, address: [#{address}], userid: [#{userid}]") if ems_id == :ignore
       @ems_ids_for_notify[key] = ems_id

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -103,7 +103,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     ret = @ems_ids_for_notify[key] || begin
       zone_id = MiqServer.my_server.zone_id
       ems = ManageIQ::Providers::Vmware::InfraManager
-            .includes(:authentications)
+            .includes(:authentications, :endpoints)
             .where(:zone_id => zone_id)
             .detect { |e| e.hostname == address && e.authentication_userid == userid }
       ems_id = ems.nil? ? :ignore : ems.id

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -186,7 +186,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
 
     _log.info("#{log_prefix} Attempting to reconnect broker for EMS with address: [#{event[:server]}] due to error: #{event[:error]}")
 
-    ems = ManageIQ::Providers::Vmware::InfraManager.find_by(:hostname => event[:server])
+    ems = ManageIQ::Providers::Vmware::InfraManager.with_hostname(event[:server]).first
     if ems.nil?
       _log.error "#{log_prefix} Unable to find EMS with address: [#{event[:server]}]"
       return

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,8 +10,14 @@ class Provider < ActiveRecord::Base
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"
 
-  default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
-  validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
+  has_many :endpoints, :through => :managers
+
+  delegate :verify_ssl,
+           :verify_ssl=,
+           :verify_ssl?,
+           :to => :default_endpoint
+
+  virtual_column :verify_ssl, :type => :integer
 
   def self.leaf_subclasses
     descendants.select { |d| d.subclasses.empty? }
@@ -31,13 +37,9 @@ class Provider < ActiveRecord::Base
     self.class.short_token.underscore
   end
 
-  def verify_ssl=(val)
-    val = resolve_verify_ssl_value(val)
-    super
-  end
-
-  def verify_ssl?
-    verify_ssl != OpenSSL::SSL::VERIFY_NONE
+  def default_endpoint
+    default = endpoints.detect { |e| e.role == "default" }
+    default || endpoints.build(:role => "default")
   end
 
   def with_provider_connection(options = {})
@@ -55,15 +57,5 @@ class Provider < ActiveRecord::Base
     raise "no #{ui_lookup(:table => "provider")} credentials defined" if self.missing_credentials?
     raise "#{ui_lookup(:table => "provider")} failed last authentication check" unless self.authentication_status_ok?
     managers.each { |manager| EmsRefresh.queue_refresh(manager) }
-  end
-
-  private
-
-  def resolve_verify_ssl_value(val)
-    case val
-    when true  then OpenSSL::SSL::VERIFY_PEER
-    when false then OpenSSL::SSL::VERIFY_NONE
-    else            val
-    end
   end
 end

--- a/db/migrate/20141121200053_create_endpoints.rb
+++ b/db/migrate/20141121200053_create_endpoints.rb
@@ -1,0 +1,13 @@
+class CreateEndpoints < ActiveRecord::Migration
+  def change
+    create_table :endpoints do |t|
+      t.string     :role
+      t.string     :ipaddress
+      t.string     :hostname
+      t.integer    :port
+      t.belongs_to :resource, :polymorphic => true, :type => :bigint
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
+++ b/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
@@ -1,0 +1,45 @@
+class MigrateEmsAttributesToEndpoints < ActiveRecord::Migration
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Migrating EMS attributes to endpoints") do
+      ExtManagementSystem.all.each do |e|
+        Endpoint.create!(
+          :role          => "default",
+          :ipaddress     => e.ipaddress,
+          :hostname      => e.hostname,
+          :port          => e.port && e.port.to_i,
+          :resource_type => "ExtManagementSystem",
+          :resource_id   => e.id,
+        )
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating endpoints to EMS attributes") do
+      endpoints = Endpoint.where(
+        :role          => "default",
+        :resource_type => "ExtManagementSystem",
+      )
+
+      endpoints.each do |endpoint|
+        ems = ExtManagementSystem.where(:id => endpoint.resource_id).first
+
+        ems.update_attributes!(
+          :ipaddress => endpoint.ipaddress,
+          :hostname  => endpoint.hostname,
+          :port      => endpoint.port && endpoint.port.to_s
+        )
+      end
+
+      Endpoint.delete_all
+    end
+  end
+end

--- a/db/migrate/20141121200523_remove_endpoint_data_from_ems.rb
+++ b/db/migrate/20141121200523_remove_endpoint_data_from_ems.rb
@@ -1,0 +1,13 @@
+class RemoveEndpointDataFromEms < ActiveRecord::Migration
+  def up
+    remove_column :ext_management_systems, :port
+    remove_column :ext_management_systems, :ipaddress
+    remove_column :ext_management_systems, :hostname
+  end
+
+  def down
+    add_column :ext_management_systems, :port,      :string
+    add_column :ext_management_systems, :ipaddress, :string
+    add_column :ext_management_systems, :hostname,  :string
+  end
+end

--- a/db/migrate/20151222103510_add_verify_ssl_to_endpoints.rb
+++ b/db/migrate/20151222103510_add_verify_ssl_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddVerifySslToEndpoints < ActiveRecord::Migration
+  def change
+    add_column :endpoints, :verify_ssl, :integer
+  end
+end

--- a/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
+++ b/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
@@ -1,0 +1,41 @@
+class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration
+  class Provider < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Migrating Provider attributes to Endpoints") do
+      ExtManagementSystem.all.each do |ems|
+        next if ems.provider_id.nil?
+        provider = Provider.where(:id => ems.provider_id).first
+        endpoint = Endpoint.where(
+          :resource_type => "ExtManagementSystem",
+          :resource_id   => ems.id).first_or_create
+
+        endpoint.update_attributes!(:verify_ssl => provider.verify_ssl)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating Endpoints to Provider attributes") do
+      endpoints = Endpoint.where(
+        :role          => "default",
+        :resource_type => "ExtManagementSystem",
+      )
+
+      endpoints.each do |endpoint|
+        next if endpoint.verify_ssl.nil?
+        ems = ExtManagementSystem.where(:id => endpoint.resource_id).first
+        ems.provider.update_attributes!(
+          :verify_ssl => endpoint.verify_ssl)
+      end
+
+      Endpoint.delete_all
+    end
+  end
+end

--- a/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
+++ b/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
@@ -7,6 +7,10 @@ class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled # disable STI
   end
 
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   def up
     say_with_time("Migrating Provider attributes to Endpoints") do
       ExtManagementSystem.all.each do |ems|
@@ -31,7 +35,8 @@ class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration
       endpoints.each do |endpoint|
         next if endpoint.verify_ssl.nil?
         ems = ExtManagementSystem.where(:id => endpoint.resource_id).first
-        ems.provider.update_attributes!(
+        provider = Provider.where(:id => ems.provider_id).first
+        provider.update_attributes!(
           :verify_ssl => endpoint.verify_ssl)
       end
 

--- a/db/migrate/20151222105242_remove_endpoint_data_from_provider.rb
+++ b/db/migrate/20151222105242_remove_endpoint_data_from_provider.rb
@@ -1,0 +1,9 @@
+class RemoveEndpointDataFromProvider < ActiveRecord::Migration
+  def up
+    remove_column :providers, :verify_ssl
+  end
+
+  def down
+    add_column :providers, :verify_ssl, :integer
+  end
+end

--- a/db/migrate/20160120151045_add_url_to_endpoints.rb
+++ b/db/migrate/20160120151045_add_url_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddUrlToEndpoints < ActiveRecord::Migration
+  def change
+    add_column :endpoints, :url, :string
+  end
+end

--- a/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
+++ b/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
@@ -1,0 +1,46 @@
+class MigrateUrlFromProviderToEndpoints < ActiveRecord::Migration
+  class Provider < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Migrating Provider URL attribute to Endpoints") do
+      ExtManagementSystem.all.each do |ems|
+        next if ems.provider_id.nil?
+        provider = Provider.where(:id => ems.provider_id).first
+        endpoint = Endpoint.where(
+          :resource_type => "Provider",
+          :resource_id   => ems.id).first_or_create
+
+        endpoint.update_attributes!(:url => provider.url)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating Endpoints URL to Provider") do
+      endpoints = Endpoint.where(
+        :role          => "default",
+        :resource_type => "Provider",
+      )
+
+      endpoints.each do |endpoint|
+        next if endpoint.url.nil?
+        ems = ExtManagementSystem.where(:id => endpoint.resource_id).first
+        provider = Provider.where(:id => ems.provider_id).first
+        provider.update_attributes!(
+          :url => endpoint.url)
+      end
+
+      Endpoint.delete_all
+    end
+  end
+end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -172,7 +172,10 @@ describe EmsCloudController do
            "default_verify"   => "[FILTERED]"
 
       expect(response.status).to eq(200)
-      expect(ManageIQ::Providers::Openstack::CloudManager.where(:hostname => 'host_openstack', :name => 'foo_openstack', :port => '5000').count).to eq(1)
+      expect(ManageIQ::Providers::Openstack::CloudManager.with_hostname('host_openstack')
+                                                         .with_port('5000')
+                                                         .where(:name => 'foo_openstack')
+                                                         .count).to eq(1)
     end
   end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -188,7 +188,7 @@ describe EmsCloudController do
     end
 
     it 'gets the restful show link and timeline link paths' do
-      session[:settings] = {:views =>{:vm_summary_cool => ""}}
+      session[:settings] = {:views => {:vm_summary_cool => ""}}
       post :create,
            "button"           => "add",
            "hostname"         => "host_openstack",
@@ -207,9 +207,9 @@ describe EmsCloudController do
       expect(show_link_actual_path).to eq("/ems_cloud/#{openstack.id}")
 
       post :show,
-           "button"           => "timeline",
-           "display"          => "timeline",
-           "id"               => openstack.id
+           "button"  => "timeline",
+           "display" => "timeline",
+           "id"      => openstack.id
 
       expect(response.status).to eq(200)
       show_link_actual_path = controller.send(:show_link, openstack, :display => "timeline")
@@ -248,7 +248,7 @@ describe EmsCloudController do
   end
 
   context "#update_ems_button_validate" do
-    let(:mocked_ems) { double(ManageIQ::Providers::Openstack::CloudManager, id: 1) }
+    let(:mocked_ems) { double(ManageIQ::Providers::Openstack::CloudManager, :id => 1) }
     it "calls authentication_check with save = true if validation is done for an existing record" do
       allow(controller).to receive(:set_ems_record_vars)
       allow(controller).to receive(:render)

--- a/spec/migrations/20141121200153_migrate_ems_attributes_to_endpoints_spec.rb
+++ b/spec/migrations/20141121200153_migrate_ems_attributes_to_endpoints_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+require_migration
+
+describe MigrateEmsAttributesToEndpoints do
+  let(:ems_stub)      { migration_stub(:ExtManagementSystem) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it 'migrates EMS attributes to endpoints' do
+      ems = ems_stub.create!(
+        :ipaddress => "1.2.3.4",
+        :hostname  => "example.org",
+        :port      => "123"
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(1)
+      expect(endpoint_stub.first).to have_attributes(
+        :role          => "default",
+        :ipaddress     => "1.2.3.4",
+        :hostname      => "example.org",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+    end
+
+    it 'handles nil port value properly' do
+      ems_stub.create!(
+        :ipaddress => "1.2.3.4",
+        :hostname  => "example.org",
+      )
+
+      migrate
+
+      expect(endpoint_stub.first).to have_attributes(
+        :ipaddress => "1.2.3.4",
+        :hostname  => "example.org",
+        :port      => nil,
+      )
+    end
+  end
+
+  migration_context :down do
+    it 'migrates endpoints to EMS attributes' do
+      ems = ems_stub.create!
+      endpoint_stub.create!(
+        :role          => "default",
+        :ipaddress     => "1.2.3.4",
+        :hostname      => "example.org",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(0)
+      expect(ems.reload).to have_attributes(
+        :ipaddress => "1.2.3.4",
+        :hostname  => "example.org",
+        :port      => "123",
+      )
+    end
+
+    it 'handles nil port value properly' do
+      ems = ems_stub.create!
+      endpoint_stub.create!(
+        :role          => "default",
+        :ipaddress     => "1.2.3.4",
+        :hostname      => "example.org",
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+
+      migrate
+
+      expect(ems.reload).to have_attributes(
+        :ipaddress => "1.2.3.4",
+        :hostname  => "example.org",
+        :port      => nil,
+      )
+    end
+  end
+end

--- a/spec/migrations/20151222103721_migrate_provider_attributes_to_endpoints_spec.rb
+++ b/spec/migrations/20151222103721_migrate_provider_attributes_to_endpoints_spec.rb
@@ -4,11 +4,15 @@ require_migration
 describe MigrateProviderAttributesToEndpoints do
   let(:provider_stub) { migration_stub(:Provider) }
   let(:endpoint_stub) { migration_stub(:Endpoint) }
+  let(:ems_stub)      { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
     it 'migrates Provider attributes to Endpoints' do
-      provider_stub.create!(
+      provider = provider_stub.create!(
         :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+      )
+      ems_stub.create!(
+        :provider_id => provider.id
       )
 
       migrate
@@ -20,8 +24,11 @@ describe MigrateProviderAttributesToEndpoints do
     end
 
     it 'handles nil port value properly' do
-      provider_stub.create!(
+      provider = provider_stub.create!(
         :verify_ssl => nil
+      )
+      ems_stub.create!(
+        :provider_id => provider.id
       )
 
       migrate
@@ -35,8 +42,14 @@ describe MigrateProviderAttributesToEndpoints do
   migration_context :down do
     it 'migrates Endpoints to Provider attributes' do
       provider = provider_stub.create!
+      ems      = ems_stub.create!(
+        :provider_id => provider.id
+      )
       endpoint_stub.create!(
-        :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id,
+        :role          => "default",
+        :verify_ssl    => OpenSSL::SSL::VERIFY_NONE
       )
 
       migrate

--- a/spec/migrations/20151222103721_migrate_provider_attributes_to_endpoints_spec.rb
+++ b/spec/migrations/20151222103721_migrate_provider_attributes_to_endpoints_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require_migration
+
+describe MigrateProviderAttributesToEndpoints do
+  let(:provider_stub) { migration_stub(:Provider) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it 'migrates Provider attributes to Endpoints' do
+      provider_stub.create!(
+        :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(1)
+      expect(endpoint_stub.first).to have_attributes(
+        :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+      )
+    end
+
+    it 'handles nil port value properly' do
+      provider_stub.create!(
+        :verify_ssl => nil
+      )
+
+      migrate
+
+      expect(endpoint_stub.first).to have_attributes(
+        :verify_ssl => nil
+      )
+    end
+  end
+
+  migration_context :down do
+    it 'migrates Endpoints to Provider attributes' do
+      provider = provider_stub.create!
+      endpoint_stub.create!(
+        :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(0)
+      expect(provider.reload).to have_attributes(
+        :verify_ssl => OpenSSL::SSL::VERIFY_NONE
+      )
+    end
+
+    it 'handles nil port value properly' do
+      provider = provider_stub.create!
+      endpoint_stub.create!(
+        :verify_ssl => nil
+      )
+
+      migrate
+
+      expect(provider.reload).to have_attributes(
+        :verify_ssl => nil
+      )
+    end
+  end
+end

--- a/spec/migrations/20160120151642_migrate_url_from_provider_to_endpoints_spec.rb
+++ b/spec/migrations/20160120151642_migrate_url_from_provider_to_endpoints_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require_migration
+
+describe MigrateUrlFromProviderToEndpoints do
+  let(:provider_stub) { migration_stub(:Provider) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+  let(:ems_stub)      { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it 'migrates Provider URL to Endpoints' do
+      provider = provider_stub.create!(
+        :url => "example.com"
+      )
+      ems_stub.create!(
+        :provider_id => provider.id
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(1)
+      expect(endpoint_stub.first).to have_attributes(
+        :url => "example.com"
+      )
+    end
+
+    it 'handles nil port value properly' do
+      provider = provider_stub.create!(
+        :url => nil
+      )
+      ems_stub.create!(
+        :provider_id => provider.id
+      )
+
+      migrate
+
+      expect(endpoint_stub.first).to have_attributes(
+        :url => nil
+      )
+    end
+  end
+
+  migration_context :down do
+    it 'migrates Endpoint URL to Provider attributes' do
+      provider = provider_stub.create!
+      ems      = ems_stub.create!(
+        :provider_id => provider.id
+      )
+      endpoint_stub.create!(
+        :resource_type => "Provider",
+        :resource_id   => ems.id,
+        :role          => "default",
+        :url           => "example.com"
+      )
+
+      migrate
+
+      expect(endpoint_stub.count).to eq(0)
+      expect(provider.reload).to have_attributes(
+        :url => "example.com"
+      )
+    end
+
+    it 'handles nil port value properly' do
+      provider = provider_stub.create!
+      endpoint_stub.create!(
+        :url => nil
+      )
+
+      migrate
+
+      expect(provider.reload).to have_attributes(
+        :url => nil
+      )
+    end
+  end
+end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -47,12 +47,4 @@ describe Endpoint do
       end
     end
   end
-
-  context "#tenant" do
-    let(:tenant) { FactoryGirl.create(:tenant) }
-    it "has a tenant" do
-      provider = FactoryGirl.create(:provider, :tenant => tenant)
-      expect(tenant.providers).to include(provider)
-    end
-  end
 end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe Endpoint do
+  let(:endpoint) { described_class.new }
+
+  describe "#verify_ssl" do
+    context "when non set" do
+      it "is default to verify ssl" do
+        expect(endpoint.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+        expect(endpoint).to be_verify_ssl
+      end
+    end
+
+    context "when set to false" do
+      before { endpoint.verify_ssl = false }
+
+      it "is verify none" do
+        expect(endpoint.verify_ssl).to eq(OpenSSL::SSL::VERIFY_NONE)
+        expect(endpoint).not_to be_verify_ssl
+      end
+    end
+
+    context "when set to true" do
+      before { endpoint.verify_ssl = true }
+
+      it "is verify peer" do
+        expect(endpoint.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+        expect(endpoint).to be_verify_ssl
+      end
+    end
+
+    context "when set to verify none" do
+      before { endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE }
+
+      it "is verify none" do
+        expect(endpoint.verify_ssl).to eq(OpenSSL::SSL::VERIFY_NONE)
+        expect(endpoint).not_to be_verify_ssl
+      end
+    end
+
+    context "when set to verify peer" do
+      before { endpoint.verify_ssl = OpenSSL::SSL::VERIFY_PEER }
+
+      it "is verify peer" do
+        expect(endpoint.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+        expect(endpoint).to be_verify_ssl
+      end
+    end
+  end
+
+  context "#tenant" do
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    it "has a tenant" do
+      provider = FactoryGirl.create(:provider, :tenant => tenant)
+      expect(tenant.providers).to include(provider)
+    end
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -36,11 +36,7 @@ describe ExtManagementSystem do
   end
 
   it ".ems_infra_discovery_types" do
-    expected_types = [
-      "scvmm",
-      "rhevm",
-      "virtualcenter"
-    ]
+    expected_types = %w(scvmm rhevm virtualcenter)
 
     expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
   end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -52,36 +52,41 @@ describe ExtManagementSystem do
 
   context "#ipaddress / #ipaddress=" do
     it "will delegate to the default endpoint" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :ipaddress => "1.2.3.4")
+      ems = FactoryGirl.build(:ems_vmware, :ipaddress => "1.2.3.4")
       expect(ems.default_endpoint.ipaddress).to eq "1.2.3.4"
     end
 
     it "with nil" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :ipaddress => nil)
+      ems = FactoryGirl.build(:ems_vmware, :ipaddress => nil)
       expect(ems.default_endpoint.ipaddress).to be_nil
     end
   end
 
   context "#hostname / #hostname=" do
     it "will delegate to the default endpoint" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :hostname => "example.org")
+      ems = FactoryGirl.build(:ems_vmware, :hostname => "example.org")
       expect(ems.default_endpoint.hostname).to eq "example.org"
     end
 
     it "with nil" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :hostname => nil)
+      ems = FactoryGirl.build(:ems_vmware, :hostname => nil)
       expect(ems.default_endpoint.hostname).to be_nil
     end
   end
 
   context "#port, #port=" do
     it "will delegate to the default endpoint" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :port => 1234)
+      ems = FactoryGirl.build(:ems_vmware, :port => 1234)
+      expect(ems.default_endpoint.port).to eq 1234
+    end
+
+    it "will delegate a string to the default endpoint" do
+      ems = FactoryGirl.build(:ems_vmware, :port => "1234")
       expect(ems.default_endpoint.port).to eq 1234
     end
 
     it "with nil" do
-      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :port => nil)
+      ems = FactoryGirl.build(:ems_vmware, :port => nil)
       expect(ems.default_endpoint.port).to be_nil
     end
   end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -50,6 +50,42 @@ describe ExtManagementSystem do
     expect(described_class.ems_cloud_discovery_types).to eq(expected_types)
   end
 
+  context "#ipaddress / #ipaddress=" do
+    it "will delegate to the default endpoint" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :ipaddress => "1.2.3.4")
+      expect(ems.default_endpoint.ipaddress).to eq "1.2.3.4"
+    end
+
+    it "with nil" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :ipaddress => nil)
+      expect(ems.default_endpoint.ipaddress).to be_nil
+    end
+  end
+
+  context "#hostname / #hostname=" do
+    it "will delegate to the default endpoint" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :hostname => "example.org")
+      expect(ems.default_endpoint.hostname).to eq "example.org"
+    end
+
+    it "with nil" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :hostname => nil)
+      expect(ems.default_endpoint.hostname).to be_nil
+    end
+  end
+
+  context "#port, #port=" do
+    it "will delegate to the default endpoint" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :port => 1234)
+      expect(ems.default_endpoint.port).to eq 1234
+    end
+
+    it "with nil" do
+      ems = ManageIQ::Providers::Vmware::InfraManager.create!(:name => "xxx", :port => nil)
+      expect(ems.default_endpoint.port).to be_nil
+    end
+  end
+
   context "with two small envs" do
     before(:each) do
       @zone1 = FactoryGirl.create(:small_environment)

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -62,8 +62,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   end
 
   def assert_ems
-    expect(@ems).to have_attributes(
-      :port => "6443",
+    @ems.should have_attributes(
+      :port => 6443,
       :type => "ManageIQ::Providers::Kubernetes::ContainerManager"
     )
   end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   end
 
   it "will perform a full refresh on k8s" do
-    2.times do  # Run twice to verify that a second run with existing data does not change anything
+    2.times do # Run twice to verify that a second run with existing data does not change anything
       VCR.use_cassette("#{described_class.name.underscore}") do # , :record => :new_episodes) do
         EmsRefresh.refresh(@ems)
       end
@@ -62,7 +62,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :port => 6443,
       :type => "ManageIQ::Providers::Kubernetes::ContainerManager"
     )

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -44,8 +44,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_ems
-    expect(@ems).to have_attributes(
-      :port => "8443",
+    @ems.should have_attributes(
+      :port => 8443,
       :type => "ManageIQ::Providers::Openshift::ContainerManager"
     )
   end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -44,7 +44,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_ems
-    @ems.should have_attributes(
+    expect(@ems).to have_attributes(
       :port => 8443,
       :type => "ManageIQ::Providers::Openshift::ContainerManager"
     )

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -16,6 +16,8 @@
 describe ApiController do
   include Rack::Test::Methods
 
+  ENDPOINT_ATTRS = ApiController::Providers::ENDPOINT_ATTRS
+
   let(:default_credentials) { {"userid" => "admin1", "password" => "password1"} }
   let(:metrics_credentials) { {"userid" => "admin2", "password" => "password2", "auth_type" => "metrics"} }
   let(:compound_credentials) { [default_credentials, metrics_credentials] }
@@ -39,7 +41,7 @@ describe ApiController do
     {
       "type"      => "ManageIQ::Providers::Redhat::InfraManager",
       "name"      => "sample rhevm",
-      "port"      => "5000",
+      "port"      => 5000,
       "hostname"  => "sample_rhevm.provider.com",
       "ipaddress" => "100.200.300.2"
     }
@@ -115,10 +117,12 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_rhevm])
+      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
+      expect(ExtManagementSystem.exists?(provider_id)).to be_true
+      endpoint = ExtManagementSystem.find(provider_id).default_endpoint
+      expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
     end
 
     it "supports openshift creation with auth_key specified" do
@@ -142,7 +146,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_rhevm])
+      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -155,7 +159,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_vmware])
+      expect_results_to_match_hash("results", [sample_vmware.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -171,7 +175,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_rhevm])
+      expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
@@ -189,7 +193,8 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_vmware, sample_rhevm])
+      expect_results_to_match_hash("results",
+                                   [sample_vmware.except(*ENDPOINT_ATTRS), sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       results = @result["results"]
       p1_id, p2_id = results.first["id"], results.second["id"]
@@ -222,9 +227,9 @@ describe ApiController do
 
       run_post(providers_url(provider.id), gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
-      expect_single_resource_query("id" => provider.id, "name" => "updated provider", "port" => "8080")
+      expect_single_resource_query("id" => provider.id, "name" => "updated provider")
       expect(provider.reload.name).to eq("updated provider")
-      expect(provider.port).to eq("8080")
+      expect(provider.port).to eq(8080)
     end
 
     it "supports updates of credentials" do
@@ -356,7 +361,7 @@ describe ApiController do
     it "supports single provider refresh" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      provider  = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url(provider.id), gen_request(:refresh))
@@ -367,10 +372,10 @@ describe ApiController do
     it "supports multiple provider refreshes" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      p1  = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      p1 = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
       p1.update_authentication(:default => default_credentials.symbolize_keys)
 
-      p2  = FactoryGirl.create(:ext_management_system, sample_rhevm.symbolize_keys.except(:type))
+      p2 = FactoryGirl.create(:ext_management_system, sample_rhevm.symbolize_keys.except(:type))
       p2.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url, gen_request(:refresh, [{"href" => providers_url(p1.id)},

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -132,7 +132,7 @@ describe ApiController do
 
       expect_request_success
       expect_result_resource_keys_to_be_like_klass("results", "id", Integer)
-      expect_results_to_match_hash("results", [sample_openshift])
+      expect_results_to_match_hash("results", [sample_openshift.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -120,7 +120,7 @@ describe ApiController do
       expect_results_to_match_hash("results", [sample_rhevm.except(*ENDPOINT_ATTRS)])
 
       provider_id = @result["results"].first["id"]
-      expect(ExtManagementSystem.exists?(provider_id)).to be_true
+      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
       expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
     end

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -127,7 +127,7 @@ describe ApiController do
       run_get(providers_url(provider.id), :attributes => "authentications")
 
       expect_request_success
-      expect_result_to_match_hash(@result, "name" => "sample", "hostname" => "sample.com")
+      expect_result_to_match_hash(@result, "name" => "sample")
       expect_result_to_have_keys(%w(authentications))
       authentication = @result["authentications"].first
       expect(authentication["userid"]).to eq("admin")


### PR DESCRIPTION
This PR supercedes #3654 

Adds the initial layer of multi-endpoint functionality by extracting out host information to a separate `Endpoints` model from `ExtManagementSystem`.

As the initial work on more work to come, this PR is backwards compatible with the pre-multi-endpoint ManageIQ utilising delegates and virtual columns. You shouldn't notice a thing ;)

Please check this @blomquisg @Fryguy 