### PR TITLE
without_scope was added to undo a default scope but is unused. :fire:

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -68,10 +68,6 @@ module ArRegion
       where(:id => region_to_range(region_number)).scoping { yield }
     end
 
-    def without_scope(&blk)
-      with_exclusive_scope(&blk)
-    end
-
     def conditions_for_my_region_default_scope
       # NOTE: These conditions MUST NOT be specified in Hash format because they are used for defining default_scope in models
       #       and would be applied for the creation of objects in addition to finds. Since :id is used in the condition this


### PR DESCRIPTION
While investigating replication we found that without_scope was added
with a default_scope "conditions_for_my_region" in 0ac04a1d033f0aeeea
but the former is unused.

Rails has unscoped to remove this scoping so we don't need it either way.