### PR TITLE
Use LinuxAdmin::Hardware to get the proper CPU Core total

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -26,7 +26,7 @@ gem "httpclient",              "~>2.5.3",           :require => false
 gem "image-inspector-client",  "~>1.0.0",           :require => false
 gem "kubeclient",              "=0.8.0",            :require => false
 gem "hawkular-client",         "~>0.1.2",           :require => false
-gem "linux_admin",             "~>0.13.0",          :require => false
+gem "linux_admin",             "~>0.14.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false

--- a/gems/pending/util/miq-system.rb
+++ b/gems/pending/util/miq-system.rb
@@ -46,19 +46,9 @@ class MiqSystem
   end
 
   def self.num_cpus
-    if Sys::Platform::IMPL == :linux
-      @num_cpus ||= begin
-        filename = "/proc/cpuinfo"
-        count = 0
-        MiqSystem.readfile_async(filename).to_s.split("\n").each do |line|
-          next if line.strip.empty?
-          count += 1 if (line.split(":").first.strip == 'processor')
-        end
-        count
-      end
-    else
-      return nil
-    end
+    return unless Sys::Platform::IMPL == :linux
+    require 'linux_admin'
+    @num_cpus ||= LinuxAdmin::Hardware.new.total_cores
   end
 
   def self.memory


### PR DESCRIPTION
Previously on a system with 2 sockets and 4 cores_per_socket we would get:
irb(main):001:0> MiqSystem.num_cpus
=> 5