### PR TITLE
fix misspelled Europe in some azure regions descriptions

### DIFF
--- a/app/models/manageiq/providers/azure/regions.rb
+++ b/app/models/manageiq/providers/azure/regions.rb
@@ -36,11 +36,11 @@ module ManageIQ
         },
         "northeurope" => {
           :name        => "northeurope",
-          :description => "North Eurpoe",
+          :description => "North Europe",
         },
         "westeurope" => {
           :name        => "westeurope",
-          :description => "West Eurpoe",
+          :description => "West Europe",
         },
         "eastasia" => {
           :name        => "eastasia",


### PR DESCRIPTION
Hey guys,
Sorry to be pernickety but I found out that "Europe" was misspelled "Eurpoe" in some azure's region descriptions and so was the region's label in the UI so I wanted to fix that.

Thanks !