### PR TITLE
Added @right_cell_text for Automate Simulation screen

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -126,6 +126,7 @@ module ApplicationController::Automate
     @breadcrumbs = []
     drop_breadcrumb(:name => "Resolve", :url => "/miq_ae_tools/resolve")
     @lastaction = "resolve"
+    @right_cell_text = "Simulation"
 
     case params[:button]
     when "throw"    then resolve_button_throw

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -21,7 +21,7 @@
             .row
               .col-md-7#explorer
                 %h1#explorer_title
-                  = URI.unescape(@right_cell_text)
+                  = URI.unescape(@right_cell_text) if @right_cell_text
                   -# Link to clear the current applied filter, will be moved via JS to the right cell header
                   %span#clear_search{:style => "display:none"}
                     - if route_exists?(:action => 'adv_search_clear')


### PR DESCRIPTION
URI.unescape was blowing up since @right_cell_text was nil. This issue was introduced with changes in https://github.com/ManageIQ/manageiq/pull/6140 for https://bugzilla.redhat.com/show_bug.cgi?id=1282606. Added code to set @right_cell_text and also added check to only URI.unescape if @right_cell_text is not nil

https://bugzilla.redhat.com/show_bug.cgi?id=1299010

@dclarizio please review.

![screenshot from 2016-01-15 12 46 50](https://cloud.githubusercontent.com/assets/3450808/12360449/12fd7cb8-bb86-11e5-8bec-911e68a0586c.png)
