### PR TITLE
Make BottleneckEvent.delete_future_events_for_obj work for STI

### DIFF
--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -6,8 +6,7 @@ class BottleneckEvent < ActiveRecord::Base
   serialize :context_data
 
   def self.last_created_on(obj)
-    event = where("resource_type = ? AND resource_id = ?", obj.class.base_class.name, obj.id)
-            .order("created_on DESC").first
+    event = where(:resource => obj).order("created_on DESC").first
     event ? event.created_on : nil
   end
 

--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -58,7 +58,7 @@ class BottleneckEvent < ActiveRecord::Base
   end
 
   def self.delete_future_events_for_obj(obj)
-    delete_all(:resource_type => obj.class.name, :resource_id => obj.id, :future => true)
+    delete_all(:resource => obj, :future => true)
   end
 
   def context

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -107,4 +107,39 @@ describe BottleneckEvent do
       it { is_expected.to be_same_time_as(bottleneck_event.created_on) }
     end
   end
+
+  describe ".delete_future_events_for_obj" do
+    let(:resource) { FactoryGirl.create(resource_name) }
+    let!(:bottleneck_event) { BottleneckEvent.create!(:resource => resource, :future => true) }
+
+    before { BottleneckEvent.delete_future_events_for_obj(resource) }
+
+    context "for a host_redhat resource" do
+      let(:resource_name) { :host_redhat }
+      it "deletes the future event" do
+        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "for a host_vmware resource" do
+      let(:resource_name) { :host_vmware }
+      it "deletes the future event" do
+        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "for a miq_enterprise resource" do
+      let(:resource_name) { :miq_enterprise }
+      it "deletes the future event" do
+        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "for a ems_cluster_openstack resource" do
+      let(:resource_name) { :ems_cluster_openstack }
+      it "deletes the future event" do
+        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -77,7 +77,7 @@ describe BottleneckEvent do
     end
   end
 
-  describe "#last_created_on" do
+  describe ".last_created_on" do
     subject { described_class.last_created_on(resource) }
     let(:resource) { FactoryGirl.create(resource_name) }
     let!(:bottleneck_event) { BottleneckEvent.create!(:resource => resource) }


### PR DESCRIPTION
BottleneckEvent.delete_future_events_for_obj suffered from the same as in 33b2f2c
It would not detect STI resources such as Host.

This fixes this and also make use of letting rails STI brain decide which resource_type to use

https://bugzilla.redhat.com/show_bug.cgi?id=1296113