### PR TITLE
Don't use _type, but let rails derive the _type

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -215,7 +215,7 @@ class MiqAlert < ActiveRecord::Base
   end
 
   def add_status_post_evaluate(target, result)
-    status = target.miq_alert_statuses.first_or_initialize
+    status = miq_alert_statuses.find_or_initialize_by(:resource => target)
     status.result = result
     status.evaluated_on = Time.now.utc
     status.save

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -177,12 +177,14 @@ class MiqAlert < ActiveRecord::Base
   def postpone_evaluation?(target)
     # TODO: Are there some alerts that we always want to evaluate?
 
-    # If a miq alert status exists for our resource and alert, and it has not been delay_next_evaluation seconds since it was evaluated, return false so we can skip evaluation
+    # If a miq alert status exists for our resource and alert, and it has not been delay_next_evaluation seconds since
+    # it was evaluated, return true so we can skip evaluation
     delay_next_evaluation = (options || {}).fetch_path(:notifications, :delay_next_evaluation)
     start_skipping_at = Time.now.utc - (delay_next_evaluation || 10.minutes).to_i
+    statuses_not_expired = miq_alert_statuses.where(:resource => target, :result => true)
+                           .where(miq_alert_statuses.arel_table[:evaluated_on].gt(start_skipping_at))
 
-    statuses_not_expired = miq_alert_statuses.where("result = ? AND resource_type = ? AND resource_id = ? AND evaluated_on > ?", true, target.class.base_class.name, target.id, start_skipping_at).count
-    if statuses_not_expired > 0
+    if statuses_not_expired.count > 0
       _log.info("Skipping re-evaluation of Alert [#{description}] for target: [#{target.name}] with delay_next_evaluation [#{delay_next_evaluation}]")
       return true
     else
@@ -213,11 +215,9 @@ class MiqAlert < ActiveRecord::Base
   end
 
   def add_status_post_evaluate(target, result)
-    existing = miq_alert_statuses.find_by(:resource => target)
-    status = existing.nil? ? MiqAlertStatus.new : existing
+    status = target.miq_alert_statuses.first_or_initialize
     status.result = result
     status.evaluated_on = Time.now.utc
-    status.resource = target
     status.save
     miq_alert_statuses << status
   end
@@ -653,7 +653,7 @@ class MiqAlert < ActiveRecord::Base
       return false
     end
 
-    status = miq_alert_statuses.find_by(:resource => target)
+    status = target.miq_alert_statuses.first
     if status
       since_last_eval = (Time.now.utc - status.evaluated_on)
       eval_options[:starting_on] = if (since_last_eval >= eval_options[:duration])

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -213,7 +213,7 @@ class MiqAlert < ActiveRecord::Base
   end
 
   def add_status_post_evaluate(target, result)
-    existing = miq_alert_statuses.find_by(:resource_type => target.class.base_class.name, :resource_id => target.id)
+    existing = miq_alert_statuses.find_by(:resource => target)
     status = existing.nil? ? MiqAlertStatus.new : existing
     status.result = result
     status.evaluated_on = Time.now.utc
@@ -653,7 +653,7 @@ class MiqAlert < ActiveRecord::Base
       return false
     end
 
-    status = miq_alert_statuses.find_by(:resource_type => target.class.base_class.name, :resource_id => target.id)
+    status = miq_alert_statuses.find_by(:resource => target)
     if status
       since_last_eval = (Time.now.utc - status.evaluated_on)
       eval_options[:starting_on] = if (since_last_eval >= eval_options[:duration])

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -659,7 +659,7 @@ class MiqServer < ActiveRecord::Base
   def permitted_groups
     groups = miq_groups.order(:sequence).to_a
     groups = zone.miq_groups.order(:sequence).to_a if groups.empty?
-    groups = MiqGroup.where(:resource_id => nil, :resource_type => nil).order(:sequence).to_a if groups.empty?
+    groups = MiqGroup.where(:resource => nil).order(:sequence).to_a if groups.empty?
     groups
   end
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -111,7 +111,7 @@ module MiqServer::LogManagement
   end
 
   def last_log_sync_on
-    log_files.order(:updated_on => :desc).pluck(:updated_on).first
+    log_files.maximum(:updated_on)
   end
 
   def last_log_sync_message

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -111,14 +111,12 @@ module MiqServer::LogManagement
   end
 
   def last_log_sync_on
-    rec = LogFile.where(:resource => self).order("updated_on DESC").select("updated_on").first
-    rec.nil? ? nil : rec.updated_on
+    log_files.order(:updated_on => :desc).pluck(:updated_on).first
   end
 
   def last_log_sync_message
-    last_log = LogFile.where(:resource => self).order("updated_on DESC").first
-    return nil if last_log.nil? || last_log.miq_task.nil?
-    last_log.miq_task.message
+    last_log = log_files.order(:updated_on => :desc).first
+    last_log.try(:miq_task).try!(:message)
   end
 
   def post_logs(options)
