### PR TITLE
dont use rails runner to start evm_server.rb

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -19,10 +19,7 @@ class EvmApplication
     _log.info("EVM Startup initiated")
 
     MiqServer.kill_all_workers
-    rr      = File.expand_path(Rails.root)
-    runner  = File.join(rr, "bin/rails runner")
-    program = File.join(rr, "lib/workers/bin/evm_server.rb")
-    command_line = "#{runner} #{program}"
+    command_line = File.expand_path("lib/workers/bin/evm_server.rb", Rails.root)
 
     env_options = {}
     env_options["EVMSERVER"] = "true" if MiqEnvironment::Command.is_appliance?

--- a/lib/workers/bin/evm_server.rb
+++ b/lib/workers/bin/evm_server.rb
@@ -1,7 +1,8 @@
-require "workers/evm_server"
-if MiqEnvironment::Process.is_rails_runner?
-  EvmServer.start(*ARGV)
-else
-  puts "run with rails runner evm_server.rb"
-  exit 1
+#!/usr/bin/env ruby
+
+if !defined?(MiqEnvironment) || !MiqEnvironment::Process.is_rails_runner?
+  require File.expand_path('../../../../config/environment', __FILE__)
 end
+
+require "workers/evm_server"
+EvmServer.start(*ARGV)


### PR DESCRIPTION
I had thought we were not going to run our app using rails runner, but just use basic rails environment instead.

I left our original stub so if it is run via rails runner, it will still work.

/cc @matthewd @Fryguy @jrafanie @chessbyte do you remember this discussion? Did something change?
/cc @matthewd can you remind us of the merits? Besides quicker start time and one less wrapper script?