### PR TITLE
Remove 'ManageIQ' from title from pdf report of pod

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -783,6 +783,7 @@ en:
       ManageIQ::Providers::Azure::CloudManager:                             Cloud Provider (Microsoft Azure)
       ManageIQ::Providers::Atomic::ContainerManager:                        Container Provider (Atomic)
       ManageIQ::Providers::Kubernetes::ContainerManager:                    Container Provider (Kubernetes)
+      ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:    Pod (Kubernetes)
       ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (Openshift)
       ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (Openshift Enterprise)
       MiqAction:                Action


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1285864

before
<img width="1072" alt="screen shot 2016-01-18 at 16 13 19" src="https://cloud.githubusercontent.com/assets/14937244/12394798/6a65e8b2-bdfe-11e5-93e0-edac0ec98eb8.png">

after
<img width="1154" alt="screen shot 2016-01-18 at 16 11 20" src="https://cloud.githubusercontent.com/assets/14937244/12394782/49acd720-bdfe-11e5-91d7-5202b640e71a.png">
