### PR TITLE
Remove MiqServer#reset (for ntp change) in favor of Config::Activator

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -459,18 +459,9 @@ class MiqServer < ActiveRecord::Base
     end
   end
 
-  def reset
-    # TODO: Need to handle calling this during startup because it results in starting generic workers from the main process
-    # MiqGenericWorker.update_config
-    # XXX
-
-    # When the vmdb is reset, need to check the ntp settings, and apply them
-    ntp_reload_queue
-  end
-
   # Restart the local server
   def restart
-    raise "Server reset is only supported on Linux" unless MiqEnvironment::Command.is_linux?
+    raise "Server restart is only supported on Linux" unless MiqEnvironment::Command.is_linux?
 
     _log.info("Server restart initiating...")
     update_attribute(:status, "restarting")

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -26,7 +26,7 @@ module MiqServer::NtpManagement
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in atStartup of miq_server and on a configuration change for the server
   def ntp_reload(ntp_settings = server_ntp_settings)
-    return unless MiqEnvironment::Command.is_appliance?
+    return unless MiqEnvironment::Command.is_appliance? # matches ntp_reload_queue's guard clause
 
     if @ntp_settings && @ntp_settings == ntp_settings
       _log.info("Skipping reload of ntp settings since they are unchanged")

--- a/app/models/miq_server/queue_management.rb
+++ b/app/models/miq_server/queue_management.rb
@@ -55,6 +55,8 @@ module MiqServer::QueueManagement
   end
 
   def ntp_reload_queue
+    return unless MiqEnvironment::Command.is_appliance? # matches ntp_reload's guard clause
+
     MiqQueue.put_or_update(
       :class_name  => "MiqServer",
       :instance_id => id,

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -277,8 +277,6 @@ module VMDB
       update_cache_metadata
 
       activate
-
-      svr.reset if svr
     end
 
     def save_file(filename)

--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -22,6 +22,10 @@ module VMDB
         Vmdb::Loggers.apply_config(data)
       end
 
+      def ntp(_data)
+        MiqServer.my_server.ntp_reload_queue unless MiqServer.my_server.nil? rescue nil
+      end
+
       def session(data)
         Session.timeout data.timeout
         Session.interval data.interval


### PR DESCRIPTION
In addition, ntp_reload only runs on appliances, so queue it only on appliances.

This was extracted from configuration revamp.  I'm trying to work on saving changes to settings, and this `svr.reset` was in the way.

@jrafanie Please review.