### PR TITLE
Dynamic rates

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -115,7 +115,8 @@ class ChargebackController < ApplicationController
     end
     @sortcol = session[:rates_sortcol].nil? ? 0 : session[:rates_sortcol].to_i
     @sortdir = session[:rates_sortdir].nil? ? "ASC" : session[:rates_sortdir]
-    @view, @pages = get_view(ChargebackRate, :conditions => ["rate_type=?", "Compute"])  # Get the records (into a view) and the paginator
+    # Get the records (into a view) and the paginator
+    @view, @pages = get_view(ChargebackRate, :conditions => ["rate_type=?", "Compute"])
     @current_page = @pages[:current] unless @pages.nil?  # save the current page number
     session[:rates_sortcol] = @sortcol
     session[:rates_sortdir] = @sortdir
@@ -150,8 +151,8 @@ class ChargebackController < ApplicationController
       @sb[:rate_storage].description = @edit[:new][:description]
       if params[:button] == "add"
         cb_rate_set_record_vars
-        @sb[:rate_compute].chargeback_rate_details.replace(@sb[:rate_details].select{ |k| k.rate_type == "Compute" })
-        @sb[:rate_storage].chargeback_rate_details.replace(@sb[:rate_details].select{ |k| k.rate_type == "Storage" })
+        @sb[:rate_compute].chargeback_rate_details.replace(@sb[:rate_details].select { |k| k.rate_type == "Compute" })
+        @sb[:rate_storage].chargeback_rate_details.replace(@sb[:rate_details].select { |k| k.rate_type == "Storage" })
         if @sb[:rate_compute].save && @sb[:rate_storage].save
           AuditEvent.success(build_saved_audit(@sb[:rate_compute], @edit))
           AuditEvent.success(build_saved_audit(@sb[:rate_storage], @edit))
@@ -301,7 +302,7 @@ class ChargebackController < ApplicationController
     @edit = session[:edit]
     unless params[:select_all].nil?
       if params[:select_all] != "null"
-        @edit[:selected_rd_remove] = @sb[:rate_details].select{ |k| k.rate != "0" }
+        @edit[:selected_rd_remove] = @sb[:rate_details].select { |k| k.rate != "0" }
         enable_button = true
       else
         @edit[:selected_rd_remove] = []
@@ -322,12 +323,12 @@ class ChargebackController < ApplicationController
       if params[:select] != "null"
         enable_button = true
         if @edit[:selected_rd_remove].nil?
-          @edit[:selected_rd_remove] = @sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }
+          @edit[:selected_rd_remove] = @sb[:rate_details].select { |k| k.rate != "0" && k.id == params[:select].to_i }
         else
-          @edit[:selected_rd_remove] = ((@sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }) + @edit[:selected_rd_remove]).uniq
+          @edit[:selected_rd_remove] = ((@sb[:rate_details].select { |k| k.rate != "0" && k.id == params[:select].to_i }) + @edit[:selected_rd_remove]).uniq
         end
       else
-        @edit[:selected_rd_remove] = (@sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }).delete(@edit[:selected_rd_remove] )
+        @edit[:selected_rd_remove] = (@sb[:rate_details].select { |k| k.rate != "0" && k.id == params[:select].to_i }).delete(@edit[:selected_rd_remove])
         @edit[:selected_rd_remove].nil? ? enable_button = false : enable_button = true
       end
       render :update do |page|
@@ -351,12 +352,12 @@ class ChargebackController < ApplicationController
         end
         page << javascript_for_cb_button_add_metric_visibility(params[:metric] != "null")
       elsif !params[:group].nil?
-        rate_details_level = (params[:level] == 'Compute' || params[:level].nil?) ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute"} : @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type=="Storage" }
+        rate_details_level = (params[:level] == 'Compute' || params[:level].nil?) ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute"} : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
         @edit[:new][:metrics] = chargeback_details_metrics(rate_details_level, params[:group])
         @edit[:new][:group] = params[:group]
         page.replace_html("add_metric_fields", :partial => "cb_rate_add_metrics")
       elsif !params[:level].nil?
-        rate_details_level = (params[:level] == 'Compute') ? @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type =="Compute"} : @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type=="Storage" }
+        rate_details_level = (params[:level] == 'Compute') ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type =="Compute"} : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
         @edit[:new][:groups] = chargeback_details_groups(rate_details_level)
         @edit[:new][:level] = params[:level]
         # showing all the metrics of the selected group
@@ -375,12 +376,12 @@ class ChargebackController < ApplicationController
       selected_metrics = @edit[:selected_metrics].split(',')
       selected_metrics.each do |sm|
         # if the detail is not selectable by metric we select by description (for the Fixed rates datail)
-        rate_detail = @sb[:rate_details].select{ |k| k.metric == sm || k.description == sm }
+        rate_detail = @sb[:rate_details].select { |k| k.metric == sm || k.description == sm }
         rate_detail[0].rate = 1.0
         @added_rds.push(rate_detail[0])
       end
     when "add_all"
-      @added_rds =   @sb[:rate_details].select{ |k| k.rate == "0" }
+      @added_rds =  @sb[:rate_details].select { |k| k.rate == "0" }
       @added_rds.each do |r|
         r.rate = 1.0
       end
@@ -396,7 +397,7 @@ class ChargebackController < ApplicationController
     case params[:button]
     when "remove_single"
       rd_id = params[:rd].to_i
-      rate_detail = @sb[:rate_details].select {|k| k.id == rd_id}
+      rate_detail = @sb[:rate_details].select { |k| k.id == rd_id }
       rate_detail[0].rate = "0"
     when "remove_selected"
       selected_metrics = @edit[:selected_rd_remove]
@@ -414,7 +415,7 @@ class ChargebackController < ApplicationController
 
   def cb_rate_show
     @display = "main"
-    @sb[:selected_rate_details] = (@record[0].chargeback_rate_details + @record[1].chargeback_rate_details).uniq.select{ |k| k.rate != "0" }
+    @sb[:selected_rate_details] = (@record[0].chargeback_rate_details + @record[1].chargeback_rate_details).uniq.select { |k| k.rate != "0" }
     @sb[:selected_rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
     if @record.nil?
       redirect_to :action => "cb_rates_list", :flash_msg => _("Error: Record no longer exists in the database"), :flash_error => true
@@ -437,7 +438,7 @@ class ChargebackController < ApplicationController
       end
       process_cb_rates(rates_compute, "destroy") unless rates_compute.empty?
       # delete the storage rate (id_compute_rate + 1)
-      rates_storage = rates_compute.map { |v|; v + 1}
+      rates_storage = rates_compute.map { |v|; v + 1 }
       process_cb_rates(rates_storage, "destroy") unless rates_storage.empty?
 
       add_flash(_("The selected %s were deleted") % ui_lookup(:models => "ChargebackRate"), :info, true) unless flash_errors?
@@ -455,9 +456,9 @@ class ChargebackController < ApplicationController
       end
       cb_rate = ChargebackRate.find_by_id(params[:id])
       process_cb_rates(rates_compute, "destroy") unless rates_compute.empty?
-      rates_storage = rates_compute.map { |v|; v.to_i + 1} unless rates_compute.empty?
+      rates_storage = rates_compute.map { |v|; v.to_i + 1 } unless rates_compute.empty?
 
-      process_cb_rates(rates_storage, "destroy")  unless rates_storage.empty?
+      process_cb_rates(rates_storage, "destroy") unless rates_storage.empty?
 
       add_flash(_("The selected %s was deleted") % ui_lookup(:model => "ChargebackRate"), :info, true) unless flash_errors?
       self.x_node = "root"

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -1,4 +1,5 @@
 class ChargebackController < ApplicationController
+  include ChargebackHelper
   @@fixture_dir = File.join(Rails.root, "db/fixtures")
 
   before_action :check_privileges
@@ -23,7 +24,7 @@ class ChargebackController < ApplicationController
     if x_active_tree == :cb_rates_tree
       @record = identify_record(params[:id], ChargebackRate)
       nodeid = x_build_node_id(@record)
-      params[:id] = "xx-#{@record.rate_type}_#{nodeid}"
+      params[:id] = "xx-#{@record.description}"
       params[:tree] = x_active_tree.to_s
       tree_select
     end
@@ -114,20 +115,10 @@ class ChargebackController < ApplicationController
     end
     @sortcol = session[:rates_sortcol].nil? ? 0 : session[:rates_sortcol].to_i
     @sortdir = session[:rates_sortdir].nil? ? "ASC" : session[:rates_sortdir]
-
-    @view, @pages = get_view(ChargebackRate, :conditions => ["rate_type=?", x_node.split('-').last])  # Get the records (into a view) and the paginator
-
+    @view, @pages = get_view(ChargebackRate, :conditions => ["rate_type=?", "Compute"])  # Get the records (into a view) and the paginator
     @current_page = @pages[:current] unless @pages.nil?  # save the current page number
     session[:rates_sortcol] = @sortcol
     session[:rates_sortdir] = @sortdir
-
-    if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice] || params[:page]
-      render :update do |page|                    # Use RJS to update the display
-        page.replace("gtl_div", :partial => "layouts/x_gtl", :locals => {:action_url => "cb_rates_list"})
-        page.replace_html("paging_div", :partial => "layouts/x_pagingcontrols")
-        page << "miqSparkle(false)"
-      end
-    end
   end
 
   def cb_rate_edit
