### PR TITLE
Don't show summary of instance KeyPairs

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -34,9 +34,13 @@ module AuthenticationMixin
     authentications.select { |a| a.kind_of?(ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair) }
   end
 
+  def authentication_for_providers
+    authentications.where.not(:authtype => nil)
+  end
+
   def authentication_for_summary
     summary = []
-    authentications.each do |a|
+    authentication_for_providers.each do |a|
       summary << {
         :authtype       => a.authtype,
         :status         => a.status,
@@ -87,7 +91,7 @@ module AuthenticationMixin
   end
 
   def authentication_status
-    ordered_auths = authentications.sort_by(&:status_severity)
+    ordered_auths = authentication_for_providers.sort_by(&:status_severity)
     ordered_auths.last.try(:status) || "None"
   end
 


### PR DESCRIPTION
Only return an auth summary if there is an authtype so that instance keypairs aren't listed on the provider summary page.

https://github.com/ManageIQ/manageiq/issues/6150

cc @Ladas 