### PR TITLE
Remove region default scope

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,6 +1,4 @@
 class Condition < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   include UuidMixin
   before_validation :default_name_to_guid, :on => :create
 

--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -1,5 +1,3 @@
 class ConditionSet < ActiveRecord::Base
   acts_as_miq_set
-
-  default_scope { where conditions_for_my_region_default_scope }
 end

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -1,5 +1,4 @@
 class CustomButton < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
   has_one       :resource_action, :as => :resource, :dependent => :destroy, :autosave => true
 
   serialize :options

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -1,8 +1,6 @@
 class CustomButtonSet < ActiveRecord::Base
   acts_as_miq_set
 
-  default_scope  { where conditions_for_my_region_default_scope }
-
   def self.find_all_by_class_name(class_name, class_id = nil)
     ordering = ->(o) { [o.set_data[:group_index].to_s, o.name] }
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1,8 +1,6 @@
 require 'awesome_spawn'
 
 class MiqAction < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   include UuidMixin
   before_validation :default_name_to_guid, :on => :create
   before_destroy    :check_policy_contents_empty_on_destroy

--- a/app/models/miq_action_set.rb
+++ b/app/models/miq_action_set.rb
@@ -1,5 +1,3 @@
 class MiqActionSet < ActiveRecord::Base
   acts_as_miq_set
-
-  default_scope { where conditions_for_my_region_default_scope }
 end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -1,6 +1,4 @@
 class MiqAlert < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   include UuidMixin
 
   serialize :expression

--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -1,8 +1,6 @@
 class MiqAlertSet < ActiveRecord::Base
   acts_as_miq_set
 
-  default_scope { where conditions_for_my_region_default_scope }
-
   before_validation :default_name_to_guid, :on => :create
 
   include AssignmentMixin

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -1,6 +1,4 @@
 class MiqEventDefinition < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   include UuidMixin
 
   validates_presence_of     :name

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -1,8 +1,6 @@
 class MiqEventDefinitionSet < ActiveRecord::Base
   acts_as_miq_set
 
-  default_scope { where conditions_for_my_region_default_scope }
-
   def self.seed
     CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/) do |csv_row|
       set = csv_row.to_hash

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -3,8 +3,6 @@ class MiqGroup < ActiveRecord::Base
   SYSTEM_GROUP = "system"
   TENANT_GROUP = "tenant"
 
-  default_scope { where(conditions_for_my_region_default_scope) }
-
   belongs_to :tenant
   belongs_to :miq_user_role
   belongs_to :resource, :polymorphic => true

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,8 +1,6 @@
 # TODO: Import/Export support
 
 class MiqPolicy < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   acts_as_miq_taggable
   acts_as_miq_set_member
   include_concern 'ImportExport'

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -1,8 +1,6 @@
 class MiqPolicySet < ActiveRecord::Base
   acts_as_miq_set
 
-  default_scope { where conditions_for_my_region_default_scope }
-
   before_validation :default_name_to_guid, :on => :create
   before_destroy    :destroy_policy_tags
 

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -11,8 +11,6 @@ class MiqReport < ActiveRecord::Base
   include_concern 'Search'
   include YAMLImportExportMixin
 
-  default_scope { where conditions_for_my_region_default_scope }
-
   serialize :cols
   serialize :conditions
   serialize :where_clause

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -3,8 +3,6 @@
 require 'simple-rss'
 
 class MiqWidget < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   default_value_for :enabled, true
   default_value_for :read_only, false
 

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -1,8 +1,6 @@
 class MiqWidgetSet < ActiveRecord::Base
   acts_as_miq_set
 
-  default_scope { where conditions_for_my_region_default_scope }
-
   before_destroy :destroy_user_versions
 
   WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/dashboards"))

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -1,6 +1,4 @@
 class ScanItem < ActiveRecord::Base
-  default_scope { where conditions_for_my_region_default_scope }
-
   serialize :definition
   acts_as_miq_set_member
   include UuidMixin

--- a/app/models/scan_item_set.rb
+++ b/app/models/scan_item_set.rb
@@ -1,5 +1,3 @@
 class ScanItemSet < ActiveRecord::Base
   acts_as_miq_set
-
-  default_scope { where conditions_for_my_region_default_scope }
 end

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -491,11 +491,9 @@ workers:
         - miq_alerts
         - miq_databases
         - miq_enterprises
-        - miq_events
         - miq_event_definitions
         - miq_globals
         - miq_groups
-        - miq_license_contents
         - miq_policies
         - miq_policy_contents
         - miq_product_features