@@ -137,14 +128,17 @@ class ChargebackController < ApplicationController
       add_flash("#{!@sb[:rate] || @sb[:rate].id.blank? ? _("Add of new %s was cancelled by the user") % ui_lookup(:model => "ChargebackRate") :
         _("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description}}")
       get_node_info(x_node)
-      @sb[:rate] = @sb[:rate_details] = nil
+      # We create the rate compute and the rate storage.
+      # The @sb[:rate_details] var groups both (compute and storage) rate details
+      @sb[:rate_compute] = @sb[:rate_storage] = @sb[:rate_details] = nil
       @edit = session[:edit] = nil  # clean out the saved info
       session[:changed] =  false
       replace_right_cell
     when "save", "add"
       id = params[:id] && params[:button] == "save" ? params[:id] : "new"
       return unless load_edit("cbrate_edit__#{id}", "replace_cell__chargeback")
-      @sb[:rate] = @edit[:rate] if @edit && @edit[:rate]
+      @sb[:rate_compute] = @edit[:rate_compute] if @edit && @edit[:rate_compute]
+      @sb[:rate_storage] = @edit[:rate_storage] if @edit && @edit[:rate_storage]
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
         add_flash(_("%s is required") % "Description", :error)
         render :update do |page|
@@ -152,21 +146,25 @@ class ChargebackController < ApplicationController
         end
         return
       end
-      @sb[:rate].description = @edit[:new][:description]
-      @sb[:rate].rate_type = @edit[:new][:rate_type] if @edit[:new][:rate_type]
+      @sb[:rate_compute].description = @edit[:new][:description]
+      @sb[:rate_storage].description = @edit[:new][:description]
       if params[:button] == "add"
         cb_rate_set_record_vars
-        @sb[:rate].chargeback_rate_details.replace(@sb[:rate_details])
-
-        if @sb[:rate].save
-          AuditEvent.success(build_saved_audit(@sb[:rate], @edit))
-          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description})
+        @sb[:rate_compute].chargeback_rate_details.replace(@sb[:rate_details].select{ |k| k.rate_type == "Compute" })
+        @sb[:rate_storage].chargeback_rate_details.replace(@sb[:rate_details].select{ |k| k.rate_type == "Storage" })
+        if @sb[:rate_compute].save && @sb[:rate_storage].save
+          AuditEvent.success(build_saved_audit(@sb[:rate_compute], @edit))
+          AuditEvent.success(build_saved_audit(@sb[:rate_storage], @edit))
+          add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate_compute].description})
           @edit = session[:edit] = nil  # clean out the saved info
           session[:changed] =  @changed = false
           get_node_info(x_node)
           replace_right_cell([:cb_rates])
         else
-          @sb[:rate].errors.each do |field, msg|
+          @sb[:rate_compute].errors.each do |field, msg|
+            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          end
+          @sb[:rate_storage].errors.each do |field, msg|
             add_flash("#{field.to_s.capitalize} #{msg}", :error)
           end
           @sb[:rate_details].each do |detail|
@@ -182,15 +180,19 @@ class ChargebackController < ApplicationController
         # Detect errors saving rate details
         rate_detail_error = false
         @sb[:rate_details].each { |detail| rate_detail_error = true if detail.save == false }
-        if rate_detail_error == false && @sb[:rate].save
-          AuditEvent.success(build_saved_audit(@sb[:rate], @edit))
-          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate].description})
+        if rate_detail_error == false && @sb[:rate_compute].save && @sb[:rate_storage].save
+          AuditEvent.success(build_saved_audit(@sb[:rate_compute], @edit))
+          AuditEvent.success(build_saved_audit(@sb[:rate_storage], @edit))
+          add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @sb[:rate_compute].description})
           @edit = session[:edit] = nil  # clean out the saved info
           @changed = false
           get_node_info(x_node)
           replace_right_cell([:cb_rates])
         else
-          @sb[:rate].errors.each do |field, msg|
+          @sb[:rate_compute].errors.each do |field, msg|
+            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          end
+          @sb[:rate_storage].errors.each do |field, msg|
             add_flash("#{field.to_s.capitalize} #{msg}", :error)
           end
           @sb[:rate_details].each do |detail|
@@ -208,15 +210,26 @@ class ChargebackController < ApplicationController
       if params[:typ] == "copy" # if tab was not changed
         session[:changed] = true
         @sb[:rate_details] = []
-        rate = ChargebackRate.find(obj[0])
-        @sb[:rate] = ChargebackRate.new
-        @sb[:rate].description = "Copy of " + rate.description
-        @sb[:rate].rate_type = rate.rate_type
-        rate_details = rate.chargeback_rate_details
+
+        rate_compute = ChargebackRate.find(obj[0])
+        # the storage_rate has id = compute_storage_id + 1 by convention
+        rate_storage = ChargebackRate.find(obj[0].to_i + 1)
+
+        @sb[:rate_compute] = ChargebackRate.new
+        @sb[:rate_compute].description = "Copy of " + rate_compute.description
+        @sb[:rate_compute].rate_type = rate_compute.rate_type
+
+        @sb[:rate_storage] = ChargebackRate.new
+        @sb[:rate_storage].description = "Copy of " + rate_storage.description
+        @sb[:rate_storage].rate_type = rate_storage.rate_type
+
+        # uniting the two rates details into one variable
+        rate_details = (rate_compute.chargeback_rate_details + rate_storage.chargeback_rate_details).uniq
         # Create new rate detail records for copied rate record
         rate_details.each do |r|
           detail = ChargebackRateDetail.new
           detail.description = r[:description]
+          detail.chargeback_rate_id = r[:chargeback_rate_id]
           detail.source = r[:source]
           detail.rate = r[:rate]
           detail.per_time = r[:per_time]
@@ -228,34 +241,36 @@ class ChargebackController < ApplicationController
         end
       else
         session[:changed] = false
-        @sb[:rate] = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0])
-        @sb[:rate_details] = @sb[:rate].chargeback_rate_details.to_a
+        @sb[:rate_compute] = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0])
+        # the rate_storage has a rate_compute_id (rate) +1 by convention
+        @sb[:rate_storage] = params[:typ] == "new" ? ChargebackRate.new : ChargebackRate.find(obj[0].to_i + 1)
+
+        @sb[:rate_details] = (@sb[:rate_compute].chargeback_rate_details.to_a + @sb[:rate_storage].chargeback_rate_details.to_a).uniq
+
         if @sb[:rate_details].blank?
           fixture_file = File.join(@@fixture_dir, "chargeback_rates.yml")
           if File.exist?(fixture_file)
             fixture = YAML.load_file(fixture_file)
             fixture.each do |cbr|
