### PR TITLE
Services/Workloads - fix Templates & Images tree

### DIFF
--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
   def tree_init_options(_tree_name)
-    super.update(:leaf => 'Template')
+    super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
   end
 
   def set_locals_for_render


### PR DESCRIPTION
As it is, in Services/Workloads, the tree in Templates & Images is empty. Looks like a typo when splitting the TreeBuilder instances, "Template" => "MiqTemplate" fixes it.

https://bugzilla.redhat.com/show_bug.cgi?id=1290300

Note to anyone testing: You need to **clear the session** for this change to work.