@@ -208,7 +206,7 @@ module MiqServer::LogManagement
   end
 
   def delete_old_requested_logs
-    LogFile.destroy_all(:historical => false, :resource => self)
+    log_files.where(:historical => false).destroy_all
   end
 
   def delete_active_log_collections_queue

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -111,12 +111,12 @@ module MiqServer::LogManagement
   end
 
   def last_log_sync_on
-    rec = LogFile.where(:resource_type => self.class.name, :resource_id => id).order("updated_on DESC").select("updated_on").first
+    rec = LogFile.where(:resource => self).order("updated_on DESC").select("updated_on").first
     rec.nil? ? nil : rec.updated_on
   end
 
   def last_log_sync_message
-    last_log = LogFile.where(:resource_type => self.class.name, :resource_id => id).order("updated_on DESC").first
+    last_log = LogFile.where(:resource => self).order("updated_on DESC").first
     return nil if last_log.nil? || last_log.miq_task.nil?
     last_log.miq_task.message
   end
@@ -208,7 +208,7 @@ module MiqServer::LogManagement
   end
 
   def delete_old_requested_logs
-    LogFile.destroy_all(:historical => false, :resource_id => id, :resource_type => self.class.name)
+    LogFile.destroy_all(:historical => false, :resource => self)
   end
 
   def delete_active_log_collections_queue

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -129,7 +129,7 @@ module ServiceMixin
 
   def parent_services(svc = self)
     srs = ServiceResource.where(:resource => svc)
-    svc = srs.collect { |sr| service = sr.send(sr.resource_type.underscore) }.compact
+    srs.collect { |sr| sr.public_send(sr.resource_type.underscore) }.compact
   end
 
   def sub_services(options = {})

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -128,7 +128,7 @@ module ServiceMixin
   end
 
   def parent_services(svc = self)
-    srs = ServiceResource.where(:resource_type => svc.class.name, :resource_id => svc.id)
+    srs = ServiceResource.where(:resource => svc)
     svc = srs.collect { |sr| service = sr.send(sr.resource_type.underscore) }.compact
   end
 

--- a/app/models/policy_event.rb
+++ b/app/models/policy_event.rb
@@ -41,7 +41,7 @@ class PolicyEvent < ActiveRecord::Base
       end
 
       (r[:miq_actions] + r[:miq_policy_sets]).each do|c|
-        pe.contents << PolicyEventContent.new(:resource_id => c.id, :resource_type => c.class.name, :resource_description => c.description)
+        pe.contents << PolicyEventContent.new(:resource => c, :resource_description => c.description)
       end
       pe.save
     end

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -483,7 +483,7 @@ module VimPerformanceAnalysis
 
     rel
       .where("timestamp > ? and timestamp <= ?", start_time.utc, end_time.utc)
-      .where(:resource_type => obj.class.base_class.name, :resource_id => obj.id)
+      .where(:resource => obj)
       .order("timestamp")
       .select(options[:select])
       .to_a


### PR DESCRIPTION
Rails is able to figure out what _type and _id to use in a
polymorphic association.
This is less error-prone on objects with STI

One drawback is, that rails does not seem to precompile the query (and presumably use it for later)
I'm not sure where this might be of an impact. @kbrock  ? 
```sql
2.2.0 :007 > MiqServer.first.last_log_sync_on # with ':resource_type => obj.class.base_class.name'
  MiqServer Load (0.3ms)  SELECT  "miq_servers".* FROM "miq_servers"  ORDER BY "miq_servers"."id" ASC LIMIT 1
  MiqServer Inst Including Associations (20.0ms - 1rows)
  LogFile Load (0.2ms)  SELECT  "log_files"."updated_on" FROM "log_files" WHERE "log_files"."resource_type" = $1 AND "log_files"."resource_id" = $2  ORDER BY updated_on DESC LIMIT 1  [["resource_type", "MiqServer"], ["resource_id", 1]]
  LogFile Inst Including Associations (0.0ms - 0rows)
 => nil
2.2.0 :008 > MiqServer.first.last_log_sync_on #  # with ':resource => obj'
  MiqServer Load (0.3ms)  SELECT  "miq_servers".* FROM "miq_servers"  ORDER BY "miq_servers"."id" ASC LIMIT 1
  MiqServer Inst Including Associations (22.4ms - 1rows)
  LogFile Load (0.2ms)  SELECT  "log_files"."updated_on" FROM "log_files" WHERE "log_files"."resource_type" = 'MiqServer' AND "log_files"."resource_id" = 1  ORDER BY updated_on DESC LIMIT 1
  LogFile Inst Including Associations (0.0ms - 0rows)
```