-              if cbr[:rate_type] == x_node.split('-').last
-                rates = cbr.delete(:rates)
-                rates.each do |r|
-                  detail = ChargebackRateDetail.new
-                  detail.description = r[:description]
-                  detail.source = r[:source]
-                  # detail.rate = r[:rate]
-                  # detail.per_time = r[:per_time]
-                  detail.rate = ""
-                  detail.per_time = "hourly"
-                  detail.group = r[:group]
-                  detail.per_unit = r[:per_unit]
-                  detail.metric = r[:metric]
-                  # if the rate detail has a measure associated
-                  unless r[:measure].nil?
-                    # Copy the measure id of the rate_detail linkig with the rate_detail_measure
-                    id_measure = ChargebackRateDetailMeasure.find_by(:name => r[:measure]).id
-                    detail.chargeback_rate_detail_measure_id = id_measure
-                  end
-                  @sb[:rate_details].push(detail) unless @sb[:rate_details].include?(detail)
+              rates = cbr.delete(:rates)
+              rates.each do |r|
+                detail = ChargebackRateDetail.new
+                detail.description = r[:description]
+                detail.source = r[:source]
+                # detail.rate = r[:rate]
+                # detail.per_time = r[:per_time]
+                detail.rate = ""
+                detail.per_time = "hourly"
+                detail.group = r[:group]
+                detail.per_unit = r[:per_unit]
+                detail.metric = r[:metric]
+                # if the rate detail has a measure associated
+                unless r[:measure].nil?
+                  # Copy the measure id of the rate_detail linkig with the rate_detail_measure
+                  id_measure = ChargebackRateDetailMeasure.find_by(:name => r[:measure]).id
+                  detail.chargeback_rate_detail_measure_id = id_measure
                 end
+                @sb[:rate_details].push(detail) unless @sb[:rate_details].include?(detail)
               end
             end
           end
@@ -281,9 +296,125 @@ class ChargebackController < ApplicationController
     end
   end
 
+  # AJAX driven routine to storage the selected rate details for remove
+  def cb_selected_rd
+    @edit = session[:edit]
+    unless params[:select_all].nil?
+      if params[:select_all] != "null"
+        @edit[:selected_rd_remove] = @sb[:rate_details].select{ |k| k.rate != "0" }
+        enable_button = true
+      else
+        @edit[:selected_rd_remove] = []
+        enable_button = false
+      end
+      render :update do |page|
+        if enable_button
+          page << javascript_enable_field("btm-remove_rd")
+          page << javascript_checked_by_class("select")
+        else
+          page << javascript_disable_field("btm-remove_rd")
+          page << javascript_unchecked_by_class("select")
+        end
+      end
+    end
+
+    unless params[:select].nil?
+      if params[:select] != "null"
+        enable_button = true
+        if @edit[:selected_rd_remove].nil?
+          @edit[:selected_rd_remove] = @sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }
+        else
+          @edit[:selected_rd_remove] = ((@sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }) + @edit[:selected_rd_remove]).uniq
+        end
+      else
+        @edit[:selected_rd_remove] = (@sb[:rate_details].select{ |k| k.rate != "0" && k.id == params[:select].to_i }).delete(@edit[:selected_rd_remove] )
+        @edit[:selected_rd_remove].nil? ? enable_button = false : enable_button = true
+      end
+      render :update do |page|
+        if enable_button
+          page << javascript_enable_field("btm-remove_rd")
+        else
+          page << javascript_disable_field("btm-remove_rd")
+        end
+        page << javascript_unchecked("select_all")
+      end
+    end
+  end
+
+  # AJAX driven routine to check for changes in ANY field on the form off add rate detail in rate
+  def cb_add_rd_form_field_changed
+    @edit = session[:edit]
+    render :update do |page|
+      if !params[:metric].nil?
+        if params[:metric] != "null"
+          @edit[:selected_metrics] = params[:metric]
+        end
+        page << javascript_for_cb_button_add_metric_visibility(params[:metric] != "null")
+      elsif !params[:group].nil?
+        rate_details_level = (params[:level] == 'Compute' || params[:level].nil?) ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute"} : @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type=="Storage" }
+        @edit[:new][:metrics] = chargeback_details_metrics(rate_details_level, params[:group])
+        @edit[:new][:group] = params[:group]
+        page.replace_html("add_metric_fields", :partial => "cb_rate_add_metrics")
+      elsif !params[:level].nil?
+        rate_details_level = (params[:level] == 'Compute') ? @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type =="Compute"} : @sb[:rate_details].select{ |k| k.rate == "0" && k.rate_type=="Storage" }
+        @edit[:new][:groups] = chargeback_details_groups(rate_details_level)
+        @edit[:new][:level] = params[:level]
+        # showing all the metrics of the selected group
+        @edit[:new][:metrics] = @edit[:new][:groups].empty? ? [] : chargeback_details_metrics(rate_details_level, @edit[:new][:groups].first[1])
+        page.replace_html("add_metric_fields", :partial => "cb_rate_add_metrics")
+      end
+    end
+  end
+
+  def cb_add_rd
+    @edit = session[:edit]
+    # for save added rate details
+    @added_rds = []
+    case params[:button]
+    when "add_single"
+      selected_metrics = @edit[:selected_metrics].split(',')
+      selected_metrics.each do |sm|
+        # if the detail is not selectable by metric we select by description (for the Fixed rates datail)
+        rate_detail = @sb[:rate_details].select{ |k| k.metric == sm || k.description == sm }
+        rate_detail[0].rate = 1.0
+        @added_rds.push(rate_detail[0])
+      end
+    when "add_all"
+      @added_rds =   @sb[:rate_details].select{ |k| k.rate == "0" }
+      @added_rds.each do |r|
+        r.rate = 1.0
+      end
+    end
+    cb_rate_set_form_vars
+    # flag to maintain the save button visible
+    @edit[:new][:added_metric] = true
+    replace_right_cell
+  end
+
+  def cb_remove_rd
+    @edit = session[:edit]
+    case params[:button]
+    when "remove_single"
+      rd_id = params[:rd].to_i
+      rate_detail = @sb[:rate_details].select {|k| k.id == rd_id}
+      rate_detail[0].rate = "0"
+    when "remove_selected"
+      selected_metrics = @edit[:selected_rd_remove]
+      selected_metrics.each do |sm|
+        # if the detail is not selectable by metric we select by description (for the Fixed rates datail)
+        rate_detail = @sb[:rate_details].select{ |k| k.id == sm.id }
+        rate_detail[0].rate = "0"
+      end
+    end
+    cb_rate_set_form_vars
+    # flag to maintain the save button visible
+    @edit[:new][:added_metric] = true
+    replace_right_cell
+  end
+
   def cb_rate_show
     @display = "main"
-    @sb[:selected_rate_details] = @record.chargeback_rate_details.to_a
+    @sb[:selected_rate_details] = (@record[0].chargeback_rate_details + @record[1].chargeback_rate_details).uniq.select{ |k| k.rate != "0" }
     @sb[:selected_rate_details].sort_by! { |rd| [rd[:group].downcase, rd[:description].downcase] }
     if @record.nil?
       redirect_to :action => "cb_rates_list", :flash_msg => _("Error: Record no longer exists in the database"), :flash_error => true
@@ -294,16 +425,21 @@ class ChargebackController < ApplicationController
   # Delete all selected or single displayed action(s)
   def cb_rates_delete
     assert_privileges("chargeback_rates_delete")
