### PR TITLE
Disable inheritance of method :key in VimHash

### DIFF
--- a/gems/pending/VMwareWebService/VimTypes.rb
+++ b/gems/pending/VMwareWebService/VimTypes.rb
@@ -5,6 +5,7 @@ class VimHash < Hash
   undef_method(:id)   if method_defined?(:id)
   undef_method(:type) if method_defined?(:type)
   undef_method(:size) if method_defined?(:size)
+  undef_method(:key)  if method_defined?(:key)
 
   def initialize(xsiType = nil, vimType = nil)
     self.xsiType = xsiType


### PR DESCRIPTION
The inherited Hash :key method is clashing with the behavior of
VimHash to access a key using :method_missing and sym.to_s.

https://bugzilla.redhat.com/show_bug.cgi?id=1298844