### PR TITLE
Removed network metrics view and collection from containers

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -74,11 +74,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
 
       mem_resid = "#{@target.name}/#{group_id}/memory/usage"
       process_mem_gauges_data(fetch_gauges_data(mem_resid))
-
-      net_resid = "#{@target.name}/#{group_id}/network"
-      net_counters = [fetch_counters_rate("#{net_resid}/tx"),
-                      fetch_counters_rate("#{net_resid}/rx")]
-      process_net_counters_rate(compute_summation(net_counters))
     end
 
     def collect_group_metrics

--- a/product/charts/layouts/daily_perf_charts/Container.yaml
+++ b/product/charts/layouts/daily_perf_charts/Container.yaml
@@ -10,8 +10,3 @@
   :columns:
   - derived_memory_used
   - derived_memory_available
-
-- :title: Network I/O (KBps)
-  :type: Line
-  :columns:
-  - net_usage_rate_average

--- a/product/charts/layouts/hourly_perf_charts/Container.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Container.yaml
@@ -10,8 +10,3 @@
   :columns:
   - derived_memory_used
   - derived_memory_available
-
-- :title: Network I/O (KBps)
-  :type: Line
-  :columns:
-  - net_usage_rate_average

--- a/product/charts/layouts/realtime_perf_charts/Container.yaml
+++ b/product/charts/layouts/realtime_perf_charts/Container.yaml
@@ -10,8 +10,3 @@
   :columns:
   - derived_memory_used
   - derived_memory_available
-
-- :title: Network I/O (KBps)
-  :type: Line
-  :columns:
-  - net_usage_rate_average

--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture_spec.rb
@@ -78,7 +78,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
             ]
           }
         ],
-        :expected => {}
+        :node_expected      => {},
+        :container_expected => {}
       },
       {
         :counters => [
@@ -112,11 +113,17 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
             ]
           }
         ],
-        :expected => {
-          Time.at(1446500000).utc => {
+        :node_expected      => {
+          Time.at(1_446_500_000).utc => {
             "cpu_usage_rate_average"     => 10.0,
             "mem_usage_absolute_average" => 50.0,
             "net_usage_rate_average"     => 10.0
+          }
+        },
+        :container_expected => {
+          Time.at(1_446_500_000).utc => {
+            "cpu_usage_rate_average"     => 10.0,
+            "mem_usage_absolute_average" => 50.0
           }
         }
       }
@@ -140,7 +147,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
 
         _, values_by_ts = @node.perf_collect_metrics('realtime')
 
-        expect(values_by_ts['target']).to eq(exercise[:expected])
+        expect(values_by_ts['target']).to eq(exercise[:node_expected])
       end
     end
 
@@ -162,7 +169,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture do
 
         _, values_by_ts = @container.perf_collect_metrics('realtime')
 
-        expect(values_by_ts['target']).to eq(exercise[:expected])
+        expect(values_by_ts['target']).to eq(exercise[:container_expected])
       end
     end
   end


### PR DESCRIPTION
Network is per-Pod, so container network metrics will probably never exist.
Network metrics graphs (and collection) per container should be dropped. 