-    rates = []
+    # we show the compute rates
+    rates_compute = []
     if !params[:id] # showing a list
-      rates = find_checked_items
-      if rates.empty?
+      rates_compute = find_checked_items
+      if rates_compute.empty?
         add_flash(_("No %s were selected for deletion") % ui_lookup(:models => "ChargebackRate"), :error)
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
-      process_cb_rates(rates, "destroy")  unless rates.empty?
+      process_cb_rates(rates_compute, "destroy") unless rates_compute.empty?
+      # delete the storage rate (id_compute_rate + 1)
+      rates_storage = rates_compute.map { |v|; v + 1}
+      process_cb_rates(rates_storage, "destroy") unless rates_storage.empty?
+
       add_flash(_("The selected %s were deleted") % ui_lookup(:models => "ChargebackRate"), :info, true) unless flash_errors?
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
@@ -315,12 +451,16 @@ class ChargebackController < ApplicationController
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
-        rates.push(params[:id])
+        rates_compute.push(params[:id])
       end
       cb_rate = ChargebackRate.find_by_id(params[:id])
-      process_cb_rates(rates, "destroy")  unless rates.empty?
+      process_cb_rates(rates_compute, "destroy") unless rates_compute.empty?
+      rates_storage = rates_compute.map { |v|; v.to_i + 1} unless rates_compute.empty?
+
+      process_cb_rates(rates_storage, "destroy")  unless rates_storage.empty?
+
       add_flash(_("The selected %s was deleted") % ui_lookup(:model => "ChargebackRate"), :info, true) unless flash_errors?
-      self.x_node = "xx-#{cb_rate.rate_type}"
+      self.x_node = "root"
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
       replace_right_cell([:cb_rates])
@@ -434,14 +574,13 @@ class ChargebackController < ApplicationController
       if node == "root"
         @sb[:rate] = @record = @sb[:selected_rate_details] = nil
         @right_cell_text = _("All %s") % ui_lookup(:models => "ChargebackRate")
-      elsif ["xx-Compute", "xx-Storage"].include?(node)
-        @sb[:rate] = @record = @sb[:selected_rate_details] = nil
-        @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
         cb_rates_list
       else
-        @record = ChargebackRate.find(from_cid(node.split('_').last.split('-').last))
+        # record has now two rates with the same descriptions (Compute, Storage)
+        @record = ChargebackRate.where("description = ?", node.split('_').last.split('-').last)
         @sb[:action] = nil
-        @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ => @record.rate_type, :model => ui_lookup(:model => "ChargebackRate"), :name => @record.description}
+        # we use the compute rate ([0]) for reference
+        @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "ChargebackRate"), :name => @record[0].description}
         cb_rate_show
       end
     elsif x_active_tree == :cb_assignments_tree
@@ -537,21 +676,25 @@ class ChargebackController < ApplicationController
   # Set form variables for edit
   def cb_rate_set_form_vars
     @edit = {}
-    @edit[:rate] = @sb[:rate]
-    @edit[:key] = "cbrate_edit__#{@sb[:rate].id || "new"}"
+    @edit[:rate_compute] = @sb[:rate_compute]
+    @edit[:rate_storage] = @sb[:rate_storage]
+
+    @edit[:key] = "cbrate_edit__#{@sb[:rate_compute].id || "new"}"
+
     @edit[:rate_details] = @sb[:rate_details]
+
     @edit[:new]     = HashWithIndifferentAccess.new
     @edit[:current] = HashWithIndifferentAccess.new
-    @edit[:rec_id] = @sb[:rate].id || nil
+    @edit[:rec_id] = @sb[:rate_compute].id || nil
     @in_a_form = true
 
-    @edit[:new][:description] = @sb[:rate].description
-    @edit[:new][:rate_type] = @sb[:rate].rate_type ? @sb[:rate].rate_type : x_node.split('-').last
+    @edit[:new][:description] = @sb[:rate_compute].description
     @edit[:new][:details] = []
 
-    @sb[:rate_details].each do |r|
+    @sb[:rate_details].select { |k| k.rate != "0" }.each do |r|
       temp = {}
       temp[:rate] = (!r.rate.nil? && r.rate != "") ? r.rate : 0
+      temp[:id] = r.id
       temp[:per_time] = r.per_time ? r.per_time : "hourly"
       temp[:per_unit] = r.per_unit
       temp[:detail_measure] = r.detail_measure
@@ -564,13 +707,41 @@ class ChargebackController < ApplicationController
       "weekly"  => "Weekly",
       "monthly" => "Monthly"
     }
+    # creating a new set of rate details whose rate is 0
+    rate_details_compute_for_add = @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute" }
+    rate_details_storage_for_add = @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
+
+    # if dont exist rate details not show the add rate detail form
+    if rate_details_compute_for_add.empty? && rate_details_storage_for_add.empty?
+      @edit[:new][:show_form] = false
+    else
+      @edit[:new][:show_form] = true
+      @edit[:new][:levels] = %w(Compute Storage)
+      if !session[:edit].nil?
+        @edit[:new][:level] = session[:edit][:new][:level]
+        @edit[:new][:group] = session[:edit][:new][:group]
+        rate_details_for_add = @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == @edit[:new][:level] }
+        @edit[:new][:groups] = chargeback_details_groups(rate_details_for_add)
+        if @edit[:new][:groups].value?(@edit[:new][:group])
+          @edit[:new][:metrics] = chargeback_details_metrics(rate_details_for_add, @edit[:new][:group])
+        else
+          @edit[:new][:metrics] = chargeback_details_metrics(rate_details_for_add, @edit[:new][:groups].first.second)
+        end
+      else
+        @edit[:new][:level] = "Compute"
+        rate_details_for_add = !rate_details_compute_for_add.empty? ? rate_details_compute_for_add : rate_details_storage_for_add
+        @edit[:new][:groups] = chargeback_details_groups(rate_details_for_add)
+        @edit[:new][:metrics] = chargeback_details_metrics(rate_details_for_add, @edit[:new][:groups].first.second)
+      end
+    end
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit] = @edit
   end
 
   # Get variables from edit form
   def cb_rate_get_form_vars
-    @sb[:rate] = @edit[:rate]
+    @sb[:rate_compute] = @edit[:rate_compute]
+    @sb[:rate_storage] = @edit[:rate_storage]
     @edit[:new][:description] = params[:description] if params[:description]
     @edit[:new][:details].each_with_index do |_detail, i|
       @edit[:new][:details][i][:rate] = params["rate_#{i}".to_sym] if params["rate_#{i}".to_sym]
@@ -580,12 +751,14 @@ class ChargebackController < ApplicationController
   end
 
   def cb_rate_set_record_vars
+    # Updating only the rates detail with rate values different from 0
+    sb_temp = @sb[:rate_details].select { |k| k.rate != "0" }
     @edit[:new][:details].each_with_index do |_rate, i|
-      @sb[:rate_details][i].rate               = @edit[:new][:details][i][:rate]
-      @sb[:rate_details][i].per_time           = @edit[:new][:details][i][:per_time]
-      @sb[:rate_details][i].per_unit           = @edit[:new][:details][i][:per_unit]
-      @sb[:rate_details][i].chargeback_rate_id = @sb[:rate].id
+      sb_temp[i].rate               = @edit[:new][:details][i][:rate]
+      sb_temp[i].per_time           = @edit[:new][:details][i][:per_time]
+      sb_temp[i].per_unit           = @edit[:new][:details][i][:per_unit]
     end
+    @sb[:rate_details] = (sb_temp + @sb[:rate_details].select { |k| k.rate == "0" }).uniq
   end
 
   # Set record vars for save
@@ -811,6 +984,11 @@ class ChargebackController < ApplicationController
         presenter[:set_visible_elements][:paging_div] = true
         presenter[:set_visible_elements][:form_buttons_div] = true
         presenter[:set_visible_elements][:pc_div_1] = false
