### PR TITLE
API - /api .identity - add .locale to retrieve user's default language

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -70,6 +70,11 @@ class ApiController
         :role       => group.miq_user_role_name,
         :tenant     => group.tenant.name,
         :groups     => user.miq_groups.pluck(:description),
+      }
+    end
+
+    def user_settings
+      {
         :locale     => I18n.locale.to_s.sub('-', '_'),
       }
     end

--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -69,7 +69,8 @@ class ApiController
         :group_href => "#{@req[:api_prefix]}/groups/#{group.id}",
         :role       => group.miq_user_role_name,
         :tenant     => group.tenant.name,
-        :groups     => user.miq_groups.pluck(:description)
+        :groups     => user.miq_groups.pluck(:description),
+        :locale     => I18n.locale.to_s.sub('-', '_'),
       }
     end
 

--- a/app/controllers/api_controller/entrypoint.rb
+++ b/app/controllers/api_controller/entrypoint.rb
@@ -11,6 +11,7 @@ class ApiController
         :version     => @version,
         :versions    => entrypoint_versions,
         :identity    => auth_identity,
+        :settings    => user_settings,
         :collections => entrypoint_collections
       }
       render_resource :entrypoint, res

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe "API entrypoint" do
+  include Rack::Test::Methods
+
+  before(:each) do
+    init_api_spec_env
+  end
+
+  def app
+    Vmdb::Application
+  end
+
+  it "returns a :settings hash" do
+    api_basic_authorize
+
+    run_get entrypoint_url
+
+    expect_single_resource_query
+    expect_result_to_have_keys(%w(settings))
+    expect(@result['settings']).to be_kind_of(Hash)
+  end
+
+  it "returns a locale" do
+    api_basic_authorize
+
+    run_get entrypoint_url
+
+    expect(%w(en en_US)).to include(@result['settings']['locale'])
+  end
+end


### PR DESCRIPTION
In SSUI, we need to know the user's preferred language to set angular-gettext to the right language.

This adds a `.locale` attribute, under the `.identity` object returned as part of the `GET /api/` response.

Uses the same approach as for main ui's html lang attribute - will return either a ISO 639 language code (`en`), or a ISO 639 _ ISO 3166 pair (`en_US`).


@abellotti what do you think about this change please?

@mzazrivec ping ;)