### PR TITLE
Refactor MiqAeEvent#automate_user_ids

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -19,6 +19,8 @@ class EmsCluster < ActiveRecord::Base
   has_many    :policy_events, -> { order "timestamp" }
   has_many    :miq_events,             :as => :target,    :dependent => :destroy
 
+  delegate :tenant_identity, :to => :ext_management_system
+
   virtual_column :v_ram_vr_ratio,      :type => :float,   :uses => [:aggregate_memory, :aggregate_vm_memory]
   virtual_column :v_cpu_vr_ratio,      :type => :float,   :uses => [:aggregate_cpu_total_cores, :aggregate_vm_cpus]
   virtual_column :v_parent_datacenter, :type => :string,  :uses => :all_relationships

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -209,6 +209,10 @@ class EmsEvent < EventStream
     event.send(target_type)
   end
 
+  def tenant_identity
+    (vm_or_template || ext_management_system).tenant_identity
+  end
+
   private
 
   def self.create_event(event)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -511,4 +511,8 @@ class ExtManagementSystem < ActiveRecord::Base
   def self.datastore?
     IsoDatastore.where(:ems_id => all).exists?
   end
+
+  def tenant_identity
+    User.super_admin.tap { |u| u.current_group = tenant.default_miq_group }
+  end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -154,6 +154,8 @@ class Host < ActiveRecord::Base
   alias_method :parent_cluster, :ems_cluster
   alias_method :owning_cluster, :ems_cluster
 
+  delegate :tenant_identity, :to => :ext_management_system
+
   include RelationshipMixin
   self.default_relationship_type = "ems_metadata"
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -871,36 +871,21 @@ class MiqAction < ActiveRecord::Base
     vim.cancelTask(task_mor)
   end
 
-  def automate_user_ids(target)
-    case target
-    when VmOrTemplate
-      group  = target.miq_group
-      user   = target.evm_owner
-      user   = User.super_admin if user.nil? || !user.miq_groups.include?(group)
-      tenant = target.tenant
-    when Host
-      user   = User.super_admin
-      tenant = target.ext_management_system.tenant
-      group  = tenant.default_miq_group
-    end
-
-    raise "A group is needed to raise an event. [#{target.class.name}] id:[#{target.id}]" unless group
-    [user.id, group.id, tenant.id]
-  end
-
   def action_custom_automation(action, rec, inputs)
     ae_hash = action.options[:ae_hash] || {}
     automate_attrs = ae_hash.reject { |key, _value| MiqAeEngine::DEFAULT_ATTRIBUTES.include?(key) }
     automate_attrs[:request] = action.options[:ae_request]
     MiqAeEngine.set_automation_attributes_from_objects([inputs[:policy], inputs[:ems_event]], automate_attrs)
-    user_id, group_id, tenant_id = automate_user_ids(rec)
+
+    user = rec.tenant_identity
+    raise "A user is needed to raise an action to automate. [#{rec.class.name}] id:[#{rec.id}] action: [#{action.description}]" unless user
 
     args = {
       :object_type      => rec.class.base_class.name,
       :object_id        => rec.id,
-      :user_id          => user_id,
-      :miq_group_id     => group_id,
-      :tenant_id        => tenant_id,
+      :user_id          => user.id,
+      :miq_group_id     => user.current_group.id,
+      :tenant_id        => user.current_tenant.id,
       :attrs            => automate_attrs,
       :instance_name    => "REQUEST",
       :automate_message => action.options[:ae_message] || "create",

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -666,4 +666,8 @@ class MiqServer < ActiveRecord::Base
   def server_timezone
     get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
   end
+
+  def tenant_identity
+    User.super_admin
+  end
 end # class MiqServer

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -32,6 +32,7 @@ module MiqRequestMixin
   def get_user
     @user ||= User.find_by_userid(userid)
   end
+  alias_method :tenant_identity, :get_user
 
   def tags
     tag_ids.to_miq_a.each do |tag_id|

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -5,6 +5,8 @@ class ResourcePool < ActiveRecord::Base
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many   :miq_events,            :as => :target, :dependent => :destroy
 
+  delegate :tenant_identity, :to => :ext_management_system
+
   include SerializedEmsRefObjMixin
   include FilterableMixin
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -205,9 +205,14 @@ class Service < ActiveRecord::Base
   def v_total_vms
     vms.size
   end
- 
+
   def set_tenant_from_group
     self.tenant_id = miq_group.tenant_id if miq_group
   end
 
+  def tenant_identity
+    user = evm_owner
+    user = User.super_admin.tap { |u| u.current_group = miq_group } if user.nil? || !user.groups_include?(miq_group)
+    user
+  end
 end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -851,4 +851,8 @@ class Storage < ActiveRecord::Base
                                                      !ext_management_systems.first.kind_of?(ManageIQ::Providers::Vmware::InfraManager)
     {:available => true,   :message => nil}
   end
+
+  def tenant_identity
+    ext_management_systems.first.tenant_identity
+  end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1918,6 +1918,12 @@ class VmOrTemplate < ActiveRecord::Base
      template_tenant_ids, vm_tenant_ids]
   end
 
+  def tenant_identity
+    user = evm_owner
+    user = User.super_admin.tap { |u| u.current_group = miq_group } if user.nil? || !user.groups_include?(miq_group)
+    user
+  end
+
   private
 
   def set_tenant_from_group


### PR DESCRIPTION
Rename method to tenant_identity.
Change the method to return the objects instead of object ids.