+        if @edit[:new][:added_metric]
+          presenter[:set_visible_elements][:buttons_on] = true
+          presenter[:set_visible_elements][:buttons_off] = false
+        end
+        # Use JS to update the display
         locals = {:record_id => @edit[:rec_id]}
         if x_active_tree == :cb_rates_tree
           locals[:action_url] = 'cb_rate_edit'
@@ -832,8 +1010,7 @@ class ChargebackController < ApplicationController
       presenter[:set_visible_elements][:form_buttons_div] = false
       presenter[:set_visible_elements][:pc_div_1] = true
       if (x_active_tree == :cb_assignments_tree && x_node == "root") ||
-         (x_active_tree == :cb_reports_tree && !@report) ||
-         (x_active_tree == :cb_rates_tree && x_node == "root")
+         (x_active_tree == :cb_reports_tree && !@report)
         presenter[:set_visible_elements][:toolbar] = false
         presenter[:set_visible_elements][:pc_div_1] = false
       end
@@ -841,7 +1018,8 @@ class ChargebackController < ApplicationController
     end
 
     if @record && !@in_a_form
-      presenter[:record_id] = @record.id
+      # We use the Compute rate (first) for reference
+      presenter[:record_id] = @record.first.id
     else
       presenter[:record_id] = @edit && @edit[:rec_id] && @in_a_form ? @edit[:rec_id] : nil
     end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -352,12 +352,12 @@ class ChargebackController < ApplicationController
         end
         page << javascript_for_cb_button_add_metric_visibility(params[:metric] != "null")
       elsif !params[:group].nil?
-        rate_details_level = (params[:level] == 'Compute' || params[:level].nil?) ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute"} : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
+        rate_details_level = (params[:level] == 'Compute' || params[:level].nil?) ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute" } : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
         @edit[:new][:metrics] = chargeback_details_metrics(rate_details_level, params[:group])
         @edit[:new][:group] = params[:group]
         page.replace_html("add_metric_fields", :partial => "cb_rate_add_metrics")
       elsif !params[:level].nil?
-        rate_details_level = (params[:level] == 'Compute') ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type =="Compute"} : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
+        rate_details_level = (params[:level] == 'Compute') ? @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Compute" } : @sb[:rate_details].select { |k| k.rate == "0" && k.rate_type == "Storage" }
         @edit[:new][:groups] = chargeback_details_groups(rate_details_level)
         @edit[:new][:level] = params[:level]
         # showing all the metrics of the selected group
@@ -381,7 +381,7 @@ class ChargebackController < ApplicationController
         @added_rds.push(rate_detail[0])
       end
     when "add_all"
-      @added_rds =  @sb[:rate_details].select { |k| k.rate == "0" }
+      @added_rds = @sb[:rate_details].select { |k| k.rate == "0" }
       @added_rds.each do |r|
         r.rate = 1.0
       end
@@ -403,7 +403,7 @@ class ChargebackController < ApplicationController
       selected_metrics = @edit[:selected_rd_remove]
       selected_metrics.each do |sm|
         # if the detail is not selectable by metric we select by description (for the Fixed rates datail)
-        rate_detail = @sb[:rate_details].select{ |k| k.id == sm.id }
+        rate_detail = @sb[:rate_details].select { |k| k.id == sm.id }
         rate_detail[0].rate = "0"
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -527,6 +527,15 @@ module ApplicationHelper
     end
   end
 
+  # Show/hide the Add metric button on Chargeback
+  def javascript_for_cb_button_add_metric_visibility(display)
+    if display
+      "$('.cb_add_metric_off').hide();$('.cb_add_metric_on').show();".html_safe
+    else
+      "$('.cb_add_metric_off').show();$('.cb_add_metric_on').hide();".html_safe
+    end
+  end
+
   def javascript_for_miq_button_visibility_changed(changed)
     return "" if changed == session[:changed]
     session[:changed] = changed

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -190,12 +190,10 @@ class ApplicationHelper::ToolbarChooser
   def center_toolbar_filename_chargeback
     if @report && x_active_tree == :cb_reports_tree
       return "chargeback_center_tb"
-    elsif x_active_tree == :cb_rates_tree && x_node != "root"
-      if ["Compute", "Storage"].include?(x_node.split('-').last)
+    elsif x_active_tree == :cb_rates_tree && x_node == "root"
         return "chargebacks_center_tb"
       else
         return "chargeback_center_tb"
-      end
     end
     "blank_view_tb"
   end

--- a/app/helpers/chargeback_helper.rb
+++ b/app/helpers/chargeback_helper.rb
@@ -1,21 +1,18 @@
 module ChargebackHelper
   def chargeback_details_groups(chargeback_details)
-    groups = Hash.new
+    groups = {}
     chargeback_details.each_with_index do |r|
       new_group = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
-      groups[new_group] = r[:group] unless groups.has_key?(new_group)
+      groups[new_group] = r[:group] unless groups.key?(new_group)
     end
     groups
   end
+
   def chargeback_details_metrics(chargeback_details, group)
-    metrics = Hash.new
+    metrics = {}
     chargeback_details.each_with_index do |r|
       if r[:metric].nil? then r[:metric] = r[:description] end
