### PR TITLE
[WIP] Unifying the entity saving functions in save_inventory_container.rb.

### DIFF
--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -59,8 +59,8 @@ module ContainerSummaryHelper
     textual_key_value_group(@record.selector_parts.to_a)
   end
 
-  def textual_container_node_selectors
-    textual_key_value_group(@record.node_selector_parts.to_a)
+  def textual_container_selectors
+    textual_key_value_group(@record.selector_parts.to_a)
   end
 
   def textual_container_image

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -11,7 +11,7 @@ class ContainerGroup < ActiveRecord::Base
   has_many :container_definitions, :dependent => :destroy
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
-  has_many :node_selector_parts, -> { where(:section => "node_selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
   has_many :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
   belongs_to :container_node
   has_and_belongs_to_many :container_services, :join_table => :container_groups_container_services

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -212,7 +212,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_groups, hashes, deletes, [:ems_ref],
-                         [:container_definitions, :containers, :labels, :node_selector_parts, :container_conditions,
+                         [:container_definitions, :containers, :labels, :selector_parts, :container_conditions,
                           :container_volumes], [:container_node, :container_replicator, :project, :namespace, :build_pod_name])
     store_ids_for_new_records(ems.container_groups, hashes, :ems_ref)
   end
@@ -387,20 +387,6 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(entity.selector_parts, hashes, deletes, [:section, :name])
     store_ids_for_new_records(entity.selector_parts, hashes, [:section, :name])
-  end
-
-  def save_node_selector_parts_inventory(entity, hashes, target = nil)
-    return if hashes.nil?
-
-    entity.node_selector_parts(true)
-    deletes = if target.kind_of?(ExtManagementSystem)
-                entity.node_selector_parts.dup
-              else
-                []
-              end
-
-    save_inventory_multi(entity.node_selector_parts, hashes, deletes, [:section, :name])
-    store_ids_for_new_records(entity.node_selector_parts, hashes, [:section, :name])
   end
 
   def save_container_builds_inventory(ems, hashes, target = nil)

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -279,7 +279,7 @@ module ManageIQ::Providers::Kubernetes
       new_result[:container_conditions] = parse_conditions(pod)
 
       new_result[:labels] = parse_labels(pod)
-      new_result[:node_selector_parts] = parse_node_selector_parts(pod)
+      new_result[:selector_parts] = parse_selector_parts(pod)
       new_result[:container_volumes] = parse_volumes(pod.spec.volumes)
       new_result
     end
@@ -454,10 +454,6 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_selector_parts(entity)
       parse_identifying_attributes(entity.spec.selector, 'selectors')
-    end
-
-    def parse_node_selector_parts(entity)
-      parse_identifying_attributes(entity.spec.nodeSelector, 'node_selectors')
     end
 
     def parse_identifying_attributes(attributes, section)

--- a/app/views/container_group/_main.html.haml
+++ b/app/views/container_group/_main.html.haml
@@ -5,7 +5,7 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Labels"),
                                                                :items => textual_group_container_labels}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Node Selector"),
-                                                               :items => textual_container_node_selectors}
+                                                               :items => textual_container_selectors}
     = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Volumes"),
                                                                           :items => textual_group_volumes}
   .col-md-12.col-lg-6

--- a/db/migrate/20160120152947_rename_container_group_node_selectors_to_selectors.rb
+++ b/db/migrate/20160120152947_rename_container_group_node_selectors_to_selectors.rb
@@ -1,0 +1,31 @@
+class RenameContainerGroupNodeSelectorsToSelectors < ActiveRecord::Migration
+  include MigrationHelper
+
+  def up
+    if CustomAttribute.table_exists?
+      # We want to change CustomAttribute only for ContainerGroup.selector_parts
+      # In the up case:
+      #   Only ContainerGroup use the scope name "node_selectors" so we can just,
+      #   change the section field without checking relations to ContainerGroup.
+      say_with_time("Renaming node_selectors to selectors in '#{CustomAttribute.table_name}'") do
+        CustomAttribute.where(:section => "node_selectors").update_all(:section => "selectors")
+      end
+    end
+  end
+
+  def down
+    # We want to change CustomAttribute only for ContainerGroup.selector_parts
+    # In the down case:
+    #   This is more tricky :-)
+    #   We want to select only CustomAttribute belonging to a ContainerGroup.selector_parts.
+    #   The scope name "selectors" is used in other classes. We need to change only
+    #   container_group.selector_parts.
+    if ContainerGroup.table_exists?
+      say_with_time("Renaming selectors to node_selectors in '#{ContainerGroup.table_name}'") do
+        ContainerGroup.all.each do |container_group|
+          container_group.selector_parts.where(:section => "selectors").update_all(:section => "node_selectors")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Try to unify save_selector_parts_inventory and
save_node_selector_parts_inventory in
app/models/ems_refresh/save_inventory_container.rb.