### PR TITLE
Fix searching for Hosts by vmm_vendor

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -133,6 +133,7 @@ class Host < ActiveRecord::Base
   virtual_column :enabled_run_level_6_services, :type => :string_set,  :uses => :host_services
   virtual_column :last_scan_on,                 :type => :time,        :uses => :last_drift_state_timestamp
   virtual_column :v_annotation,                 :type => :string,      :uses => :hardware
+  virtual_column :vmm_vendor,                   :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
 
   virtual_has_many   :resource_pools,                               :uses => :all_relationships

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -197,6 +197,17 @@ describe Rbac do
         end
       end
     end
+
+    context "searching for hosts" do
+      it "can filter results by vmm_vendor" do
+        host = FactoryGirl.create(:host, :vmm_vendor => "vmware")
+        expression = MiqExpression.new("=" => {"field" => "Host-vmm_vendor", "value" => "VMware"})
+
+        results = Rbac.search(:class => "Host", :filter => expression).first
+
+        expect(results).to include(host.id)
+      end
+    end
   end
 
   context "common setup" do


### PR DESCRIPTION
Rbac will try to optimize a search in SQL wherever
possible. Searching for hosts by vmm_vendor is complicated by the fact
that this data is wrapped in some additional behavior that changes the
case when getting/setting. Because it filters in both SQL and ruby, it
won't ever meet both criteria because the field will be presented in
different cases.

The shortest path to fix this is to make `#vmm_vendor` a virtual column,
which will prevent Rbac from trying to search for this in SQL. A side
effect of this change will be a small performance hit because in theory
more rows can be returned to be instanciated and filtered in ruby.

It may be more desirable to have Rbac handle this better, removing the
need for this change. This would best be handled in a future revision.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1291854

***

/cc @gtanzillo 
@miq-bot add-label bug