-      metrics[r[:description]] = r[:metric] unless r[:group] != group and (r[:rate] != "0" || r[:rate] != "")
-    end
-    metrics
-  end
-
+      metrics[r
   def get_valids_columns()
      hash_columns = { :start_date               => :datetime,
                       :end_date                 => :datetime,
@@ -38,5 +35,8 @@ module ChargebackHelper
      end
      hash_columns = hash_columns.merge(:total_cost => :float)
      hash_columns
+  end[:description]] = r[:metric] unless r[:group] != group && (r[:rate] != "0" || r[:rate] != "")
+    end
+    metrics
   end
 end

--- a/app/helpers/chargeback_helper.rb
+++ b/app/helpers/chargeback_helper.rb
@@ -12,30 +12,7 @@ module ChargebackHelper
     metrics = {}
     chargeback_details.each_with_index do |r|
       if r[:metric].nil? then r[:metric] = r[:description] end
-      metrics[r
-  def get_valids_columns()
-     hash_columns = { :start_date               => :datetime,
-                      :end_date                 => :datetime,
-                      :interval_name            => :string,
-                      :display_range            => :string,
-                      :vm_name                  => :string,
-                      :owner_name               => :string
-                    }
-     ChargebackRate.where( :default => true ).each do |cb|
-       cb.chargeback_rate_details.where.not(:rate => "0").each do |rd|
-         column = rd.group+"_"+rd.source
-         if rd.group != "fixed"
-           hash_columns = hash_columns.merge((column + "_metric").to_sym => :float, (column + "_cost").to_sym => :float)
-           hash_columns = hash_columns.merge((rd.group + "_metric").to_sym => :float, (rd.group + "_cost").to_sym => :float)
-         else
-           hash_columns = hash_columns.merge((column + "_cost").to_sym => :float)
-           hash_columns = hash_columns.merge((rd.group + "_cost").to_sym => :float)
-         end
-       end
-     end
-     hash_columns = hash_columns.merge(:total_cost => :float)
-     hash_columns
-  end[:description]] = r[:metric] unless r[:group] != group && (r[:rate] != "0" || r[:rate] != "")
+      metrics[r[:description]] = r[:metric] unless r[:group] != group && (r[:rate] != "0" || r[:rate] != "")
     end
     metrics
   end

--- a/app/helpers/chargeback_helper.rb
+++ b/app/helpers/chargeback_helper.rb
@@ -1,0 +1,42 @@
+module ChargebackHelper
+  def chargeback_details_groups(chargeback_details)
+    groups = Hash.new
+    chargeback_details.each_with_index do |r|
+      new_group = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
+      groups[new_group] = r[:group] unless groups.has_key?(new_group)
+    end
+    groups
+  end
+  def chargeback_details_metrics(chargeback_details, group)
+    metrics = Hash.new
+    chargeback_details.each_with_index do |r|
+      if r[:metric].nil? then r[:metric] = r[:description] end
+      metrics[r[:description]] = r[:metric] unless r[:group] != group and (r[:rate] != "0" || r[:rate] != "")
+    end
+    metrics
+  end
+
+  def get_valids_columns()
+     hash_columns = { :start_date               => :datetime,
+                      :end_date                 => :datetime,
+                      :interval_name            => :string,
+                      :display_range            => :string,
+                      :vm_name                  => :string,
+                      :owner_name               => :string
+                    }
+     ChargebackRate.where( :default => true ).each do |cb|
+       cb.chargeback_rate_details.where.not(:rate => "0").each do |rd|
+         column = rd.group+"_"+rd.source
+         if rd.group != "fixed"
+           hash_columns = hash_columns.merge((column + "_metric").to_sym => :float, (column + "_cost").to_sym => :float)
+           hash_columns = hash_columns.merge((rd.group + "_metric").to_sym => :float, (rd.group + "_cost").to_sym => :float)
+         else
+           hash_columns = hash_columns.merge((column + "_cost").to_sym => :float)
+           hash_columns = hash_columns.merge((rd.group + "_cost").to_sym => :float)
+         end
+       end
+     end
+     hash_columns = hash_columns.merge(:total_cost => :float)
+     hash_columns
+  end
+end

--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -106,8 +106,20 @@ module JsHelper
       .html_safe
   end
 
+  # checking by class
+  def javascript_checked_by_class(element)
+    "if ($('.#{j_str(element)}').prop('type') == 'checkbox') {$('.#{j_str(element)}').prop('checked', 'checked');}"
+      .html_safe
+  end
+
   def javascript_unchecked(element)
     "if ($('##{j_str(element)}').prop('type') == 'checkbox') {$('##{j_str(element)}').prop('checked', false);}"
+      .html_safe
+  end
+
+  # unchecking by class
+  def javascript_unchecked_by_class(element)
+    "if ($('.#{j_str(element)}').prop('type') == 'checkbox') {$('.#{j_str(element)}').prop('checked', false);}"
       .html_safe
   end
 

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,45 +1,4 @@
 class Chargeback < ActsAsArModel
-  set_columns_hash(
-    :start_date               => :datetime,
-    :end_date                 => :datetime,
-    :interval_name            => :string,
-    :display_range            => :string,
-    :vm_name                  => :string,
-    :owner_name               => :string,
-    :cpu_allocated_metric     => :float,
-    :cpu_allocated_cost       => :float,
-    :cpu_used_cost            => :float,
-    :cpu_used_metric          => :float,
-    :cpu_cost                 => :float,
-    :cpu_metric               => :float,
-    :disk_io_used_cost        => :float,
-    :disk_io_used_metric      => :float,
-    :disk_io_cost             => :float,
-    :disk_io_metric           => :float,
-    :fixed_compute_1_cost     => :float,
-    :fixed_compute_2_cost     => :float,
-    :fixed_storage_1_cost     => :float,
-    :fixed_storage_2_cost     => :float,
-    :fixed_2_cost             => :float,
-    :fixed_cost               => :float,
-    :memory_allocated_cost    => :float,
-    :memory_allocated_metric  => :float,
-    :memory_used_cost         => :float,
-    :memory_used_metric       => :float,
-    :memory_cost              => :float,
-    :memory_metric            => :float,
-    :net_io_used_cost         => :float,
-    :net_io_used_metric       => :float,
-    :net_io_cost              => :float,
-    :net_io_metric            => :float,
-    :storage_allocated_cost   => :float,
-    :storage_allocated_metric => :float,
-    :storage_used_cost        => :float,
-    :storage_used_metric      => :float,
-    :storage_cost             => :float,
-    :storage_metric           => :float,
-    :total_cost               => :float
-  )
 
   RATES = YAML.load_file(File.join(Rails.root, "db/fixtures/chargeback_rates.yml"))
 
@@ -174,6 +133,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.column_names
+    set_columns_hash(valids_columns)
     @column_names ||= columns.collect(&:name).sort
   end
 
@@ -267,6 +227,30 @@ class Chargeback < ActsAsArModel
     end
 
     [start_time, end_time]
+  end
+
+  def self.valids_columns
+    hash_columns = {:start_date    => :datetime,
+                    :end_date      => :datetime,
+                    :interval_name => :string,
+                    :display_range => :string,
+                    :vm_name       => :string,
+                    :owner_name    => :string
+                   }
+    ChargebackRate.where(:default => true).each do |cb|
+      cb.chargeback_rate_details.where.not(:rate => "0").each do |rd|
+        column = rd.group + "_" + rd.source
+        if rd.group != "fixed"
+          hash_columns = hash_columns.merge((column + "_metric").to_sym => :float, (column + "_cost").to_sym => :float)
+          hash_columns = hash_columns.merge((rd.group + "_metric").to_sym => :float, (rd.group + "_cost").to_sym => :float)
+        else
+          hash_columns = hash_columns.merge((column + "_cost").to_sym => :float)
+          hash_columns = hash_columns.merge((rd.group + "_cost").to_sym => :float)
+        end
+      end
+    end
+    hash_columns = hash_columns.merge(:total_cost => :float)
+    hash_columns
   end
 
   def self.report_col_options

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -14,29 +14,46 @@ class TreeBuilderChargebackRates < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, options)
-    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
-    case options[:type]
-    when :cb_assignments, :cb_rates
-      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
+    def x_get_tree_roots(count_only, options)
+      # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
+      case options[:type]
+      when :cb_assignments
+        rate_types = ChargebackRate::VALID_CB_RATE_TYPES
 
-      if count_only
-        rate_types.length
-      else
-        objects = []
-        rate_types.sort.each do |rtype|
-          img = rtype.downcase == "compute" ? "hardware-processor" : "hardware-disk"
-          objects.push(
-            :id    => rtype,
-            :text  => rtype,
-            :image => img,
-            :tip   => rtype
-          )
+        if count_only
+          rate_types.length
+        else
+          objects = []
+          rate_types.sort.each do |rtype|
+            img = rtype.downcase == "compute" ? "hardware-processor" : "hardware-disk"
+            objects.push(
+              :id    => rtype,
+              :text  => rtype,
+              :image => img,
+              :tip   => rtype
+            )
+          end
+          objects
         end
-        objects
+      when :cb_rates
+        # the rate accordion merge the compute rate and the storage rate in one unic rate grouping by description
+        rates = ChargebackRate.all
+        grouped_rates = rates.group_by(&:description)
+        if count_only
+          grouped_rates.length
+        else
+          objects = []
+          grouped_rates.sort.each do |description_group|
+            objects.push(
+              :id    => description_group[0],
+              :text  => description_group[0],
+              :image => 'chargeback_rate',
+            )
+          end
+          objects
+        end
       end
     end
-  end
 
   # Handle custom tree nodes (object is a Hash)
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -14,46 +14,46 @@ class TreeBuilderChargebackRates < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-    def x_get_tree_roots(count_only, options)
-      # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
-      case options[:type]
-      when :cb_assignments
-        rate_types = ChargebackRate::VALID_CB_RATE_TYPES
+  def x_get_tree_roots(count_only, options)
+    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
+    case options[:type]
+    when :cb_assignments
+      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
 
-        if count_only
-          rate_types.length
-        else
-          objects = []
-          rate_types.sort.each do |rtype|
-            img = rtype.downcase == "compute" ? "hardware-processor" : "hardware-disk"
-            objects.push(
-              :id    => rtype,
-              :text  => rtype,
-              :image => img,
-              :tip   => rtype
-            )
-          end
-          objects
+      if count_only
+        rate_types.length
+      else
+        objects = []
+        rate_types.sort.each do |rtype|
+          img = rtype.downcase == "compute" ? "hardware-processor" : "hardware-disk"
+          objects.push(
+            :id    => rtype,
+            :text  => rtype,
+            :image => img,
+            :tip   => rtype
+          )
         end
