### PR TITLE
Use DRb's builtin caching mechanism

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -222,12 +222,20 @@ RUBY
     end
 
     def self.setup_drb_for_ruby_method
+      require 'drb/timeridconv'
+      DRb.install_id_conv(DRb::TimerIdConv.new(drb_cache_timeout))
       drb_front  = MiqAeMethodService::MiqAeServiceFront.new
       drb        = DRb.start_service("druby://127.0.0.1:0", drb_front)
     end
 
+    def self.drb_cache_timeout
+      1.hour
+    end
+
     def self.teardown_drb_for_ruby_method
       DRb.stop_service
+      # Set the ID conv to nil so that the cache can be GC'ed
+      DRb.install_id_conv(nil)
     end
 
     def self.invoke_inline_ruby(aem, obj, inputs)

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -139,22 +139,15 @@ module MiqAeMethodService
     def instantiate(uri)
       obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?
-      drb_return(MiqAeServiceObject.new(obj, self))
+      MiqAeServiceObject.new(obj, self)
     rescue => e
       return nil
-    end
-
-    def drb_return(obj)
-      # Save a reference to the object, so that we control when it gets deleted.  Otherwise, Ruby Garbage Collection may remove it prematurely.
-      # If it is removed prematurely and then referenced by the method, we get a DRb recycled object error
-      #@drb_server_references << obj
-      obj
     end
 
     def object(path = nil)
       obj = @workspace.get_obj_from_path(path)
       return nil if obj.nil?
-      drb_return MiqAeServiceObject.new(obj, self)
+      MiqAeServiceObject.new(obj, self)
     end
 
     def hash_to_query(hash)
@@ -182,7 +175,7 @@ module MiqAeMethodService
     end
 
     def current_object
-      @current_object ||= drb_return(MiqAeServiceObject.new(@workspace.current_object, self))
+      @current_object ||= MiqAeServiceObject.new(@workspace.current_object, self)
     end
 
     def current_method
@@ -203,7 +196,7 @@ module MiqAeMethodService
 
     def objects(aobj)
       aobj.collect do |obj|
-        obj = drb_return(MiqAeServiceObject.new(obj, self)) unless obj.kind_of?(MiqAeServiceObject)
+        obj = MiqAeServiceObject.new(obj, self) unless obj.kind_of?(MiqAeServiceObject)
         obj
       end
     end
@@ -215,7 +208,7 @@ module MiqAeMethodService
     end
 
     def execute(m, *args)
-      drb_return MiqAeServiceMethods.send(m, *args)
+      MiqAeServiceMethods.send(m, *args)
     rescue NoMethodError => err
       raise MiqAeException::MethodNotFound, err.message
     end

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -147,7 +147,7 @@ module MiqAeMethodService
     def drb_return(obj)
       # Save a reference to the object, so that we control when it gets deleted.  Otherwise, Ruby Garbage Collection may remove it prematurely.
       # If it is removed prematurely and then referenced by the method, we get a DRb recycled object error
-      @drb_server_references << obj
+      #@drb_server_references << obj
       obj
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -109,12 +109,12 @@ module MiqAeMethodService
         if results.nil?
           ret = nil
         elsif results.kind_of?(Array)
-          ret = drb_return(results.collect { |r| wrap_results(r) })
+          ret = results.collect { |r| wrap_results(r) }
         elsif results.kind_of?(ActiveRecord::Relation)
-          ret = drb_return(results.collect { |r| wrap_results(r) })
+          ret = results.collect { |r| wrap_results(r) }
         elsif results.kind_of?(ActiveRecord::Base)
           klass = MiqAeMethodService.const_get("MiqAeService#{results.class.name.gsub(/::/, '_')}")
-          ret = drb_return(klass.new(results))
+          ret = klass.new(results)
         else
           ret = results
         end
@@ -124,14 +124,6 @@ module MiqAeMethodService
 
     def wrap_results(results)
       self.class.wrap_results(results)
-    end
-
-    def self.drb_return(obj)
-      MiqAeService.current ? MiqAeService.current.drb_return(obj) : obj
-    end
-
-    def drb_return(obj)
-      self.class.drb_return(obj)
     end
 
     #

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
@@ -33,7 +33,7 @@ module MiqAeServiceMiqProvisionMixin
   end
 
   def check_quota(quota_type, options = {})
-    drb_return(object_send(:check_quota, quota_type, options))
+    object_send(:check_quota, quota_type, options)
   end
 
   def eligible_resources(rsc_type)

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -99,15 +99,6 @@ module MiqAeServiceSpec
           expect(miq_ae_service.vmdb(name)).to be("#{prefix}#{name}".constantize)
         end
       end
-
-      it "cache object references" do
-        FactoryGirl.create(:vm_vmware)
-        FactoryGirl.create(:vm_vmware)
-
-        vms = miq_ae_service.vmdb('vm').find(:all)
-        cache = miq_ae_service.instance_variable_get(:@drb_server_references)
-        expect(cache.any? { |x| x.object_id == vms.object_id }).to be_truthy
-      end
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1297097

Previously we have been using our own caching mechanism to
cache objects sent as references to the Automate Methods. We have
gotten DRb recycled object errors, since some of the objects which
were sent as references were not being cached.
DRb has a builtin caching mechanism based on TimerIdConv, which
we are starting to use in this PR.