@@ -519,7 +517,6 @@ workers:
         - schema_migrations
         - server_roles
         - sessions
-        - vim_performances
         - vim_performance_states
         - vim_performance_tag_values
         - vmdb_database_metrics

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -492,6 +492,7 @@ workers:
         - miq_databases
         - miq_enterprises
         - miq_events
+        - miq_event_definitions
         - miq_globals
         - miq_groups
         - miq_license_contents
@@ -514,6 +515,7 @@ workers:
         - miq_widget_contents
         - miq_workers
         - rss_feeds
+        - scan_items
         - schema_migrations
         - server_roles
         - sessions

--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -1,0 +1,29 @@
+class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
+  class MiqEventDefinition < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ScanItem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Configuration < ActiveRecord::Base
+    serialize :settings, Vmdb::ConfigurationEncoder
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing rows from newly excluded tables") do
+      region_cond = ActiveRecord::Base.region_to_conditions(Rails.root.join("REGION").read.to_i)
+      MiqEventDefinition.where.not(region_cond).delete_all
+      ScanItem.where.not(region_cond).delete_all
+    end
+
+    say_with_time("Adding tables to replication worker exclude list") do
+      Configuration.where(:typ => "vmdb").each do |c|
+        c.settings[:workers][:worker_base][:replication_worker][:replication][:exclude_tables] << MiqEventDefinition.table_name << ScanItem.table_name
+        c.save!
+      end
+    end
+  end
+end

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -68,13 +68,6 @@ module ArRegion
       where(:id => region_to_range(region_number)).scoping { yield }
     end
 
-    def conditions_for_my_region_default_scope
-      # NOTE: These conditions MUST NOT be specified in Hash format because they are used for defining default_scope in models
-      #       and would be applied for the creation of objects in addition to finds. Since :id is used in the condition this
-      #       would result in all instances getting the the same id .
-      ["#{quoted_table_name}.id >= ? AND #{quoted_table_name}.id <= ?", rails_sequence_start, rails_sequence_end]
-    end
-
     def id_in_current_region?(id)
       id_to_region(id) == my_region_number
     end

--- a/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
+++ b/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+require_migration
+
+describe RemoveReplicatedRowsFromNewlyExcludedTables do
+  let(:event_def_stub) { migration_stub(:MiqEventDefinition) }
+  let(:scan_item_stub) { migration_stub(:ScanItem) }
+  let(:conf_stub)      { migration_stub(:Configuration) }
+
+  migration_context :up do
+    before do
+      path_double = double
+      allow(Rails).to receive(:root).and_return(path_double)
+      allow(path_double).to receive(:join).and_return(path_double)
+      allow(path_double).to receive(:read).and_return("99")
+    end
+
+    it "removes the rows from the tables" do
+      event_def_stub.create!(:id => 99_000_000_000_005)
+      event_def_stub.create!(:id => 5)
+      event_def_stub.create!(:id => 1_000_000_000_005)
+
+      scan_item_stub.create!(:id => 99_000_000_000_005)
+      scan_item_stub.create!(:id => 5)
+      scan_item_stub.create!(:id => 1_000_000_000_005)
+
+      migrate
+
+      expect(event_def_stub.count).to eq 1
+      expect(event_def_stub.first.id).to eq 99_000_000_000_005
+
+      expect(scan_item_stub.count).to eq 1
+      expect(scan_item_stub.first.id).to eq 99_000_000_000_005
+    end
+
+    it "adds newly excluded tables to the replication worker configuration" do
+      empty_settings = {
+        :workers => {
+          :worker_base => {
+            :replication_worker => {
+              :replication => {
+                :exclude_tables => []
+              }
+            }
+          }
+        }
+      }
+      config = conf_stub.create!(:typ => "vmdb", :settings => empty_settings)
+
+      migrate
+
+      config.reload
+      excludes = config.settings[:workers][:worker_base][:replication_worker][:replication][:exclude_tables]
+      expect(excludes).to include(event_def_stub.table_name)
+      expect(excludes).to include(scan_item_stub.table_name)
+    end
+  end
+end


### PR DESCRIPTION
The original intention of scoping models to a region was so that
the global region didn't access rows that didn't belong to it.
This mattered specifically for seeded tables where the global
region would have its own versions of the same rows.

This idea was conceived before the ability to exclude tables from
replication was added. Because we can now exclude the tables that we
don't want the global region to see there is no longer any reason to
set a default scope on these tables as no database will ever have
rows from more than one region.

Original commit sha 0ac04a1d033f0aeeea45ad5344b1752726aad300

@gtanzillo @jrafanie @Fryguy please review