-      when :cb_rates
-        # the rate accordion merge the compute rate and the storage rate in one unic rate grouping by description
-        rates = ChargebackRate.all
-        grouped_rates = rates.group_by(&:description)
-        if count_only
-          grouped_rates.length
-        else
-          objects = []
-          grouped_rates.sort.each do |description_group|
-            objects.push(
-              :id    => description_group[0],
-              :text  => description_group[0],
-              :image => 'chargeback_rate',
-            )
-          end
-          objects
+        objects
+      end
+    when :cb_rates
+      # the rate accordion merge the compute rate and the storage rate in one unic rate grouping by description
+      rates = ChargebackRate.all
+      grouped_rates = rates.group_by(&:description)
+      if count_only
+        grouped_rates.length
+      else
+        objects = []
+        grouped_rates.sort.each do |description_group|
+          objects.push(
+            :id    => description_group[0],
+            :text  => description_group[0],
+            :image => 'chargeback_rate',
+          )
         end
+        objects
       end
     end
+  end
 
   # Handle custom tree nodes (object is a Hash)
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/views/chargeback/_cb_rate_add_metrics.html.haml
+++ b/app/views/chargeback/_cb_rate_add_metrics.html.haml
@@ -1,0 +1,43 @@
+- url = url_for(:action => 'cb_add_rd_form_field_changed')
+%tr
+  %td
+    = select_tag("level", options_for_select(@edit[:new][:levels], @edit[:new][:level]), :class => "selectpicker")
+    :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('level', '#{url}')
+  %td
+    = select_tag("group", options_for_select(@edit[:new][:groups], @edit[:new][:group]), :class => "selectpicker", :disabled => @edit[:new][:groups].empty? )
+    :javascript
+        miqSelectPickerEvent('group', '#{url}')
+  %td
+    = select_tag("metric", options_for_select(@edit[:new][:metrics]), :multiple => true, :class => "selectpicker", :disabled => @edit[:new][:metrics].empty?)
+    :javascript
+        miqSelectPickerEvent('metric', '#{url}')
+  %td
+    - title = _("Add Metric(s)")
+    = button_tag("<span class=\"glyphicon glyphicon-plus\">#{_(title)}</span>".html_safe,
+                :disabled => "disabled",
+                :class => "cb_add_metric_off btn btn-default")
+
+    = button_tag( "<span class=\"glyphicon glyphicon-plus\">#{_(title)}</span>".html_safe,
+                 :style => "display: none;",
+                 :class   => "cb_add_metric_on btn btn-primary",
+                 :alt     => t = _(" Add new Metrics"),
+                 :title   => t,
+                 :type    => "submit",
+                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_add_rd", :button => "add_single")}');")
+  %td{:style => "padding-left: 20px;"}
+    = button_tag( "<span class=\"glyphicon pficon-add-circle-o\">#{_(" Add all Metrics")}</span>".html_safe,
+                 :class   => "cb_add_all_metric_on btn btn-primary btn-left",
+                 :alt     => _(" Add all Metrics"),
+                 :title   => t,
+                 :type    => "submit",
+                 :onclick => "miqAjaxButton('#{url_for(:action => "cb_add_rd", :button => "add_all")}');")
+
+- if @edit[:new][:groups].empty?
+  %tr
+    %th{:colspan => "4"}
+      .alert.alert-info
+        %span.pficon.pficon-info
+        %strong
+          = h("All available rate details for this level are already in use")

--- a/app/views/chargeback/_cb_rate_add_metrics.html.haml
+++ b/app/views/chargeback/_cb_rate_add_metrics.html.haml
@@ -6,7 +6,7 @@
         miqInitSelectPicker();
         miqSelectPickerEvent('level', '#{url}')
   %td
-    = select_tag("group", options_for_select(@edit[:new][:groups], @edit[:new][:group]), :class => "selectpicker", :disabled => @edit[:new][:groups].empty? )
+    = select_tag("group", options_for_select(@edit[:new][:groups], @edit[:new][:group]), :class => "selectpicker", :disabled => @edit[:new][:groups].empty?)
     :javascript
         miqSelectPickerEvent('group', '#{url}')
   %td
@@ -19,7 +19,7 @@
                 :disabled => "disabled",
                 :class => "cb_add_metric_off btn btn-default")
 
-    = button_tag( "<span class=\"glyphicon glyphicon-plus\">#{_(title)}</span>".html_safe,
+    = button_tag("<span class=\"glyphicon glyphicon-plus\">#{_(title)}</span>".html_safe,
                  :style => "display: none;",
                  :class   => "cb_add_metric_on btn btn-primary",
                  :alt     => t = _(" Add new Metrics"),
@@ -27,7 +27,7 @@
                  :type    => "submit",
                  :onclick => "miqAjaxButton('#{url_for(:action => "cb_add_rd", :button => "add_single")}');")
   %td{:style => "padding-left: 20px;"}
-    = button_tag( "<span class=\"glyphicon pficon-add-circle-o\">#{_(" Add all Metrics")}</span>".html_safe,
+    = button_tag("<span class=\"glyphicon pficon-add-circle-o\">#{_(" Add all Metrics")}</span>".html_safe,
                  :class   => "cb_add_all_metric_on btn btn-primary btn-left",
                  :alt     => _(" Add all Metrics"),
                  :title   => t,

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -38,7 +38,7 @@
       = button_tag("<span class=\"pficon-delete\">#{t = _(" Remove selected rate details")}</span>".html_safe,
                    :class   => "btn btn-primary btn-sm",
                    :id      => "btm-remove_rd",
-                   :alt     => t ,
+                   :alt     => t,
                    :disabled => "disabled",
                    :type    => "submit",
                    :onclick => "miqAjaxButton('#{url_for(:action => "cb_remove_rd", :button => "remove_selected")}');")
@@ -55,7 +55,7 @@
           %th= _('Per Unit')
           %th= ''
       %tbody
-        - @sb[:rate_details].select{ |k| k.rate != "0" }.each_with_index do |r, i|
+        - @sb[:rate_details].select { |k| k.rate != "0" }.each_with_index do |r, i|
           - @cur_group = r[:group] if @cur_group.nil?
           - if @cur_group != r[:group]
             - @cur_group = r[:group]

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,4 +1,6 @@
-- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate].id || "new"}")
+- url = url_for(:action => 'cb_rate_form_field_changed', :id => "#{@sb[:rate_compute].id || "new"}")
+- url_select = url_for(:action => 'cb_selected_rd')
+
 #form_div
   %h3
     = _('Basic Info')
@@ -11,43 +13,96 @@
                         :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
                         :class => "form-control")
         = javascript_tag(javascript_focus('description'))
-
   %hr
-
-  %h3= _('Rate Details')
-  %table.table.table-bordered
-    %thead
-      %tr
-        %th= _('Group')
-        %th= _('Description')
-        %th= _('Rate')
-        %th= _('Per Time')
-        %th= _('Per Unit')
-    %tbody
-      - @sb[:rate_details].each_with_index do |r, i|
-        - @cur_group = r[:group] if @cur_group.nil?
-        - if @cur_group != r[:group]
-          - @cur_group = r[:group]
+  %h3= _('Add Rate Details')
+  .col-md-8
+    - if @edit[:new][:show_form]
+      %table
+        %thead
           %tr
-            %td.active{:colspan => "6"} &nbsp;
+            %th= _('Level')
+            %th= _('Group')
+            %th= _('Metric')
+            %th= _('')
+        %tbody{:id => "add_metric_fields"}
+          = render(:partial => "cb_rate_add_metrics")
+    - else
+      .alert.alert-info
+        %span.pficon.pficon-info
+        %strong
+          = h("No rate details for add")
+.col-md-12
+  %br
+  .panel.panel-default
+    .panel-heading{:style => "text-align: right;"}
+      = button_tag("<span class=\"pficon-delete\">#{t = _(" Remove selected rate details")}</span>".html_safe,
+                   :class   => "btn btn-primary btn-sm",
+                   :id      => "btm-remove_rd",
+                   :alt     => t ,
+                   :disabled => "disabled",
+                   :type    => "submit",
+                   :onclick => "miqAjaxButton('#{url_for(:action => "cb_remove_rd", :button => "remove_selected")}');")
+    %table.table.table-bordered
+      %thead
         %tr
-          %td
-            = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
-          %td
-            = r[:description]
-          %td{:align => 'right'}
-            = text_field_tag("rate_#{i}", @edit[:new][:details][i][:rate],
-              :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %td
-            = select_tag("per_time_#{i}",
-              options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][i][:per_time]),
-              "data-miq_observe" => {:url => url}.to_json)
-            - measure = @edit[:new][:details][i][:detail_measure]
-            - if measure.nil?
-              /if the rate detail don't have a metric associated, display the per_unit_display
+          %th
+            = check_box_tag('select_all', 'all', nil, "data-miq_observe_checkbox" => {:url => url_select}.to_json)
+          %th= _('Level')
+          %th= _('Group')
+          %th= _('Description')
+          %th= _('Rate')
+          %th= _('Per Time')
+          %th= _('Per Unit')
+          %th= ''
+      %tbody
+        - @sb[:rate_details].select{ |k| k.rate != "0" }.each_with_index do |r, i|
+          - @cur_group = r[:group] if @cur_group.nil?
+          - if @cur_group != r[:group]
+            - @cur_group = r[:group]
+            %tr
+              %td.active{:colspan => "8"} &nbsp;
+          - if !@added_rds.nil? && @added_rds.include?(r)
+            - class_add_rds = "add_rds"
+          %tr{:class => class_add_rds}
+            %td
+              = check_box_tag("select", @edit[:new][:details][i][:id], nil, "data-miq_observe_checkbox" => {:url => url_select}.to_json, :class => "select")
+            %td
+              - if r.rate_type == "Compute"
+                = image_tag "icons/new/hardware-processor.png"
+              - else
+                = image_tag "icons/new/hardware-disk.png"
+              = r.rate_type
+            %td
+              = Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize)
+            %td
+              = r[:description]
+            %td{:align => 'right'}
+              = text_field_tag("rate_#{i}", @edit[:new][:details][i][:rate],
+                :maxlength => MAX_NAME_LEN, "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+            %td
+              = select_tag("per_time_#{i}",
+                options_for_select(@edit[:new][:per_time_types].invert, @edit[:new][:details][i][:per_time]),
+                "data-miq_observe" => {:url => url}.to_json)
+              - measure = @edit[:new][:details][i][:detail_measure]
+              - if measure.nil?
+                /if the rate detail don't have a metric associated, display the per_unit_display
+                %td
+                  = r.per_unit_display
+              - else
+                /if the rate detail have a metric associated, display an options field with per_unit selected
+                %td
+                  = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
               %td
-                = r.per_unit_display
-            - else
-              /if the rate detail have a metric associated, display an options field with per_unit selected
-              %td
-                = select_tag("per_unit_#{i}", options_for_select(measure.measures, r.per_unit), "data-miq_observe" => {:url => url}.to_json)
+                = button_tag("<span class=\"pficon-delete\"></span>".html_safe,
+                              :class   => "btn btn-primary btn-xs",
+                              :alt     => t,
+                              :type    => "submit",
+                              :onclick => "miqAjaxButton('#{url_for(:action => "cb_remove_rd", :button => "remove_single", :rd => r.id)}');")
+              :javascript
+                // check or un uncheck the rate detail checkbox
+                $(document).ready(function () {
+                    $("[id^=select]").prop('checked', false);
+                    $(".btm-remove_rd").attr("disabled","disabled");
+                    $('.add_rds').fadeIn().fadeOut().fadeIn().fadeOut().fadeIn().fadeOut().fadeIn();
+                    $('.add_rds').addClass('add_rds_off').removeClass('add_rds');
+                });

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -9,12 +9,13 @@
         = _('Description')
       .col-md-8
         %p.form-control-static
-          = h(@record.description)
+          = h(@record.first.description)
   %hr
   %h3= _('Rate Details')
   %table.table.table-bordered
     %thead
       %tr
+        %th= _('Level')
         %th= _('Group')
         %th= _('Description')
         %th= _('Rate')
@@ -28,6 +29,12 @@
           %tr
             %td.active{:colspan => "6"} &nbsp;
         %tr
+          %td
+            - if r.rate_type == "Compute"
+              = image_tag "icons/new/hardware-processor.png"
+            - else
+              = image_tag "icons/new/hardware-disk.png"
+            = r.rate_type
           %td
             = h(Dictionary.gettext(r[:group], :type => :rate_detail_group, :notfound => :titleize))
           %td

--- a/app/views/chargeback/_rates_tabs.html.haml
+++ b/app/views/chargeback/_rates_tabs.html.haml
@@ -2,8 +2,6 @@
   -# Toplevel Tabbar
   - if x_active_tree == :cb_rates_tree
     - if x_node == "root"
-      = render :partial => "rates_list"
-    - elsif %w(Compute Storage).include?(x_node.split('-').last)
       = render :partial => "cb_rates"
     - else
       = render :partial => "cb_rate_show"

--- a/app/views/layouts/_x_taskbar.html.haml
+++ b/app/views/layouts/_x_taskbar.html.haml
@@ -8,8 +8,13 @@
     = render_toolbars
 
     - if @record
+      -# Temporal solution. Only for Chargeback because @record is a array with compute and Storage rate
+      - if @record[0].nil?
+        - id = @record.id
+      - else
+        - id = @record[0].id
       :javascript
-        ManageIQ.record.recordId = '#{@record.id}';
+        ManageIQ.record.recordId = '#{id}';
     - else
       :javascript
         ManageIQ.record.recordId = null;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,10 @@ Vmdb::Application.routes.draw do
         cb_assign_update
         cb_rate_edit
         cb_rate_form_field_changed
+        cb_add_rd_form_field_changed
+        cb_add_rd
+        cb_remove_rd
+        cb_selected_rd
         cb_rate_show
         cb_rates_delete
         cb_rates_list


### PR DESCRIPTION
# Dynamic Rates
With this pull request we aim to make clearer the process of setting up a rate and leave open the possibility of adding more levels of pricing in the future (to charging for Envelope, OpenShift users etc.)
## Compute and Storage Rate joined together in one Rate with his rate details
First of all we will change the rate view to show one rate that groups the Compute metrics and the Storage metrics. It is maintained the class models and the actual assignments process. This implies changes in the accordion and the rate views. 

_Compute and Storage Rate joined together in one Rate:_
![](http://res.cloudinary.com/ddtbdqfq7/image/upload/v1452873040/Captura_de_pantalla_de_2016-01-15_16-50-14_wnuxb4.png)
## Selectable metrics for a rate
At present, the CF rate has a predefined rate metrics in a table way. With this part of the new feature the admin can choose the metrics that he want in the CF rate. Also can delete the metrics that not need in the rate:

_View of the new functionality:_
![](http://res.cloudinary.com/ddtbdqfq7/image/upload/v1452780299/pull-request-enero_2_yukcyw.png)

## Selectable columns for a Chargeback report
In a report based on Chargeback the columns that are shown must be the same that are selected on a rate.  A compute rate is defined with Allocated CPU Metrics and DiskIO metric, this columns are the only that the chargeback report show for to select.